### PR TITLE
Fix breakage from LLVM 3.8 API change

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -178,9 +178,11 @@ Function * BPFModule::make_reader(Module *mod, Type *type) {
   Function *fn = Function::Create(fn_type, GlobalValue::ExternalLinkage,
                                   "reader" + std::to_string(readers_.size()), mod);
   auto arg_it = fn->arg_begin();
-  Argument *arg_in = arg_it++;
+  Argument *arg_in = &*arg_it;
+  ++arg_it;
   arg_in->setName("in");
-  Argument *arg_out = arg_it++;
+  Argument *arg_out = &*arg_it;
+  ++arg_it;
   arg_out->setName("out");
 
   BasicBlock *label_entry = BasicBlock::Create(*ctx_, "entry", fn);
@@ -240,11 +242,14 @@ Function * BPFModule::make_writer(Module *mod, Type *type) {
   Function *fn = Function::Create(fn_type, GlobalValue::ExternalLinkage,
                                   "writer" + std::to_string(writers_.size()), mod);
   auto arg_it = fn->arg_begin();
-  Argument *arg_out = arg_it++;
+  Argument *arg_out = &*arg_it;
+  ++arg_it;
   arg_out->setName("out");
-  Argument *arg_len = arg_it++;
+  Argument *arg_len = &*arg_it;
+  ++arg_it;
   arg_len->setName("len");
-  Argument *arg_in = arg_it++;
+  Argument *arg_in = &*arg_it;
+  ++arg_it;
   arg_in->setName("in");
 
   BasicBlock *label_entry = BasicBlock::Create(*ctx_, "entry", fn);

--- a/src/cc/frontends/b/codegen_llvm.cc
+++ b/src/cc/frontends/b/codegen_llvm.cc
@@ -1180,7 +1180,7 @@ StatusTuple CodegenLLVM::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
     TRY2((*formal)->accept(this));
     Value *ptr = vars_[formal->get()];
     if (!ptr) return mkstatus_(n, "cannot locate memory location for arg %s", (*formal)->id_->c_str());
-    B.CreateStore(arg, ptr);
+    B.CreateStore(&*arg, ptr);
 
     // Type *ptype;
     // if ((*formal)->is_struct()) {


### PR DESCRIPTION
There is some difference in how to take a pointer from an iterator. This
code should work for both 3.7 and 3.8 APIs.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>