### PR TITLE
Drop PROTO macro syntax and introduce alternative

### DIFF
--- a/examples/tunnel_monitor/monitor.c
+++ b/examples/tunnel_monitor/monitor.c
@@ -57,37 +57,43 @@ int handle_egress(struct __sk_buff *skb) {
 
 // parse the outer vxlan frame
 int handle_outer(struct __sk_buff *skb) {
-  BEGIN(ethernet);
-  PROTO(ethernet) {
-    // filter bcast/mcast from the stats
-    if (ethernet->dst & (1ull << 40))
-      return 1;
-    switch (ethernet->type) {
-      case 0x0800: goto ip;
-    }
-    goto EOP;
+  u8 *skb_cursor = 0;
+
+  struct ethernet_t *ethernet = bpf_consume_skb(skb_cursor, sizeof(*ethernet));
+
+  // filter bcast/mcast from the stats
+  if (ethernet->dst & (1ull << 40))
+    goto finish;
+
+  switch (ethernet->type) {
+    case 0x0800: goto ip;
+    default: goto finish;
   }
-  PROTO(ip) {
-    skb->cb[CB_SIP] = ip->src;
-    skb->cb[CB_DIP] = ip->dst;
-    switch (ip->nextp) {
-      case 17: goto udp;
-    }
-    goto EOP;
+
+ip: ;
+  struct ip_t *ip = bpf_consume_skb(skb_cursor, sizeof(*ip));
+  skb->cb[CB_SIP] = ip->src;
+  skb->cb[CB_DIP] = ip->dst;
+
+  switch (ip->nextp) {
+    case 17: goto udp;
+    default: goto finish;
   }
-  PROTO(udp) {
-    switch (udp->dport) {
-      case 4789: goto vxlan;
-    }
-    goto EOP;
+
+udp: ;
+  struct udp_t *udp = bpf_consume_skb(skb_cursor, sizeof(*udp));
+  switch (udp->dport) {
+    case 4789: goto vxlan;
+    default: goto finish;
   }
-  PROTO(vxlan) {
-    skb->cb[CB_VNI] = vxlan->key;
-    skb->cb[CB_OFFSET] = (u64)vxlan + sizeof(*vxlan);
-    parser.call(skb, 2);
-    goto EOP;
-  }
-EOP:
+
+vxlan: ;
+  struct vxlan_t *vxlan = bpf_consume_skb(skb_cursor, sizeof(*vxlan));
+  skb->cb[CB_VNI] = vxlan->key;
+  skb->cb[CB_OFFSET] = (u64)vxlan + sizeof(*vxlan);
+  parser.call(skb, 2);
+
+finish:
   return 1;
 }
 
@@ -100,19 +106,19 @@ int handle_inner(struct __sk_buff *skb) {
     .outer_sip = skb->cb[CB_SIP],
     .outer_dip = skb->cb[CB_DIP]
   };
-  BEGIN_OFFSET(ethernet, skb->cb[CB_OFFSET]);
-  PROTO(ethernet) {
-    switch (ethernet->type) {
-      case 0x0800: goto ip;
-    }
-    goto EOP;
+  u8 *skb_cursor = (u8 *)(u64)skb->cb[CB_OFFSET];
+
+  struct ethernet_t *ethernet = bpf_consume_skb(skb_cursor, sizeof(*ethernet));
+  switch (ethernet->type) {
+    case 0x0800: goto ip;
+    default: goto finish;
   }
-  PROTO(ip) {
-    key.inner_sip = ip->src;
-    key.inner_dip = ip->dst;
-    goto EOP;
-  }
-EOP:
+ip: ;
+  struct ip_t *ip = bpf_consume_skb(skb_cursor, sizeof(*ip));
+  key.inner_sip = ip->src;
+  key.inner_dip = ip->dst;
+
+finish:
   // consistent ordering
   if (key.outer_dip < key.outer_sip)
     swap_ipkey(&key);

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -42,18 +42,8 @@ __attribute__((section("maps/" _table_type))) \
 struct _name##_table_t _name
 
 // packet parsing state machine helpers
-#define BEGIN(next) \
-  u64 _parse_cursor = 0; \
-  goto next
-#define BEGIN_OFFSET(next, _base_offset) \
-  u64 _parse_cursor = (_base_offset); \
-  goto next
-
-#define PROTO(name) \
-  goto EOP; \
-name: ; \
-  struct name##_t *name __attribute__((deprecated("packet"))) = (void *)_parse_cursor; \
-  _parse_cursor += sizeof(*name);
+#define cursor_advance(_cursor, _len) \
+  ({ void *_tmp = _cursor; _cursor += _len; _tmp; })
 
 char _license[4] SEC("license") = "GPL";
 

--- a/src/cc/export/proto.h
+++ b/src/cc/export/proto.h
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
+#include <uapi/linux/if_ether.h>
+
+#define BPF_PACKET_HEADER __attribute__((packed)) __attribute__((deprecated("packet")))
+
 struct ethernet_t {
   unsigned long long  dst:48;
   unsigned long long  src:48;
   unsigned int        type:16;
-} __attribute__((packed));
+} BPF_PACKET_HEADER;
 
 struct dot1q_t {
   unsigned short pri:3;
   unsigned short cfi:1;
   unsigned short vlanid:12;
   unsigned short type;
-} __attribute__((packed));
+} BPF_PACKET_HEADER;
 
 struct arp_t {
   unsigned short      htype;
@@ -37,7 +41,7 @@ struct arp_t {
   unsigned long long  spa:32;
   unsigned long long  tha:48;
   unsigned int        tpa;
-} __attribute__((packed));
+} BPF_PACKET_HEADER;
 
 struct ip_t {
   unsigned char   ver:4;           // byte 0
@@ -54,14 +58,14 @@ struct ip_t {
   unsigned short  hchecksum;
   unsigned int    src;            // byte 12
   unsigned int    dst;            // byte 16
-} __attribute__((packed));
+} BPF_PACKET_HEADER;
 
 struct udp_t {
   unsigned short sport;
   unsigned short dport;
   unsigned short length;
   unsigned short crc;
-} __attribute__((packed));
+} BPF_PACKET_HEADER;
 
 struct tcp_t {
   unsigned short  src_port;   // byte 0
@@ -81,7 +85,7 @@ struct tcp_t {
   unsigned short  rcv_wnd;
   unsigned short  cksum;      // byte 16
   unsigned short  urg_ptr;
-} __attribute__((packed));
+} BPF_PACKET_HEADER;
 
 struct vxlan_t {
   unsigned int rsv1:4;
@@ -90,4 +94,4 @@ struct vxlan_t {
   unsigned int rsv3:24;
   unsigned int key:24;
   unsigned int rsv4:8;
-} __attribute__((packed));
+} BPF_PACKET_HEADER;

--- a/tests/cc/test_clang.py
+++ b/tests/cc/test_clang.py
@@ -13,12 +13,10 @@ class TestClang(TestCase):
         text = """
 #include <bcc/proto.h>
 int handle_packet(void *ctx) {
-  BEGIN(ethernet);
-  PROTO(ethernet) {
-    bpf_trace_printk("ethernet->dst = %llx, ethernet->src = %llx\\n",
-                     ethernet->dst, ethernet->src);
-  }
-EOP:
+  u8 *cursor = 0;
+  struct ethernet_t *ethernet = cursor_advance(cursor, sizeof(*ethernet));
+  bpf_trace_printk("ethernet->dst = %llx, ethernet->src = %llx\\n",
+                   ethernet->dst, ethernet->src);
   return 0;
 }
 """


### PR DESCRIPTION
* Feedback given by some external users was that the PROTO syntax was
  opaque and unintuitive. As such, drop that macro and introduce an
  alternative syntax.
* Convert all to use 'cursor_advance' macro API
* Add kernel in_ether.h header to proto.h, and convert many literals to use the macro equivalent.
  Considered adding TCP/UDP definitions as well, but the header including that has more dependencies
  that I would rather not force on the user.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>