### PR TITLE
Add kprobe auto-cleanup and header fix

### DIFF
--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -19,4 +19,7 @@ int hello(void *ctx) {
 b = BPF(text=prog)
 fn = b.load_func("hello", BPF.KPROBE)
 BPF.attach_kprobe(fn, "sys_clone")
-call(["cat", "/sys/kernel/debug/tracing/trace_pipe"])
+try:
+    call(["cat", "/sys/kernel/debug/tracing/trace_pipe"])
+except KeyboardInterrupt:
+    pass

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -17,7 +17,7 @@
 #define __BPF_HELPERS_H
 
 #include <uapi/linux/bpf.h>
-#include <linux/if_packet.h>
+#include <uapi/linux/if_packet.h>
 #include <linux/version.h>
 
 /* helper macro to place programs, maps, license in

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -229,3 +229,25 @@ cleanup:
   return rc;
 }
 
+int bpf_detach_kprobe(const char *event_desc) {
+  int rc = -1, kfd = -1;
+
+  kfd = open("/sys/kernel/debug/tracing/kprobe_events", O_WRONLY | O_APPEND, 0);
+  if (kfd < 0) {
+    perror("open(kprobe_events)");
+    goto cleanup;
+  }
+
+  if (write(kfd, event_desc, strlen(event_desc)) < 0) {
+    perror("write(kprobe_events)");
+    goto cleanup;
+  }
+  rc = 0;
+
+cleanup:
+  if (kfd >= 0)
+    close(kfd);
+
+  return rc;
+}
+

--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -41,6 +41,7 @@ int bpf_attach_socket(int sockfd, int progfd);
 int bpf_open_raw_sock(const char *name);
 
 int bpf_attach_kprobe(int progfd, const char *event, const char *event_desc, pid_t pid, int cpu, int group_fd);
+int bpf_detach_kprobe(const char *event_desc);
 
 #define LOG_BUF_SIZE 65536
 extern char bpf_log_buf[LOG_BUF_SIZE];


### PR DESCRIPTION
* Add bpf_detach_kprobe helper to libbpf
* Automatically invoke detach at python program exit
* Add "uapi/" to one include in helpers.h

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>