### PR TITLE
Fix map.clear() usage for array type maps

### DIFF
--- a/src/cc/bpf_common.cc
+++ b/src/cc/bpf_common.cc
@@ -122,6 +122,18 @@ int bpf_table_fd_id(void *program, size_t id) {
   return mod->table_fd(id);
 }
 
+int bpf_table_type(void *program, const char *table_name) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return -1;
+  return mod->table_type(table_name);
+}
+
+int bpf_table_type_id(void *program, size_t id) {
+  auto mod = static_cast<ebpf::BPFModule *>(program);
+  if (!mod) return -1;
+  return mod->table_type(id);
+}
+
 const char * bpf_table_name(void *program, size_t id) {
   auto mod = static_cast<ebpf::BPFModule *>(program);
   if (!mod) return nullptr;

--- a/src/cc/bpf_common.h
+++ b/src/cc/bpf_common.h
@@ -40,6 +40,8 @@ size_t bpf_num_tables(void *program);
 size_t bpf_table_id(void *program, const char *table_name);
 int bpf_table_fd(void *program, const char *table_name);
 int bpf_table_fd_id(void *program, size_t id);
+int bpf_table_type(void *program, const char *table_name);
+int bpf_table_type_id(void *program, size_t id);
 const char * bpf_table_name(void *program, size_t id);
 const char * bpf_table_key_desc(void *program, const char *table_name);
 const char * bpf_table_key_desc_id(void *program, size_t id);

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -488,6 +488,15 @@ int BPFModule::table_fd(size_t id) const {
   return (*tables_)[id].fd;
 }
 
+int BPFModule::table_type(const string &name) const {
+  return table_type(table_id(name));
+}
+
+int BPFModule::table_type(size_t id) const {
+  if (id >= tables_->size()) return -1;
+  return (*tables_)[id].type;
+}
+
 const char * BPFModule::table_name(size_t id) const {
   if (id >= tables_->size()) return nullptr;
   return (*tables_)[id].name.c_str();

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -68,6 +68,8 @@ class BPFModule {
   int table_fd(size_t id) const;
   int table_fd(const std::string &name) const;
   const char * table_name(size_t id) const;
+  int table_type(const std::string &name) const;
+  int table_type(size_t id) const;
   const char * table_key_desc(size_t id) const;
   const char * table_key_desc(const std::string &name) const;
   size_t table_key_size(size_t id) const;

--- a/src/cc/frontends/b/codegen_llvm.cc
+++ b/src/cc/frontends/b/codegen_llvm.cc
@@ -1232,9 +1232,15 @@ StatusTuple CodegenLLVM::visit(Node* root, vector<TableDesc> &tables) {
   //TRY2(print_parser());
 
   for (auto table : tables_) {
+    bpf_map_type map_type = BPF_MAP_TYPE_UNSPEC;
+    if (table.first->type_id()->name_ == "FIXED_MATCH")
+      map_type = BPF_MAP_TYPE_HASH;
+    else if (table.first->type_id()->name_ == "INDEXED")
+      map_type = BPF_MAP_TYPE_ARRAY;
     tables.push_back({
       table.first->id_->name_,
       table_fds_[table.first],
+      map_type,
       table.first->key_type_->bit_width_ >> 3,
       table.first->leaf_type_->bit_width_ >> 3,
       table.first->size_,

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -408,6 +408,7 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
         return false;
       }
     }
+    table.type = map_type;
     table.fd = bpf_create_map(map_type, table.key_size, table.leaf_size, table.max_entries);
     if (table.fd < 0) {
       C.getDiagnostics().Report(Decl->getLocStart(), diag::err_expected)

--- a/src/cc/table_desc.h
+++ b/src/cc/table_desc.h
@@ -26,6 +26,7 @@ namespace ebpf {
 struct TableDesc {
   std::string name;
   int fd;
+  int type;
   size_t key_size;  // sizes are in bytes
   size_t leaf_size;
   size_t max_entries;

--- a/tools/pidpersec
+++ b/tools/pidpersec
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# vim: ts=8 noet sw=8
 #
 # pidpersec	Count new processes (via fork).
 #		For Linux, uses BCC, eBPF. See .c file.
@@ -32,8 +33,8 @@ while (1):
 	try:
 		sleep(1)
 	except KeyboardInterrupt:
-		pass; exit()
+		exit()
 
 	print("%s: PIDs/sec: %d" % (strftime("%H:%M:%S"),
-	    (b["stats"][S_COUNT].value - last)))
-	last = b["stats"][S_COUNT].value
+	    (b["stats"][S_COUNT].value)))
+	b["stats"].clear()


### PR DESCRIPTION
Calling delete on an array type map entry does not have an effect.
Instead, the entry needs to be zeroed out, since the array slot always
exists. To avoid unnecessary calls to update(), only call update() when
the map type is array-like. The type was not exposed to python up until
now, so add it.

Fixes: #142 
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>