### PR TITLE
Map functions are now pass-by-value

### DIFF
--- a/examples/tc_neighbor_sharing.c
+++ b/examples/tc_neighbor_sharing.c
@@ -29,9 +29,7 @@ int classify_wan(struct __sk_buff *skb) {
   }
   ip: {
     struct ip_t *ip = cursor_advance(cursor, sizeof(*ip));
-    u32 dip = ip->dst;
-    struct ipkey key = {.client_ip=dip};
-    int *val = learned_ips.lookup(&key);
+    int *val = learned_ips.lookup((struct ipkey){ip->dst});
     if (val)
       return *val;
     goto EOP;
@@ -54,10 +52,7 @@ int classify_neighbor(struct __sk_buff *skb) {
   }
   ip: {
     struct ip_t *ip = cursor_advance(cursor, sizeof(*ip));
-    u32 sip = ip->src;
-    struct ipkey key = {.client_ip=sip};
-    int val = 1;
-    learned_ips.update(&key, &val);
+    learned_ips.update((struct ipkey){ip->src}, 1);
     goto EOP;
   }
 EOP:

--- a/examples/tunnel_monitor/monitor.c
+++ b/examples/tunnel_monitor/monitor.c
@@ -124,8 +124,7 @@ finish:
   // consistent ordering
   if (key.outer_dip < key.outer_sip)
     swap_ipkey(&key);
-  struct counters zleaf = {0};
-  struct counters *leaf = stats.lookup_or_init(&key, &zleaf);
+  struct counters *leaf = stats.lookup_or_init(key, (struct counters){0});
   if (is_ingress) {
     lock_xadd(&leaf->rx_pkts, 1);
     lock_xadd(&leaf->rx_bytes, skb->len);

--- a/src/cc/b_frontend_action.cc
+++ b/src/cc/b_frontend_action.cc
@@ -134,6 +134,12 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
         SourceRange argRange(Call->getArg(0)->getLocStart(),
                              Call->getArg(Call->getNumArgs()-1)->getLocEnd());
         string args = rewriter_.getRewrittenText(argRange);
+        string arg0 = rewriter_.getRewrittenText(SourceRange(Call->getArg(0)->getLocStart(),
+                                                             Call->getArg(0)->getLocEnd()));
+        string arg1;
+        if (Call->getNumArgs() > 1)
+          arg1 = rewriter_.getRewrittenText(SourceRange(Call->getArg(1)->getLocStart(),
+                                                        Call->getArg(1)->getLocEnd()));
 
         // find the table fd, which was opened at declaration time
         auto table_it = tables_.find(Ref->getDecl()->getName());
@@ -143,45 +149,42 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           return false;
         }
         string fd = to_string(table_it->second.fd);
+        string pseudo_fd = "bpf_pseudo_fd(1, " + fd + ")";
         string prefix, suffix;
         string map_update_policy = "BPF_ANY";
+        string name = Ref->getDecl()->getName();
         string txt;
         if (memb_name == "lookup_or_init") {
-          string map_update_policy = "BPF_NOEXIST";
-          string name = Ref->getDecl()->getName();
-          string arg0 = rewriter_.getRewrittenText(SourceRange(Call->getArg(0)->getLocStart(),
-                                                               Call->getArg(0)->getLocEnd()));
-          string arg1 = rewriter_.getRewrittenText(SourceRange(Call->getArg(1)->getLocStart(),
-                                                               Call->getArg(1)->getLocEnd()));
-          string lookup = "bpf_map_lookup_elem_(bpf_pseudo_fd(1, " + fd + ")";
-          string update = "bpf_map_update_elem_(bpf_pseudo_fd(1, " + fd + ")";
-          txt  = "({typeof(" + name + ".leaf) *leaf = " + lookup + ", " + arg0 + "); ";
-          txt += "if (!leaf) {";
-          txt += " " + update + ", " + arg0 + ", " + arg1 + ", " + map_update_policy + ");";
-          txt += " leaf = " + lookup + ", " + arg0 + ");";
-          txt += " if (!leaf) return 0;";
-          txt += "}";
-          txt += "leaf;})";
+          map_update_policy = "BPF_NOEXIST";
+          string lookup = "bpf_map_lookup_elem_(" + pseudo_fd;
+          string update = "bpf_map_update_elem_(" + pseudo_fd;
+          txt  = "({typeof(" + name + ".leaf) *_leaf; ";
+          txt += "typeof(" + name + ".key) _key = " + arg0 + "; ";
+          txt += "typeof(" + name + ".leaf) _zleaf = " + arg1 + "; ";
+          txt += "_leaf = " + lookup + ", &_key); ";
+          txt += "if (!_leaf) {";
+          txt += " " + update + ", &_key, &_zleaf, " + map_update_policy + ");";
+          txt += " _leaf = " + lookup + ", &_key);";
+          txt += " if (!_leaf) return 0;";
+          txt += "} ";
+          txt += "_leaf;})";
+        } else if (memb_name == "lookup") {
+          txt  = "({typeof(" + name + ".leaf) *_leaf; ";
+          txt += "typeof(" + name + ".key) _key = " + arg0 + "; ";
+          txt += "_leaf = bpf_map_lookup_elem(" + pseudo_fd + ", &_key); ";
+          txt += "_leaf;})";
+        } else if (memb_name == "update") {
+          txt  = "({typeof(" + name + ".key) _key = " + arg0 + "; ";
+          txt += "typeof(" + name + ".leaf) _leaf = " + arg1 + "; ";
+          txt += "bpf_map_update_elem(" + pseudo_fd + ", &_key, &_leaf, " + map_update_policy + ");})";
+        } else if (memb_name == "delete") {
+          txt  = "({typeof(" + name + ".key) _key = " + arg0 + "; ";
+          txt += "bpf_map_delete_elem(" + pseudo_fd + ", &_key);})";
+        } else if (memb_name == "call") {
+          txt = "bpf_tail_call_(" + pseudo_fd + ", " + args + ")";
         } else {
-          if (memb_name == "lookup") {
-            prefix = "bpf_map_lookup_elem";
-            suffix = ")";
-          } else if (memb_name == "update") {
-            prefix = "bpf_map_update_elem";
-            suffix = ", " + map_update_policy + ")";
-          } else if (memb_name == "delete") {
-            prefix = "bpf_map_delete_elem";
-            suffix = ")";
-          } else if (memb_name == "call") {
-            prefix = "bpf_tail_call_";
-            suffix = ")";
-          } else {
-            llvm::errs() << "error: unknown bpf_table operation " << memb_name << "\n";
-            return false;
-          }
-          prefix += "((void *)bpf_pseudo_fd(1, " + fd + "), ";
-
-          txt = prefix + args + suffix;
+          llvm::errs() << "error: unknown bpf_table operation " << memb_name << "\n";
+          return false;
         }
         if (!rewriter_.isRewritable(Call->getLocStart())) {
           C.getDiagnostics().Report(Call->getLocStart(), diag::err_expected)

--- a/src/cc/b_frontend_action.cc
+++ b/src/cc/b_frontend_action.cc
@@ -159,8 +159,12 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           string lookup = "bpf_map_lookup_elem_(" + pseudo_fd;
           string update = "bpf_map_update_elem_(" + pseudo_fd;
           txt  = "({typeof(" + name + ".leaf) *_leaf; ";
-          txt += "typeof(" + name + ".key) _key = " + arg0 + "; ";
-          txt += "typeof(" + name + ".leaf) _zleaf = " + arg1 + "; ";
+          txt += "typeof(" + name + ".key) _key __attribute__((aligned(8))); ";
+          txt += "memset(&_key, 0, sizeof(_key)); ";
+          txt += "_key = " + arg0 + "; ";
+          txt += "typeof(" + name + ".leaf) _zleaf __attribute__((aligned(8))); ";
+          txt += "memset(&_zleaf, 0, sizeof(_zleaf)); ";
+          txt += "_zleaf = " + arg1 + "; ";
           txt += "_leaf = " + lookup + ", &_key); ";
           txt += "if (!_leaf) {";
           txt += " " + update + ", &_key, &_zleaf, " + map_update_policy + ");";
@@ -170,15 +174,23 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           txt += "_leaf;})";
         } else if (memb_name == "lookup") {
           txt  = "({typeof(" + name + ".leaf) *_leaf; ";
-          txt += "typeof(" + name + ".key) _key = " + arg0 + "; ";
+          txt += "typeof(" + name + ".key) _key __attribute__((aligned(8))); ";
+          txt += "memset(&_key, 0, sizeof(_key)); ";
+          txt += "_key = " + arg0 + "; ";
           txt += "_leaf = bpf_map_lookup_elem(" + pseudo_fd + ", &_key); ";
           txt += "_leaf;})";
         } else if (memb_name == "update") {
-          txt  = "({typeof(" + name + ".key) _key = " + arg0 + "; ";
-          txt += "typeof(" + name + ".leaf) _leaf = " + arg1 + "; ";
+          txt  = "({typeof(" + name + ".key) _key __attribute__((aligned(8))); ";
+          txt += "memset(&_key, 0, sizeof(_key)); ";
+          txt += "_key = " + arg0 + "; ";
+          txt += "typeof(" + name + ".leaf) _leaf __attribute__((aligned(8))); ";
+          txt += "memset(&_leaf, 0, sizeof(_leaf)); ";
+          txt += "_leaf = " + arg1 + "; ";
           txt += "bpf_map_update_elem(" + pseudo_fd + ", &_key, &_leaf, " + map_update_policy + ");})";
         } else if (memb_name == "delete") {
-          txt  = "({typeof(" + name + ".key) _key = " + arg0 + "; ";
+          txt  = "({typeof(" + name + ".key) _key __attribute__((aligned(8))); ";
+          txt += "memset(&_key, 0, sizeof(_key)); ";
+          txt += "_key = " + arg0 + "; ";
           txt += "bpf_map_delete_elem(" + pseudo_fd + ", &_key);})";
         } else if (memb_name == "call") {
           txt = "bpf_tail_call_(" + pseudo_fd + ", " + args + ")";

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -31,10 +31,10 @@
 struct _name##_table_t { \
   _key_type key; \
   _leaf_type leaf; \
-  _leaf_type * (*lookup) (_key_type *); \
-  _leaf_type * (*lookup_or_init) (_key_type *, _leaf_type *); \
-  int (*update) (_key_type *, _leaf_type *); \
-  int (*delete) (_key_type *); \
+  _leaf_type * (*lookup) (_key_type); \
+  _leaf_type * (*lookup_or_init) (_key_type, _leaf_type); \
+  int (*update) (_key_type, _leaf_type); \
+  int (*delete) (_key_type); \
   void (*call) (void *, int index); \
   _leaf_type data[_max_entries]; \
 }; \

--- a/tests/cc/test_brb.c
+++ b/tests/cc/test_brb.c
@@ -75,10 +75,10 @@ int pem(struct __sk_buff *skb) {
     if (!meta.prog_id) {
         /* from external */
         ifindex = skb->ingress_ifindex;
-        tx_port_id_p = pem_ifindex.lookup(&ifindex);
+        tx_port_id_p = pem_ifindex.lookup(ifindex);
         if (tx_port_id_p) {
             tx_port_id = *tx_port_id_p;
-            dest_p = pem_dest.lookup(&tx_port_id);
+            dest_p = pem_dest.lookup(tx_port_id);
             if (dest_p) {
                 skb->cb[0] = dest_p->prog_id;
                 skb->cb[1] = dest_p->port_id;
@@ -88,12 +88,12 @@ int pem(struct __sk_buff *skb) {
     } else {
         /* from internal */
         rx_port = meta.rx_port_id;
-        ifindex_p = pem_port.lookup(&rx_port);
+        ifindex_p = pem_port.lookup(rx_port);
         if (ifindex_p) {
 #if 1
             /* accumulate stats, may hurt performance slightly */
             u32 index = 0;
-            u32 *value = pem_stats.lookup(&index);
+            u32 *value = pem_stats.lookup(index);
             if (value)
                 lock_xadd(value, 1);
 #endif
@@ -130,17 +130,17 @@ static int br_common(struct __sk_buff *skb, int which_br) {
             if (dmac.addr == 0xffffffffffffULL) {
                  index = 0;
                  if (which_br == 1)
-                     rtrif_p = br1_rtr.lookup(&index);
+                     rtrif_p = br1_rtr.lookup(index);
                  else 
-                     rtrif_p = br2_rtr.lookup(&index);
+                     rtrif_p = br2_rtr.lookup(index);
                  if (rtrif_p)
                      bpf_clone_redirect(skb, *rtrif_p, 0);
              } else {
                  /* the dmac address should match the router's */
                  if (which_br == 1)
-                     rtrif_p = br1_mac_ifindex.lookup(&dmac);
+                     rtrif_p = br1_mac_ifindex.lookup(dmac);
                  else
-                     rtrif_p = br2_mac_ifindex.lookup(&dmac);
+                     rtrif_p = br2_mac_ifindex.lookup(dmac);
                  if (rtrif_p)
                      bpf_clone_redirect(skb, *rtrif_p, 0);
              }
@@ -173,18 +173,18 @@ static int br_common(struct __sk_buff *skb, int which_br) {
         if (arpop == 2) {
             index = 0;
             if (which_br == 1)
-                rtrif_p = br1_rtr.lookup(&index);
+                rtrif_p = br1_rtr.lookup(index);
             else
-                rtrif_p = br2_rtr.lookup(&index);
+                rtrif_p = br2_rtr.lookup(index);
             if (rtrif_p) {
                 __u32 ifindex = *rtrif_p;
                 eth_addr_t smac;
 
                 smac.addr = ethernet->src;
                 if (which_br == 1)
-                    br1_mac_ifindex.update(&smac, &ifindex);
+                    br1_mac_ifindex.update(smac, ifindex);
                 else
-                    br2_mac_ifindex.update(&smac, &ifindex);
+                    br2_mac_ifindex.update(smac, ifindex);
             }
         }
         goto xmit;
@@ -197,15 +197,15 @@ static int br_common(struct __sk_buff *skb, int which_br) {
 
 xmit:
     if (which_br == 1)
-        tx_port_id_p = br1_mac.lookup(&dmac);
+        tx_port_id_p = br1_mac.lookup(dmac);
     else
-        tx_port_id_p = br2_mac.lookup(&dmac);
+        tx_port_id_p = br2_mac.lookup(dmac);
     if (tx_port_id_p) {
         tx_port_id = *tx_port_id_p;
         if (which_br == 1)
-            dest_p = br1_dest.lookup(&tx_port_id);
+            dest_p = br1_dest.lookup(tx_port_id);
         else
-            dest_p = br2_dest.lookup(&tx_port_id);
+            dest_p = br2_dest.lookup(tx_port_id);
         if (dest_p) {
             skb->cb[0] = dest_p->prog_id;
             skb->cb[1] = dest_p->port_id;

--- a/tests/cc/test_brb2.c
+++ b/tests/cc/test_brb2.c
@@ -9,15 +9,11 @@ BPF_TABLE("hash", u32, u32, pem_dest, 256);
 BPF_TABLE("array", u32, u32, pem_stats, 1);
 
 int pem(struct __sk_buff *skb) {
-    u32 ifindex_in, *ifindex_p;
-
-    ifindex_in = skb->ingress_ifindex;
-    ifindex_p = pem_dest.lookup(&ifindex_in);
+    u32 *ifindex_p = pem_dest.lookup(skb->ingress_ifindex);
     if (ifindex_p) {
 #if 1
         /* accumulate stats */
-        u32 index = 0;
-        u32 *value = pem_stats.lookup(&index);
+        u32 *value = pem_stats.lookup(0);
         if (value)
             lock_xadd(value, 1);
 #endif

--- a/tests/cc/test_call1.c
+++ b/tests/cc/test_call1.c
@@ -15,8 +15,7 @@ int parse_ether(struct __sk_buff *skb) {
   size_t cur = 0;
   size_t next = cur + 14;
 
-  int key = S_ETHER;
-  u64 *leaf = stats.lookup(&key);
+  u64 *leaf = stats.lookup(S_ETHER);
   if (leaf) (*leaf)++;
 
   switch (bpf_dext_pkt(skb, cur + 12, 0, 16)) {
@@ -31,8 +30,7 @@ int parse_arp(struct __sk_buff *skb) {
   size_t cur = 14;  // TODO: get from ctx
   size_t next = cur + 28;
 
-  int key = S_ARP;
-  u64 *leaf = stats.lookup(&key);
+  u64 *leaf = stats.lookup(S_ARP);
   if (leaf) (*leaf)++;
 
   jump.call(skb, S_EOP);
@@ -43,8 +41,7 @@ int parse_ip(struct __sk_buff *skb) {
   size_t cur = 14;  // TODO: get from ctx
   size_t next = cur + 20;
 
-  int key = S_IP;
-  u64 *leaf = stats.lookup(&key);
+  u64 *leaf = stats.lookup(S_IP);
   if (leaf) (*leaf)++;
 
   jump.call(skb, S_EOP);
@@ -52,8 +49,7 @@ int parse_ip(struct __sk_buff *skb) {
 }
 
 int eop(struct __sk_buff *skb) {
-  int key = S_EOP;
-  u64 *leaf = stats.lookup(&key);
+  u64 *leaf = stats.lookup(S_EOP);
   if (leaf) (*leaf)++;
   return 1;
 }

--- a/tests/cc/test_stat1.c
+++ b/tests/cc/test_stat1.c
@@ -46,8 +46,7 @@ int on_packet(struct __sk_buff *skb) {
       key.sip = ip->dst;
       tx = 1;
     }
-    struct IPLeaf zleaf = {0};
-    struct IPLeaf *leaf = stats.lookup_or_init(&key, &zleaf);
+    struct IPLeaf *leaf = stats.lookup_or_init(key, (struct IPLeaf){0});
     lock_xadd(&leaf->rx_pkts, rx);
     lock_xadd(&leaf->tx_pkts, tx);
   }

--- a/tests/cc/test_trace2.c
+++ b/tests/cc/test_trace2.c
@@ -1,13 +1,9 @@
 // Copyright (c) PLUMgrid, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License")
 #include <linux/ptrace.h>
-struct Ptr { u64 ptr; };
-struct Counters { u64 stat1; };
-BPF_TABLE("hash", struct Ptr, struct Counters, stats, 1024);
+BPF_TABLE("hash", u64, u64, stats, 1024);
 
 int count_sched(struct pt_regs *ctx) {
-  struct Ptr key = {.ptr=ctx->bx};
-  struct Counters zleaf = {0};
-  stats.lookup_or_init(&key, &zleaf)->stat1++;
+  (*stats.lookup_or_init(ctx->bx, 0))++;
   return 0;
 }

--- a/tests/cc/test_trace2.py
+++ b/tests/cc/test_trace2.py
@@ -10,14 +10,10 @@ from unittest import main, TestCase
 
 text = """
 #include <linux/ptrace.h>
-struct Ptr { u64 ptr; };
-struct Counters { u64 stat1; };
-BPF_TABLE("hash", struct Ptr, struct Counters, stats, 1024);
+BPF_TABLE("hash", u64, u64, stats, 1024);
 
 int count_sched(struct pt_regs *ctx) {
-  struct Ptr key = {.ptr=ctx->bx};
-  struct Counters zleaf = {0};
-  stats.lookup_or_init(&key, &zleaf)->stat1++;
+  (*stats.lookup_or_init(ctx->bx, 0))++;
   return 0;
 }
 """
@@ -33,7 +29,7 @@ class TestTracingEvent(TestCase):
         for i in range(0, 100):
             sleep(0.01)
         for key, leaf in self.stats.items():
-            print("ptr %x:" % key.ptr, "stat1 %x" % leaf.stat1)
+            print("ptr %x:" % key.value, "stat1 %x" % leaf.value)
 
 if __name__ == "__main__":
     main()

--- a/tests/cc/test_xlate1.c
+++ b/tests/cc/test_xlate1.c
@@ -43,8 +43,7 @@ int on_packet(struct __sk_buff *skb) {
     struct arp_t *arp = cursor_advance(cursor, sizeof(*arp));
     orig_dip = arp->tpa;
     orig_sip = arp->spa;
-    struct IPKey key = {.dip=orig_dip, .sip=orig_sip};
-    xleaf = xlate.lookup(&key);
+    xleaf = xlate.lookup((struct IPKey){orig_dip, orig_sip});
     if (xleaf) {
       arp->tpa = xleaf->xdip;
       arp->spa = xleaf->xsip;
@@ -57,8 +56,7 @@ int on_packet(struct __sk_buff *skb) {
     struct ip_t *ip = cursor_advance(cursor, sizeof(*ip));
     orig_dip = ip->dst;
     orig_sip = ip->src;
-    struct IPKey key = {.dip=orig_dip, .sip=orig_sip};
-    xleaf = xlate.lookup(&key);
+    xleaf = xlate.lookup((struct IPKey){orig_dip, orig_sip});
     if (xleaf) {
       ip->dst = xleaf->xdip;
       incr_cksum_l3(&ip->hchecksum, orig_dip, xleaf->xdip);


### PR DESCRIPTION
As a convenience to avoid extra variables, trying out if passing by
value and using the rewriter to construct the pointer is cleaner. It
seems that the code has fewer lines, though in some cases the lines
are longer.

The best example of a cleaner source file is in tc_neighbor_sharing.c.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>