### PR TITLE
bpf: Wrap `bcc_procutils_which_so` as `BPF.find_library`

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -432,6 +432,10 @@ class BPF(object):
             raise Exception("could not determine address of symbol %s" % symname)
         return sym.module, sym.offset
 
+    @staticmethod
+    def find_library(libname):
+        return lib.bcc_procutils_which_so(libname)
+
     def attach_uprobe(self, name="", sym="", addr=None,
             fn_name="", pid=-1, cpu=0, group_fd=-1):
         """attach_uprobe(name="", sym="", addr=None, fn_name=""

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -111,6 +111,9 @@ class bcc_symbol(ct.Structure):
             ('offset', ct.c_ulonglong),
         ]
 
+lib.bcc_procutils_which_so.restype = ct.c_char_p
+lib.bcc_procutils_which_so.argtypes = [ct.c_char_p]
+
 lib.bcc_resolve_symname.restype = ct.c_int
 lib.bcc_resolve_symname.argtypes = [
     ct.c_char_p, ct.c_char_p, ct.c_ulonglong, ct.POINTER(bcc_symbol)]


### PR DESCRIPTION
This class method was being used outside of the BPF class in the `tracer` and `usdt` tools.

Fixes #509

cc @brendangregg 