### PR TITLE
Automatically bump memlock ulimit

### DIFF
--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -32,11 +32,11 @@ function ns_run() {
   sudo ip netns exec $ns ethtool -K eth0 tx off
   sudo ip addr add dev $ns.out 172.16.1.1/24
   sudo ip link set $ns.out up
-  sudo bash -c "ulimit -l 10240; PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd $1 $2"
+  sudo bash -c "PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd $1 $2"
   return $?
 }
 function sudo_run() {
-  sudo bash -c "ulimit -l 10240; PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd $1 $2"
+  sudo bash -c "PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd $1 $2"
   return $?
 }
 function simple_run() {


### PR DESCRIPTION
Instead of requiring the user to bump the ulimit in their shell before
starting a bcc script, try to setrlimit automatically when a failure
occurs. Since there is no getrusage for memlock limit, unfortunately we
have to brute force setting the limit. For now, just try bpf() once and
then try to set unlimited ulimit, then try bpf() again.

Fixes: #281
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>