### PR TITLE
bcc-lua: switch to quiet by default

### DIFF
--- a/src/lua/bcc/run.lua
+++ b/src/lua/bcc/run.lua
@@ -20,7 +20,7 @@ return function()
 
   local function print_usage()
     io.stderr:write(string.format(
-      "usage: %s [[--so-path=PATH|--version|--quiet] --] path_to_script.lua [...]\n",
+      "usage: %s [[--so-path=PATH|--version|--verbose] --] path_to_script.lua [...]\n",
       progname))
     os.exit(1)
   end
@@ -41,8 +41,8 @@ return function()
       rawset(_G, "LIBBCC_SO_PATH", string.lstrip(k, "--so-path="))
     elseif k == "--llvm-debug" then
       rawset(_G, "LIBBCC_LLVM_DEBUG", 1)
-    elseif k == "-q" or k == "--quiet" then
-      log.enabled = false
+    elseif k == "-V" or k == "--verbose" then
+      log.enabled = true
     elseif k == "-v" or k == "--version" then
       print_version()
     else

--- a/src/lua/bcc/vendor/helpers.lua
+++ b/src/lua/bcc/vendor/helpers.lua
@@ -169,5 +169,5 @@ setmetatable(_G, {
   end,
 })
 
-rawset(_G, "log", { info = logline, enabled = true })
+rawset(_G, "log", { info = logline, enabled = false })
 rawset(_G, "class", require("bcc.vendor.middleclass"))


### PR DESCRIPTION
use --verbose to turn verbose output

Signed-off-by: Alexei Starovoitov <ast@fb.com>