### PR TITLE
Clean some brittle parts of clang rewriter

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,6 @@
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
-#include_directories(${CMAKE_CURRENT_SOURCE_DIR}/compat/include)
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/cc/b_frontend_action.h
+++ b/src/cc/b_frontend_action.h
@@ -68,6 +68,7 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
  public:
   explicit BTypeVisitor(clang::ASTContext &C, clang::Rewriter &rewriter,
                         std::map<std::string, BPFTable> &tables);
+  bool TraverseCallExpr(clang::CallExpr *Call);
   bool VisitFunctionDecl(clang::FunctionDecl *D);
   bool VisitCallExpr(clang::CallExpr *Call);
   bool VisitVarDecl(clang::VarDecl *Decl);
@@ -79,6 +80,7 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   clang::Rewriter &rewriter_;  /// modifications to the source go into this class
   llvm::raw_ostream &out_;  /// for debugging
   std::map<std::string, BPFTable> &tables_;  /// store the open FDs
+  std::vector<std::string> fn_args_;
 };
 
 // A helper class to the frontend action, walks the decls

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -72,8 +72,7 @@ static u64 (*bpf_ktime_get_ns)(void) =
 	(void *) BPF_FUNC_ktime_get_ns;
 static int (*bpf_trace_printk_)(const char *fmt, u64 fmt_size, ...) =
 	(void *) BPF_FUNC_trace_printk;
