### PR TITLE
Bump ulimit for locked memory in test wrapper

### DIFF
--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -32,11 +32,11 @@ function ns_run() {
   sudo ip netns exec $ns ethtool -K eth0 tx off
   sudo ip addr add dev $ns.out 172.16.1.1/24
   sudo ip link set $ns.out up
-  sudo bash -c "PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd $1 $2"
+  sudo bash -c "ulimit -l 10240; PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd $1 $2"
   return $?
 }
 function sudo_run() {
-  sudo bash -c "PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd $1 $2"
+  sudo bash -c "ulimit -l 10240; PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd $1 $2"
   return $?
 }
 function simple_run() {


### PR DESCRIPTION
This follows from a change in upstream kernel for counting bpf maps
against the locked memory limit.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>