### PR TITLE
Add ability to export maps, enables cross-program sharing

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 # tell the shared library where it is being installed so it can find shared header files
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBCC_INSTALL_PREFIX='\"${CMAKE_INSTALL_PREFIX}\"'")
 
-add_library(bcc SHARED bpf_common.cc bpf_module.cc libbpf.c perf_reader.c)
+add_library(bcc SHARED bpf_common.cc bpf_module.cc libbpf.c perf_reader.c shared_table.cc)
 set_target_properties(bcc PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
 
 # BPF is still experimental otherwise it should be available

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -46,6 +46,10 @@ struct _name##_table_t { \
 __attribute__((section("maps/" _table_type))) \
 struct _name##_table_t _name
 
+#define BPF_TABLE_EXPORT(_name) \
+__attribute__((section("maps/export"))) \
+struct _name##_table_t __##_name
+
 // Table for pushing custom events to userspace via ring buffer
 #define BPF_PERF_OUTPUT(_name) \
 struct _name##_table_t { \

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -46,7 +46,9 @@ struct _name##_table_t { \
 __attribute__((section("maps/" _table_type))) \
 struct _name##_table_t _name
 
-#define BPF_TABLE_EXPORT(_name) \
+// define a table same as above but allow it to be referenced by other modules
+#define BPF_TABLE_PUBLIC(_table_type, _key_type, _leaf_type, _name, _max_entries) \
+BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries); \
 __attribute__((section("maps/export"))) \
 struct _name##_table_t __##_name
 

--- a/src/cc/shared_table.cc
+++ b/src/cc/shared_table.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016 PLUMgrid, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "shared_table.h"
+
+namespace ebpf {
+
+using std::string;
+
+SharedTables * SharedTables::instance_;
+
+SharedTables * SharedTables::instance() {
+  if (!instance_) {
+    instance_ = new SharedTables;
+  }
+  return instance_;
+}
+
+int SharedTables::lookup_fd(const string &name) const {
+  auto table = tables_.find(name);
+  if (table == tables_.end())
+    return -1;
+  return table->second;
+}
+
+bool SharedTables::insert_fd(const string &name, int fd) {
+  if (tables_.find(name) != tables_.end())
+    return false;
+  tables_[name] = fd;
+  return true;
+}
+
+}

--- a/src/cc/shared_table.h
+++ b/src/cc/shared_table.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 PLUMgrid, Inc.
+ * Copyright (c) 2016 PLUMgrid, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,28 +16,23 @@
 
 #pragma once
 
-#include <cstdint>
+#include <map>
 #include <string>
-
-namespace llvm {
-class Function;
-}
 
 namespace ebpf {
 
-struct TableDesc {
-  std::string name;
-  int fd;
-  int type;
-  size_t key_size;  // sizes are in bytes
-  size_t leaf_size;
-  size_t max_entries;
-  std::string key_desc;
-  std::string leaf_desc;
-  llvm::Function *key_sscanf;
-  llvm::Function *leaf_sscanf;
-  llvm::Function *key_snprintf;
-  llvm::Function *leaf_snprintf;
+struct TableDesc;
+
+class SharedTables {
+ public:
+  static SharedTables * instance();
+  // add an fd to the shared table, return true if successfully inserted
+  bool insert_fd(const std::string &name, int fd);
+  // lookup an fd in the shared table, or -1 if not found
+  int lookup_fd(const std::string &name) const;
+ private:
+  static SharedTables *instance_;
+  std::map<std::string, int> tables_;
 };
 
-}  // namespace ebpf
+}

--- a/tests/cc/test_clang.py
+++ b/tests/cc/test_clang.py
@@ -295,5 +295,9 @@ BPF_TABLE("array", int, union emptyu, t3, 1);
 """
         b = BPF(text=text, cflags=["-DMYFLAG"])
 
+    def test_exported_maps(self):
+        b1 = BPF(text="""BPF_TABLE_PUBLIC("hash", int, int, table1, 10);""")
+        b2 = BPF(text="""BPF_TABLE("extern", int, int, table1, 10);""")
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Allow a program to export a map for other programs to use. This enables
cross-program map sharing.

parent program syntax:
BPF_TABLE("array", int, int, shared, 10);
BPF_TABLE_EXPORT(shared);

child program syntax:
BPF_TABLE("extern", int, int, shared, 10);

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>