### PR TITLE
Fixup dependencies of bcc-tools package

### DIFF
--- a/SPECS/bcc.spec
+++ b/SPECS/bcc.spec
@@ -51,16 +51,19 @@ Shared Library for BPF Compiler Collection (BCC)
 
 %package -n libbcc-examples
 Summary: Examples for BPF Compiler Collection (BCC)
+Requires: libbcc
 %description -n libbcc-examples
 Examples for BPF Compiler Collection (BCC)
 
 %package -n python-bcc
 Summary: Python bindings for BPF Compiler Collection (BCC)
+Requires: libbcc
 %description -n python-bcc
 Python bindings for BPF Compiler Collection (BCC)
 
 %package -n bcc-tools
 Summary: Command line tools for BPF Compiler Collection (BCC)
+Requires: python-bcc
 %description -n bcc-tools
 Command line tools for BPF Compiler Collection (BCC)
 

--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,6 @@ Depends: libbcc, python
 Description: Python wrappers for BPF Compiler Collection (BCC)
 
 Package: bcc-tools
-Architecture: amd64
-Depends: libbcc, python
+Architecture: all
+Depends: python-bcc
 Description: Command line tools for BPF Compiler Collection (BCC)


### PR DESCRIPTION
This should depend on python-bcc, which itself depends on libbcc.

Fixes: #291
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>