### PR TITLE
Fix unary operator handling of probe reads with parens

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -109,6 +109,9 @@ class ProbeChecker : public RecursiveASTVisitor<ProbeChecker> {
     needs_probe_ = false;
     return false;
   }
+  bool VisitParenExpr(ParenExpr *E) {
+    return false;
+  }
   bool VisitDeclRefExpr(DeclRefExpr *E) {
     if (ptregs_.find(E->getDecl()) != ptregs_.end())
       needs_probe_ = true;

--- a/tests/cc/test_clang.py
+++ b/tests/cc/test_clang.py
@@ -249,5 +249,19 @@ int kprobe____kmalloc(struct pt_regs *ctx, size_t size) {
     return 0;
 }""", debug=4)
 
+    def test_unop_probe_read(self):
+        text = """
+#include <linux/blkdev.h>
+int trace_entry(struct pt_regs *ctx, struct request *req) {
+    if (!(req->bio->bi_rw & 1))
+        return 1;
+    if (((req->bio->bi_rw)))
+        return 1;
+    return 0;
+}
+"""
+        b = BPF(text=text)
+        fn = b.load_func("trace_entry", BPF.KPROBE)
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Testing for bpf_probe_read should not include parenethes when walking
the tree, since the inner operation will have already been rewritten.

Fixes: #289
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>