### PR TITLE
Documentation and tcp4connect enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Editor's files
 *.swp
 *.swo
 *.pyc
+
+# Build artefacts
+/build/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -112,12 +112,15 @@ To build the toolchain from source, one needs:
 
 ### Install build dependencies
 ```
+# Trusty and older
 VER=trusty
 echo "deb http://llvm.org/apt/$VER/ llvm-toolchain-$VER-3.7 main
 deb-src http://llvm.org/apt/$VER/ llvm-toolchain-$VER-3.7 main" | \
   sudo tee /etc/apt/sources.list.d/llvm.list
 wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
+
+# All versions
 sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
   libllvm3.7 llvm-3.7-dev libclang-3.7-dev python zlib1g-dev
 ```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ many possible capabilities.
 
 See [INSTALL.md](INSTALL.md) for installation steps on your platform.
 
+## FAQ
+
+See [FAQ.txt](FAQ.txt) for the most common troubleshoot questions.
+
 ## Contents
 
 Some of these are single files that contain both C and Python, others have a


### PR DESCRIPTION
I started to play around with kprobes this week-end. Here are some enhancements from my local notes. Hope it can help other people getting started!

- on Ubuntu Wily: LLVM dependencies are in the default repositories, no need for extra ones
- ignore ``/build`` build directory. It is manually created but it is also the recommended setup, so makes sense to ignore it
- add a reference to the FAQ.txt which looks like a good resource for early troubleshoot :)

Regarding ``tcpv4connect.py``, it may not be the best thing to do, I'm just starting to experiment with this API. I'm using Ubuntu Wily stock kernel (``Linux jt-laptop 4.2.0-22-generic #27-Ubuntu SMP Thu Dec 17 22:57:08 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux``). Under this kernel I observed that all probes seems to share a single output pipe so that competing probe may cause other to fail parsing their output.

A possible workaround is to tag messages and filter based on the tag. I wonder if there is a more efficient way to do it?