### PR TITLE
Let bcc debian build depend on 3.7|3.8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Brenden Blanco <bblanco@plumgrid.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.5
-Build-Depends: debhelper (>= 9), cmake, libllvm3.7, llvm-3.7-dev, libclang-3.7-dev
+Build-Depends: debhelper (>= 9), cmake, libllvm3.7 | libllvm3.8, llvm-3.7-dev | llvm-3.8-dev, libclang-3.7-dev | libclang-3.8-dev
 Homepage: https://github.com/iovisor/bcc
 
 Package: libbcc
@@ -20,7 +20,7 @@ Description: Shared Library for BPF Compiler Collection (BCC)
 
 Package: python-bcc
 Architecture: all
-Depends: libbcc, python
+Depends: libbcc, python, binutils
 Description: Python wrappers for BPF Compiler Collection (BCC)
 
 Package: bcc-tools


### PR DESCRIPTION
In Xenial, llvm 3.8 will be available upstream without manual apt steps.
Add those packages as a possible dependency in our build.