### PR TITLE
Remove the BPF_EXPORT macro, use rewriter instead

### DIFF
--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -9,7 +9,6 @@ from bpf import BPF
 from subprocess import call
 
 prog = """
-BPF_EXPORT(hello)
 int hello(void *ctx) {
   char fmt[] = "Hello, World!\\n";
   bpf_trace_printk(fmt, sizeof(fmt));

--- a/examples/vlan_learning.c
+++ b/examples/vlan_learning.c
@@ -15,7 +15,6 @@ BPF_TABLE("hash", u64, struct ifindex_leaf_t, egress, 4096);
 // redirect based on mac -> out_ifindex (config-driven)
 BPF_TABLE("hash", u64, struct ifindex_leaf_t, ingress, 4096);
 
-BPF_EXPORT(handle_phys2virt)
 int handle_phys2virt(struct __sk_buff *skb) {
   BEGIN(ethernet);
   PROTO(ethernet) {
@@ -37,7 +36,6 @@ EOP:
   return 1;
 }
 
-BPF_EXPORT(handle_virt2phys)
 int handle_virt2phys(struct __sk_buff *skb) {
   BEGIN(ethernet);
   PROTO(ethernet) {

--- a/examples/vlan_learning.py
+++ b/examples/vlan_learning.py
@@ -44,7 +44,7 @@ class ifindex_leaf_t(Structure):
                 ("tx_bytes", c_ulonglong)]
 
 # load the bpf program
-b = BPF(src_file="examples/vlan_learning.c", debug=0)
+b = BPF(src_file="examples/vlan_learning.c", debug=1)
 phys_fn = b.load_func("handle_phys2virt", BPF.SCHED_CLS)
 virt_fn = b.load_func("handle_virt2phys", BPF.SCHED_CLS)
 

--- a/examples/vlan_learning.py
+++ b/examples/vlan_learning.py
@@ -44,7 +44,7 @@ class ifindex_leaf_t(Structure):
                 ("tx_bytes", c_ulonglong)]
 
 # load the bpf program
-b = BPF(src_file="examples/vlan_learning.c", debug=1)
+b = BPF(src_file="examples/vlan_learning.c", debug=0)
 phys_fn = b.load_func("handle_phys2virt", BPF.SCHED_CLS)
 virt_fn = b.load_func("handle_virt2phys", BPF.SCHED_CLS)
 

--- a/src/cc/b_frontend_action.cc
+++ b/src/cc/b_frontend_action.cc
@@ -39,6 +39,12 @@ BTypeVisitor::BTypeVisitor(ASTContext &C, Rewriter &rewriter, map<string, BPFTab
 }
 
 bool BTypeVisitor::VisitFunctionDecl(FunctionDecl *D) {
+  // put each non-static non-inline function decl in its own section, to be
+  // extracted by the MemoryManager
+  if (D->isExternallyVisible() && D->hasBody()) {
+    string attr = string("__attribute__((section(\".") + D->getName().str() + "\")))";
+    rewriter_.InsertText(D->getLocStart(), attr);
+  }
   return true;
 }
 

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -42,8 +42,6 @@ __attribute__((section("maps/" _table_type))) \
 struct _name##_table_t _name
 
 // packet parsing state machine helpers
-#define STATE_MACHINE(name) \
-  BPF_EXPORT(name) int _##name(struct __sk_buff *skb)
 #define BEGIN(next) \
   u64 _parse_cursor = 0; \
   goto next
@@ -53,10 +51,6 @@ struct _name##_table_t _name
 name: ; \
   struct name##_t *name __attribute__((deprecated("packet"))) = (void *)_parse_cursor; \
   _parse_cursor += sizeof(*name);
-
-// export this function to llvm by putting it into a specially named section
-//#define BPF_EXPORT(_ret, _name, ...) SEC("." #_name) _ret _name(__VA_ARGS__)
-#define BPF_EXPORT(_name) __attribute__((section("." #_name)))
 
 char _license[4] SEC("license") = "GPL";
 
@@ -163,7 +157,7 @@ static inline void bpf_store_dword(void *skb, u64 off, u64 val) {
 
 struct bpf_context;
 
-//static inline __attribute__((always_inline))
+static inline __attribute__((always_inline))
 SEC("helpers")
 u64 bpf_dext_pkt(void *pkt, u64 off, u64 bofs, u64 bsz) {
   if (bofs == 0 && bsz == 8) {
@@ -186,7 +180,7 @@ u64 bpf_dext_pkt(void *pkt, u64 off, u64 bofs, u64 bsz) {
   return 0;
 }
 
-//static inline __attribute__((always_inline))
+static inline __attribute__((always_inline))
 SEC("helpers")
 void bpf_dins_pkt(void *pkt, u64 off, u64 bofs, u64 bsz, u64 val) {
   // The load_xxx function does a bswap before returning the short/word/dword,
@@ -229,21 +223,25 @@ void bpf_dins_pkt(void *pkt, u64 off, u64 bofs, u64 bsz, u64 val) {
   }
 }
 
+static inline __attribute__((always_inline))
 SEC("helpers")
 void * bpf_map_lookup_elem_(uintptr_t map, void *key) {
   return bpf_map_lookup_elem((void *)map, key);
 }
 
+static inline __attribute__((always_inline))
 SEC("helpers")
 int bpf_map_update_elem_(uintptr_t map, void *key, void *value, u64 flags) {
   return bpf_map_update_elem((void *)map, key, value, flags);
 }
 
+static inline __attribute__((always_inline))
 SEC("helpers")
 int bpf_map_delete_elem_(uintptr_t map, void *key) {
   return bpf_map_delete_elem((void *)map, key);
 }
 
+static inline __attribute__((always_inline))
 SEC("helpers")
 int bpf_l3_csum_replace_(void *ctx, u64 off, u64 from, u64 to, u64 flags) {
   switch (flags & 0xf) {
@@ -259,6 +257,7 @@ int bpf_l3_csum_replace_(void *ctx, u64 off, u64 from, u64 to, u64 flags) {
   return bpf_l3_csum_replace(ctx, off, from, to, flags);
 }
 
+static inline __attribute__((always_inline))
 SEC("helpers")
 int bpf_l4_csum_replace_(void *ctx, u64 off, u64 from, u64 to, u64 flags) {
   switch (flags & 0xf) {

--- a/tests/cc/test_brb.c
+++ b/tests/cc/test_brb.c
@@ -54,7 +54,6 @@ BPF_TABLE("array", u32, u32, br2_rtr, 1);
 // <mac, ifindex>
 BPF_TABLE("hash", eth_addr_t, u32, br2_mac_ifindex, 1);
 
-BPF_EXPORT(pem)
 int pem(struct __sk_buff *skb) {
     bpf_metadata_t meta = {};
     u32 ifindex;
@@ -217,12 +216,10 @@ EOP:
     return 0;
 }
 
-BPF_EXPORT(br1)
 int br1(struct __sk_buff *skb) {
     return br_common(skb, 1);
 }
 
-BPF_EXPORT(br2)
 int br2(struct __sk_buff *skb) {
     return br_common(skb, 2);
 }

--- a/tests/cc/test_brb2.c
+++ b/tests/cc/test_brb2.c
@@ -8,7 +8,6 @@ BPF_TABLE("hash", u32, u32, pem_dest, 256);
 // <0, tx_pkts>
 BPF_TABLE("array", u32, u32, pem_stats, 1);
 
-BPF_EXPORT(pem)
 int pem(struct __sk_buff *skb) {
     u32 ifindex_in, *ifindex_p;
 

--- a/tests/cc/test_call1.c
+++ b/tests/cc/test_call1.c
@@ -11,7 +11,6 @@ enum states {
   S_IP
 };
 
-BPF_EXPORT(parse_ether)
 int parse_ether(struct __sk_buff *skb) {
   size_t cur = 0;
   size_t next = cur + 14;
@@ -28,7 +27,6 @@ int parse_ether(struct __sk_buff *skb) {
   return 1;
 }
 
-BPF_EXPORT(parse_arp)
 int parse_arp(struct __sk_buff *skb) {
   size_t cur = 14;  // TODO: get from ctx
   size_t next = cur + 28;
@@ -41,7 +39,6 @@ int parse_arp(struct __sk_buff *skb) {
   return 1;
 }
 
-BPF_EXPORT(parse_ip)
 int parse_ip(struct __sk_buff *skb) {
   size_t cur = 14;  // TODO: get from ctx
   size_t next = cur + 20;
@@ -54,7 +51,6 @@ int parse_ip(struct __sk_buff *skb) {
   return 1;
 }
 
-BPF_EXPORT(eop)
 int eop(struct __sk_buff *skb) {
   int key = S_EOP;
   u64 *leaf = stats.lookup(&key);

--- a/tests/cc/test_stat1.c
+++ b/tests/cc/test_stat1.c
@@ -14,7 +14,6 @@ struct IPLeaf {
 
 BPF_TABLE("hash", struct IPKey, struct IPLeaf, stats, 256);
 
-BPF_EXPORT(on_packet)
 int on_packet(struct __sk_buff *skb) {
   BEGIN(ethernet);
 

--- a/tests/cc/test_trace2.c
+++ b/tests/cc/test_trace2.c
@@ -5,7 +5,6 @@ struct Ptr { u64 ptr; };
 struct Counters { u64 stat1; };
 BPF_TABLE("hash", struct Ptr, struct Counters, stats, 1024);
 
-BPF_EXPORT(count_sched)
 int count_sched(struct pt_regs *ctx) {
   struct Ptr key = {.ptr=ctx->bx};
   struct Counters zleaf = {0};

--- a/tests/cc/test_trace2.py
+++ b/tests/cc/test_trace2.py
@@ -14,7 +14,6 @@ struct Ptr { u64 ptr; };
 struct Counters { u64 stat1; };
 BPF_TABLE("hash", struct Ptr, struct Counters, stats, 1024);
 
-BPF_EXPORT(count_sched)
 int count_sched(struct pt_regs *ctx) {
   struct Ptr key = {.ptr=ctx->bx};
   stats.data[(u64)&key].stat1++;

--- a/tests/cc/test_trace3.c
+++ b/tests/cc/test_trace3.c
@@ -27,7 +27,6 @@ static u32 log2l(u64 v) {
     return log2(v);
 }
 
-BPF_EXPORT(probe_blk_start_request)
 int probe_blk_start_request(struct pt_regs *ctx) {
   struct Request rq = {.rq = ctx->di};
   struct Time tm = {.start = bpf_ktime_get_ns()};
@@ -35,7 +34,6 @@ int probe_blk_start_request(struct pt_regs *ctx) {
   return 0;
 }
 
-BPF_EXPORT(probe_blk_update_request)
 int probe_blk_update_request(struct pt_regs *ctx) {
   struct Request rq = {.rq = ctx->di};
   struct Time *tm = requests.lookup(&rq);

--- a/tests/cc/test_xlate1.c
+++ b/tests/cc/test_xlate1.c
@@ -13,7 +13,6 @@ struct IPLeaf {
 };
 BPF_TABLE("hash", struct IPKey, struct IPLeaf, xlate, 1024);
 
-BPF_EXPORT(on_packet)
 int on_packet(struct __sk_buff *skb) {
 
   u32 orig_dip = 0;


### PR DESCRIPTION
* Add a BFrontentAction to recognize any external linkage function as
  being available for export, and internally set the section attribute.
* Change bpf helpers to be static inline

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>