### PR TITLE
Change to simulator arguments for readability

### DIFF
--- a/examples/simulation.py
+++ b/examples/simulation.py
@@ -26,7 +26,8 @@ class Simulation(object):
         else:
             ns_ipdb = IPDB(nl=NetNS(name))
             if disable_ipv6:
-                cmd = ["sysctl", "-q", "-w", "net.ipv6.conf.default.disable_ipv6=1"]
+                cmd = ["sysctl", "-q", "-w",
+                       "net.ipv6.conf.default.disable_ipv6=1"]
                 nsp = NSPopen(ns_ipdb.nl.netns, cmd)
                 nsp.wait(); nsp.release()
             ns_ipdb.interfaces.lo.up().commit()
@@ -48,6 +49,10 @@ class Simulation(object):
             if ipaddr: v.add_ip("%s" % ipaddr)
             if macaddr: v.address = macaddr
             v.up()
+        if disable_ipv6:
+            cmd = ["sysctl", "-q", "-w",
+                   "net.ipv6.conf.%s.disable_ipv6=1" % out_ifc.ifname]
+            subprocess.call(cmd)
         if fn and out_ifc:
             self.ipdb.nl.tc("add", "ingress", out_ifc["index"], "ffff:")
             self.ipdb.nl.tc("add-filter", "bpf", out_ifc["index"], ":1",

--- a/tests/cc/test_brb.py
+++ b/tests/cc/test_brb.py
@@ -109,7 +109,7 @@ class TestBPFSocket(TestCase):
         br_dest_map[c_uint(curr_br_pid)] = br_dest_map.Leaf(prog_id_pem, curr_pem_pid)
         self.pem_port[c_uint(curr_pem_pid)] = c_uint(ifindex)
         self.pem_ifindex[c_uint(ifindex)] = c_uint(curr_pem_pid)
-        mac_addr = br_mac_map.Key(int(EUI(vm_mac.decode())))
+        mac_addr = br_mac_map.Key(int(EUI(vm_mac)))
         br_mac_map[mac_addr] = c_uint(curr_br_pid)
 
     def config_maps(self):


### PR DESCRIPTION
* Let one argument be optional
* Disable ipv6 for whole namespace once
* Python 2/3 compatibility fix

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>