### PR TITLE
Bug fix around USDT argument handling for constants

### DIFF
--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -204,13 +204,14 @@ class USDTProbeLocation(object):
                 any_reg = "(" + "|".join(qregs + dregs + wregs + bregs) + ")"
 
                 # -4@$0, 8@$1234
-                m = re.match(r'(\-?)(\d+)@\$(\d+)', arg)
+                m = re.match(r'(\-?)(\d+)@\$(\-?)(\d+)', arg)
                 if m is not None:
+                        sign = -1 if len(m.group(3)) > 0 else 1
                         self.args.append(USDTArgument(
                                 int(m.group(2)),
                                 m.group(1) == '-',
                                 self,
-                                constant=int(m.group(3))
+                                constant=sign*int(m.group(4))
                                 ))
                         return
 


### PR DESCRIPTION
For USDT arguments of the form `-4@$-1`, the parsing logic would fail
because it didn't expect the second number (the actual value of the
USDT argument as a constant) to be negative. Discovered during my
experiments with OpenJDK probes (libjvm). This is now fixed.