### PR TITLE
Remove runtime dependency on gcc stdarg headers and make

### DIFF
--- a/SPECS/bcc.el6.spec
+++ b/SPECS/bcc.el6.spec
@@ -88,7 +88,6 @@ make install/strip DESTDIR=%{buildroot}
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)
-Requires: make, gcc
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 
@@ -109,6 +108,7 @@ Python bindings for BPF Compiler Collection (BCC)
 %files -n libbcc
 /usr/lib64/*
 /usr/share/bcc/include/*
+/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.el6.spec.in
+++ b/SPECS/bcc.el6.spec.in
@@ -88,7 +88,6 @@ make install/strip DESTDIR=%{buildroot}
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)
-Requires: make, gcc
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 
@@ -109,6 +108,7 @@ Python bindings for BPF Compiler Collection (BCC)
 %files -n libbcc
 /usr/lib64/*
 /usr/share/bcc/include/*
+/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.el7.spec
+++ b/SPECS/bcc.el7.spec
@@ -57,7 +57,6 @@ make install/strip DESTDIR=%{buildroot}
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)
-Requires: make, gcc
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 
@@ -78,6 +77,7 @@ Python bindings for BPF Compiler Collection (BCC)
 %files -n libbcc
 /usr/lib64/*
 /usr/share/bcc/include/*
+/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.el7.spec.in
+++ b/SPECS/bcc.el7.spec.in
@@ -57,7 +57,6 @@ make install/strip DESTDIR=%{buildroot}
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)
-Requires: make, gcc
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 
@@ -78,6 +77,7 @@ Python bindings for BPF Compiler Collection (BCC)
 %files -n libbcc
 /usr/lib64/*
 /usr/share/bcc/include/*
+/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.f22.spec
+++ b/SPECS/bcc.f22.spec
@@ -57,7 +57,6 @@ make install/strip DESTDIR=%{buildroot}
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)
-Requires: make, gcc
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 
@@ -78,6 +77,7 @@ Python bindings for BPF Compiler Collection (BCC)
 %files -n libbcc
 /usr/lib64/*
 /usr/share/bcc/include/*
+/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.f22.spec.in
+++ b/SPECS/bcc.f22.spec.in
@@ -57,7 +57,6 @@ make install/strip DESTDIR=%{buildroot}
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)
-Requires: make, gcc
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 
@@ -78,6 +77,7 @@ Python bindings for BPF Compiler Collection (BCC)
 %files -n libbcc
 /usr/lib64/*
 /usr/share/bcc/include/*
+/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.spec
+++ b/SPECS/bcc.spec
@@ -45,7 +45,6 @@ make install/strip DESTDIR=%{buildroot}
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)
-Requires: gcc, make
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 
@@ -73,6 +72,7 @@ Command line tools for BPF Compiler Collection (BCC)
 %files -n libbcc
 /usr/lib64/*
 /usr/share/bcc/include/*
+/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/iovisor/bcc
 
 Package: libbcc
 Architecture: amd64
-Depends: libc6, libstdc++6, make, gcc
+Depends: libc6, libstdc++6
 Description: Shared Library for BPF Compiler Collection (BCC)
  Shared Library for BPF Compiler Collection to control BPF programs
  from userspace.

--- a/debian/libbcc.install
+++ b/debian/libbcc.install
@@ -1,3 +1,4 @@
 usr/include/bcc/*
 usr/lib/x86_64-linux-gnu/libbcc*
 usr/share/bcc/include/*
+usr/share/bcc/lib/*

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -62,5 +62,8 @@ install(DIRECTORY compat/linux/ COMPONENT libbcc
   FILES_MATCHING PATTERN "*.h")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libbcc.pc COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(DIRECTORY clang COMPONENT libbcc
+  DESTINATION share/bcc/lib
+  FILES_MATCHING PATTERN "*.h")
 
 add_subdirectory(frontends)

--- a/src/cc/clang/include/stdarg.h
+++ b/src/cc/clang/include/stdarg.h
@@ -1,0 +1,52 @@
+/*===---- stdarg.h - Variable argument handling ----------------------------===
+ *
+ * Copyright (c) 2008 Eli Friedman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __STDARG_H
+#define __STDARG_H
+
+#ifndef _VA_LIST
+typedef __builtin_va_list va_list;
+#define _VA_LIST
+#endif
+#define va_start(ap, param) __builtin_va_start(ap, param)
+#define va_end(ap)          __builtin_va_end(ap)
+#define va_arg(ap, type)    __builtin_va_arg(ap, type)
+
+/* GCC always defines __va_copy, but does not define va_copy unless in c99 mode
+ * or -ansi is not specified, since it was not part of C90.
+ */
+#define __va_copy(d,s) __builtin_va_copy(d,s)
+
+#if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L || !defined(__STRICT_ANSI__)
+#define va_copy(dest, src)  __builtin_va_copy(dest, src)
+#endif
+
+/* Hack required to make standard headers work, at least on Ubuntu */
+#ifndef __GNUC_VA_LIST
+#define __GNUC_VA_LIST 1
+#endif
+typedef __builtin_va_list __gnuc_va_list;
+
+#endif /* __STDARG_H */

--- a/src/cc/frontends/clang/kbuild_helper.h
+++ b/src/cc/frontends/clang/kbuild_helper.h
@@ -93,13 +93,9 @@ class TmpDir {
 //  Note: Depending on environment, different cache locations may be desired. In
 //  case we eventually support non-root user programs, cache in $HOME.
 class KBuildHelper {
- private:
-  int learn_flags(const std::string &tmpdir, const char *uname_release, const char *cachefile);
  public:
   KBuildHelper();
-  int get_flags(const char *uname_release, std::vector<std::string> *cflags);
- private:
-  std::string cache_dir_;
+  int get_flags(const char *uname_machine, std::vector<std::string> *cflags);
 };
 
 }  // namespace ebpf

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -90,11 +90,12 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
 
   vector<const char *> flags_cstr({"-O0", "-emit-llvm", "-I", dstack.cwd(),
                                    "-Wno-deprecated-declarations",
+                                   "-Wno-gnu-variable-sized-type-not-at-end",
                                    "-x", "c", "-c", abs_file.c_str()});
 
   KBuildHelper kbuild_helper;
   vector<string> kflags;
-  if (kbuild_helper.get_flags(un.release, &kflags))
+  if (kbuild_helper.get_flags(un.machine, &kflags))
     return -1;
   kflags.push_back("-include");
   kflags.push_back(BCC_INSTALL_PREFIX "/share/bcc/include/bcc/helpers.h");


### PR DESCRIPTION
Remove the runtime dependency on gcc's stdarg.h. Do this by packaging
the (non-GPL) version shipped with clang. This allows the bulk of
kbuild_helper to be removed, at the expense of hardcoding the kernel
include paths. If in the future the kernel make system changes again to
require different -I paths, we'll have to think this through again.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>