### PR TITLE
Add packet read syntax to c parser

### DIFF
--- a/src/cc/b_frontend_action.h
+++ b/src/cc/b_frontend_action.h
@@ -40,7 +40,7 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   bool VisitCallExpr(clang::CallExpr *Call);
   bool VisitVarDecl(clang::VarDecl *Decl);
   bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *E);
-  bool VisitDeclRefExpr(clang::DeclRefExpr *E);
+  bool VisitMemberExpr(clang::MemberExpr *E);
 
  private:
   clang::ASTContext &C;

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -129,7 +129,8 @@ int BPFModule::load_file_module(unique_ptr<llvm::Module> *mod, const string &fil
   }
 
   vector<const char *> flags_cstr({"-O0", "-emit-llvm", "-I", dstack.cwd(),
-                                  "-x", "c", "-c", abs_file.c_str()});
+                                   "-Wno-deprecated-declarations",
+                                   "-x", "c", "-c", abs_file.c_str()});
 
   KBuildHelper kbuild_helper;
   vector<string> kflags;

--- a/src/cc/proto.h
+++ b/src/cc/proto.h
@@ -1,0 +1,58 @@
+#include <linux/types.h>
+
+struct ethernet_t {
+  u64 dst:48;
+  u64 src:48;
+  u32 type:16;
+} __attribute__((packed));
+
+struct dot1q_t {
+  u32 pri:3;
+  u32 cfi:1;
+  u32 vlanid:12;
+  u32 type:16;
+} __attribute__((packed));
+
+struct ip_t {
+  u32 ver:4;              // byte 0
+  u32 hlen:4;
+  u32 tos:8;
+  u32 tlen:16;
+  u32 identification:16;  // byte 4
+  u32 ffo_unused:1;
+  u32 df:1;
+  u32 mf:1;
+  u32 foffset:13;
+  u32 ttl:8;              // byte 8
+  u32 nextp:8;
+  u32 hchecksum:16;
+  u32 src:32;             // byte 12
+  u32 dst:32;             // byte 16
+} __attribute__((packed));
+
+struct udp_t {
+  u32 sport:16;
+  u32 dport:16;
+  u32 length:16;
+  u32 crc:16;
+} __attribute__((packed));
+
+struct tcp_t {
+  u16 src_port:16;  // byte 0
+  u16 dst_port:16;
+  u32 seq_num:32;   // byte 4
+  u32 ack_num:32;   // byte 8
+  u8 offset:4;      // byte 12
+  u8 reserved:4;
+  u8 flag_cwr:1;
+  u8 flag_ece:1;
+  u8 flag_urg:1;
+  u8 flag_ack:1;
+  u8 flag_psh:1;
+  u8 flag_rst:1;
+  u8 flag_syn:1;
+  u8 flag_fin:1;
+  u16 rcv_wnd:16;
+  u16 cksum:16;     // byte 16
+  u16 urg_ptr:16;
+} __attribute__((packed));

--- a/tests/jit/test1.c
+++ b/tests/jit/test1.c
@@ -1,4 +1,5 @@
 #include "../../src/cc/bpf_helpers.h"
