### PR TITLE
Fix breakage in bpf_probe_read from #196

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -277,7 +277,7 @@ bool BTypeVisitor::VisitMemberExpr(MemberExpr *E) {
       string base_type = Ref->getType()->getPointeeType().getAsString();
       string pre, post;
       pre = "({ " + E->getType().getAsString() + " _val; memset(&_val, 0, sizeof(_val));";
-      pre += " bpf_probe_read(&_val, sizeof(_val), ";
+      pre += " bpf_probe_read(&_val, sizeof(_val), (u64)";
       post = " + offsetof(" + base_type + ", " + F->getName().str() + ")";
       post += "); _val; })";
       rewriter_.InsertText(E->getLocStart(), pre);


### PR DESCRIPTION
Argument needs to be cast to u64, otherwise it is adding a whole pointer
stride.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>