### PR TITLE
Reorder P4 struct key initializers and blocks

### DIFF
--- a/src/cc/frontends/p4/compiler/ebpfTable.py
+++ b/src/cc/frontends/p4/compiler/ebpfTable.py
@@ -275,6 +275,11 @@ class EbpfTable(object):
         keyname = "key"
         valueName = "value"
 
+        serializer.newline()
+        serializer.emitIndent()
+        serializer.appendFormat("{0}:", program.getLabel(self))
+        serializer.newline()
+
         serializer.emitIndent()
         serializer.blockStart()
 
@@ -283,17 +288,12 @@ class EbpfTable(object):
         serializer.newline()
 
         serializer.emitIndent()
-        serializer.appendFormat("struct {0} {1};", self.keyTypeName, keyname)
+        serializer.appendFormat("struct {0} {1} = {{}};", self.keyTypeName, keyname)
         serializer.newline()
 
         serializer.emitIndent()
         serializer.appendFormat(
             "struct {0} *{1};", self.valueTypeName, valueName)
-        serializer.newline()
-
-        serializer.newline()
-        serializer.emitIndent()
-        serializer.appendFormat("{0}:", program.getLabel(self))
         serializer.newline()
 
         self.key.serializeConstruction(serializer, keyname, program)


### PR DESCRIPTION
The basic_routing.p4 program was failing verification due to missed map
key initializers in some paths. Put the goto label at the head of the
block and add a " = {}" for each key declaration inside the block.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>