### PR TITLE
syncsnoop migrated to use bpf_perf_events

### DIFF
--- a/man/man8/syncsnoop.8
+++ b/man/man8/syncsnoop.8
@@ -11,6 +11,10 @@ be useful to know if they are happening and how frequently.
 This works by tracing the kernel sys_sync() function using dynamic tracing, and
 will need updating to match any changes to this function.
 
+This makes use of a Linux 4.5 feature (bpf_perf_event_output());
+for kernels older than 4.5, see the version under tools/old,
+which uses an older mechanism.
+
 This program is also a basic example of eBPF/bcc.
 
 Since this uses BPF, only the root user can use this tool.

--- a/tools/old/syncsnoop.py
+++ b/tools/old/syncsnoop.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+# @lint-avoid-python-3-compatibility-imports
+#
+# syncsnoop Trace sync() syscall.
+#           For Linux, uses BCC, eBPF. Embedded C.
+#
+# Written as a basic example of BCC trace & reformat. See
+# examples/hello_world.py for a BCC trace with default output example.
+#
+# Copyright (c) 2015 Brendan Gregg.
+# Licensed under the Apache License, Version 2.0 (the "License")
+#
+# 13-Aug-2015   Brendan Gregg   Created this.
+
+from __future__ import print_function
+from bcc import BPF
+
+# load BPF program
+b = BPF(text="""
+void kprobe__sys_sync(void *ctx) {
+    bpf_trace_printk("sync()\\n");
+};
+""")
+
+# header
+print("%-18s %s" % ("TIME(s)", "CALL"))
+
+# format output
+while 1:
+    (task, pid, cpu, flags, ts, msg) = b.trace_fields()
+    print("%-18.9f %s" % (ts, msg))

--- a/tools/syncsnoop.py
+++ b/tools/syncsnoop.py
@@ -19,8 +19,6 @@ import ctypes as ct
 
 # load BPF program
 b = BPF(text="""
-#include <linux/string.h>
-
 struct data_t {
     u64 ts;
 };

--- a/tools/syncsnoop.py
+++ b/tools/syncsnoop.py
@@ -27,8 +27,7 @@ BPF_PERF_OUTPUT(events);
 
 void kprobe__sys_sync(void *ctx) {
     struct data_t data = {};
-    data.ts = bpf_ktime_get_ns();
-    data.ts = data.ts / 1000;
+    data.ts = bpf_ktime_get_ns() / 1000;
     events.perf_submit(ctx, &data, sizeof(data));
 };
 """)

--- a/tools/syncsnoop.py
+++ b/tools/syncsnoop.py
@@ -23,7 +23,6 @@ b = BPF(text="""
 
 struct data_t {
     u64 ts;
-    char msg[6];
 };
 
 BPF_PERF_OUTPUT(events);
@@ -32,15 +31,13 @@ void kprobe__sys_sync(void *ctx) {
     struct data_t data = {};
     data.ts = bpf_ktime_get_ns();
     data.ts = data.ts / 1000;
-    strcpy(data.msg,"Sync()");
     events.perf_submit(ctx, &data, sizeof(data));
 };
 """)
 
 class Data(ct.Structure):
     _fields_ = [
-        ("ts", ct.c_ulonglong),
-        ("msg", ct.c_char * 6)
+        ("ts", ct.c_ulonglong)
     ]
 
 # header
@@ -49,7 +46,7 @@ print("%-18s %s" % ("TIME(s)", "CALL"))
 # process event
 def print_event(cpu, data, size):
     event = ct.cast(data, ct.POINTER(Data)).contents
-    print("%-18.9f %s" % (float(event.ts) / 1000000, event.msg))
+    print("%-18.9f sync()" % (float(event.ts) / 1000000))
 
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)


### PR DESCRIPTION
I have added in a strcpy to copy in the Sync() text, I am thinking it might be best to just print this from python. Thoughts?

Al