### PR TITLE
[RFC] Basic implementation of stacktrace table

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -25,6 +25,12 @@ R"********(
 #error "CONFIG_BPF_SYSCALL is undefined, please check your .config or ask your Linux distro to enable this feature"
 #endif
 
+#ifdef PERF_MAX_STACK_DEPTH
+#define BPF_MAX_STACK_DEPTH PERF_MAX_STACK_DEPTH
+#else
+#define BPF_MAX_STACK_DEPTH 127
+#endif
+
 /* helper macro to place programs, maps, license in
  * different sections in elf_bpf file. Section names
  * are interpreted by elf_bpf loader
@@ -104,6 +110,16 @@ struct _name##_table_t _name
 #define BPF_HISTOGRAM(...) \
   BPF_HISTX(__VA_ARGS__, BPF_HIST3, BPF_HIST2, BPF_HIST1)(__VA_ARGS__)
 
+#define BPF_STACK_TRACE(_name, _max_entries) \
+struct _name##_table_t { \
+  int key; \
+  struct { u64 data[BPF_MAX_STACK_DEPTH]; } leaf; \
+  int (*lookup) (void *); \
+  struct { u64 data[BPF_MAX_STACK_DEPTH]; } data[_max_entries]; \
+}; \
+__attribute__((section("maps/stacktrace"))) \
+struct _name##_table_t _name
+
 // packet parsing state machine helpers
 #define cursor_advance(_cursor, _len) \
   ({ void *_tmp = _cursor; _cursor += _len; _tmp; })
@@ -170,7 +186,7 @@ static int (*bpf_skb_load_bytes)(void *ctx, int offset, void *to, u32 len) =
   (void *) BPF_FUNC_skb_load_bytes;
 #endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
-static int (*bpf_get_stackid)(void *ctx, void *map) =
+static int (*bpf_get_stackid_)(void *ctx, void *map, u64 flags) =
   (void *) BPF_FUNC_get_stackid;
 static int (*bpf_csum_diff)(void *from, u64 from_size, void *to, u64 to_size, u64 seed) =
   (void *) BPF_FUNC_csum_diff;
@@ -362,6 +378,11 @@ static inline __attribute__((always_inline))
 SEC("helpers")
 int bpf_map_delete_elem_(uintptr_t map, void *key) {
   return bpf_map_delete_elem((void *)map, key);
+}
+
+static inline __attribute__((always_inline))
+int bpf_get_stackid(uintptr_t map, void *ctx, u64 flags) {
+  return bpf_get_stackid_(ctx, (void *)map, flags);
 }
 
 static inline __attribute__((always_inline))

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -48,6 +48,7 @@ struct _name##_table_t { \
   int (*delete) (_key_type *); \
   void (*call) (void *, int index); \
   void (*increment) (_key_type); \
+  int (*get_stackid) (void *, u64); \
   _leaf_type data[_max_entries]; \
 }; \
 __attribute__((section("maps/" _table_type))) \
@@ -110,15 +111,12 @@ struct _name##_table_t _name
 #define BPF_HISTOGRAM(...) \
   BPF_HISTX(__VA_ARGS__, BPF_HIST3, BPF_HIST2, BPF_HIST1)(__VA_ARGS__)
 
+struct bpf_stacktrace {
+  u64 ip[BPF_MAX_STACK_DEPTH];
+};
+
 #define BPF_STACK_TRACE(_name, _max_entries) \
-struct _name##_table_t { \
-  int key; \
-  struct { u64 data[BPF_MAX_STACK_DEPTH]; } leaf; \
-  int (*lookup) (void *); \
-  struct { u64 data[BPF_MAX_STACK_DEPTH]; } data[_max_entries]; \
-}; \
-__attribute__((section("maps/stacktrace"))) \
-struct _name##_table_t _name
+  BPF_TABLE("stacktrace", int, struct bpf_stacktrace, _name, _max_entries);
 
 // packet parsing state machine helpers
 #define cursor_advance(_cursor, _len) \

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -354,8 +354,14 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           txt += ", bpf_get_smp_processor_id(), " + args_other + ")";
         } else {
           if (memb_name == "lookup") {
-            prefix = "bpf_map_lookup_elem";
-            suffix = ")";
+            if (table_it->type == BPF_MAP_TYPE_STACK_TRACE) {
+              prefix = "bpf_get_stackid";
+              // TODO: expose the different flags, how?
+              suffix = ", 0)";
+            } else {
+              prefix = "bpf_map_lookup_elem";
+              suffix = ")";
+            }
           } else if (memb_name == "update") {
             prefix = "bpf_map_update_elem";
             suffix = ", " + map_update_policy + ")";
@@ -578,6 +584,8 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
     } else if (A->getName() == "maps/perf_array") {
       if (KERNEL_VERSION(major,minor,0) >= KERNEL_VERSION(4,3,0))
         map_type = BPF_MAP_TYPE_PERF_EVENT_ARRAY;
+    } else if (A->getName() == "maps/stacktrace") {
+      map_type = BPF_MAP_TYPE_STACK_TRACE;
     } else if (A->getName() == "maps/extern") {
       is_extern = true;
       table.fd = SharedTables::instance()->lookup_fd(table.name);

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -48,6 +48,8 @@ add_test(NAME py_array WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_array sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_array.py)
 add_test(NAME py_uprobes WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_uprobes sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_uprobes.py)
+add_test(NAME py_test_stackid WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_stackid sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_stackid.py)
 
 add_test(NAME py_test_dump_func WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_dump_func simple ${CMAKE_CURRENT_SOURCE_DIR}/test_dump_func.py)

--- a/tests/python/test_stackid.py
+++ b/tests/python/test_stackid.py
@@ -14,7 +14,9 @@ BPF_STACK_TRACE(stack_traces, 10240);
 BPF_HASH(stack_entries, int, int);
 BPF_HASH(stub);
 int kprobe__htab_map_delete_elem(struct pt_regs *ctx, struct bpf_map *map, u64 *k) {
-    int id = stack_traces.lookup(ctx);
+    int id = stack_traces.get_stackid(ctx, (BPF_F_REUSE_STACKID));
+    if (id < 0)
+        return 0;
     int key = 1;
     stack_entries.update(&key, &id);
     return 0;
@@ -29,7 +31,7 @@ int kprobe__htab_map_delete_elem(struct pt_regs *ctx, struct bpf_map *map, u64 *
         self.assertIn(k, stack_entries)
         stackid = stack_entries[k]
         self.assertIsNotNone(stackid)
-        stack = stack_traces[stackid].data
+        stack = stack_traces[stackid].ip
         self.assertEqual(b.ksym(stack[0]), "htab_map_delete_elem")
 
 

--- a/tests/python/test_stackid.py
+++ b/tests/python/test_stackid.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python
+# Copyright (c) PLUMgrid, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+import bcc
+import unittest
+
+class TestStackid(unittest.TestCase):
+    def test_simple(self):
+        b = bcc.BPF(text="""
+#include <uapi/linux/ptrace.h>
+#include <linux/bpf.h>
+BPF_STACK_TRACE(stack_traces, 10240);
+BPF_HASH(stack_entries, int, int);
+BPF_HASH(stub);
+int kprobe__htab_map_delete_elem(struct pt_regs *ctx, struct bpf_map *map, u64 *k) {
+    int id = stack_traces.lookup(ctx);
+    int key = 1;
+    stack_entries.update(&key, &id);
+    return 0;
+}
+""")
+        stub = b["stub"]
+        stack_traces = b["stack_traces"]
+        stack_entries = b["stack_entries"]
+        try: del stub[stub.Key(1)]
+        except: pass
+        k = stack_entries.Key(1)
+        self.assertIn(k, stack_entries)
+        stackid = stack_entries[k]
+        self.assertIsNotNone(stackid)
+        stack = stack_traces[stackid].data
+        self.assertEqual(b.ksym(stack[0]), "htab_map_delete_elem")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is the initial implementation of bpf_get_stackid with python
helpers. This doesn't expose the different methods of calling
(kernel/user, fast, or reuse).

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>