### PR TITLE
Translate multiple pointer dereference into bpr_probe_read

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -62,7 +63,6 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   explicit BTypeVisitor(clang::ASTContext &C, clang::Rewriter &rewriter,
                         std::vector<TableDesc> &tables);
   bool TraverseCallExpr(clang::CallExpr *Call);
-  bool TraverseMemberExpr(clang::MemberExpr *E);
   bool VisitFunctionDecl(clang::FunctionDecl *D);
   bool VisitCallExpr(clang::CallExpr *Call);
   bool VisitVarDecl(clang::VarDecl *Decl);
@@ -76,6 +76,7 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   llvm::raw_ostream &out_;  /// for debugging
   std::vector<TableDesc> &tables_;  /// store the open FDs
   std::vector<clang::ParmVarDecl *> fn_args_;
+  std::set<clang::Expr *> visited_;
 };
 
 // A helper class to the frontend action, walks the decls


### PR DESCRIPTION
This commit adds support for multiple consecutive and nested pointer
dereference of function arguments that should be converted to
bpf_probe_read. The logic works by marking variables as needing a
probe_read if they come from the register argument, and then applying
this property transitively.

Supported syntax:
```
int trace_entry(struct pt_regs *ctx, struct file *file) {
    struct vfsmount *mnt = file->f_path.mnt;
    struct super_block *k = mnt->mnt_sb;
    const char *name = file->f_path.dentry->d_name.name;
```

Not supported: probe reads from map leaves, probe reads after explicit casts.

Fixes: #188
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>