### PR TITLE
Improve coverage for kprobe event_re

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -239,7 +239,9 @@ int bpf_attach_kprobe(int progfd, const char *event,
   }
 
   if (write(kfd, event_desc, strlen(event_desc)) < 0) {
-    perror("write(kprobe_events)");
+    fprintf(stderr, "write of \"%s\" into kprobe_events failed: %s\n", event_desc, strerror(errno));
+    if (errno == EINVAL)
+      fprintf(stderr, "check dmesg output for possible cause\n");
     goto cleanup;
   }
 

--- a/tests/cc/test_trace4.py
+++ b/tests/cc/test_trace4.py
@@ -30,5 +30,12 @@ class TestKprobeRgx(TestCase):
         k2 = self.b["stats"].Key(2)
         self.assertEqual(self.b["stats"][k1].val, self.b["stats"][k2].val + 1)
 
+class TestKprobeReplace(TestCase):
+    def setUp(self):
+        self.b = BPF(text="int empty(void *ctx) { return 0; }")
+
+    def test_periods(self):
+        self.b.attach_kprobe(event_re="^tcp_enter_cwr.*", fn_name="empty")
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This makes the attachment of kprobes to arbitrary events more robust.

Issue 1: Functions with '.' characters should not have similarly named
 probes.
Issue 2: Functions in the blacklist should not be attached to.
Issue 3: Some functions matched by regex cannot actually be attached to,
 despite not being in the blacklist...possibly the blacklist is outdated?
 Instead, warn instead of error during bulk regex attach.
Issue 4: Attaching to large numbers of kprobes gets to be very slow. For
 now, leave this unresolved. For reasonably sized regexes, startup times
 may be acceptable, and shutdown times are actually the worse part. To
 speed up shutdown, one could add the following after the last
 attach_kprobe to disable auto-cleanup:
  ```
  from bcc import open_kprobes
  open_kprobes = {}
  ```
 Then, once the program is exited, one must manually
  `echo "" > kprobe_events`

Some numbers:
attaching to event_re='tcp_*': 2 sec startup, 15 sec shutdown
attaching to event_re='b*': 10 sec startup, 75 sec shutdown
attaching to event_re='*': unknown (>20 min) startup, unknown shutdown
The slowdowns appear to be exponential, doubtful that '*' will ever
complete.

Fixes: #199
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>