### PR TITLE
avoid include file linux/bpf.h in helpers.h

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -16,8 +16,7 @@
 #ifndef __BPF_HELPERS_H
 #define __BPF_HELPERS_H
 
-#include <linux/bpf.h>
-#include <linux/filter.h>
+#include <uapi/linux/bpf.h>
 #include <linux/if_packet.h>
 #include <linux/version.h>
 


### PR DESCRIPTION
   o use uapi/linux/bpf.h instead
   o to be consistent with kernel/samples/bpf/

Signed-off-by: Yonghong Song <yhs@plumgrid.com>