### PR TITLE
lua: Properly support high-range 64 addresses

### DIFF
--- a/examples/lua/memleak.lua
+++ b/examples/lua/memleak.lua
@@ -148,7 +148,7 @@ return function(BPF, utils)
     if args.pid == nil then
       sym = sym .. " [kernel]"
     end
-    return string.format("%s (%x)", sym, addr)
+    return string.format("%s (%p)", sym, addr)
   end
 
   local function print_outstanding()
@@ -174,7 +174,7 @@ return function(BPF, utils)
         end
 
         if args.show_allocs then
-          print("\taddr = %x size = %s" % {tonumber(address), tonumber(info.size)})
+          print("\taddr = %p size = %s" % {address, tonumber(info.size)})
         end
       end
     end

--- a/examples/lua/offcputime.lua
+++ b/examples/lua/offcputime.lua
@@ -107,7 +107,7 @@ return function(BPF, utils)
 
   for k, v in counts:items() do
     for addr in stack_traces:walk(tonumber(k.stack_id)) do
-      print("    %-16x %s" % {addr, ksym:lookup(addr)})
+      print("    %-16p %s" % {addr, ksym:lookup(addr)})
     end
     print("    %-16s %s" % {"-", ffi.string(k.name)})
     print("        %d\n" % tonumber(v))

--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -188,8 +188,8 @@ function Bpf:attach_uprobe(args)
   local path, addr = LD.check_path_symbol(args.name, args.sym, args.addr)
   local fn = self:load_func(args.fn_name, 'BPF_PROG_TYPE_KPROBE')
   local ptype = args.retprobe and "r" or "p"
-  local ev_name = string.format("%s_%s_0x%x", ptype, path:gsub("[^%a%d]", "_"), addr)
-  local desc = string.format("%s:uprobes/%s %s:0x%x", ptype, ev_name, path, addr)
+  local ev_name = string.format("%s_%s_0x%p", ptype, path:gsub("[^%a%d]", "_"), addr)
+  local desc = string.format("%s:uprobes/%s %s:0x%p", ptype, ev_name, path, addr)
 
   log.info(desc)
 

--- a/src/lua/bcc/ld.lua
+++ b/src/lua/bcc/ld.lua
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ]]
 local ffi = require("ffi")
+local posix = require("bcc.vendor.posix")
 
 local _find_library_cache = {}
 local function _find_library(name)
@@ -60,7 +61,7 @@ local function _find_load_address(path)
     path)
 
   if addr then
-    addr = tonumber(addr, 16)
+    addr = posix.tonumber64(addr, 16)
     _find_load_address_cache[path] = addr
   end
 
@@ -85,7 +86,7 @@ local function _find_symbol(path, sym)
     path, sym)
 
   if addr then
-    addr = tonumber(addr, 16)
+    addr = posix.tonumber64(addr, 16)
     symbols[sym] = addr
   end
 

--- a/src/lua/bcc/table.lua
+++ b/src/lua/bcc/table.lua
@@ -286,7 +286,7 @@ function StackTrace:walk(id)
       return nil
     end
 
-    local addr = tonumber(pstack[0].ip[i])
+    local addr = pstack[0].ip[i]
     if addr == 0 then
       return nil
     end

--- a/src/lua/bcc/vendor/posix.lua
+++ b/src/lua/bcc/vendor/posix.lua
@@ -29,6 +29,8 @@ int clock_nanosleep(clockid_t clock_id, int flags,
   const struct timespec *request, struct timespec *remain);
 
 int get_nprocs(void);
+
+uint64_t strtoull(const char *nptr, char **endptr, int base);
 ]]
 
 local CLOCK = {
@@ -62,9 +64,15 @@ local function cpu_count()
   return tonumber(ffi.C.get_nprocs())
 end
 
+local function tonumber64(n, base)
+  assert(type(n) == "string")
+  return ffi.C.strtoull(n, nil, base or 10)
+end
+
 return {
   time_ns=time_ns,
   sleep=sleep,
   CLOCK=CLOCK,
   cpu_count=cpu_count,
+  tonumber64=tonumber64,
 }


### PR DESCRIPTION
Lua's native Number type is a 64-bit double with 52-bit precision, which
was causing rounding errors when storing and working with high-range
memory addresses (namely, addresses from the kernel, which are all in
the `0xffffffff........` range).

To work around this, we've made sure to never call `tonumber` on any
variables that represent memory addresses, and instead continue
operating on them with their native types: LuaJIT can work with the
underlying `uint64_t` type for these values and transparently perform
all kinds of numeric operations.

The only limitation of working with native 64-bit types in LuaJIT is
that they cannot be printed with the language's default `string.format`
API. To give better UX to probe writers, these APIs have been
monkeypatched so the `%p` format specifier will now properly handle
64-bit addresses and print them in an appropriate format.

Fixes https://github.com/iovisor/bcc/issues/488