### PR TITLE
Add clang command line invocation to debug=0x4

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -138,6 +138,13 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
   // Initialize a compiler invocation object from the clang (-cc1) arguments.
   const driver::ArgStringList &ccargs = cmd.getArguments();
 
+  if (flags_ & 0x4) {
+    llvm::errs() << "clang";
+    for (auto arg : ccargs)
+      llvm::errs() << " " << arg;
+    llvm::errs() << "\n";
+  }
+
   // first pass
   auto invocation1 = make_unique<CompilerInvocation>();
   if (!CompilerInvocation::CreateFromArgs(*invocation1, const_cast<const char **>(ccargs.data()),


### PR DESCRIPTION
This adds the command line arguments of clang to debug flag 0x4 in the
clang frontend.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>