### PR TITLE
Add field support to trace_print and friends

### DIFF
--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -6,14 +6,13 @@
 # sudo ./hello_world.py"
 
 from bpf import BPF
-from subprocess import call
 
 prog = """
 int hello(void *ctx) {
   bpf_trace_printk("Hello, World!\\n");
   return 0;
-};
+}
 """
 b = BPF(text=prog)
 b.attach_kprobe(event="sys_clone", fn_name="hello")
-b.trace_print()
+b.trace_print(fmt="{1} {5}")


### PR DESCRIPTION
Add trace_readline_fields helper to parse the output of trace_pipe
Add field parsing support to trace_print. Addresses #149.
Fix typo in trace_open s/trace/tracefile/
Make nonblocking=False the default in trace_readline
Use IOError vs BlockingIOError for greater compatibility (untested)

Fixes: #149
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>