### PR TITLE
Automatically detect key/leaf type in clang

### DIFF
--- a/examples/vlan_learning.py
+++ b/examples/vlan_learning.py
@@ -122,7 +122,7 @@ for i in range(0, num_clients):
     # assign this client to the given worker
     idx = ipdb.interfaces["wrk%dp1" % worker_choice]["index"]
     mac = int(macaddr.replace(":", ""), 16)
-    ingress.update(c_ulonglong(mac), ifindex_leaf_t(idx, 0, 0))
+    ingress.update(ingress.Key(mac), ingress.Leaf(idx, 0, 0))
 
     cmd = ["bash", "-c", "for i in {1..8}; do curl 172.16.1.5 -o /dev/null; sleep 1; done"]
     client_processes.append(NSPopen(client.nl.netns, cmd))

--- a/examples/vlan_learning.py
+++ b/examples/vlan_learning.py
@@ -38,18 +38,13 @@ num_workers = 3
 num_clients = 9
 num_vlans = 16
 
-class ifindex_leaf_t(Structure):
-    _fields_ = [("out_ifindex", c_int),
-                ("tx_pkts", c_ulonglong),
-                ("tx_bytes", c_ulonglong)]
-
 # load the bpf program
 b = BPF(src_file="examples/vlan_learning.c", debug=0)
 phys_fn = b.load_func("handle_phys2virt", BPF.SCHED_CLS)
 virt_fn = b.load_func("handle_virt2phys", BPF.SCHED_CLS)
 
-ingress = b.get_table("ingress", c_ulonglong, ifindex_leaf_t)
-egress = b.get_table("egress", c_ulonglong, ifindex_leaf_t)
+ingress = b.get_table("ingress")
+egress = b.get_table("egress")
 
 ipdb_workers = []
 ipdb_clients = []

--- a/src/cc/b_frontend_action.h
+++ b/src/cc/b_frontend_action.h
@@ -41,6 +41,23 @@ struct BPFTable {
   size_t key_size;
   size_t leaf_size;
   size_t max_entries;
+  std::string key_desc;
+  std::string leaf_desc;
+};
+
+// Helper visitor for constructing a string representation of a key/leaf decl
+class BMapDeclVisitor : public clang::RecursiveASTVisitor<BMapDeclVisitor> {
+ public:
+  explicit BMapDeclVisitor(clang::ASTContext &C, std::string &result);
+  bool VisitRecordDecl(clang::RecordDecl *Decl);
+  bool VisitFieldDecl(clang::FieldDecl *Decl);
+  bool VisitBuiltinType(const clang::BuiltinType *T);
+  bool VisitTypedefType(const clang::TypedefType *T);
+  bool VisitTagType(const clang::TagType *T);
+  const std::string & str() const { return result_; }
+ private:
+  clang::ASTContext &C;
+  std::string &result_;
 };
 
 // Type visitor and rewriter for B programs.
@@ -54,7 +71,6 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   bool VisitFunctionDecl(clang::FunctionDecl *D);
   bool VisitCallExpr(clang::CallExpr *Call);
   bool VisitVarDecl(clang::VarDecl *Decl);
-  bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *E);
   bool VisitBinaryOperator(clang::BinaryOperator *E);
   bool VisitImplicitCastExpr(clang::ImplicitCastExpr *E);
 

--- a/src/cc/bpf_common.cc
+++ b/src/cc/bpf_common.cc
@@ -71,4 +71,16 @@ int bpf_table_fd(void *program, const char *table_name) {
   return mod->table_fd(table_name);
 }
 
+const char * bpf_table_key_desc(void *program, const char *table_name) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return nullptr;
+  return mod->table_key_desc(table_name);
+}
+
+const char * bpf_table_leaf_desc(void *program, const char *table_name) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return nullptr;
+  return mod->table_leaf_desc(table_name);
+}
+
 }

--- a/src/cc/bpf_common.h
+++ b/src/cc/bpf_common.h
@@ -28,6 +28,8 @@ unsigned bpf_module_kern_version(void *program);
 void * bpf_function_start(void *program, const char *name);
 size_t bpf_function_size(void *program, const char *name);
 int bpf_table_fd(void *program, const char *table_name);
