### PR TITLE
Cleanups for some build/compile failures

### DIFF
--- a/src/cc/kbuild_helper.cc
+++ b/src/cc/kbuild_helper.cc
@@ -52,7 +52,7 @@ int KBuildHelper::learn_flags(const string &tmpdir, const char *uname_release, c
     if (!cf)
       return -1;
   }
-  string cmd = "make -s";
+  string cmd = "make CROSS_COMPILE= -s";
   cmd += " -C " KERNEL_MODULES_DIR "/" + string(uname_release) + "/build";
   cmd += " M=" + tmpdir + " dummy.o";
   int rc = ::system(cmd.c_str());

--- a/src/cc/kbuild_helper.h
+++ b/src/cc/kbuild_helper.h
@@ -57,7 +57,7 @@ class DirStack {
   char cwd_[256];
 };
 
-static int ftw_cb(const char *path, const struct stat *, int) {
+static int ftw_cb(const char *path, const struct stat *, int, struct FTW *) {
   return ::remove(path);
 }
 
@@ -73,7 +73,7 @@ class TmpDir {
       ok_ = true;
   }
   ~TmpDir() {
-    if (::ftw(prefix_.c_str(), ftw_cb, 20) < 0)
+    if (::nftw(prefix_.c_str(), ftw_cb, 20, FTW_DEPTH) < 0)
       ::perror("ftw");
     else
       ::remove(prefix_.c_str());


### PR DESCRIPTION
* Change ftw to nftw, and do depth-first tmpdir cleanup
* Scrub CROSS_COMPILE variable before kbuild_helpers

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>