### PR TITLE
Fix for find_symbol method, issue #478

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -464,7 +464,8 @@ class BPF(object):
             return symbols[sym]
 
         with os.popen("""/usr/bin/objdump -tT %s | \
-                awk -v sym=%s '$NF == sym && ($4 == ".text" || $4 == "text.hot" || $4 == "text.unlikely") \
+                awk -v sym=%s '$NF == sym && ($4 == ".text" \
+                || $4 == "text.hot" || $4 == "text.unlikely") \
                 { print $1; exit }'""" % (path, sym)) as f:
             data = f.read().rstrip()
         if not data:

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -464,7 +464,7 @@ class BPF(object):
             return symbols[sym]
 
         with os.popen("""/usr/bin/objdump -tT %s | \
-                awk -v sym=%s '$NF == sym && $4 == ".text"  \
+                awk -v sym=%s '$NF == sym && ($4 == ".text" || $4 == "text.hot" || $4 == "text.unlikely") \
                 { print $1; exit }'""" % (path, sym)) as f:
             data = f.read().rstrip()
         if not data:


### PR DESCRIPTION
As discussed in issue #478 this is a proposed fix for "find_symbol method" to solve the issue that attach_uprobe fails to resolve symbols in some cases, in particular when trying to resolve functions placed in subsections text.hot and text.unlikely. 