### PR TITLE
IPv6 strings with an inet6_ntoa

### DIFF
--- a/man/man8/tcpconnect.8
+++ b/man/man8/tcpconnect.8
@@ -55,12 +55,10 @@ IP
 IP address family (4 or 6)
 .TP
 SADDR
-Source IP address. IPv4 as a dotted quad, IPv6 shows "..." then the last 4
-bytes (check for newer versions of this tool for the full address).
+Source IP address.
 .TP
 DADDR
-Destination IP address. IPv4 as a dotted quad, IPv6 shows "..." then the last 4
-bytes (check for newer versions of this tool for the full address).
+Destination IP address.
 .TP
 DPORT
 Destination port

--- a/tools/tcpconnect_example.txt
+++ b/tools/tcpconnect_example.txt
@@ -10,15 +10,13 @@ PID    COMM         IP SADDR            DADDR            DPORT
 1479   telnet       4  127.0.0.1        127.0.0.1        23
 1469   curl         4  10.201.219.236   54.245.105.25    80
 1469   curl         4  10.201.219.236   54.67.101.145    80
-11072  ssh          6  ...fe8203ac      ...fe82abcd      22
+1991   telnet       6  ::1              ::1              23
+2015   ssh          6  fe80::2000:bff:fe82:3ac fe80::2000:bff:fe82:3ac 22
 
 This output shows four connections, one from a "telnet" process, two from
 "curl", and one from "ssh". The output details shows the IP version, source
 address, destination address, and destination port. This traces attempted
 connections: these may have failed.
-
-IPv4 addresses are printed as dotted quads. Only the last 4 bytes of IPv6
-addresses are printed for now (check for updated versions of this tool).
 
 The overhead of this tool should be negligible, since it is only tracing the
 kernel functions performing connect. It is not tracing every packet and then


### PR DESCRIPTION
This has a simple implementation of an inet6_ntoa() in tcpconnect. If this proves suitable, we can move it to bcc __init.__.py.

Known shortcomings: requires "re" package (on my systems that's usually there, whereas netaddr usually isn't). Also doesn't shorten maximum run, so is RFC4291 but not RFC5952 (missing 4.2.1), however, most of the time it is producing RFC5952 addresses. I think it works fine for now, but someone later might drop in a better Python implementation.