### PR TITLE
Fix recursive loop in parsing pointer to self struct

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -64,7 +64,10 @@ bool BMapDeclVisitor::VisitRecordDecl(RecordDecl *D) {
   result_ += "\", [";
   for (auto F : D->getDefinition()->fields()) {
     result_ += "[";
-    TraverseDecl(F);
+    if (F->getType()->isPointerType())
+      result_ += "\"unsigned long long\"";
+    else
+      TraverseDecl(F);
     if (F->isBitField())
       result_ += ", " + to_string(F->getBitWidthValue(C));
     result_ += "], ";


### PR DESCRIPTION
Issue occurs in the description visitor class, when the struct used in a
map key is a pointer to self, as in:

struct node;
struct node {
  struct node *next;
};

Avoid this in the desc by using "unsigned long long" for all pointers.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>