### PR TITLE
Percpu support

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -570,9 +570,9 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
       map_type = BPF_MAP_TYPE_HASH;
     } else if (A->getName() == "maps/array") {
       map_type = BPF_MAP_TYPE_ARRAY;
-    } else if (A->getName() == "maps/pc_hash") {
+    } else if (A->getName() == "maps/percpu_hash") {
       map_type = BPF_MAP_TYPE_PERCPU_HASH;
-    } else if (A->getName() == "maps/pc_array") {
+    } else if (A->getName() == "maps/percpu_array") {
       map_type = BPF_MAP_TYPE_PERCPU_ARRAY;
     } else if (A->getName() == "maps/histogram") {
       if (table.key_desc == "\"int\"")

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -570,6 +570,12 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
       map_type = BPF_MAP_TYPE_HASH;
     } else if (A->getName() == "maps/array") {
       map_type = BPF_MAP_TYPE_ARRAY;
+    } else if (A->getName() == "maps/pc_hash") {
+      if (KERNEL_VERSION(major,minor,0) >= KERNEL_VERSION(4,5,0))
+        map_type = BPF_MAP_TYPE_PERCPU_HASH;
+    } else if (A->getName() == "maps/pc_array") {
+      if (KERNEL_VERSION(major,minor,0) >= KERNEL_VERSION(4,5,0))
+        map_type = BPF_MAP_TYPE_PERCPU_ARRAY;
     } else if (A->getName() == "maps/histogram") {
       if (table.key_desc == "\"int\"")
         map_type = BPF_MAP_TYPE_ARRAY;

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -571,11 +571,9 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
     } else if (A->getName() == "maps/array") {
       map_type = BPF_MAP_TYPE_ARRAY;
     } else if (A->getName() == "maps/pc_hash") {
-      if (KERNEL_VERSION(major,minor,0) >= KERNEL_VERSION(4,5,0))
-        map_type = BPF_MAP_TYPE_PERCPU_HASH;
+      map_type = BPF_MAP_TYPE_PERCPU_HASH;
     } else if (A->getName() == "maps/pc_array") {
-      if (KERNEL_VERSION(major,minor,0) >= KERNEL_VERSION(4,5,0))
-        map_type = BPF_MAP_TYPE_PERCPU_ARRAY;
+      map_type = BPF_MAP_TYPE_PERCPU_ARRAY;
     } else if (A->getName() == "maps/histogram") {
       if (table.key_desc == "\"int\"")
         map_type = BPF_MAP_TYPE_ARRAY;

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -228,7 +228,7 @@ class BPF(object):
         cls = type(str(desc[0]), (base,), dict(_fields_=fields))
         return cls
 
-    def get_table(self, name, keytype=None, leaftype=None, func_reducer=None):
+    def get_table(self, name, keytype=None, leaftype=None, reducer=None):
         map_id = lib.bpf_table_id(self.module, name.encode("ascii"))
         map_fd = lib.bpf_table_fd(self.module, name.encode("ascii"))
         if map_fd < 0:
@@ -243,7 +243,7 @@ class BPF(object):
             if not leaf_desc:
                 raise Exception("Failed to load BPF Table %s leaf desc" % name)
             leaftype = BPF._decode_table_type(json.loads(leaf_desc.decode()))
-        return Table(self, map_id, map_fd, keytype, leaftype, func_reducer)
+        return Table(self, map_id, map_fd, keytype, leaftype, reducer=reducer)
 
     def __getitem__(self, key):
         if key not in self.tables:

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -228,7 +228,7 @@ class BPF(object):
         cls = type(str(desc[0]), (base,), dict(_fields_=fields))
         return cls
 
-    def get_table(self, name, keytype=None, leaftype=None):
+    def get_table(self, name, keytype=None, leaftype=None, func_reducer=None):
         map_id = lib.bpf_table_id(self.module, name.encode("ascii"))
         map_fd = lib.bpf_table_fd(self.module, name.encode("ascii"))
         if map_fd < 0:
@@ -243,7 +243,7 @@ class BPF(object):
             if not leaf_desc:
                 raise Exception("Failed to load BPF Table %s leaf desc" % name)
             leaftype = BPF._decode_table_type(json.loads(leaf_desc.decode()))
-        return Table(self, map_id, map_fd, keytype, leaftype)
+        return Table(self, map_id, map_fd, keytype, leaftype, func_reducer)
 
     def __getitem__(self, key):
         if key not in self.tables:

--- a/tests/python/test_percpu.py
+++ b/tests/python/test_percpu.py
@@ -8,6 +8,35 @@ import unittest as ut
 
 class TestPercpu(ut.TestCase):
 
+    def test_u64(self):
+        test_prog1 = """
+        BPF_TABLE("pc_hash", u32, u64, stats, 1);
+        int hello_world(void *ctx) {
+            u32 key=0;
+            u64 value = 0, *val;
+            val = stats.lookup_or_init(&key, &value);
+            *val += 1;
+            return 0;
+        }
+        """
+        self.addCleanup(self.cleanup)
+        bpf_code = BPF(text=test_prog1)
+        stats_map = bpf_code.get_table("stats")
+        bpf_code.attach_kprobe(event="sys_clone", fn_name="hello_world")
+        sleep(1)
+        self.assertEqual(len(stats_map),1)
+        for x in range(0, 10):
+            ini = stats_map.Leaf(0,0,0,0,0,0,0,0)
+            stats_map[ stats_map.Key(0) ] = ini
+            sleep(1)
+            k = stats_map[ stats_map.Key(0) ]
+            x = stats_map.sum(stats_map.Key(0))
+            y = stats_map.average(stats_map.Key(0))
+            z = stats_map.max(stats_map.Key(0))
+            print (x.value)
+            self.assertGreater(x.value, 1L)
+            self.assertGreater(z.value, 1L)
+
     def test_u32(self):
         test_prog1 = """
         BPF_TABLE("pc_array", u32, u32, stats, 1);

--- a/tests/python/test_percpu.py
+++ b/tests/python/test_percpu.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# Copyright (c) PLUMgrid, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+from bcc import BPF
+from time import sleep
+import unittest as ut
+
+class TestPercpu(ut.TestCase):
+
+    def test_u32(self):
+        test_prog1 = """
+        BPF_TABLE("pc_array", u32, u32, stats, 1);
+        int hello_world(void *ctx) {
+            u32 key=0;
+            u32 value = 0, *val;
+            val = stats.lookup_or_init(&key, &value);
+            *val += 1;
+            return 0;
+        }
+        """
+        self.addCleanup(self.cleanup)
+        bpf_code = BPF(text=test_prog1)
+        stats_map = bpf_code.get_table("stats")
+        bpf_code.attach_kprobe(event="sys_clone", fn_name="hello_world")
+        sleep(1)
+        self.assertEqual(len(stats_map),1)
+        for x in range(0, 10):
+            ini = stats_map.Leaf(0,0,0,0,0,0,0,0)
+            stats_map[ stats_map.Key(0) ] = ini
+            sleep(1)
+            k = stats_map[ stats_map.Key(0) ]
+            x = stats_map.sum(stats_map.Key(0))
+            y = stats_map.average(stats_map.Key(0))
+            z = stats_map.max(stats_map.Key(0))
+            self.assertGreater(x.value, 1L)
+            self.assertGreater(z.value, 1L)
+
+    def test_struct_custom_func(self):
+        test_prog2 = """
+        typedef struct counter {
+        u32 c1;
+        u32 c2;
+        } counter;
+        BPF_TABLE("pc_hash", u32, counter, stats, 1);
+        int hello_world(void *ctx) {
+            u32 key=0;
+            counter value = {0,0}, *val;
+            val = stats.lookup_or_init(&key, &value);
+            val->c1 += 1;
+            val->c2 += 1;
+            return 0;
+        }
+        """
+        self.addCleanup(self.cleanup)
+        bpf_code = BPF(text=test_prog2)
+        stats_map = bpf_code.get_table("stats",
+                reducer=lambda x,y: stats_map.sLeaf(x.c1+y.c1))
+        bpf_code.attach_kprobe(event="sys_clone", fn_name="hello_world")
+        sleep(1)
+        self.assertEqual(len(stats_map),1)
+        for x in range(0, 10):
+            ini = stats_map.Leaf()
+            for i in ini:
+                i = stats_map.sLeaf(0,0)
+            stats_map[ stats_map.Key(0) ] = ini
+            sleep(1)
+            k = stats_map[ stats_map.Key(0) ]
+            self.assertGreater(k.c1, 1L)
+
+    def cleanup(self):
+        BPF.detach_kprobe("sys_clone")
+
+
+if __name__ == "__main__":
+    ut.main()


### PR DESCRIPTION
This patch enables **percpu** tables (hash/array) support in bcc. Following are the notes related to this patch.

1. It provides two additional keywords **pc_hash** and **pc_array** so that users can create percpu hash/array table.

2. These tables use an array of Leaf rather than single Leaf object to set/get the data from the kernel, so pc_hash/pc_array **Leaf** data type is an array of Leaf with array size equal to total number of cpu. Individual/original Leaf data type can be used via **sLeaf ** type. This change will not effect other tables type.

3. As only 8-bytes aligned data can be passed to kernel for getting/setting the key/value item, so only 8-bytes aligned data types (simple or structure) are allowed with exception to u32/int data types. In case of wrong/invalid leaf data types, this patch will throw an error. More data types can be added upon feedback.

4. pc_hash/pc_array tables setter (__setitem__) requires the user to create/initialize/pass the whole array (type Leaf) rather than just one instance (sLeaf).

5. When getting a key/value pair of pc_hash/array table user have the option to either get the whole array or apply some reducer function like **sum**, **average**, **max** and get the individual object (sLeaf data type). Default reducer functions are provided for simple data types, for complex data types (structs) user can define their own reducer function (in form of lambda function) and pass them to the pc_hash/array class.

6. This patch also includes a very simple test case, testing all of these features on u32, u64 and aligned structure data type.