### PR TITLE
Don't include git tag in .so suffix

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBCC_INSTALL_PREFIX='\"${CMAKE_INSTALL_PREFIX}\"'")
 
 add_library(bcc SHARED bpf_common.cc bpf_module.cc libbpf.c)
-set_target_properties(bcc PROPERTIES VERSION ${REVISION} SOVERSION 0)
+set_target_properties(bcc PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
 
 # BPF is still experimental otherwise it should be available
 #llvm_map_components_to_libnames(llvm_libs bpf mcjit irreader passes)


### PR DESCRIPTION
The git hash was being include in the shared library name. This leads to
polution of the /usr/lib directory. Instead, just use the latest tag in
the library suffix.

As a developer, you will need to clean up the /usr/lib/libbcc* files
whenever a new tag is created.

Fixes: #207
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>