### PR TITLE
Support automatic kprobe event detection in common case

### DIFF
--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -8,6 +8,4 @@
 
 from bcc import BPF
 
-b = BPF(text='void hello(void *ctx) { bpf_trace_printk("Hello, World!\\n"); }')
-b.attach_kprobe(event="sys_clone", fn_name="hello")
-b.trace_print()
+BPF(text='void sys_clone(void *ctx) { bpf_trace_printk("Hello, World!\\n"); }').trace_print()


### PR DESCRIPTION
* In the simple case, a user only creates 1 C function to be used with
  kprobes. Detect this common case and don't require the user to repeat
  themselves by passing the fn_name to attach_kprobe().
  e.g.: BPF(text='int sys_clone(void *ctx) {/*do stuff*/}').trace_print()

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>