### PR TITLE
Add option for custom log string to bpf_prog_load

### DIFF
--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -37,13 +37,14 @@ int bpf_get_next_key(int fd, void *key, void *next_key);
 
 int bpf_prog_load(enum bpf_prog_type prog_type,
 		  const struct bpf_insn *insns, int insn_len,
-		  const char *license, unsigned kern_version);
+		  const char *license, unsigned kern_version,
+		  char *log_buf, unsigned log_buf_size);
 int bpf_attach_socket(int sockfd, int progfd);
 
 /* create RAW socket and bind to interface 'name' */
 int bpf_open_raw_sock(const char *name);
 
-int bpf_attach_kprobe(int progfd, const char *event, const char *event_desc, pid_t pid, int cpu, int group_fd);
+int bpf_attach_kprobe(int progfd, const char *event, const char *event_desc, int pid, int cpu, int group_fd);
 int bpf_detach_kprobe(const char *event_desc);
 
 #define LOG_BUF_SIZE 65536

--- a/src/python/bpf/__init__.py
+++ b/src/python/bpf/__init__.py
@@ -60,7 +60,7 @@ lib.bpf_attach_socket.restype = ct.c_int
 lib.bpf_attach_socket.argtypes = [ct.c_int, ct.c_int]
 lib.bpf_prog_load.restype = ct.c_int
 lib.bpf_prog_load.argtypes = [ct.c_int, ct.c_void_p, ct.c_size_t,
-        ct.c_char_p, ct.c_uint]
+        ct.c_char_p, ct.c_uint, ct.c_char_p, ct.c_uint]
 lib.bpf_attach_kprobe.restype = ct.c_int
 lib.bpf_attach_kprobe.argtypes = [ct.c_int, ct.c_char_p, ct.c_char_p, ct.c_int, ct.c_int, ct.c_int]
 lib.bpf_detach_kprobe.restype = ct.c_int
@@ -192,7 +192,8 @@ class BPF(object):
                 lib.bpf_function_start(self.module, func_name.encode("ascii")),
                 lib.bpf_function_size(self.module, func_name.encode("ascii")),
                 lib.bpf_module_license(self.module),
-                lib.bpf_module_kern_version(self.module))
+                lib.bpf_module_kern_version(self.module),
+                None, 0)
 
         if fd < 0:
             print((ct.c_char * 65536).in_dll(lib, "bpf_log_buf").value)


### PR DESCRIPTION
bpf_prog_load was unconditionally printing the error from the kernel to
stderr. If libbpf is used in a library, that library may want to collect
the error to a custom location (a logfile). So, provide an option to
store the string elsewhere than stderr.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>