### PR TITLE
Add BPF_HASH macro with variadic arguments

### DIFF
--- a/examples/disksnoop.c
+++ b/examples/disksnoop.c
@@ -16,7 +16,7 @@
 struct key_t {
 	struct request *req;
 };
-BPF_TABLE("hash", struct key_t, u64, start, 10240);
+BPF_HASH(start, struct key_t);
 
 int do_request(struct pt_regs *ctx, struct request *req) {
 	struct key_t key = {};

--- a/examples/vfsreadlat.c
+++ b/examples/vfsreadlat.c
@@ -17,7 +17,7 @@ struct key_t {
 	u32 pid;
 };
 
-BPF_TABLE("hash", struct key_t, u64, start, 10240);
+BPF_HASH(start, struct key_t);
 BPF_TABLE("array", int, u64, dist, 64);
 
 static unsigned int log2(unsigned int v)

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -41,6 +41,20 @@ struct _name##_table_t { \
 __attribute__((section("maps/" _table_type))) \
 struct _name##_table_t _name
 
+#define BPF_HASH1(_name) \
+  BPF_TABLE("hash", u64, u64, _name, 10240)
+#define BPF_HASH2(_name, _key_type) \
+  BPF_TABLE("hash", _key_type, u64, _name, 10240)
+#define BPF_HASH3(_name, _key_type, _leaf_type) \
+  BPF_TABLE("hash", _key_type, _leaf_type, _name, 10240)
+// helper for default-variable macro function
+#define BPF_HASHX(_1, _2, _3, NAME, ...) NAME
+
+// Define a hash function, some arguments optional
+// BPF_HASH(name, key_type=u64, leaf_type=u64, size=10240)
+#define BPF_HASH(...) \
+  BPF_HASHX(__VA_ARGS__, BPF_HASH3, BPF_HASH2, BPF_HASH1)(__VA_ARGS__)
+
 // packet parsing state machine helpers
 #define cursor_advance(_cursor, _len) \
   ({ void *_tmp = _cursor; _cursor += _len; _tmp; })

--- a/tests/cc/test_clang.py
+++ b/tests/cc/test_clang.py
@@ -100,5 +100,13 @@ int do_request(struct pt_regs *ctx, int req) {
         b = BPF(text=text, debug=0)
         fn = b.load_func("do_request", BPF.KPROBE)
 
+    def test_bpf_hash(self):
+        text = """
+BPF_HASH(table1);
+BPF_HASH(table2, u32);
+BPF_HASH(table3, u32, int);
+"""
+        b = BPF(text=text, debug=0)
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
* Usage: BPF_HASH(tablename, key_type=u64, leaf_type=u64)
  2nd and 3rd arguments are optional in the C++ default argument style

Fixes: #135
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>