### PR TITLE
python commands module is removed in python 3, use subprocess

### DIFF
--- a/tests/cc/test_brb.py
+++ b/tests/cc/test_brb.py
@@ -73,7 +73,6 @@ import sys
 from time import sleep
 from unittest import main, TestCase
 import subprocess
-import commands
 import struct
 
 arg1 = sys.argv.pop(1)
@@ -232,8 +231,10 @@ class TestBPFSocket(TestCase):
         self.config_router_ns(self.ns_router, self.vm1_rtr_ip, self.vm2_rtr_ip)
 
         # get vm mac address
-        self.vm1_mac = commands.getoutput('ip netns exec ' + self.ns1 + ' cat /sys/class/net/eth0/address')
-        self.vm2_mac = commands.getoutput('ip netns exec ' + self.ns2 + ' cat /sys/class/net/eth0/address')
+        self.vm1_mac = subprocess.check_output(["ip", "netns", "exec", self.ns1, "cat", "/sys/class/net/eth0/address"])
+	self.vm1_mac = self.vm1_mac.strip()
+        self.vm2_mac = subprocess.check_output(["ip", "netns", "exec", self.ns2, "cat", "/sys/class/net/eth0/address"])
+	self.vm2_mac = self.vm2_mac.strip()
 
         # load the program and configure maps
         self.config_maps()

--- a/tests/cc/test_brb2.py
+++ b/tests/cc/test_brb2.py
@@ -66,7 +66,6 @@ import sys
 from time import sleep
 from unittest import main, TestCase
 import subprocess
-import commands
 
 arg1 = sys.argv.pop(1)
 


### PR DESCRIPTION
Signed-off-by: Yonghong Song <yhs@plumgrid.com>