### PR TITLE
Embed runtime header files in libbcc.so

### DIFF
--- a/SPECS/bcc.el6.spec
+++ b/SPECS/bcc.el6.spec
@@ -107,8 +107,6 @@ Python bindings for BPF Compiler Collection (BCC)
 
 %files -n libbcc
 /usr/lib64/*
-/usr/share/bcc/include/*
-/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.el6.spec.in
+++ b/SPECS/bcc.el6.spec.in
@@ -107,8 +107,6 @@ Python bindings for BPF Compiler Collection (BCC)
 
 %files -n libbcc
 /usr/lib64/*
-/usr/share/bcc/include/*
-/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.el7.spec
+++ b/SPECS/bcc.el7.spec
@@ -76,8 +76,6 @@ Python bindings for BPF Compiler Collection (BCC)
 
 %files -n libbcc
 /usr/lib64/*
-/usr/share/bcc/include/*
-/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.el7.spec.in
+++ b/SPECS/bcc.el7.spec.in
@@ -76,8 +76,6 @@ Python bindings for BPF Compiler Collection (BCC)
 
 %files -n libbcc
 /usr/lib64/*
-/usr/share/bcc/include/*
-/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.f22.spec
+++ b/SPECS/bcc.f22.spec
@@ -76,8 +76,6 @@ Python bindings for BPF Compiler Collection (BCC)
 
 %files -n libbcc
 /usr/lib64/*
-/usr/share/bcc/include/*
-/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.f22.spec.in
+++ b/SPECS/bcc.f22.spec.in
@@ -76,8 +76,6 @@ Python bindings for BPF Compiler Collection (BCC)
 
 %files -n libbcc
 /usr/lib64/*
-/usr/share/bcc/include/*
-/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/SPECS/bcc.spec
+++ b/SPECS/bcc.spec
@@ -71,8 +71,6 @@ Command line tools for BPF Compiler Collection (BCC)
 
 %files -n libbcc
 /usr/lib64/*
-/usr/share/bcc/include/*
-/usr/share/bcc/lib/*
 /usr/include/bcc/*
 
 %files -n libbcc-examples

--- a/debian/libbcc.install
+++ b/debian/libbcc.install
@@ -1,4 +1,2 @@
 usr/include/bcc/*
 usr/lib/x86_64-linux-gnu/libbcc*
-usr/share/bcc/include/*
-usr/share/bcc/lib/*

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -32,10 +32,7 @@ if (CMAKE_COMPILER_IS_GNUCC)
   endif()
 endif()
 
-# tell the shared library where it is being installed so it can find shared header files
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBCC_INSTALL_PREFIX='\"${CMAKE_INSTALL_PREFIX}\"'")
-
-add_library(bcc SHARED bpf_common.cc bpf_module.cc libbpf.c perf_reader.c shared_table.cc)
+add_library(bcc SHARED bpf_common.cc bpf_module.cc libbpf.c perf_reader.c shared_table.cc exported_files.cc)
 set_target_properties(bcc PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
 
 # BPF is still experimental otherwise it should be available
@@ -52,9 +49,6 @@ target_link_libraries(bcc b_frontend clang_frontend ${clang_libs} ${llvm_libs} L
 
 install(TARGETS bcc LIBRARY COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(DIRECTORY export/ COMPONENT libbcc
-  DESTINATION share/bcc/include/bcc
-  FILES_MATCHING PATTERN "*.h")
 install(FILES bpf_common.h bpf_module.h ../libbpf.h COMPONENT libbcc
   DESTINATION include/bcc)
 install(DIRECTORY compat/linux/ COMPONENT libbcc
@@ -62,8 +56,5 @@ install(DIRECTORY compat/linux/ COMPONENT libbcc
   FILES_MATCHING PATTERN "*.h")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libbcc.pc COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-install(DIRECTORY clang COMPONENT libbcc
-  DESTINATION share/bcc/lib
-  FILES_MATCHING PATTERN "*.h")
 
 add_subdirectory(frontends)

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -47,7 +47,7 @@ class BPFModule {
   llvm::Function * make_writer(llvm::Module *mod, llvm::Type *type);
   void dump_ir(llvm::Module &mod);
   int load_file_module(std::unique_ptr<llvm::Module> *mod, const std::string &file, bool in_memory);
-  int load_includes(const std::string &tmpfile);
+  int load_includes(const std::string &text);
   int load_cfile(const std::string &file, bool in_memory, const char *cflags[], int ncflags);
   int kbuild_flags(const char *uname_release, std::vector<std::string> *cflags);
   int run_pass_manager(llvm::Module &mod);

--- a/src/cc/clang/include/stdarg.h
+++ b/src/cc/clang/include/stdarg.h
@@ -1,3 +1,4 @@
+R"********(
 /*===---- stdarg.h - Variable argument handling ----------------------------===
  *
  * Copyright (c) 2008 Eli Friedman
@@ -50,3 +51,4 @@ typedef __builtin_va_list va_list;
 typedef __builtin_va_list __gnuc_va_list;
 
 #endif /* __STDARG_H */