+const char * bpf_table_key_desc(void *program, const char *table_name);
+const char * bpf_table_leaf_desc(void *program, const char *table_name);
 
 #ifdef __cplusplus
 }

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -408,6 +408,20 @@ int BPFModule::table_fd(const string &name) const {
   return table_it->second.fd;
 }
 
+const char * BPFModule::table_key_desc(const string &name) const {
+  if (codegen_) return nullptr;
+  auto table_it = tables_->find(name);
+  if (table_it == tables_->end()) return nullptr;
+  return table_it->second.key_desc.c_str();
+}
+
+const char * BPFModule::table_leaf_desc(const string &name) const {
+  if (codegen_) return nullptr;
+  auto table_it = tables_->find(name);
+  if (table_it == tables_->end()) return nullptr;
+  return table_it->second.leaf_desc.c_str();
+}
+
 int BPFModule::load(const string &filename, const string &proto_filename) {
   if (!sections_.empty()) {
     fprintf(stderr, "Program already initialized\n");

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -54,6 +54,8 @@ class BPFModule {
   uint8_t * start(const std::string &name) const;
   size_t size(const std::string &name) const;
   int table_fd(const std::string &name) const;
+  const char * table_key_desc(const std::string &name) const;
+  const char * table_leaf_desc(const std::string &name) const;
   char * license() const;
   unsigned kern_version() const;
  private:

--- a/tests/cc/test_stat1.py
+++ b/tests/cc/test_stat1.py
@@ -17,12 +17,15 @@ arg2 = ""
 if len(sys.argv) > 1:
   arg2 = sys.argv.pop(1)
 
-class Key(Structure):
-    _fields_ = [("dip", c_uint),
-                ("sip", c_uint)]
-class Leaf(Structure):
-    _fields_ = [("rx_pkts", c_ulong),
-                ("tx_pkts", c_ulong)]
+Key = None
+Leaf = None
+if arg1.endswith(".b"):
+    class Key(Structure):
+        _fields_ = [("dip", c_uint),
+                    ("sip", c_uint)]
+    class Leaf(Structure):
+        _fields_ = [("rx_pkts", c_ulong),
+                    ("tx_pkts", c_ulong)]
 
 class TestBPFSocket(TestCase):
     def setUp(self):
@@ -38,7 +41,7 @@ class TestBPFSocket(TestCase):
         #    leaf = self.stats.lookup(key)
         #    print(IPAddress(key.sip), "=>", IPAddress(key.dip),
         #          "rx", leaf.rx_pkts, "tx", leaf.tx_pkts)
-        key = Key(IPAddress("172.16.1.2").value, IPAddress("172.16.1.1").value)
+        key = self.stats.Key(IPAddress("172.16.1.2").value, IPAddress("172.16.1.1").value)
         leaf = self.stats.lookup(key)
         self.assertEqual(leaf.rx_pkts, 100)
         self.assertEqual(leaf.tx_pkts, 100)

--- a/tests/cc/test_trace1.py
+++ b/tests/cc/test_trace1.py
@@ -14,11 +14,14 @@ arg2 = ""
 if len(sys.argv) > 1:
   arg2 = sys.argv.pop(1)
 
-class Key(Structure):
-    _fields_ = [("fd", c_ulong)]
-class Leaf(Structure):
-    _fields_ = [("stat1", c_ulong),
-                ("stat2", c_ulong)]
+Key = None
+Leaf = None
+if arg1.endswith(".b"):
+    class Key(Structure):
+        _fields_ = [("fd", c_ulong)]
+    class Leaf(Structure):
+        _fields_ = [("stat1", c_ulong),
+                    ("stat2", c_ulong)]
 
 class TestKprobe(TestCase):
     def setUp(self):


### PR DESCRIPTION
* Parse the key and leaf types used for table definition, and pass the
  type info back into python using a json transport
* Remove the subscript operator support
* Migrate the tests that are able to drop they Key/Leaf definition. Keep
  it around for the tests that are B/C compatible

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>