### PR TITLE
Python: fix detach_kprobe()

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -575,7 +575,7 @@ class BPF(object):
         ev_name = "p_" + event.replace("+", "_").replace(".", "_")
         if ev_name not in open_kprobes:
             raise Exception("Kprobe %s is not attached" % event)
-        os.close(open_kprobes[ev_name])
+        lib.perf_reader_free(open_kprobes[ev_name])
         desc = "-:kprobes/%s" % ev_name
         res = lib.bpf_detach_kprobe(desc.encode("ascii"))
         if res < 0:
@@ -612,7 +612,7 @@ class BPF(object):
         ev_name = "r_" + event.replace("+", "_").replace(".", "_")
         if ev_name not in open_kprobes:
             raise Exception("Kretprobe %s is not attached" % event)
-        os.close(open_kprobes[ev_name])
+        lib.perf_reader_free(open_kprobes[ev_name])
         desc = "-:kprobes/%s" % ev_name
         res = lib.bpf_detach_kprobe(desc.encode("ascii"))
         if res < 0:


### PR DESCRIPTION
As open_kprobes contains not fd but pointer to struct perf_reader,
it should call lib.perf_reader_free() instead of os.close()