### PR TITLE
Fix for 2 tests

### DIFF
--- a/src/bpf.py
+++ b/src/bpf.py
@@ -169,7 +169,7 @@ class BPF(object):
             ifindex = int(f.read())
         if not isinstance(fn, BPF.Function):
             raise Exception("arg 1 must be of type BPF.Function")
-        res = lib.bpf_attach_filter(fn.fd, fn.name, ifindex, prio, classid)
+        res = lib.bpf_attach_filter(fn.fd, fn.name.encode("ascii"), ifindex, prio, classid)
         if res < 0:
             raise Exception("Failed to filter with BPF")
 

--- a/tests/jit/test2.py
+++ b/tests/jit/test2.py
@@ -32,8 +32,8 @@ class TestBPFSocket(TestCase):
         key = Key(IPAddress("172.16.1.1").value, IPAddress("172.16.1.2").value)
         leaf = Leaf(IPAddress("192.168.1.1").value, IPAddress("192.168.1.2").value, 0)
         self.xlate.put(key, leaf)
-        udp = socket(AF_INET, SOCK_DGRAM)
-        udp.sendto(b"a" * 10, ("172.16.1.1", 5000))
+        with socket(AF_INET, SOCK_DGRAM) as udp:
+            udp.sendto(b"a" * 10, ("172.16.1.1", 5000))
         leaf = self.xlate.get(key)
         self.assertGreater(leaf.xlated_pkts, 0)
 


### PR DESCRIPTION
- name needed to be right ctype
- python runtime was complaining about dangling socket fd

Signed-off-by: Brenden Blanco bblanco@plumgrid.com
