### PR TITLE
Prepare deb build for nightly target

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Brenden Blanco <bblanco@plumgrid.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.5
-Build-Depends: debhelper (>= 9), cmake, libllvm3.8, llvm-3.8-dev, libclang-3.8-dev
+Build-Depends: debhelper (>= 9), cmake, libllvm3.7, llvm-3.7-dev, libclang-3.7-dev
 Homepage: https://github.com/iovisor/bcc
 
 Package: libbcc

--- a/scripts/build-release-rpm.sh
+++ b/scripts/build-release-rpm.sh
@@ -16,9 +16,11 @@ llvmver=3.7.1
 # only the most recent tag
 git_tag_latest=$(git describe --abbrev=0)
 git_rev_count=$(git rev-list $git_tag_latest.. --count)
-release=0
-if [[ "$git_rev_count" != "0" ]]; then
-  release=$(git log --pretty='g%h' -n 1)
+git_rev_count=$[$git_rev_count+1]
+git_subject=$(git log --pretty="%s" -n 1)
+release=$git_rev_count
+if [[ "$git_rev_count" != "1" ]]; then
+  release="${release}.git.$(git log --pretty='%h' -n 1)"
 fi
 revision=${git_tag_latest:1}
 

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -16,9 +16,11 @@ llvmver=3.7.1
 # only the most recent tag
 git_tag_latest=$(git describe --abbrev=0)
 git_rev_count=$(git rev-list $git_tag_latest.. --count)
-release=0
-if [[ "$git_rev_count" != "0" ]]; then
-  release=$(git log --pretty='g%h' -n 1)
+git_rev_count=$[$git_rev_count+1]
+git_subject=$(git log --pretty="%s" -n 1)
+release=$git_rev_count
+if [[ "$git_rev_count" != "1" ]]; then
+  release="${release}.git.$(git log --pretty='%h' -n 1)"
 fi
 revision=${git_tag_latest:1}
 


### PR DESCRIPTION
Add incremental release numbering for deb targets.
Tweak rpm release numbering as well.
I switched back to 3.7.1 (stable) clang on the buildbot so roll back that version as well.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>