### PR TITLE
Add support for static helper functions

### DIFF
--- a/tests/cc/test_brb.c
+++ b/tests/cc/test_brb.c
@@ -104,7 +104,6 @@ int pem(struct __sk_buff *skb) {
     return 1;
 }
 
-static int br_common(struct __sk_buff *skb, int which_br) __attribute__((always_inline));
 static int br_common(struct __sk_buff *skb, int which_br) {
     u8 *cursor = 0;
     u16 proto;


### PR DESCRIPTION
This adds support for static helper functions that can be reused. It is
not necessary to include pt_regs in the helper functions, even though
external pointers may be dereferenced. Arguments in the helpers can also
be reordered.

Fixes: #224 #217
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>