### PR TITLE
Fix probe reads on char[] types

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -304,7 +304,7 @@ bool BTypeVisitor::VisitMemberExpr(MemberExpr *E) {
   string rhs = rewriter_.getRewrittenText(SourceRange(rhs_start, E->getLocEnd()));
   string base_type = base->getType()->getPointeeType().getAsString();
   string pre, post;
-  pre = "({ " + E->getType().getAsString() + " _val; memset(&_val, 0, sizeof(_val));";
+  pre = "({ typeof(" + E->getType().getAsString() + ") _val; memset(&_val, 0, sizeof(_val));";
   pre += " bpf_probe_read(&_val, sizeof(_val), (u64)";
   post = " + offsetof(" + base_type + ", " + rhs + ")";
   post += "); _val; })";

--- a/tests/cc/test_clang.py
+++ b/tests/cc/test_clang.py
@@ -165,5 +165,12 @@ int trace_entry(struct pt_regs *ctx, struct file *file) {
         b = BPF(text=text, debug=0)
         fn = b.load_func("trace_entry", BPF.KPROBE)
 
+    def test_char_array_probe(self):
+        BPF(text="""#include <linux/blkdev.h>
+int kprobe__blk_update_request(struct pt_regs *ctx, struct request *req) {
+    bpf_trace_printk("%s\\n", req->rq_disk->disk_name);
+    return 0;
+}""")
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
It is easy enough to wrap the type in a typeof(), otherwise the rewriter
would need to do a deeper parsing of the type information to place it
properly next to the variable name.

Fixes: #219
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>