### PR TITLE
Improve json type support for misc struct/union types

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -49,6 +49,7 @@ class BMapDeclVisitor : public clang::RecursiveASTVisitor<BMapDeclVisitor> {
   bool VisitBuiltinType(const clang::BuiltinType *T);
   bool VisitTypedefType(const clang::TypedefType *T);
   bool VisitTagType(const clang::TagType *T);
+  bool VisitPointerType(const clang::PointerType *T);
  private:
   clang::ASTContext &C;
   std::string &result_;

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -518,7 +518,13 @@ class BPF(object):
                     fields.append((t[0], BPF._decode_table_type(t[1]), t[2]))
             else:
                 raise Exception("Failed to decode type %s" % str(t))
-        cls = type(str(desc[0]), (ct.Structure,), dict(_fields_=fields))
+        base = ct.Structure
+        if len(desc) > 2:
+            if desc[2] == u"union":
+                base = ct.Union
+            elif desc[2] == u"struct":
+                base = ct.Structure
+        cls = type(str(desc[0]), (base,), dict(_fields_=fields))
         return cls
 
     def get_table(self, name, keytype=None, leaftype=None):


### PR DESCRIPTION
The ability of the clang rewriter to extract the type information for
some types of structs, unions, and pointers to the aforementioned was
somewhat buggy. This became exposed in a test_clang case after a user
upgraded to a newer kernel, wherein the struct definition changed. The
functionality in question is only used to pass json-ified representation
of the struct to python in order to program the Key/Leaf metaclass.

Improve support for this and other types, including unions.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>