### PR TITLE
Allowing more natural syntax for tracepoints with no "tp" struct prefix

### DIFF
--- a/man/man8/argdist.8
+++ b/man/man8/argdist.8
@@ -92,7 +92,8 @@ You may use the parameters directly, or valid C expressions that involve the
 parameters, such as "size % 10".
 Tracepoints may access a special structure called "tp" that is formatted according
 to the tracepoint format (which you can obtain using tplist). For example, the
-block:block_rq_complete tracepoint can access tp.nr_sector.
+block:block_rq_complete tracepoint can access tp.nr_sector. You may also use the
+members of the "tp" struct directly, e.g. "nr_sector" instead of "tp.nr_sector".
 Return probes can use the argument values received by the
 function when it was entered, through the $entry(paramname) special variable.
 Return probes can also access the function's return value in $retval, and the
@@ -147,11 +148,11 @@ Count fork() calls in libc across all processes, grouped by pid:
 .TP
 Print histogram of number of sectors in completing block I/O requests:
 #
-.B argdist -H 't:block:block_rq_complete():u32:tp.nr_sector'
+.B argdist -H 't:block:block_rq_complete():u32:nr_sector'
 .TP
 Aggregate interrupts by interrupt request (IRQ):
 #
-.B argdist -C 't:irq:irq_handler_entry():int:tp.irq'
+.B argdist -C 't:irq:irq_handler_entry():int:irq'
 .TP
 Print histograms of sleep() and nanosleep() parameter values:
 #

--- a/man/man8/trace.8
+++ b/man/man8/trace.8
@@ -92,7 +92,9 @@ same special keywords as in the predicate (arg1, arg2, etc.).
 In tracepoints, both the predicate and the arguments may refer to the tracepoint
 format structure, which is stored in the special "tp" variable. For example, the
 block:block_rq_complete tracepoint can print or filter by tp.nr_sector. To 
-discover the format of your tracepoint, use the tplist tool.
+discover the format of your tracepoint, use the tplist tool. Note that you can
+also use the members of the "tp" struct directly, e.g "nr_sector" instead of
+"tp.nr_sector".
 
 The predicate expression and the format specifier replacements for printing
 may also use the following special keywords: $pid, $tgid to refer to the 
@@ -118,7 +120,7 @@ Trace returns from the readline function in bash and print the return value as a
 .TP
 Trace the block:block_rq_complete tracepoint and print the number of sectors completed:
 #
-.B trace 't:block:block_rq_complete """%d sectors"", tp.nr_sector'
+.B trace 't:block:block_rq_complete """%d sectors"", nr_sector'
 .SH SOURCE
 This is from bcc.
 .IP


### PR DESCRIPTION
For example:

```
# argdist -C 't:irq:irq_handler_entry():u32:irq'
```

(instead of `tp.irq` which was required previously)