### PR TITLE
Add index-based function references to c api

### DIFF
--- a/src/cc/b_frontend_action.cc
+++ b/src/cc/b_frontend_action.cc
@@ -25,9 +25,7 @@
 
 #include "b_frontend_action.h"
 
-extern "C"
-int bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size,
-                   int max_entries);
+#include "libbpf.h"
 
 namespace ebpf {
 
@@ -90,7 +88,7 @@ bool BTypeVisitor::VisitFunctionDecl(FunctionDecl *D) {
   // put each non-static non-inline function decl in its own section, to be
   // extracted by the MemoryManager
   if (D->isExternallyVisible() && D->hasBody()) {
-    string attr = string("__attribute__((section(\".bpf.fn.") + D->getName().str() + "\")))\n";
+    string attr = string("__attribute__((section(\"") + BPF_FN_PREFIX + D->getName().str() + "\")))\n";
     rewriter_.InsertText(D->getLocStart(), attr);
     // remember the arg names of the current function...first one is the ctx
     fn_args_.clear();

--- a/src/cc/b_frontend_action.cc
+++ b/src/cc/b_frontend_action.cc
@@ -90,7 +90,7 @@ bool BTypeVisitor::VisitFunctionDecl(FunctionDecl *D) {
   // put each non-static non-inline function decl in its own section, to be
   // extracted by the MemoryManager
   if (D->isExternallyVisible() && D->hasBody()) {
-    string attr = string("__attribute__((section(\".") + D->getName().str() + "\")))\n";
+    string attr = string("__attribute__((section(\".bpf.fn.") + D->getName().str() + "\")))\n";
     rewriter_.InsertText(D->getLocStart(), attr);
     // remember the arg names of the current function...first one is the ctx
     fn_args_.clear();

--- a/src/cc/bpf_common.cc
+++ b/src/cc/bpf_common.cc
@@ -41,16 +41,40 @@ void bpf_module_destroy(void *program) {
   delete mod;
 }
 
+size_t bpf_num_functions(void *program) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return 0;
+  return mod->num_functions();
+}
+
+const char * bpf_function_name(void *program, size_t id) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return nullptr;
+  return mod->function_name(id);
+}
+
 void * bpf_function_start(void *program, const char *name) {
   auto mod = static_cast<ebpf::BPFModule *>(program);
   if (!mod) return nullptr;
-  return mod->start(name);
+  return mod->function_start(name);
+}
+
+void * bpf_function_start_id(void *program, size_t id) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return nullptr;
+  return mod->function_start(id);
 }
 
 size_t bpf_function_size(void *program, const char *name) {
   auto mod = static_cast<ebpf::BPFModule *>(program);
   if (!mod) return 0;
-  return mod->size(name);
+  return mod->function_size(name);
+}
+
+size_t bpf_function_size_id(void *program, size_t id) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return 0;
+  return mod->function_size(id);
 }
 
 char * bpf_module_license(void *program) {
@@ -65,10 +89,28 @@ unsigned bpf_module_kern_version(void *program) {
   return mod->kern_version();
 }
 
+size_t bpf_num_tables(void *program) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return -1;
+  return mod->num_tables();
+}
+
 int bpf_table_fd(void *program, const char *table_name) {
   auto mod = static_cast<ebpf::BPFModule *>(program);
   if (!mod) return -1;
   return mod->table_fd(table_name);
+}
+
+int bpf_table_fd_id(void *program, size_t id) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return -1;
+  return mod->table_fd(id);
+}
+
+const char * bpf_table_name(void *program, size_t id) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return nullptr;
+  return mod->table_name(id);
 }
 
 const char * bpf_table_key_desc(void *program, const char *table_name) {
@@ -77,10 +119,22 @@ const char * bpf_table_key_desc(void *program, const char *table_name) {
   return mod->table_key_desc(table_name);
 }
 
+const char * bpf_table_key_desc_id(void *program, size_t id) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return nullptr;
+  return mod->table_key_desc(id);
+}
+
 const char * bpf_table_leaf_desc(void *program, const char *table_name) {
   auto mod = static_cast<ebpf::BPFModule *>(program);
   if (!mod) return nullptr;
   return mod->table_leaf_desc(table_name);
+}
+
+const char * bpf_table_leaf_desc_id(void *program, size_t id) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return nullptr;
+  return mod->table_leaf_desc(id);
 }
 
 }

--- a/src/cc/bpf_common.h
+++ b/src/cc/bpf_common.h
@@ -29,11 +29,20 @@ void * bpf_module_create_from_string(const char *text, unsigned flags);
 void bpf_module_destroy(void *program);
 char * bpf_module_license(void *program);
 unsigned bpf_module_kern_version(void *program);
+size_t bpf_num_functions(void *program);
+const char * bpf_function_name(void *program, size_t id);
+void * bpf_function_start_id(void *program, size_t id);
 void * bpf_function_start(void *program, const char *name);
+size_t bpf_function_size_id(void *program, size_t id);
 size_t bpf_function_size(void *program, const char *name);
+size_t bpf_num_tables(void *program);
 int bpf_table_fd(void *program, const char *table_name);
+int bpf_table_fd_id(void *program, size_t id);
+const char * bpf_table_name(void *program, size_t id);
 const char * bpf_table_key_desc(void *program, const char *table_name);
