### PR TITLE
Fix an uninitialized variable access in test_clang

### DIFF
--- a/tests/cc/test_clang_complex.c
+++ b/tests/cc/test_clang_complex.c
@@ -100,8 +100,9 @@ int handle_packet(struct __sk_buff *skb) {
     goto EOP;
   }
 
-  struct ip_t *ip = cursor_advance(cursor, sizeof(*ip));
+  struct ip_t *ip;
   ip: {
+    ip = cursor_advance(cursor, sizeof(*ip));
     switch (ip->nextp) {
       case 6: goto tcp;
       case 17: goto udp;


### PR DESCRIPTION
Signed-off-by: Yonghong Song <yhs@plumgrid.com>