### PR TITLE
Add support for nixos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,12 @@ FOREACH(DIR ${LLVM_INCLUDE_DIRS})
   include_directories("${DIR}/../tools/clang/include")
 ENDFOREACH()
 
+# Set to a string path if system places kernel lib directory in
+# non-default location.
+if(NOT DEFINED BCC_KERNEL_MODULES_DIR)
+  set(BCC_KERNEL_MODULES_DIR "/lib/modules")
+endif()
+
 # Set to non-zero if system installs kernel headers with split source and build
 # directories in /lib/modules/`uname -r`/. This is the case for debian and
 # suse, to the best of my knowledge.

--- a/src/cc/frontends/clang/CMakeLists.txt
+++ b/src/cc/frontends/clang/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_DIR='\"${BCC_KERNEL_MODULES_DIR}\"'")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_SUFFIX='\"${BCC_KERNEL_MODULES_SUFFIX}\"'")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_HAS_SOURCE_DIR=${BCC_KERNEL_HAS_SOURCE_DIR}")
 add_library(clang_frontend loader.cc b_frontend_action.cc kbuild_helper.cc)

--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -68,6 +68,7 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
     cflags->push_back("-I" + kdir_ + "/build/./arch/"+arch+"/include/uapi");
     cflags->push_back("-I" + kdir_ + "/build/arch/"+arch+"/include/generated/uapi");
     cflags->push_back("-I" + kdir_ + "/build/include/uapi");
+    cflags->push_back("-I" + kdir_ + "/build/include/generated");
     cflags->push_back("-I" + kdir_ + "/build/include/generated/uapi");
   }
 

--- a/src/cc/frontends/clang/kbuild_helper.h
+++ b/src/cc/frontends/clang/kbuild_helper.h
@@ -19,8 +19,6 @@
 #include <vector>
 #include <unistd.h>
 
-#define KERNEL_MODULES_DIR "/lib/modules"
-
 namespace ebpf {
 
 struct FileDeleter {


### PR DESCRIPTION
Two changes that enables bcc to build and work nicely on nixos:

- add `-I/build/include/generated` when calculating cflags. This is where `autoconf.h` with `#define CONFIG_BPF_SYSCALL 1` lives so it is critical. This appears to be true not only for nixos, but I checked Ubuntu 14.04.3 LTS too and the location was the same.
- bcc quite reasonably assumes that the kernel modules dir is `/lib/modules/`, encoded using `#define KERNEL_MODULES_DIR "/lib/modules"`. This is not true for nixos however. The proposed patch:
  - introduces a `BCC_KERNEL_MODULES_DIR` cmake flag
  - defaults that flag to `/lib/modules`, so no breaking change
  - sets `KERNEL_MODULES_DIR` based on that flag.

  This allows us to override `KERNEL_MODULES_DIR` when building bcc for nixos.
 