+const char * bpf_table_key_desc_id(void *program, size_t id);
 const char * bpf_table_leaf_desc(void *program, const char *table_name);
+const char * bpf_table_leaf_desc_id(void *program, size_t id);
 
 #ifdef __cplusplus
 }

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -63,6 +63,7 @@
 #include "b_frontend_action.h"
 #include "bpf_module.h"
 #include "kbuild_helper.h"
+#include "libbpf.h"
 
 namespace ebpf {
 

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -76,7 +76,7 @@ using std::unique_ptr;
 using std::vector;
 using namespace llvm;
 
-const string BPFModule::FN_PREFIX = ".bpf.fn.";
+const string BPFModule::FN_PREFIX = BPF_FN_PREFIX;
 
 // Snooping class to remember the sections as the JIT creates them
 class MyMemoryManager : public SectionMemoryManager {

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -38,6 +38,7 @@ class Parser;
 
 class BPFModule {
  private:
+  static const std::string FN_PREFIX;
   int init_engine();
   int parse();
   int finalize();
@@ -51,10 +52,19 @@ class BPFModule {
   ~BPFModule();
   int load(const std::string &filename, const std::string &proto_filename);
   int load_string(const std::string &text);
-  uint8_t * start(const std::string &name) const;
-  size_t size(const std::string &name) const;
+  size_t num_functions() const;
+  uint8_t * function_start(size_t id) const;
+  uint8_t * function_start(const std::string &name) const;
+  const char * function_name(size_t id) const;
+  size_t function_size(size_t id) const;
+  size_t function_size(const std::string &name) const;
+  size_t num_tables() const;
+  int table_fd(size_t id) const;
   int table_fd(const std::string &name) const;
+  const char * table_name(size_t id) const;
+  const char * table_key_desc(size_t id) const;
   const char * table_key_desc(const std::string &name) const;
+  const char * table_leaf_desc(size_t id) const;
   const char * table_leaf_desc(const std::string &name) const;
   char * license() const;
   unsigned kern_version() const;
@@ -70,6 +80,8 @@ class BPFModule {
   std::unique_ptr<ebpf::cc::CodegenLLVM> codegen_;
   std::map<std::string, std::tuple<uint8_t *, uintptr_t>> sections_;
   std::unique_ptr<std::map<std::string, BPFTable>> tables_;
+  std::vector<std::string> table_names_;
+  std::vector<std::string> function_names_;
 };
 
 }  // namespace ebpf

--- a/src/cc/codegen_llvm.cc
+++ b/src/cc/codegen_llvm.cc
@@ -1166,7 +1166,7 @@ StatusTuple CodegenLLVM::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
   Function *fn = mod_->getFunction(n->id_->name_);
   if (fn) return mkstatus_(n, "Function %s already defined", n->id_->c_str());
   fn = Function::Create(fn_type, GlobalValue::ExternalLinkage, n->id_->name_, mod_);
-  fn->setSection(".bpf.fn." + n->id_->name_);
+  fn->setSection(BPF_FN_PREFIX + n->id_->name_);
 
   BasicBlock *label_entry = BasicBlock::Create(ctx(), "entry", fn);
   B.SetInsertPoint(label_entry);

--- a/src/cc/codegen_llvm.cc
+++ b/src/cc/codegen_llvm.cc
@@ -1166,7 +1166,7 @@ StatusTuple CodegenLLVM::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
   Function *fn = mod_->getFunction(n->id_->name_);
   if (fn) return mkstatus_(n, "Function %s already defined", n->id_->c_str());
   fn = Function::Create(fn_type, GlobalValue::ExternalLinkage, n->id_->name_, mod_);
-  fn->setSection("." + n->id_->name_);
+  fn->setSection(".bpf.fn." + n->id_->name_);
 
   BasicBlock *label_entry = BasicBlock::Create(ctx(), "entry", fn);
   B.SetInsertPoint(label_entry);

--- a/src/cc/codegen_llvm.h
+++ b/src/cc/codegen_llvm.h
@@ -37,6 +37,8 @@ class StructType;
 class SwitchInst;
 }
 
+#define BPF_FN_PREFIX ".bpf.fn."
+
 namespace ebpf {
 namespace cc {
 

--- a/src/cc/codegen_llvm.h
+++ b/src/cc/codegen_llvm.h
@@ -37,8 +37,6 @@ class StructType;
 class SwitchInst;
 }
 
-#define BPF_FN_PREFIX ".bpf.fn."
-
 namespace ebpf {
 namespace cc {
 

--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -49,6 +49,10 @@ int bpf_detach_kprobe(const char *event_desc);
 #define LOG_BUF_SIZE 65536
 extern char bpf_log_buf[LOG_BUF_SIZE];
 
+// Put non-static/inline functions in their own section with this prefix +
+// fn_name to enable discovery by the bcc library.
+#define BPF_FN_PREFIX ".bpf.fn."
+
 /* ALU ops on registers, bpf_add|sub|...: dst_reg += src_reg */
 
 #define BPF_ALU64_REG(OP, DST, SRC)				\


### PR DESCRIPTION
* Add the index based API so that an external api (bcc-fuse) can iterate
  through the maps and functions that were compiled in this program.
* Add a more unique section prefix to disambiguate exportable functions.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>