### PR TITLE
Minor endian and debug enhancement

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -688,7 +688,7 @@ BFrontendAction::BFrontendAction(llvm::raw_ostream &os, unsigned flags)
 }
 
 void BFrontendAction::EndSourceFileAction() {
-  if (flags_ & 0x4)
+  if (flags_ & DEBUG_PREPROCESSOR)
     rewriter_->getEditBuffer(rewriter_->getSourceMgr().getMainFileID()).write(llvm::errs());
   rewriter_->getEditBuffer(rewriter_->getSourceMgr().getMainFileID()).write(os_);
   os_.flush();

--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -26,6 +26,8 @@
 
 #include "table_desc.h"
 
+#define DEBUG_PREPROCESSOR 0x4
+
 namespace clang {
 class ASTConsumer;
 class ASTContext;

--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -82,6 +82,9 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
   cflags->push_back("-include");
   cflags->push_back("./include/linux/kconfig.h");
   cflags->push_back("-D__KERNEL__");
+  cflags->push_back("-D__HAVE_BUILTIN_BSWAP16__");
+  cflags->push_back("-D__HAVE_BUILTIN_BSWAP32__");
+  cflags->push_back("-D__HAVE_BUILTIN_BSWAP64__");
   cflags->push_back("-Wno-unused-value");
   cflags->push_back("-Wno-pointer-sign");
 

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -155,7 +155,7 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
   // Initialize a compiler invocation object from the clang (-cc1) arguments.
   const driver::ArgStringList &ccargs = cmd.getArguments();
 
-  if (flags_ & 0x4) {
+  if (flags_ & DEBUG_PREPROCESSOR) {
     llvm::errs() << "clang";
     for (auto arg : ccargs)
       llvm::errs() << " " << arg;

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -41,6 +41,10 @@ ksym_names = {}
 ksym_loaded = 0
 _kprobe_limit = 1000
 
+DEBUG_LLVM_IR = 0x1
+DEBUG_BPF = 0x2
+DEBUG_PREPROCESSOR = 0x4
+
 @atexit.register
 def cleanup_kprobes():
     for k, v in open_kprobes.items():
@@ -132,8 +136,9 @@ class BPF(object):
             hdr_file (Optional[str]): Path to a helper header file for the `src_file`
             text (Optional[str]): Contents of a source file for the module
             debug (Optional[int]): Flags used for debug prints, can be |'d together
-                0x1: print LLVM IR to stderr
-                0x2: print BPF bytecode to stderr
+                DEBUG_LLVM_IR: print LLVM IR to stderr
+                DEBUG_BPF: print BPF bytecode to stderr
+                DEBUG_PREPROCESSOR: print Preprocessed C file to stderr
         """
 
         self._reader_cb_impl = _CB_TYPE(BPF._reader_cb)
@@ -192,7 +197,7 @@ class BPF(object):
                 lib.bpf_module_kern_version(self.module),
                 log_buf, ct.sizeof(log_buf) if log_buf else 0)
 
-        if self.debug & 0x2:
+        if self.debug & DEBUG_BPF:
             print(log_buf.value.decode(), file=sys.stderr)
 
         if fd < 0:

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -40,11 +40,6 @@ ksyms = []
 ksym_names = {}
 ksym_loaded = 0
 _kprobe_limit = 1000
-BASE_CFLAGS = [
-    '-D__HAVE_BUILTIN_BSWAP16__',
-    '-D__HAVE_BUILTIN_BSWAP32__',
-    '-D__HAVE_BUILTIN_BSWAP64__',
-]
 
 @atexit.register
 def cleanup_kprobes():
@@ -146,7 +141,6 @@ class BPF(object):
         self.debug = debug
         self.funcs = {}
         self.tables = {}
-        cflags = BASE_CFLAGS + cflags
         cflags_array = (ct.c_char_p * len(cflags))()
         for i, s in enumerate(cflags): cflags_array[i] = s.encode("ascii")
         if text:


### PR DESCRIPTION
- add DEBUG_* constants in place of the hardcoded values. Should help making self-documenting code
- move endian fixes to clang, previous PR was merged... fast :)

I was trying to automatically insert ``bpf_probe_read`` in situations like https://github.com/iovisor/bcc/blob/master/tools/solisten.py#L105 but did not find the right way. I tried tweaking https://github.com/iovisor/bcc/blob/master/src/cc/frontends/clang/b_frontend_action.cc with no success. Do you have a guide on how to run it into a debugger ?