### PR TITLE
Drop broken p4/docs symlink and create README.md+URL

### DIFF
--- a/src/cc/frontends/p4/docs/README.md
+++ b/src/cc/frontends/p4/docs/README.md
@@ -1,0 +1,3 @@
+# External references
+
+See [p4toEbpf-bcc.pdf](https://github.com/iovisor/bpf-docs/blob/master/p4/p4toEbpf-bcc.pdf)

--- a/src/cc/frontends/p4/docs/p4toEbpf-bcc.pdf
+++ b/src/cc/frontends/p4/docs/p4toEbpf-bcc.pdf
@@ -1,1 +1,0 @@
-../../../../../../bpf-docs/p4toEbpf-bcc.pdf


### PR DESCRIPTION
There was a symlink to a local file, which would instead work better as
a URL to the bpf-docs repository.

Fixes: #304
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>