### PR TITLE
get rid of version checks

### DIFF
--- a/src/cc/compat/linux/virtual_bpf.h
+++ b/src/cc/compat/linux/virtual_bpf.h
@@ -1,3 +1,4 @@
+R"********(
 /* Copyright (c) 2011-2014 PLUMgrid, http://plumgrid.com
  *
  * This program is free software; you can redistribute it and/or
@@ -380,3 +381,4 @@ struct bpf_tunnel_key {
 };
 
 #endif /* _UAPI__LINUX_BPF_H__ */
+)********"

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -142,7 +142,6 @@ static u32 (*bpf_get_prandom_u32)(void) =
 static int (*bpf_trace_printk_)(const char *fmt, u64 fmt_size, ...) =
   (void *) BPF_FUNC_trace_printk;
 int bpf_trace_printk(const char *fmt, ...) asm("llvm.bpf.extra");
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
 static void bpf_tail_call_(u64 map_fd, void *ctx, int index) {
   ((void (*)(void *, u64, int))BPF_FUNC_tail_call)(ctx, map_fd, index);
 }
@@ -156,8 +155,6 @@ static u64 (*bpf_get_current_uid_gid)(void) =
   (void *) BPF_FUNC_get_current_uid_gid;
 static int (*bpf_get_current_comm)(void *buf, int buf_size) =
   (void *) BPF_FUNC_get_current_comm;
-#endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
 static u64 (*bpf_get_cgroup_classid)(void *ctx) =
   (void *) BPF_FUNC_get_cgroup_classid;
 static u64 (*bpf_skb_vlan_push)(void *ctx, u16 proto, u16 vlan_tci) =
@@ -170,20 +167,14 @@ static int (*bpf_skb_set_tunnel_key)(void *ctx, void *from, u32 size, u64 flags)
   (void *) BPF_FUNC_skb_set_tunnel_key;
 static int (*bpf_perf_event_read)(void *map, u32 index) =
   (void *) BPF_FUNC_perf_event_read;
-#endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
 static int (*bpf_redirect)(int ifindex, u32 flags) =
   (void *) BPF_FUNC_redirect;
 static u32 (*bpf_get_route_realm)(void *ctx) =
   (void *) BPF_FUNC_get_route_realm;
 static int (*bpf_perf_event_output)(void *ctx, void *map, u32 index, void *data, u32 size) =
   (void *) BPF_FUNC_perf_event_output;
-#endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0)
 static int (*bpf_skb_load_bytes)(void *ctx, int offset, void *to, u32 len) =
   (void *) BPF_FUNC_skb_load_bytes;
-#endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
 static int (*bpf_get_stackid_)(void *ctx, void *map, u64 flags) =
   (void *) BPF_FUNC_get_stackid;
 static inline __attribute__((always_inline))
@@ -192,7 +183,6 @@ int bpf_get_stackid(uintptr_t map, void *ctx, u64 flags) {
 }
 static int (*bpf_csum_diff)(void *from, u64 from_size, void *to, u64 to_size, u64 seed) =
   (void *) BPF_FUNC_csum_diff;
-#endif
 
 /* llvm builtin functions that eBPF C program may use to
  * emit BPF_LD_ABS and BPF_LD_IND instructions

--- a/src/cc/exported_files.cc
+++ b/src/cc/exported_files.cc
@@ -26,6 +26,10 @@ namespace ebpf {
 
 map<string, const char *> ExportedFiles::headers_ = {
   {
+    "/virtual/include/bcc/bpf.h",
+    #include "compat/linux/virtual_bpf.h"
+  },
+  {
     "/virtual/include/bcc/proto.h",
     #include "export/proto.h"
   },

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -585,18 +585,15 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
         diag_.Report(Decl->getLocStart(), diag_id) << table.leaf_desc;
       }
     } else if (A->getName() == "maps/prog") {
-      if (KERNEL_VERSION(major,minor,0) >= KERNEL_VERSION(4,2,0))
-        map_type = BPF_MAP_TYPE_PROG_ARRAY;
+      map_type = BPF_MAP_TYPE_PROG_ARRAY;
     } else if (A->getName() == "maps/perf_output") {
-      if (KERNEL_VERSION(major,minor,0) >= KERNEL_VERSION(4,3,0))
-        map_type = BPF_MAP_TYPE_PERF_EVENT_ARRAY;
+      map_type = BPF_MAP_TYPE_PERF_EVENT_ARRAY;
       int numcpu = sysconf(_SC_NPROCESSORS_ONLN);
       if (numcpu <= 0)
         numcpu = 1;
       table.max_entries = numcpu;
     } else if (A->getName() == "maps/perf_array") {
-      if (KERNEL_VERSION(major,minor,0) >= KERNEL_VERSION(4,3,0))
-        map_type = BPF_MAP_TYPE_PERF_EVENT_ARRAY;
+      map_type = BPF_MAP_TYPE_PERF_EVENT_ARRAY;
     } else if (A->getName() == "maps/stacktrace") {
       map_type = BPF_MAP_TYPE_STACK_TRACE;
     } else if (A->getName() == "maps/extern") {

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -77,8 +77,6 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
   using namespace clang;
 
   string main_path = "/virtual/main.c";
-  string proto_path = "/virtual/include/bcc/proto.h";
-  string helpers_path = "/virtual/include/bcc/helpers.h";
   unique_ptr<llvm::MemoryBuffer> main_buf;
   struct utsname un;
   uname(&un);
@@ -109,6 +107,8 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
   vector<string> kflags;
   if (kbuild_helper.get_flags(un.machine, &kflags))
     return -1;
+  kflags.push_back("-include");
+  kflags.push_back("/virtual/include/bcc/bpf.h");
   kflags.push_back("-include");
   kflags.push_back("/virtual/include/bcc/helpers.h");
   kflags.push_back("-isystem");


### PR DESCRIPTION
version checks don't work at all on kernels with backported bpf bits
they also fail when /usr/include/linux/bpf.h doesn't match loaded
kernel.
Fix these issues by embedding bpf.h into libbcc.so and force load it
in clang, so we can remove all version checks and rely on verifier
complaining on unknown function call.
Later patch can make verifier errors less cryptic by converting
'unknown call 12' to strings.

while at it update bpf.h to the latest.

Signed-off-by: Alexei Starovoitov <ast@fb.com>