### PR TITLE
add ebpf method to retrieve bytecode

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -392,7 +392,7 @@ class BPF(object):
 
         return fn
 
-    def ebpf(self, func_name):
+    def dump_func(self, func_name):
         """
         Return the eBPF bytecodes for the specified function as a string
         """

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -392,6 +392,17 @@ class BPF(object):
 
         return fn
 
+    def ebpf(self, func_name):
+        """
+        Return the eBPF bytecodes for the specified function as a string
+        """
+        if lib.bpf_function_start(self.module, func_name.encode("ascii")) == None:
+            raise Exception("Unknown program %s" % func_name)
+
+        start, = lib.bpf_function_start(self.module, func_name.encode("ascii")),
+        size, = lib.bpf_function_size(self.module, func_name.encode("ascii")),
+        return ct.string_at(start, size)
+
     str2ctype = {
         u"_Bool": ct.c_bool,
         u"char": ct.c_char,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,3 +5,4 @@ configure_file(wrapper.sh.in "${CMAKE_CURRENT_BINARY_DIR}/wrapper.sh" @ONLY)
 set(TEST_WRAPPER ${CMAKE_CURRENT_BINARY_DIR}/wrapper.sh)
 
 add_subdirectory(cc)
+add_subdirectory(python)

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) PLUMgrid, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+add_test(NAME py_test_dump_func WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_dump_func simple ${CMAKE_CURRENT_SOURCE_DIR}/test_dump_func.py)

--- a/tests/python/test_dump_func.py
+++ b/tests/python/test_dump_func.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# Copyright (c) PLUMgrid, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+# test program for the 'dump_func' method
+
+from bcc import BPF
+from unittest import main, TestCase
+
+class TestDumpFunc(TestCase):
+    def test_return(self):
+        b = BPF(text="""
+            int entry(void)
+            {
+                return 1;
+            }""")
+
+        self.assertEquals(
+            "\xb7\x00\x00\x00\x01\x00\x00\x00" +
+            "\x95\x00\x00\x00\x00\x00\x00\x00",
+            b.dump_func("entry"))
+
+if __name__ == "__main__":
+    main()

--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -39,6 +39,10 @@ function sudo_run() {
   sudo bash -c "PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd $1 $2"
   return $?
 }
+function simple_run() {
+  PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd $1 $2
+  return $?
+}
 
 case $kind in
   namespace)
@@ -46,6 +50,9 @@ case $kind in
     ;;
   sudo)
     sudo_run $@
+    ;;
+  simple)
+    simple_run $@
     ;;
   *)
     echo "Invalid kind $kind"


### PR DESCRIPTION
This is useful if you want to use bcc as a compiler without running the
program.