### PR TITLE
Add libelf-dev to Ubuntu build deps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -150,7 +150,7 @@ sudo apt-get update
 
 # All versions
 sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
-  libllvm3.7 llvm-3.7-dev libclang-3.7-dev python zlib1g-dev
+  libllvm3.7 llvm-3.7-dev libclang-3.7-dev python zlib1g-dev libelf-dev
 ```
 
 ### Install and compile BCC


### PR DESCRIPTION
This was required on a Debian system, but in lieu of instructions for that distribution, and as Debian users will follow Ubuntu, would you consider verifying it on Ubuntu and accepting this PR?

The Ubuntu package is detailed here http://packages.ubuntu.com/precise/libelf-dev and the Debian (testing/stretch) package here https://packages.debian.org/stretch/libelf-dev