### PR TITLE
Automate bpf_probe_read

### DIFF
--- a/examples/task_switch.c
+++ b/examples/task_switch.c
@@ -7,13 +7,12 @@ struct key_t {
 };
 // map_type, key_type, leaf_type, table_name, num_entry
 BPF_TABLE("hash", struct key_t, u64, stats, 1024);
-int count_sched(struct pt_regs *ctx) {
+int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
   struct key_t key = {};
   u64 zero = 0, *val;
 
   key.curr_pid = bpf_get_current_pid_tgid();
-  bpf_probe_read(&key.prev_pid, 4,
-		 (void *)ctx->di + offsetof(struct task_struct, pid));
+  key.prev_pid = prev->pid;
 
   val = stats.lookup_or_init(&key, &zero);
   (*val)++;

--- a/src/cc/b_frontend_action.h
+++ b/src/cc/b_frontend_action.h
@@ -69,9 +69,12 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   explicit BTypeVisitor(clang::ASTContext &C, clang::Rewriter &rewriter,
                         std::map<std::string, BPFTable> &tables);
   bool TraverseCallExpr(clang::CallExpr *Call);
+  bool TraverseMemberExpr(clang::MemberExpr *E);
   bool VisitFunctionDecl(clang::FunctionDecl *D);
   bool VisitCallExpr(clang::CallExpr *Call);
   bool VisitVarDecl(clang::VarDecl *Decl);
+  bool VisitMemberExpr(clang::MemberExpr *E);
+  bool VisitDeclRefExpr(clang::DeclRefExpr *E);
   bool VisitBinaryOperator(clang::BinaryOperator *E);
   bool VisitImplicitCastExpr(clang::ImplicitCastExpr *E);
 
@@ -80,7 +83,7 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   clang::Rewriter &rewriter_;  /// modifications to the source go into this class
   llvm::raw_ostream &out_;  /// for debugging
   std::map<std::string, BPFTable> &tables_;  /// store the open FDs
-  std::vector<std::string> fn_args_;
+  std::vector<clang::ParmVarDecl *> fn_args_;
 };
 
 // A helper class to the frontend action, walks the decls

--- a/tests/cc/test_clang.py
+++ b/tests/cc/test_clang.py
@@ -25,5 +25,28 @@ EOP:
         b = BPF(text=text, debug=0)
         fn = b.load_func("handle_packet", BPF.SCHED_CLS)
 
+    def test_probe_read1(self):
+        text = """
+#include <linux/sched.h>
+#include <uapi/linux/ptrace.h>
+int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
+    pid_t p = prev->pid;
+    return (p != -1);
+}
+"""
+        b = BPF(text=text, debug=0)
+        fn = b.load_func("count_sched", BPF.KPROBE)
+
+    def test_probe_read2(self):
+        text = """
+#include <linux/sched.h>
+#include <uapi/linux/ptrace.h>
+int count_foo(struct pt_regs *ctx, unsigned long a, unsigned long b) {
+    return (a != b);
+}
+"""
+        b = BPF(text=text, debug=0)
+        fn = b.load_func("count_foo", BPF.KPROBE)
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
* Rewrite accesses to args beyond the first to use bpf_probe_read
 - Support struct access
 - Support POD type accesses

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>