### PR TITLE
Not working trace instances

### DIFF
--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -16,7 +16,4 @@ int hello(void *ctx) {
 """
 b = BPF(text=prog)
 b.attach_kprobe(event="sys_clone", fn_name="hello")
-try:
-    call(["cat", "/sys/kernel/debug/tracing/trace_pipe"])
-except KeyboardInterrupt:
-    pass
+b.trace_print()

--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -40,7 +40,8 @@ int bpf_attach_socket(int sockfd, int progfd);
 /* create RAW socket and bind to interface 'name' */
 int bpf_open_raw_sock(const char *name);
 
-int bpf_attach_kprobe(int progfd, const char *event, const char *event_desc, int pid, int cpu, int group_fd);
+int bpf_attach_kprobe(int progfd, const char *instance, const char *event,
+                      const char *event_desc, int pid, int cpu, int group_fd);
 int bpf_detach_kprobe(const char *event_desc);
 
 #define LOG_BUF_SIZE 65536


### PR DESCRIPTION
This code doesn't work, but may in the future if the kernel ever changes. Branch created for posterity. The python helper for trace_print will be cherry-picked without instance support.