### PR TITLE
Add pkg-config support and include compat/linux* in packaging

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(${LLVM_INCLUDE_DIRS})
 # todo: if check for kernel version
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/compat)
 add_definitions(${LLVM_DEFINITIONS})
+configure_file(libbpfprog.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libbpfprog.pc @ONLY)
 
 BISON_TARGET(Parser parser.yy ${CMAKE_CURRENT_BINARY_DIR}/parser.yy.cc COMPILE_FLAGS "-o parser.yy.cc -v --debug")
 FLEX_TARGET(Lexer lexer.ll ${CMAKE_CURRENT_BINARY_DIR}/lexer.ll.cc COMPILE_FLAGS "--c++ --o lexer.ll.cc")
@@ -45,3 +46,6 @@ install(TARGETS bpfprog LIBRARY DESTINATION lib${LIBSUFFIX})
 install(DIRECTORY export/ DESTINATION share/bcc/include/bcc
   FILES_MATCHING PATTERN "*.h")
 install(FILES bpf_common.h ../libbpf.h DESTINATION include/bcc)
+install(DIRECTORY compat/linux/ DESTINATION include/bcc/compat/linux
+  FILES_MATCHING PATTERN "*.h")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libbpfprog.pc DESTINATION lib${LIBSUFFIX}/pkgconfig)

--- a/src/cc/libbpfprog.pc.in
+++ b/src/cc/libbpfprog.pc.in
@@ -1,0 +1,14 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+datarootdir=${prefix}/share
+
+compatdir=${includedir}/bcc/compat
+
+Name: libbpfprog
+Version: @REVISION@
+Description: BPF Program library
+Requires:
+Libs: -L${libdir} -lbpfprog
+Cflags: -I${includedir} -I${compatdir}

--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -24,10 +24,6 @@
 extern "C" {
 #endif
 
-struct bpf_insn;
-enum bpf_map_type;
-enum bpf_prog_type;
-
 int bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size,
 		   int max_entries);
 int bpf_update_elem(int fd, void *key, void *value, unsigned long long flags);


### PR DESCRIPTION
Different kernel header versions has been a continuing source of pain.
Though I don't prefer this approach, it seems the most reliable way to
get a build (for the time being) is to bundle the linux/bpf*.h in a
compat directory in the target install location.

To get visibility into that compat directory from another library, one
will need to rely on pkg-config --cflags argument to pull in that compat
directory.

Future work will be to avoid bundling the compat directory if the
version of linux-libc-dev is high enough, or if the presence of the
result of 'make headers_install' from the running kernel can be
detected.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>