### PR TITLE
expose buitin byte swap methods

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -39,6 +39,11 @@ ksyms = []
 ksym_names = {}
 ksym_loaded = 0
 _kprobe_limit = 1000
+BASE_CFLAGS = [
+    '-D__HAVE_BUILTIN_BSWAP16__',
+    '-D__HAVE_BUILTIN_BSWAP32__',
+    '-D__HAVE_BUILTIN_BSWAP64__',
+]
 
 @atexit.register
 def cleanup_kprobes():
@@ -140,6 +145,7 @@ class BPF(object):
         self.debug = debug
         self.funcs = {}
         self.tables = {}
+        cflags = BASE_CFLAGS + cflags
         cflags_array = (ct.c_char_p * len(cflags))()
         for i, s in enumerate(cflags): cflags_array[i] = s.encode("ascii")
         if text:


### PR DESCRIPTION
This PR makes it possible to directly use byte swap macro from the kernel headers by advertising the compiler's builtin byte swap method. In this commit, this is simply a forced ``CFLAGS`` in the python lib.

Not sure this is the best way to do. It should probably go in the clang frontend. Especially if we want to use it from non python programs. 