### PR TITLE
Don't require "OS ABI" specification in libraries

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -429,7 +429,7 @@ class BPF(object):
             "ia64-64": "libc6,IA-64",
         }
         abi_type = mach_map.get(machine, "libc6")
-        expr = r"\s+lib%s\.[^\s]+\s+\(%s, [^)]+[^/]+([^\s]+)" % (name, abi_type)
+        expr = r"\s+lib%s\.[^\s]+\s+\(%s[^)]*[^/]+([^\s]+)" % (name, abi_type)
         with os.popen("/sbin/ldconfig -p 2>/dev/null") as f:
             data = f.read()
         res = re.search(expr, data)


### PR DESCRIPTION
The most important system libraries are listed like this by `ldconfig`:

```
libc.so.6 (libc6,x86-64, OS ABI: Linux 3.0.0) => /lib64/libc.so.6
```

But most user-level libraries don't have the "OS ABI" and will not be
found by the regular expression.

```
libz.so (libc6,x86-64) => /usr/lib64/libz.so
```

This makes the regular expression more permissive, so that it finds
those libraries as well.

I hope this doesn't cause any regressions.