+)********"

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -1,3 +1,4 @@
+R"********(
 /*
  * Copyright (c) 2015 PLUMgrid, Inc.
  *
@@ -392,3 +393,4 @@ int bpf_num_cpus() asm("llvm.bpf.extra");
 #define lock_xadd(ptr, val) ((void)__sync_fetch_and_add(ptr, val))
 
 #endif
+)********"

--- a/src/cc/export/proto.h
+++ b/src/cc/export/proto.h
@@ -1,3 +1,4 @@
+R"********(
 /*
  * Copyright (c) 2015 PLUMgrid, Inc.
  *
@@ -95,3 +96,4 @@ struct vxlan_t {
   unsigned int key:24;
   unsigned int rsv4:8;
 } BPF_PACKET_HEADER;
+)********"

--- a/src/cc/exported_files.cc
+++ b/src/cc/exported_files.cc
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 PLUMgrid, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exported_files.h"
+
+using std::map;
+using std::string;
+
+namespace ebpf {
+
+// c++11 feature for including raw string literals
+// see http://www.stroustrup.com/C++11FAQ.html#raw-strings
+
+map<string, const char *> ExportedFiles::headers_ = {
+  {
+    "/virtual/include/bcc/proto.h",
+    #include "export/proto.h"
+  },
+  {
+    "/virtual/include/bcc/helpers.h",
+    #include "export/helpers.h"
+  },
+  {
+    "/virtual/lib/clang/include/stdarg.h",
+    #include "clang/include/stdarg.h"
+  },
+};
+
+}

--- a/src/cc/exported_files.h
+++ b/src/cc/exported_files.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016 PLUMgrid, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace ebpf {
+
+class ExportedFiles {
+  static std::map<std::string, const char *> headers_;
+ public:
+  static const std::map<std::string, const char *> & headers() { return headers_; }
+};
+
+}

--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -57,7 +57,7 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
 
   cflags->push_back("-nostdinc");
   cflags->push_back("-isystem");
-  cflags->push_back(BCC_INSTALL_PREFIX "/share/bcc/lib/clang/include");
+  cflags->push_back("/virtual/lib/clang/include");
   cflags->push_back("-I./arch/"+arch+"/include");
   cflags->push_back("-Iarch/"+arch+"/include/generated/uapi");
   cflags->push_back("-Iarch/"+arch+"/include/generated");

--- a/src/cc/frontends/clang/loader.h
+++ b/src/cc/frontends/clang/loader.h
@@ -23,6 +23,7 @@
 namespace llvm {
 class Module;
 class LLVMContext;
+class MemoryBuffer;
 }
 
 namespace ebpf {
@@ -41,6 +42,7 @@ class ClangLoader {
   int parse(std::unique_ptr<llvm::Module> *mod, std::unique_ptr<std::vector<TableDesc>> *tables,
             const std::string &file, bool in_memory, const char *cflags[], int ncflags);
  private:
+  static std::map<std::string, std::unique_ptr<llvm::MemoryBuffer>> remapped_files_;
   llvm::LLVMContext *ctx_;
   unsigned flags_;
 };


### PR DESCRIPTION
To avoid installing header files needed by clang to disk
(/usr/share/bcc), embed the files as strings inside the library and feed
them to clang as memory buffers. The mechanism that we use to do this
retains all of the existing features, as in one can still do `#include
<bcc/helpers.h>`, even though it is redundant, and clang will pick up
the embedded file.

Fixes: #333
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>