### PR TITLE
Fix segfault in ~BPFModule on syntax error

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -114,9 +114,11 @@ BPFModule::~BPFModule() {
   engine_.reset();
   rw_engine_.reset();
   ctx_.reset();
-  for (auto table : *tables_) {
-    if (table.is_shared)
-      SharedTables::instance()->remove_fd(table.name);
+  if (tables_) {
+    for (auto table : *tables_) {
+      if (table.is_shared)
+        SharedTables::instance()->remove_fd(table.name);
+    }
   }
 }
 

--- a/tests/cc/test_clang.py
+++ b/tests/cc/test_clang.py
@@ -299,5 +299,9 @@ BPF_TABLE("array", int, union emptyu, t3, 1);
         b1 = BPF(text="""BPF_TABLE_PUBLIC("hash", int, int, table1, 10);""")
         b2 = BPF(text="""BPF_TABLE("extern", int, int, table1, 10);""")
 
+    def test_syntax_error(self):
+        with self.assertRaises(Exception):
+            b = BPF(text="""int failure(void *ctx) { if (); return 0; }""")
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
~BPFModule was segfaulting because tables_ was an empty pointer. The
pointer is valid only for valid compilations. Add a test as well.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>