-#define bpf_trace_printk(_fmt, ...) \
-  ({ char fmt[] = _fmt; bpf_trace_printk_(fmt, sizeof(fmt), ##__VA_ARGS__); })
+int bpf_trace_printk(const char *fmt, ...) asm("llvm.bpf.extra");
 static u64 (*bpf_clone_redirect)(void *ctx, u64 ifindex, u64 flags) =
 	(void *) BPF_FUNC_clone_redirect;
 static u64 (*bpf_get_smp_processor_id)(void) =
@@ -286,10 +285,8 @@ int bpf_l4_csum_replace_(void *ctx, u64 off, u64 from, u64 to, u64 flags) {
   return bpf_l4_csum_replace(ctx, off, from, to, flags);
 }
 
-#define incr_cksum_l3(expr, oldval, newval) \
-  bpf_l3_csum_replace_(skb, (u64)expr, oldval, newval, sizeof(newval))
-#define incr_cksum_l4(expr, oldval, newval, is_pseudo) \
-  bpf_l4_csum_replace_(skb, (u64)expr, oldval, newval, ((is_pseudo & 0x1) << 4) | sizeof(newval))
+int incr_cksum_l3(void *off, u64 oldval, u64 newval) asm("llvm.bpf.extra");
+int incr_cksum_l4(void *off, u64 oldval, u64 newval, u64 flags) asm("llvm.bpf.extra");
 
 #define lock_xadd(ptr, val) ((void)__sync_fetch_and_add(ptr, val))
 

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -20,3 +20,5 @@ add_test(NAME py_test_brb WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_brb_c sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_brb.py test_brb.c)
 add_test(NAME py_test_brb2 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_brb2_c sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_brb2.py test_brb2.c)
+add_test(NAME py_test_clang WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_clang sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_clang.py)

--- a/tests/cc/test_clang.py
+++ b/tests/cc/test_clang.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Copyright (c) PLUMgrid, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+from bpf import BPF
+from unittest import main, TestCase
+
+class TestClang(TestCase):
+    def test_complex(self):
+        b = BPF(src_file="test_clang_complex.c", debug=0)
+        fn = b.load_func("handle_packet", BPF.SCHED_CLS)
+    def test_printk(self):
+        text = """
+#include <bcc/proto.h>
+int handle_packet(void *ctx) {
+  BEGIN(ethernet);
+  PROTO(ethernet) {
+    bpf_trace_printk("ethernet->dst = %llx, ethernet->src = %llx\\n",
+                     ethernet->dst, ethernet->src);
+  }
+EOP:
+  return 0;
+}
+"""
+        b = BPF(text=text, debug=0)
+        fn = b.load_func("handle_packet", BPF.SCHED_CLS)
+
+if __name__ == "__main__":
+    main()

--- a/tests/cc/test_clang_complex.c
+++ b/tests/cc/test_clang_complex.c
@@ -1,0 +1,171 @@
+// Copyright (c) PLUMgrid, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License")
+
+#include <bcc/proto.h>
+
+// hash
+struct FwdKey {
+  u32 dip:32;
+};
+struct FwdLeaf {
+  u32 fwd_idx:32;
+};
+BPF_TABLE("hash", struct FwdKey, struct FwdLeaf, fwd_map, 1);
+
+// array
+struct ConfigKey {
+  u32 index;
+};
+struct ConfigLeaf {
+  u32 bpfdev_ip;
+  u32 slave_ip;
+};
+BPF_TABLE("array", struct ConfigKey, struct ConfigLeaf, config_map, 1);
+
+// hash
+struct MacaddrKey {
+  u32 ip;
+};
+struct MacaddrLeaf {
+  u64 mac;
+};
+BPF_TABLE("hash", struct MacaddrKey, struct MacaddrLeaf, macaddr_map, 11);
+
+// hash
+struct SlaveKey {
+  u32 slave_ip;
+};
+struct SlaveLeaf {
+  u32 slave_ifindex;
+};
+BPF_TABLE("hash", struct SlaveKey, struct SlaveLeaf, slave_map, 10);
+
+int handle_packet(struct __sk_buff *skb) {
+  int ret = 0;
+
+  if (skb->pkt_type == 0) {
+    // tx
+    // make sure configured
+    u32 slave_ip;
+
+    struct ConfigKey cfg_key = {.index = 0};
+    struct ConfigLeaf *cfg_leaf = config_map.lookup(&cfg_key);
+    if (cfg_leaf) {
+      slave_ip = cfg_leaf->slave_ip;
+    } else {
+      return 0xffffffff;
+    }
+
+    // make sure slave configured
+    // tx, default to the single slave
+    struct SlaveKey slave_key = {.slave_ip = slave_ip};
+    struct SlaveLeaf *slave_leaf = slave_map.lookup(&slave_key);
+    if (slave_leaf) {
+      ret = slave_leaf->slave_ifindex;
+    } else {
+      return 0xffffffff;
+    }
+  } else {
+    // rx, default to stack
+    ret = 0;
+  }
+
+  BEGIN(ethernet);
+
+  PROTO(ethernet) {
+    switch (ethernet->type) {
+      case 0x0806: goto arp;
+      case 0x0800: goto ip;
+      case 0x8100: goto dot1q;
+    }
+    goto EOP;
+  }
+
+  PROTO(dot1q) {
+    switch (dot1q->type) {
+      case 0x0806: goto arp;
+      case 0x0800: goto ip;
+    }
+    goto EOP;
+  }
+
+  PROTO(arp) {
+    if (skb->pkt_type) {
+      if (arp->oper == 1) {
+        struct MacaddrKey mac_key = {.ip=arp->spa};
+        struct MacaddrLeaf mac_leaf = {.mac=arp->sha};
+        macaddr_map.update(&mac_key, &mac_leaf);
+      }
+    }
+    goto EOP;
+  }
+
+  PROTO(ip) {
+    switch (ip->nextp) {
+      case 6: goto tcp;
+      case 17: goto udp;
+    }
+    goto EOP;
+  }
+  PROTO(tcp) {
+    goto EOP;
+  }
+  PROTO(udp) {
+    if (udp->dport != 5000) {
+       goto EOP;
+    }
+    if (skb->pkt_type) {
+      // lookup and then forward
+      struct FwdKey fwd_key = {.dip=ip->dst};
+      struct FwdLeaf *fwd_val = fwd_map.lookup(&fwd_key);
+      if (fwd_val) {
+         return fwd_val->fwd_idx;
+      }
+    } else {
+      // rewrite the packet and send to a pre-configured index if needed
+      u32 new_ip;
+      u32 old_ip;
+      u64 src_mac;
+      u64 dst_mac;
+
+      struct ConfigKey cfg_key = {.index = 0};
+      struct ConfigLeaf *cfg_leaf = config_map.lookup(&cfg_key);
+      if (cfg_leaf) {
+        struct MacaddrKey mac_key = {.ip = cfg_leaf->bpfdev_ip};
+        struct MacaddrLeaf *mac_leaf;
+
+        mac_key.ip = cfg_leaf->bpfdev_ip;
+        mac_leaf = macaddr_map.lookup(&mac_key);
+        if (mac_leaf) {
+          src_mac = mac_leaf->mac;
+        } else {
+          goto EOP;
+        }
+
+        mac_key.ip = cfg_leaf->slave_ip;
+        mac_leaf = macaddr_map.lookup(&mac_key);
+        if (mac_leaf) {
+          dst_mac = mac_leaf->mac;
+        } else {
+          goto EOP;
+        }
+
+        // rewrite ethernet header
+        ethernet->dst = dst_mac;
+        ethernet->src = src_mac;
+
+        // ip & udp checksum
+        incr_cksum_l4(&udp->crc, ip->src, cfg_leaf->bpfdev_ip, 1);
+        incr_cksum_l4(&udp->crc, ip->dst, cfg_leaf->slave_ip, 1);
+
+        // rewrite ip src/dst fields
+        ip->src = cfg_leaf->bpfdev_ip;
+        ip->dst = cfg_leaf->slave_ip;
+      }
+    }
+    goto EOP;
+  }
+
+EOP:
+  return ret;
+}


### PR DESCRIPTION
* Rewrites of text inside of a macro (even if just the arguments) is not
  support by clang. Convert macro definitions to pure rewrites instead.
* For packet field access, no longer require 'skb' named
  argument...instead, learn it from the function parameter list.
* Add a complex test case...supposedly this should have failed issue
  #10, but the C version does not exhibit the same failure as the B
  version.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>