### PR TITLE
bcc-lua: build bcc.lua and bcc.o in the build tree

### DIFF
--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -5,21 +5,19 @@ if (LUAJIT_LIBRARIES)
 	FILE(GLOB_RECURSE SRC_LUA ${CMAKE_CURRENT_SOURCE_DIR}/bcc/*/*.lua)
 
 	ADD_CUSTOM_COMMAND(
-		OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/src/bcc.lua
-		COMMAND ${LUAJIT} src/squish.lua
+		OUTPUT bcc.lua
+		COMMAND ${LUAJIT} ${CMAKE_CURRENT_SOURCE_DIR}/src/squish.lua ${CMAKE_CURRENT_SOURCE_DIR}
 		DEPENDS ${SRC_LUA} ${CMAKE_CURRENT_SOURCE_DIR}/squishy
-		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	)
 
 	ADD_CUSTOM_COMMAND(
-		OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/src/bcc.o
-		COMMAND ${LUAJIT} -bg src/bcc.lua src/bcc.o
-		DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/bcc.lua
-		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		OUTPUT bcc.o
+		COMMAND ${LUAJIT} -bg bcc.lua bcc.o
+		DEPENDS bcc.lua
 	)
 
 	include_directories(${LUAJIT_INCLUDE_DIR})
-	add_executable(bcc-lua src/main.c src/bcc.o)
+	add_executable(bcc-lua src/main.c bcc.o)
 	target_link_libraries(bcc-lua ${LUAJIT_LIBRARIES})
 
 	install(TARGETS bcc-lua RUNTIME DESTINATION bin)

--- a/src/lua/squishy
+++ b/src/lua/squishy
@@ -14,4 +14,4 @@ Module "bcc.table" "bcc/table.lua"
 Module "bcc.ld" "bcc/ld.lua"
 
 Main "bcc/run.lua"
-Output "src/bcc.lua"
+Output "bcc.lua"


### PR DESCRIPTION
The squishing/luajiting process during the build of bcc-lua writes a couple of files (`bcc.lua` and `bcc.o`) into the source tree. This change moves these files into the build tree so the source tree is untouched, consistent with the rest of the BCC build.

I'm not sure if this is the right way to do things (I've never touched cmake) as it looks like the rest of the build artifacts are written into `src/lua/CMakeFiles/bcc-lua.dir/src`:

    mark@ubuntu:~/bcc/build$ find src/lua/ \( -name bcc.lua -o -name '*.o' \)
    src/lua/CMakeFiles/bcc-lua.dir/src/main.c.o
    src/lua/bcc.lua
    src/lua/bcc.o

It's not immediately obvious how (or if I should) write these files into `src/lua/CMakeFiles/bcc-lua.dir`. Suggestions welcome if this isn't right (cc @vmg).