### PR TITLE
Lua tooling improvements

### DIFF
--- a/examples/lua/bashreadline.lua
+++ b/examples/lua/bashreadline.lua
@@ -1,3 +1,4 @@
+#!/usr/bin/env bcc-lua
 --[[
 Copyright 2016 GitHub, Inc
 

--- a/examples/lua/memleak.lua
+++ b/examples/lua/memleak.lua
@@ -1,3 +1,4 @@
+#!/usr/bin/env bcc-lua
 --[[
 Copyright 2016 GitHub, Inc
 

--- a/examples/lua/offcputime.lua
+++ b/examples/lua/offcputime.lua
@@ -1,3 +1,4 @@
+#!/usr/bin/env bcc-lua
 --[[
 Copyright 2016 GitHub, Inc
 

--- a/examples/lua/strlen_count.lua
+++ b/examples/lua/strlen_count.lua
@@ -1,3 +1,4 @@
+#!/usr/bin/env bcc-lua
 --[[
 Copyright 2016 GitHub, Inc
 

--- a/examples/lua/task_switch.lua
+++ b/examples/lua/task_switch.lua
@@ -1,3 +1,4 @@
+#!/usr/bin/env bcc-lua
 --[[
 Copyright 2016 GitHub, Inc
 

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -19,6 +19,7 @@ if (LUAJIT_LIBRARIES AND LUAJIT)
 	include_directories(${LUAJIT_INCLUDE_DIR})
 	add_executable(bcc-lua src/main.c bcc.o)
 	target_link_libraries(bcc-lua ${LUAJIT_LIBRARIES})
+	target_link_libraries(bcc-lua -Wl,--whole-archive bcc-static -Wl,--no-whole-archive)
 
 	install(TARGETS bcc-lua RUNTIME DESTINATION bin)
 endif()

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -2,7 +2,9 @@ find_package(LuaJIT)
 find_program(LUAJIT luajit)
 
 if (LUAJIT_LIBRARIES AND LUAJIT)
-	FILE(GLOB_RECURSE SRC_LUA ${CMAKE_CURRENT_SOURCE_DIR}/bcc/*/*.lua)
+	FILE(GLOB_RECURSE SRC_LUA
+		${CMAKE_CURRENT_SOURCE_DIR}/bcc/*.lua
+		${CMAKE_CURRENT_SOURCE_DIR}/bcc/vendor/*.lua)
 
 	ADD_CUSTOM_COMMAND(
 		OUTPUT bcc.lua

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -18,6 +18,7 @@ if (LUAJIT_LIBRARIES AND LUAJIT)
 
 	include_directories(${LUAJIT_INCLUDE_DIR})
 	add_executable(bcc-lua src/main.c bcc.o)
+	set_target_properties(bcc-lua PROPERTIES LINKER_LANGUAGE C)
 	target_link_libraries(bcc-lua ${LUAJIT_LIBRARIES})
 	target_link_libraries(bcc-lua -Wl,--whole-archive bcc-static -Wl,--no-whole-archive)
 

--- a/src/lua/bcc-probe
+++ b/src/lua/bcc-probe
@@ -17,5 +17,4 @@ limitations under the License.
 local str = require("debug").getinfo(1, "S").source:sub(2)
 local script_path = str:match("(.*/)").."/?.lua;"
 package.path = script_path..package.path
-rawset(_G, "BCC_STANDALONE_NAME", "bcc-probe")
 require("bcc.run")()

--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -41,7 +41,8 @@ function Bpf.static.cleanup_probes()
   local function detach_all(probe_type, all_probes)
     for key, probe in pairs(all_probes) do
       libbcc.perf_reader_free(probe)
-      if type(key) == "string" then
+      -- skip bcc-specific kprobes
+      if not key:starts("bcc:") then
         local desc = string.format("-:%s/%s", probe_type, key)
         log.info("detaching %s", desc)
 

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -112,4 +112,11 @@ int bcc_symcache_resolve(void *symcache, uint64_t addr, struct bcc_symbol *sym);
 void bcc_symcache_refresh(void *resolver);
 ]]
 
-return ffi.load(os.getenv("LIBBCC_SO_PATH") or rawget(_G, "LIBBCC_SO_PATH") or "bcc")
+if rawget(_G, "BCC_STANDALONE") then
+  return ffi.C
+else
+  return ffi.load(
+    os.getenv("LIBBCC_SO_PATH") or
+    rawget(_G, "LIBBCC_SO_PATH") or
+    "bcc")
+end

--- a/src/lua/bcc/run.lua
+++ b/src/lua/bcc/run.lua
@@ -16,11 +16,12 @@ limitations under the License.
 
 return function()
   require("bcc.vendor.helpers")
-  local progname = rawget(_G, "BCC_STANDALONE_NAME") or "bcc-lua"
+  local standalone = rawget(_G, "BCC_STANDALONE")
+  local progname = standalone or "bcc-probe"
 
   local function print_usage()
     io.stderr:write(string.format(
-      "usage: %s [[--so-path=PATH|--version|--verbose] --] path_to_script.lua [...]\n",
+      "usage: %s [[--version|--verbose] --] path_to_script.lua [...]\n",
       progname))
     os.exit(1)
   end
@@ -37,7 +38,7 @@ return function()
     local k = table.remove(arg, 1)
     if k == "--" then
       break
-    elseif string.starts(k, "--so-path=") then
+    elseif standalone == nil and string.starts(k, "--so-path=") then
       rawset(_G, "LIBBCC_SO_PATH", string.lstrip(k, "--so-path="))
     elseif k == "--llvm-debug" then
       rawset(_G, "LIBBCC_LLVM_DEBUG", 1)

--- a/src/lua/bcc/table.lua
+++ b/src/lua/bcc/table.lua
@@ -236,7 +236,7 @@ function PerfEventArray:initialize(bpf, map_id, map_fd, key_type, leaf_type)
 end
 
 local function _perf_id(id, cpu)
-  return string.format("perf_event_array:%d:%d", tonumber(id), cpu or 0)
+  return string.format("bcc:perf_event_array:%d:%d", tonumber(id), cpu or 0)
 end
 
 function PerfEventArray:_open_perf_buffer(cpu, callback, ctype)

--- a/src/lua/src/main.c
+++ b/src/lua/src/main.c
@@ -29,149 +29,142 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "lua.h"
 #include "lauxlib.h"
+#include "lua.h"
 #include "lualib.h"
 
 static lua_State *globalL = NULL;
 static const char *progname = NULL;
 
-static void lstop(lua_State *L, lua_Debug *ar)
-{
-	(void)ar;  /* unused arg. */
-	lua_sethook(L, NULL, 0, 0);
-	luaL_error(L, "interrupted!");
+static void lstop(lua_State *L, lua_Debug *ar) {
+  (void)ar; /* unused arg. */
+  lua_sethook(L, NULL, 0, 0);
+  luaL_error(L, "interrupted!");
 }
 
-static void laction(int i)
-{
-	signal(i, SIG_DFL);
-	lua_sethook(globalL, lstop, LUA_MASKCALL | LUA_MASKRET | LUA_MASKCOUNT, 1);
+static void laction(int i) {
+  signal(i, SIG_DFL);
+  lua_sethook(globalL, lstop, LUA_MASKCALL | LUA_MASKRET | LUA_MASKCOUNT, 1);
 }
 
-static void l_message(const char *pname, const char *msg)
-{
-	if (pname) fprintf(stderr, "%s: ", pname);
-	fprintf(stderr, "%s\n", msg);
-	fflush(stderr);
+static void l_message(const char *pname, const char *msg) {
+  if (pname)
+    fprintf(stderr, "%s: ", pname);
+  fprintf(stderr, "%s\n", msg);
+  fflush(stderr);
 }
 
-static int report(lua_State *L, int status)
-{
-	if (status && !lua_isnil(L, -1)) {
-		const char *msg = lua_tostring(L, -1);
-		if (msg == NULL) msg = "(error object is not a string)";
-		l_message(progname, msg);
-		lua_pop(L, 1);
-	}
-	return status;
+static int report(lua_State *L, int status) {
+  if (status && !lua_isnil(L, -1)) {
+    const char *msg = lua_tostring(L, -1);
+    if (msg == NULL)
+      msg = "(error object is not a string)";
+    l_message(progname, msg);
+    lua_pop(L, 1);
+  }
+  return status;
 }
 
-static int traceback(lua_State *L)
-{
-	if (!lua_isstring(L, 1))  /* 'message' not a string? */
-		return 1;  /* keep it intact */
-	lua_getfield(L, LUA_GLOBALSINDEX, "debug");
-	if (!lua_istable(L, -1)) {
-		lua_pop(L, 1);
-		return 1;
-	}
-	lua_getfield(L, -1, "traceback");
-	if (!lua_isfunction(L, -1)) {
-		lua_pop(L, 2);
-		return 1;
-	}
-	lua_pushvalue(L, 1);  /* pass error message */
-	lua_pushinteger(L, 2);  /* skip this function and traceback */
-	lua_call(L, 2, 1);  /* call debug.traceback */
-	return 1;
+static int traceback(lua_State *L) {
+  if (!lua_isstring(L, 1)) /* 'message' not a string? */
+    return 1;              /* keep it intact */
+  lua_getfield(L, LUA_GLOBALSINDEX, "debug");
+  if (!lua_istable(L, -1)) {
+    lua_pop(L, 1);
+    return 1;
+  }
+  lua_getfield(L, -1, "traceback");
+  if (!lua_isfunction(L, -1)) {
+    lua_pop(L, 2);
+    return 1;
+  }
+  lua_pushvalue(L, 1);   /* pass error message */
+  lua_pushinteger(L, 2); /* skip this function and traceback */
+  lua_call(L, 2, 1);     /* call debug.traceback */
+  return 1;
 }
 
-static int docall(lua_State *L, int narg, int clear)
-{
-	int status;
-	int base = lua_gettop(L) - narg;  /* function index */
-	lua_pushcfunction(L, traceback);  /* push traceback function */
-	lua_insert(L, base);  /* put it under chunk and args */
-	signal(SIGINT, laction);
-	status = lua_pcall(L, narg, (clear ? 0 : LUA_MULTRET), base);
-	signal(SIGINT, SIG_DFL);
-	lua_remove(L, base);  /* remove traceback function */
-	/* force a complete garbage collection in case of errors */
-	if (status != 0) lua_gc(L, LUA_GCCOLLECT, 0);
-	return status;
+static int docall(lua_State *L, int narg, int clear) {
+  int status;
+  int base = lua_gettop(L) - narg; /* function index */
+  lua_pushcfunction(L, traceback); /* push traceback function */
+  lua_insert(L, base);             /* put it under chunk and args */
+  signal(SIGINT, laction);
+  status = lua_pcall(L, narg, (clear ? 0 : LUA_MULTRET), base);
+  signal(SIGINT, SIG_DFL);
+  lua_remove(L, base); /* remove traceback function */
+  /* force a complete garbage collection in case of errors */
+  if (status != 0)
+    lua_gc(L, LUA_GCCOLLECT, 0);
+  return status;
 }
 
-static int dolibrary(lua_State *L, const char *name, int clear)
-{
-	lua_getglobal(L, "require");
-	lua_pushstring(L, name);
-	return report(L, docall(L, 1, clear));
+static int dolibrary(lua_State *L, const char *name, int clear) {
+  lua_getglobal(L, "require");
+  lua_pushstring(L, name);
+  return report(L, docall(L, 1, clear));
 }
 
 struct Smain {
-	int argc;
-	char **argv;
-	int status;
+  int argc;
+  char **argv;
+  int status;
 };
 
-static void pushargv(lua_State *L, char **argv, int argc, int offset)
-{
-	int i, j;
-	lua_createtable(L, argc, 0);
-	for (i = offset, j = 1; i < argc; i++, j++) {
-		lua_pushstring(L, argv[i]);
-		lua_rawseti(L, -2, j);
-	}
+static void pushargv(lua_State *L, char **argv, int argc, int offset) {
+  int i, j;
+  lua_createtable(L, argc, 0);
+  for (i = offset, j = 1; i < argc; i++, j++) {
+    lua_pushstring(L, argv[i]);
+    lua_rawseti(L, -2, j);
+  }
 }
 
-static int pmain(lua_State *L)
-{
-	struct Smain *s = (struct Smain *)lua_touserdata(L, 1);
-	globalL = L;
+static int pmain(lua_State *L) {
+  struct Smain *s = (struct Smain *)lua_touserdata(L, 1);
+  globalL = L;
 
-	lua_gc(L, LUA_GCSTOP, 0);
-	luaL_openlibs(L);
-	lua_gc(L, LUA_GCRESTART, 0);
+  lua_gc(L, LUA_GCSTOP, 0);
+  luaL_openlibs(L);
+  lua_gc(L, LUA_GCRESTART, 0);
 
-	s->status = dolibrary(L, "bcc", 0);
-	if (s->status)
-		return 0;
+  s->status = dolibrary(L, "bcc", 0);
+  if (s->status)
+    return 0;
 
-	lua_pushstring(L, progname);
-	lua_setglobal(L, "BCC_STANDALONE");
+  lua_pushstring(L, progname);
+  lua_setglobal(L, "BCC_STANDALONE");
 
-	pushargv(L, s->argv, s->argc, 1);
-	lua_setglobal(L, "arg");
+  pushargv(L, s->argv, s->argc, 1);
+  lua_setglobal(L, "arg");
 
-	s->status = report(L, docall(L, 0, 1));
-	return 0;
+  s->status = report(L, docall(L, 0, 1));
+  return 0;
 }
 
-int main(int argc, char **argv)
-{
-	int status;
-	struct Smain s;
-	lua_State *L = lua_open();  /* create state */
+int main(int argc, char **argv) {
+  int status;
+  struct Smain s;
+  lua_State *L = lua_open(); /* create state */
 
-	if (L == NULL) {
-		l_message(argv[0], "cannot create state: not enough memory");
-		return EXIT_FAILURE;
-	}
+  if (L == NULL) {
+    l_message(argv[0], "cannot create state: not enough memory");
+    return EXIT_FAILURE;
+  }
 
-	if (geteuid() != 0) {
-		l_message(argv[0], "bcc-lua must be ran as root");
-		return EXIT_FAILURE;
-	}
+  if (geteuid() != 0) {
+    l_message(argv[0], "bcc-lua must be ran as root");
+    return EXIT_FAILURE;
+  }
 
-	progname = argv[0];
-	s.argc = argc;
-	s.argv = argv;
-	s.status = 0;
+  progname = argv[0];
+  s.argc = argc;
+  s.argv = argv;
+  s.status = 0;
 
-	status = lua_cpcall(L, &pmain, &s);
-	report(L, status);
-	lua_close(L);
+  status = lua_cpcall(L, &pmain, &s);
+  report(L, status);
+  lua_close(L);
 
-	return (status || s.status) ? EXIT_FAILURE : EXIT_SUCCESS;
+  return (status || s.status) ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -372,7 +372,7 @@ class PerfEventArray(ArrayBase):
         super(PerfEventArray, self).__init__(*args, **kwargs)
 
     def __delitem__(self, key):
-        super(PerfEventArray, self).__init__(key)
+        super(PerfEventArray, self).__delitem__(key)
         self.close_perf_buffer(key)
 
     def open_perf_buffer(self, callback):


### PR DESCRIPTION
Some misc fixes which were bothering me:

- `bcc-lua` now links statically against `libbcc.a`. The trick is passing `--whole-archive` to `ld`, so all the symbols get linked in and can be exported. When running `bcc-lua`, the `--so-path` CLI option is disabled, and we no longer try to find the SO anywhere in the system.

- The example `lua` probes are now `+x`, and will try to run themselves through `bcc-lua` if it's in the path. Thanks to @brendangregg for the neat idea.

- `bcc-lua` now rebuilds itself when you modify the Lua sources! Finally! Turns out we were not globbing for the Lua sources properly.

- (unrelated) there was a bug in `table.py` where you couldn't manually close open perf buffers. It was calling the parent class' `__init__` instead of `__delitem__`. :)

- And last, but not least, fix the shutdown noise that @brendangregg was seeing in in #512. We were trying to "detach" the perf buffers -- perf buffers are listed as kprobes for polling, but they don't need "detaching".