### PR TITLE
Explicitly list the libelf runtime dependency

### DIFF
--- a/SPECS/bcc+clang.spec
+++ b/SPECS/bcc+clang.spec
@@ -57,6 +57,7 @@ make install/strip DESTDIR=%{buildroot}
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)
+Requires: elfutils-libelf
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 

--- a/SPECS/bcc.spec
+++ b/SPECS/bcc.spec
@@ -48,6 +48,7 @@ make install/strip DESTDIR=%{buildroot}
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)
+Requires: elfutils-libelf
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/iovisor/bcc
 
 Package: libbcc
 Architecture: amd64
-Depends: libc6, libstdc++6
+Depends: libc6, libstdc++6, libelf1
 Description: Shared Library for BPF Compiler Collection (BCC)
  Shared Library for BPF Compiler Collection to control BPF programs
  from userspace.

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(LuaJIT)
+find_program(LUAJIT luajit)
 
-if (LUAJIT_LIBRARIES)
-	find_program(LUAJIT luajit)
+if (LUAJIT_LIBRARIES AND LUAJIT)
 	FILE(GLOB_RECURSE SRC_LUA ${CMAKE_CURRENT_SOURCE_DIR}/bcc/*/*.lua)
 
 	ADD_CUSTOM_COMMAND(


### PR DESCRIPTION
The shared `libbcc.so` depends on `libelf.so`. So list this package dependency explicitly for Ubuntu and Fedora.

cc @4ast @drzaeus77 