### PR TITLE
Remove use of update() in funccount

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -186,6 +186,10 @@ class TableBase(MutableMapping):
         for k in self.keys():
             self.__delitem__(k)
 
+    def zero(self):
+        for k in self.keys():
+            self[k] = self.Leaf()
+
     def __iter__(self):
         return TableBase.Iter(self, self.Key)
 

--- a/tools/funccount.py
+++ b/tools/funccount.py
@@ -65,9 +65,13 @@ BPF_HASH(counts, struct key_t);
 int trace_count(struct pt_regs *ctx) {
     FILTER
     struct key_t key = {};
-    u64 zero = 0, *val;
-    key.ip = ctx->ip;
-    val = counts.lookup_or_init(&key, &zero);
+    u64 *val;
+    // the kprobe pc is slightly after the function starting address, align
+    // back to the start (4 byte alignment) in order to match /proc/kallsyms
+    key.ip = ctx->ip & ~3ull;
+    val = counts.lookup(&key);
+    if (!val)
+        return 0;
     (*val)++;
     return 0;
 }
@@ -81,6 +85,16 @@ else:
 if debug:
     print(bpf_text)
 b = BPF(text=bpf_text)
+counts = b.get_table("counts")
+
+# pre-insert the function addresses into the counts table
+fns = b._get_kprobe_functions(pattern)
+for fn in fns:
+    addr = b.ksymname(fn)
+    if addr == -1:
+        raise Exception("Unknown symbol name %s" % fn)
+    counts[counts.Key(addr)] = counts.Leaf()
+
 b.attach_kprobe(event_re=pattern, fn_name="trace_count")
 matched = b.num_open_kprobes()
 if matched == 0:
@@ -106,10 +120,10 @@ while (1):
         print("%-8s\n" % strftime("%H:%M:%S"), end="")
 
     print("%-16s %-26s %8s" % ("ADDR", "FUNC", "COUNT"))
-    counts = b.get_table("counts")
     for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
+        if v.value == 0: continue
         print("%-16x %-26s %8d" % (k.ip, b.ksym(k.ip), v.value))
-    counts.clear()
+    counts.zero()
 
     if exiting:
         print("Detaching...")


### PR DESCRIPTION
This is an alternative fix for #415, funccount being called in a recursive context.