### PR TITLE
Always autoload k[ret]probe__ prefixed functions

### DIFF
--- a/examples/bitehist.c
+++ b/examples/bitehist.c
@@ -38,7 +38,7 @@ static unsigned int log2l(unsigned long v)
 		return log2(v) + 1;
 }
 
-int do_request(struct pt_regs *ctx, struct request *req)
+int kprobe__blk_start_request(struct pt_regs *ctx, struct request *req)
 {
 	int index = log2l(req->__data_len / 1024);
 	u64 *leaf = dist.lookup(&index);

--- a/examples/bitehist.py
+++ b/examples/bitehist.py
@@ -18,7 +18,6 @@ from time import sleep
 
 # load BPF program
 b = BPF(src_file = "bitehist.c")
-b.attach_kprobe(event="blk_start_request", fn_name="do_request")
 
 # header
 print("Tracing... Hit Ctrl-C to end.")


### PR DESCRIPTION
This will shorten some examples, no longer requiring them to call
attach_kprobe.

Fixes: #191 
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>