### PR TITLE
Suggest Release and add X86 target in readme

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,7 +30,7 @@ To build the toolchain from source, one needs:
   * `git clone http://llvm.org/git/llvm.git`
   * `cd llvm/tools; git clone http://llvm.org/git/clang.git`
   * `cd ..; mkdir -p build/install; cd build`
-  * `cmake -G "Unix Makefiles" -DLLVM_TARGETS_TO_BUILD="BPF" -DCMAKE_INSTALL_PREFIX=$PWD/install ..`
+  * `cmake -G "Unix Makefiles" -DLLVM_TARGETS_TO_BUILD="BPF;X86" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$PWD/install ..`
   * `make -j4`
   * `make install`
   * `export PATH=$PWD/install/bin:$PATH`


### PR DESCRIPTION
The default CMAKE_BUILD_TYPE is Debug when cloning from git, suggest
Release instead.

Also, there are some worrisome warnings during cmake when X86 target is
omitted. Additionally, I may want X86 target support for a future
feature, so lets suggest it here.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>