### PR TITLE
Use GNUInstallDirs for LIBDIR variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,7 @@ enable_testing()
 
 include(cmake/GetGitRevisionDescription.cmake)
 include(cmake/version.cmake)
-get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-if(LIB64)
-  set(LIBSUFFIX 64)
-endif()
+include(GNUInstallDirs)
 
 if(NOT PYTHON_ONLY)
 find_package(BISON)

--- a/debian/libbcc.install
+++ b/debian/libbcc.install
@@ -1,3 +1,3 @@
 usr/include/bcc/*
-usr/lib/libbcc* /usr/lib/x86_64-linux-gnu/
+usr/lib/x86_64-linux-gnu/libbcc*
 usr/share/bcc/include/*

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -51,7 +51,7 @@ set(clang_libs ${libclangFrontend} ${libclangSerialization} ${libclangDriver} ${
 target_link_libraries(bcc b_frontend clang_frontend ${clang_libs} ${llvm_libs} LLVMBPFCodeGen)
 
 install(TARGETS bcc LIBRARY COMPONENT libbcc
-  DESTINATION lib${LIBSUFFIX})
+  DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(DIRECTORY export/ COMPONENT libbcc
   DESTINATION share/bcc/include/bcc
   FILES_MATCHING PATTERN "*.h")
@@ -61,6 +61,6 @@ install(DIRECTORY compat/linux/ COMPONENT libbcc
   DESTINATION include/bcc/compat/linux
   FILES_MATCHING PATTERN "*.h")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libbcc.pc COMPONENT libbcc
-  DESTINATION lib${LIBSUFFIX}/pkgconfig)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 add_subdirectory(frontends)


### PR DESCRIPTION
This should be supported in older versions of cmake, but haven't
explicitly tested those.

Fixes: #243
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>