+#include "../../src/cc/proto.h"
 
 struct IPKey {
   u32 dip;
@@ -12,91 +13,37 @@ struct IPLeaf {
 BPF_TABLE("hash", struct IPKey, struct IPLeaf, stats, 256);
 
 BPF_EXPORT(main)
-int foo(struct __sk_buff *skb) {
-  size_t next = 0, cur = 0;
-ethernet:
-{
-  cur = next; next += 14;
+int _main(struct __sk_buff *skb) {
+  BEGIN(ethernet);
 
-  switch (bpf_dext_pkt(skb, cur + 12, 0, 16)) {
-    case 0x800: goto ip;
-    case 0x8100: goto dot1q;
-    default: goto EOP;
+  PROTO(ethernet) {
+    switch (ethernet->type) {
+      case 0x0800: goto ip;
+      case 0x8100: goto dot1q;
+    }
   }
-}
-dot1q:
-{
-  cur = next; next += 4;
-
-  switch (bpf_dext_pkt(skb, cur + 2, 0, 16)) {
-    case 0x0800: goto ip;
-    default: goto EOP;
+  PROTO(dot1q) {
+    switch (dot1q->type) {
+      case 0x0800: goto ip;
+    }
   }
-}
-
-ip:
-{
-  cur = next; next += 20;
-
-  int rx = 0;
-  int tx = 0;
-  struct IPKey key = {0};
-  if (bpf_dext_pkt(skb, cur + 16, 0, 32) > bpf_dext_pkt(skb, cur + 12, 0, 32)) {
-    key.sip = bpf_dext_pkt(skb, cur + 12, 0, 32);
-    key.dip = bpf_dext_pkt(skb, cur + 16, 0, 32);
-    rx = 1;
-  } else {
-    key.dip = bpf_dext_pkt(skb, cur + 12, 0, 32);
-    key.sip = bpf_dext_pkt(skb, cur + 16, 0, 32);
-    tx = 1;
-  }
-  // try to get here:
-  //stats[key].rx_pkts += rx;
-  //stats[key].tx_pkts += tx;
-  // or here:
-  //struct IPLeaf *leaf = stats[key];
-  //if (leaf) {
-  //  __sync_fetch_and_add(&leaf->rx_pkts, rx);
-  //  __sync_fetch_and_add(&leaf->tx_pkts, tx);
-  //}
-  struct IPLeaf *leaf;
-  leaf = stats.get(&key);
-  if (!leaf) {
+  PROTO(ip) {
+    int rx = 0, tx = 0;
+    struct IPKey key;
+    if (ip->dst > ip->src) {
+      key.dip = ip->dst;
+      key.sip = ip->src;
+      rx = 1;
+    } else {
+      key.dip = ip->src;
+      key.sip = ip->dst;
+      tx = 1;
+    }
     struct IPLeaf zleaf = {0};
-    stats.put(&key, &zleaf);
-    leaf = stats.get(&key);
+    struct IPLeaf *leaf = stats.lookup_or_init(&key, &zleaf);
+    lock_xadd(&leaf->rx_pkts, rx);
+    lock_xadd(&leaf->tx_pkts, tx);
   }
-  if (leaf) {
-    __sync_fetch_and_add(&leaf->rx_pkts, rx);
-    __sync_fetch_and_add(&leaf->tx_pkts, tx);
-  }
-
-  switch (bpf_dext_pkt(skb, cur + 9, 0, 8)) {
-    case 6: goto tcp;
-    case 17: goto udp;
-    //case 47: goto gre;
-    default: goto EOP;
-  }
-}
-
-udp:
-{
-  cur = next; next += 8;
-
-  switch (bpf_dext_pkt(skb, cur + 2, 0, 16)) {
-    //case 8472: goto vxlan;
-    //case 4789: goto vxlan;
-    default: goto EOP;
-  }
-}
-
-tcp:
-{
-  cur = next; next += 20;
-
-  goto EOP;
-}
-
 EOP:
   return 0;
 }

--- a/tests/jit/test3.c
+++ b/tests/jit/test3.c
@@ -16,7 +16,7 @@ int parse_ether(struct __sk_buff *skb) {
   size_t next = cur + 14;
 
   int key = S_ETHER;
-  u64 *leaf = stats.get(&key);
+  u64 *leaf = stats.lookup(&key);
   if (leaf) (*leaf)++;
 
   switch (bpf_dext_pkt(skb, cur + 12, 0, 16)) {
@@ -33,7 +33,7 @@ int parse_arp(struct __sk_buff *skb) {
   size_t next = cur + 28;
 
   int key = S_ARP;
-  u64 *leaf = stats.get(&key);
+  u64 *leaf = stats.lookup(&key);
   if (leaf) (*leaf)++;
 
   jump.call(skb, S_EOP);
@@ -46,7 +46,7 @@ int parse_ip(struct __sk_buff *skb) {
   size_t next = cur + 20;
 
   int key = S_IP;
-  u64 *leaf = stats.get(&key);
+  u64 *leaf = stats.lookup(&key);
   if (leaf) (*leaf)++;
 
   jump.call(skb, S_EOP);
@@ -56,7 +56,7 @@ int parse_ip(struct __sk_buff *skb) {
 BPF_EXPORT(eop)
 int eop(struct __sk_buff *skb) {
   int key = S_EOP;
-  u64 *leaf = stats.get(&key);
+  u64 *leaf = stats.lookup(&key);
   if (leaf) (*leaf)++;
   return 0;
 }

--- a/tests/jit/trace2.c
+++ b/tests/jit/trace2.c
@@ -7,11 +7,7 @@ BPF_TABLE("hash", struct Ptr, struct Counters, stats, 1024);
 BPF_EXPORT(count_sched)
 int count_sched(struct pt_regs *ctx) {
   struct Ptr key = {.ptr=ctx->bx};
-#if 1
-  stats.data[(u64)&key].stat1++;
-#else
   struct Counters zleaf = {0};
-  stats.upsert(&key, &zleaf)->stat1++;
-#endif
+  stats.lookup_or_init(&key, &zleaf)->stat1++;
   return 0;
 }


### PR DESCRIPTION
- C macro-based state machine
- Add lookup_or_init helper routine instead of array syntax
- Recognize references to protocol headers and translate into dext call

Signed-off-by: Brenden Blanco bblanco@plumgrid.com
