### PR TITLE
[RFC] New USDT API

### DIFF
--- a/examples/lua/usdt_ruby.lua
+++ b/examples/lua/usdt_ruby.lua
@@ -18,10 +18,14 @@ limitations under the License.
 local program = [[
 #include <uapi/linux/ptrace.h>
 int trace_method(struct pt_regs *ctx) {
-    char fn_name[128] = {};
-    bpf_usdt_readarg_p(method__entry_2, ctx, &fn_name, sizeof(fn_name));
-    bpf_trace_printk("%s(...)\n", &fn_name);
-    return 0;
+  uint64_t addr;
+  bpf_usdt_readarg(2, ctx, &addr);
+
+  char fn_name[128] = {};
+  bpf_probe_read(&fn_name, sizeof(fn_name), (void *)addr);
+
+  bpf_trace_printk("%s(...)\n", fn_name);
+  return 0;
 };
 ]]
 

--- a/examples/lua/usdt_ruby.lua
+++ b/examples/lua/usdt_ruby.lua
@@ -1,0 +1,42 @@
+#!/usr/bin/env bcc-lua
+--[[
+Copyright 2016 GitHub, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+]]
+
+local program = [[
+#include <uapi/linux/ptrace.h>
+int trace_method(struct pt_regs *ctx) {
+    char fn_name[128] = {};
+    bpf_usdt_readarg_p(method__entry_2, ctx, &fn_name, sizeof(fn_name));
+    bpf_trace_printk("%s(...)\n", &fn_name);
+    return 0;
+};
+]]
+
+return function(BPF, util)
+  if not arg[1] then
+    print("usage: rubysyms.lua PID")
+    return
+  end
+
+  local u = util.USDT:new{pid=tonumber(arg[1])}
+  u:enable_probe{probe="method__entry", fn_name="trace_method"}
+
+  local b = BPF:new{text=program, usdt=u}
+  local pipe = b:pipe()
+  while true do
+    print(pipe:trace_fields())
+  end
+end

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -31,9 +31,8 @@ ino_t ProcStat::getinode_() {
   return (!stat(procfs_.c_str(), &s)) ? s.st_ino : -1;
 }
 
-ProcStat::ProcStat(int pid) :
-  procfs_(tfm::format("/proc/%d/exe", pid)),
-  inode_(getinode_()) {}
+ProcStat::ProcStat(int pid)
+    : procfs_(tfm::format("/proc/%d/exe", pid)), inode_(getinode_()) {}
 
 void KSyms::_add_symbol(const char *symname, uint64_t addr, void *p) {
   KSyms *ks = static_cast<KSyms *>(p);

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -205,7 +205,7 @@ struct mod_st {
 };
 
 static int _find_module(const char *modname, uint64_t start, uint64_t end,
-    void *p) {
+                        void *p) {
   struct mod_st *mod = (struct mod_st *)p;
   if (!strcmp(modname, mod->name)) {
     mod->start = start;
@@ -215,7 +215,7 @@ static int _find_module(const char *modname, uint64_t start, uint64_t end,
 }
 
 int bcc_resolve_global_addr(int pid, const char *module, const uint64_t address,
-			    uint64_t *global) {
+                            uint64_t *global) {
   struct mod_st mod = {module, 0x0};
   if (bcc_procutils_each_module(pid, _find_module, &mod) < 0 ||
       mod.start == 0x0)

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -34,7 +34,7 @@ int bcc_symcache_resolve_name(void *resolver, const char *name, uint64_t *addr);
 void bcc_symcache_refresh(void *resolver);
 
 int bcc_resolve_global_addr(int pid, const char *module, const uint64_t address,
-			    uint64_t *global);
+                            uint64_t *global);
 int bcc_find_symbol_addr(struct bcc_symbol *sym);
 int bcc_resolve_symname(const char *module, const char *symname,
                         const uint64_t addr, struct bcc_symbol *sym);

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -33,6 +33,8 @@ int bcc_symcache_resolve(void *symcache, uint64_t addr, struct bcc_symbol *sym);
 int bcc_symcache_resolve_name(void *resolver, const char *name, uint64_t *addr);
 void bcc_symcache_refresh(void *resolver);
 
+int bcc_resolve_global_addr(int pid, const char *module, const uint64_t address,
+			    uint64_t *global);
 int bcc_find_symbol_addr(struct bcc_symbol *sym);
 int bcc_resolve_symname(const char *module, const char *symname,
                         const uint64_t addr, struct bcc_symbol *sym);

--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 GitHub, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIBBCC_USDT_H
+#define LIBBCC_USDT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+void *bcc_usdt_new_frompid(int pid);
+void *bcc_usdt_new_frompath(const char *path);
+void bcc_usdt_close(void *usdt);
+
+int bcc_usdt_enable_probe(void *, const char *, const char *);
+char *bcc_usdt_genargs(void *);
+
+typedef void (*bcc_usdt_uprobe_cb)(const char *, const char *, uint64_t, int);
+void bcc_usdt_foreach_uprobe(void *usdt, bcc_usdt_uprobe_cb callback);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -408,7 +408,9 @@ int incr_cksum_l3(void *off, u64 oldval, u64 newval) asm("llvm.bpf.extra");
 int incr_cksum_l4(void *off, u64 oldval, u64 newval, u64 flags) asm("llvm.bpf.extra");
 int bpf_num_cpus() asm("llvm.bpf.extra");
 
-#define lock_xadd(ptr, val) ((void)__sync_fetch_and_add(ptr, val))
+struct pt_regs;
+int bpf_usdt_readarg(int argc, struct pt_regs *ctx, void *arg) asm("llvm.bpf.extra");
+int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("llvm.bpf.extra");
 
 #ifdef __powerpc__
 #define PT_REGS_PARM1(ctx)	((ctx)->gpr[3])
@@ -434,10 +436,7 @@ int bpf_num_cpus() asm("llvm.bpf.extra");
 #error "bcc does not support this platform yet"
 #endif
 
-#define bpf_usdt_readarg(probearg, ctx) _bpf_readarg_##probearg(ctx)
-#define bpf_usdt_readarg_p(probearg, ctx, buf, len) {\
-  u64 __addr = bpf_usdt_readarg(probearg, ctx); \
-  bpf_probe_read(buf, len, (void *)__addr); }
+#define lock_xadd(ptr, val) ((void)__sync_fetch_and_add(ptr, val))
 
 #endif
 )********"

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -434,5 +434,10 @@ int bpf_num_cpus() asm("llvm.bpf.extra");
 #error "bcc does not support this platform yet"
 #endif
 
+#define bpf_usdt_readarg(probearg, ctx) _bpf_readarg_##probearg(ctx)
+#define bpf_usdt_readarg_p(probearg, ctx, buf, len) {\
+  u64 __addr = bpf_usdt_readarg(probearg, ctx); \
+  bpf_probe_read(buf, len, (void *)__addr); }
+
 #endif
 )********"

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -472,20 +472,20 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           text = to_string(numcpu);
           rewriter_.ReplaceText(SourceRange(Call->getLocStart(), Call->getLocEnd()), text);
         } else if (Decl->getName() == "bpf_usdt_readarg_p") {
-	 text = "({ u64 __addr = 0x0; ";
-	 text += "_bpf_readarg_" + current_fn_ + "_" + args[0] + "(" +
-	  args[1] + ", &__addr, sizeof(__addr));";
-	 text += "bpf_probe_read(" + args[2] + ", " + args[3] +
-	  ", (void *)__addr);";
-	 text += "})";
-	 rewriter_.ReplaceText(
-	   SourceRange(Call->getLocStart(), Call->getLocEnd()), text);
+          text = "({ u64 __addr = 0x0; ";
+          text += "_bpf_readarg_" + current_fn_ + "_" + args[0] + "(" +
+                  args[1] + ", &__addr, sizeof(__addr));";
+          text += "bpf_probe_read(" + args[2] + ", " + args[3] +
+                  ", (void *)__addr);";
+          text += "})";
+          rewriter_.ReplaceText(
+              SourceRange(Call->getLocStart(), Call->getLocEnd()), text);
         } else if (Decl->getName() == "bpf_usdt_readarg") {
-	 text = "_bpf_readarg_" + current_fn_ + "_" + args[0] + "(" +
-	  args[1] + ", " + args[2] + ", sizeof(*(" + args[2] + ")))";
-	 rewriter_.ReplaceText(
-	   SourceRange(Call->getLocStart(), Call->getLocEnd()), text);
-	}
+          text = "_bpf_readarg_" + current_fn_ + "_" + args[0] + "(" + args[1] +
+                 ", " + args[2] + ", sizeof(*(" + args[2] + ")))";
+          rewriter_.ReplaceText(
+              SourceRange(Call->getLocStart(), Call->getLocEnd()), text);
+        }
       }
     }
   }

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -254,6 +254,7 @@ bool BTypeVisitor::VisitFunctionDecl(FunctionDecl *D) {
   // put each non-static non-inline function decl in its own section, to be
   // extracted by the MemoryManager
   if (D->isExternallyVisible() && D->hasBody()) {
+    current_fn_ = D->getName();
     string attr = string("__attribute__((section(\"") + BPF_FN_PREFIX + D->getName().str() + "\")))\n";
     rewriter_.InsertText(D->getLocStart(), attr);
     if (D->param_size() > MAX_CALLING_CONV_REGS + 1) {
@@ -470,7 +471,21 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
             numcpu = 1;
           text = to_string(numcpu);
           rewriter_.ReplaceText(SourceRange(Call->getLocStart(), Call->getLocEnd()), text);
-        }
+        } else if (Decl->getName() == "bpf_usdt_readarg_p") {
+	 text = "({ u64 __addr = 0x0; ";
+	 text += "_bpf_readarg_" + current_fn_ + "_" + args[0] + "(" +
+	  args[1] + ", &__addr, sizeof(__addr));";
+	 text += "bpf_probe_read(" + args[2] + ", " + args[3] +
+	  ", (void *)__addr);";
+	 text += "})";
+	 rewriter_.ReplaceText(
+	   SourceRange(Call->getLocStart(), Call->getLocEnd()), text);
+        } else if (Decl->getName() == "bpf_usdt_readarg") {
+	 text = "_bpf_readarg_" + current_fn_ + "_" + args[0] + "(" +
+	  args[1] + ", " + args[2] + ", sizeof(*(" + args[2] + ")))";
+	 rewriter_.ReplaceText(
+	   SourceRange(Call->getLocStart(), Call->getLocEnd()), text);
+	}
       }
     }
   }

--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -83,6 +83,7 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   std::vector<TableDesc> &tables_;  /// store the open FDs
   std::vector<clang::ParmVarDecl *> fn_args_;
   std::set<clang::Expr *> visited_;
+  std::string current_fn_;
 };
 
 // Do a depth-first search to rewrite all pointers that need to be probed

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -93,6 +93,7 @@ class ProcSyms : SymbolCache {
   ProcStat procstat_;
 
   static int _add_module(const char *, uint64_t, uint64_t, void *);
+  bool load_modules();
 
 public:
   ProcSyms(int pid);

--- a/src/cc/usdt.cc
+++ b/src/cc/usdt.cc
@@ -229,10 +229,10 @@ std::string Context::resolve_bin_path(const std::string &bin_path) {
   return result;
 }
 
-std::shared_ptr<Probe> Context::get(const std::string &probe_name) {
+Probe *Context::get(const std::string &probe_name) {
   for (auto &p : probes_) {
     if (p->name_ == probe_name)
-      return p;
+      return p.get();
   }
   return nullptr;
 }

--- a/src/cc/usdt.cc
+++ b/src/cc/usdt.cc
@@ -53,8 +53,8 @@ bool Probe::in_shared_object() {
 
 bool Probe::resolve_global_address(uint64_t *global, const uint64_t addr) {
   if (in_shared_object()) {
-    return (pid_ && !bcc_resolve_global_addr(
-          *pid_, bin_path_.c_str(), addr, global));
+    return (pid_ &&
+            !bcc_resolve_global_addr(*pid_, bin_path_.c_str(), addr, global));
   }
 
   *global = addr;
@@ -154,16 +154,16 @@ bool Probe::usdt_getarg(std::ostream &stream) {
     std::string cptr = tfm::format("*((%s *)dest)", ctype);
 
     tfm::format(stream,
-        "static inline int _bpf_readarg_%s_%d("
-        "struct pt_regs *ctx, void *dest, size_t len) {\n"
-        "  if (len != sizeof(%s)) return -1;\n",
-        attached_to_.value(), arg_n + 1, ctype);
+                "static inline int _bpf_readarg_%s_%d("
+                "struct pt_regs *ctx, void *dest, size_t len) {\n"
+                "  if (len != sizeof(%s)) return -1;\n",
+                attached_to_.value(), arg_n + 1, ctype);
 
     if (locations_.size() == 1) {
       Location &location = locations_.front();
       stream << "  ";
-      if (!location.arguments_[arg_n].assign_to_local(stream, cptr,
-                                                      bin_path_, pid_))
+      if (!location.arguments_[arg_n].assign_to_local(stream, cptr, bin_path_,
+                                                      pid_))
         return false;
       stream << "\n  return 0;\n}\n";
     } else {
@@ -175,8 +175,8 @@ bool Probe::usdt_getarg(std::ostream &stream) {
           return false;
 
         tfm::format(stream, "  case 0x%xULL: ", global_address);
-        if (!location.arguments_[arg_n].assign_to_local(stream, cptr,
-                                                        bin_path_, pid_))
+        if (!location.arguments_[arg_n].assign_to_local(stream, cptr, bin_path_,
+                                                        pid_))
           return false;
 
         stream << " return 0;\n";
@@ -211,8 +211,8 @@ void Context::add_probe(const char *binpath, const struct bcc_elf_usdt *probe) {
     }
   }
 
-  probes_.emplace_back(new Probe(binpath, probe->provider,
-        probe->name, probe->semaphore, pid_));
+  probes_.emplace_back(
+      new Probe(binpath, probe->provider, probe->name, probe->semaphore, pid_));
   probes_.back()->add_location(probe->pc, probe->arg_fmt);
 }
 
@@ -282,8 +282,7 @@ Context::Context(int pid) : pid_(pid), pid_stat_(pid), loaded_(false) {
 
 Context::~Context() {
   if (pid_stat_ && !pid_stat_->is_stale()) {
-    for (auto &p : probes_)
-      p->disable();
+    for (auto &p : probes_) p->disable();
   }
 }
 }

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -166,7 +166,7 @@ public:
 };
 
 class Context {
-  std::vector<std::shared_ptr<Probe>> probes_;
+  std::vector<std::unique_ptr<Probe>> probes_;
 
   optional<int> pid_;
   optional<ProcStat> pid_stat_;
@@ -188,8 +188,8 @@ public:
   bool loaded() const { return loaded_; }
   size_t num_probes() const { return probes_.size(); }
 
-  std::shared_ptr<Probe> get(const std::string &probe_name);
-  std::shared_ptr<Probe> get(int pos) { return probes_[pos]; }
+  Probe *get(const std::string &probe_name);
+  Probe *get(int pos) { return probes_[pos].get(); }
 
   bool enable_probe(const std::string &probe_name, const std::string &fn_name);
   bool generate_usdt_args(std::ostream &stream);

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -147,10 +147,7 @@ public:
   size_t num_arguments() const { return locations_.front().arguments_.size(); }
 
   uint64_t address(size_t n = 0) const { return locations_[n].address_; }
-
-  bool usdt_thunks(std::ostream &stream, const std::string &prefix);
-  bool usdt_cases(std::ostream &stream, const optional<int> &pid = nullopt);
-  bool usdt_getarg(std::ostream &stream, const optional<int> &pid = nullopt);
+  bool usdt_getarg(std::ostream &stream, const std::string &fn_name, const optional<int> &pid = nullopt);
 
   bool need_enable() const { return semaphore_ != 0x0; }
   bool enable(int pid);

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -127,32 +128,34 @@ class Probe {
   };
 
   std::vector<Location> locations_;
-  std::unordered_map<int, uint64_t> semaphores_;
-  std::unordered_map<int, ProcStat> enabled_semaphores_;
+
+  optional<int> pid_;
   optional<bool> in_shared_object_;
+
+  optional<std::string> attached_to_;
+  optional<uint64_t> attached_semaphore_;
 
   std::string largest_arg_type(size_t arg_n);
 
-  bool add_to_semaphore(int pid, int16_t val);
-  bool resolve_global_address(uint64_t *global, const uint64_t addr,
-                              optional<int> pid);
-  bool lookup_semaphore_addr(uint64_t *address, int pid);
+  bool add_to_semaphore(int16_t val);
+  bool resolve_global_address(uint64_t *global, const uint64_t addr);
+  bool lookup_semaphore_addr(uint64_t *address);
   void add_location(uint64_t addr, const char *fmt);
 
 public:
   Probe(const char *bin_path, const char *provider, const char *name,
-        uint64_t semaphore);
+        uint64_t semaphore, const optional<int> &pid);
 
   size_t num_locations() const { return locations_.size(); }
   size_t num_arguments() const { return locations_.front().arguments_.size(); }
 
   uint64_t address(size_t n = 0) const { return locations_[n].address_; }
-  bool usdt_getarg(std::ostream &stream, const std::string &fn_name, const optional<int> &pid = nullopt);
+  bool usdt_getarg(std::ostream &stream);
 
   bool need_enable() const { return semaphore_ != 0x0; }
-  bool enable(int pid);
-  bool disable(int pid);
-  bool enabled() const { return !enabled_semaphores_.empty(); }
+  bool enable(const std::string &fn_name);
+  bool disable();
+  bool enabled() const { return !!attached_to_; }
 
   bool in_shared_object();
   const std::string &name() { return name_; }
@@ -163,9 +166,10 @@ public:
 };
 
 class Context {
-  std::vector<Probe *> probes_;
-  std::vector<std::pair<Probe *, std::string>> uprobes_;
+  std::vector<std::shared_ptr<Probe>> probes_;
+
   optional<int> pid_;
+  optional<ProcStat> pid_stat_;
   bool loaded_;
 
   static void _each_probe(const char *binpath, const struct bcc_elf_usdt *probe,
@@ -184,8 +188,8 @@ public:
   bool loaded() const { return loaded_; }
   size_t num_probes() const { return probes_.size(); }
 
-  Probe *get(const std::string &probe_name) const;
-  Probe *get(int pos) const { return probes_[pos]; }
+  std::shared_ptr<Probe> get(const std::string &probe_name);
+  std::shared_ptr<Probe> get(int pos) { return probes_[pos]; }
 
   bool enable_probe(const std::string &probe_name, const std::string &fn_name);
   bool generate_usdt_args(std::ostream &stream);

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -134,7 +134,8 @@ class Probe {
   std::string largest_arg_type(size_t arg_n);
 
   bool add_to_semaphore(int pid, int16_t val);
-  bool resolve_global_address(uint64_t *global, const uint64_t addr, optional<int> pid);
+  bool resolve_global_address(uint64_t *global, const uint64_t addr,
+                              optional<int> pid);
   bool lookup_semaphore_addr(uint64_t *address, int pid);
   void add_location(uint64_t addr, const char *fmt);
 
@@ -155,7 +156,6 @@ public:
   bool enable(int pid);
   bool disable(int pid);
   bool enabled() const { return !enabled_semaphores_.empty(); }
-
 
   bool in_shared_object();
   const std::string &name() { return name_; }

--- a/src/cc/usdt_args.cc
+++ b/src/cc/usdt_args.cc
@@ -69,7 +69,7 @@ bool Argument::assign_to_local(std::ostream &stream,
     tfm::format(stream,
                 "{ u64 __addr = ctx->%s + (%d); %s __res = 0x0; "
                 "bpf_probe_read(&__res, sizeof(__res), (void *)__addr); "
-				"%s = __res; }",
+                "%s = __res; }",
                 *register_name_, *deref_offset_, ctype(), local_name);
     return true;
   }
@@ -82,7 +82,7 @@ bool Argument::assign_to_local(std::ostream &stream,
     tfm::format(stream,
                 "{ u64 __addr = 0x%xull + %d; %s __res = 0x0; "
                 "bpf_probe_read(&__res, sizeof(__res), (void *)__addr); "
-				"%s = __res; }",
+                "%s = __res; }",
                 global_address, *deref_offset_, ctype(), local_name);
     return true;
   }

--- a/src/cc/usdt_args.cc
+++ b/src/cc/usdt_args.cc
@@ -55,37 +55,35 @@ bool Argument::assign_to_local(std::ostream &stream,
                                const std::string &binpath,
                                const optional<int> &pid) const {
   if (constant_) {
-    tfm::format(stream, "%s = %d;\n", local_name, *constant_);
+    tfm::format(stream, "%s = %d;", local_name, *constant_);
     return true;
   }
 
   if (!deref_offset_) {
-    tfm::format(stream, "%s = (%s)ctx->%s;\n", local_name, ctype(),
+    tfm::format(stream, "%s = (%s)ctx->%s;", local_name, ctype(),
                 *register_name_);
     return true;
   }
 
   if (deref_offset_ && !deref_ident_) {
     tfm::format(stream,
-                "{\n"
-                "    u64 __temp = ctx->%s + (%d);\n"
-                "    bpf_probe_read(&%s, sizeof(%s), (void *)__temp);\n"
-                "}\n",
-                *register_name_, *deref_offset_, local_name, local_name);
+                "{ u64 __addr = ctx->%s + (%d); %s __res = 0x0; "
+                "bpf_probe_read(&__res, sizeof(__res), (void *)__addr); "
+				"%s = __res; }",
+                *register_name_, *deref_offset_, ctype(), local_name);
     return true;
   }
 
-  if (deref_offset_ && deref_ident_) {
+  if (deref_offset_ && deref_ident_ && *register_name_ == "ip") {
     uint64_t global_address;
     if (!get_global_address(&global_address, binpath, pid))
       return false;
 
     tfm::format(stream,
-                "{\n"
-                "    u64 __temp = 0x%xull + %d;\n"
-                "    bpf_probe_read(&%s, sizeof(%s), (void *)__temp);\n"
-                "}\n",
-                global_address, *deref_offset_, local_name, local_name);
+                "{ u64 __addr = 0x%xull + %d; %s __res = 0x0; "
+                "bpf_probe_read(&__res, sizeof(__res), (void *)__addr); "
+				"%s = __res; }",
+                global_address, *deref_offset_, ctype(), local_name);
     return true;
   }
 

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -112,6 +112,18 @@ int bcc_symcache_resolve(void *symcache, uint64_t addr, struct bcc_symbol *sym);
 void bcc_symcache_refresh(void *resolver);
 ]]
 
+ffi.cdef[[
+void *bcc_usdt_new_frompid(int pid);
+void *bcc_usdt_new_frompath(const char *path);
+void bcc_usdt_close(void *usdt);
+
+int bcc_usdt_enable_probe(void *, const char *, const char *);
+char *bcc_usdt_genargs(void *);
+
+typedef void (*bcc_usdt_uprobe_cb)(const char *, const char *, uint64_t, int);
+void bcc_usdt_foreach_uprobe(void *usdt, bcc_usdt_uprobe_cb callback);
+]]
+
 if rawget(_G, "BCC_STANDALONE") then
   return ffi.C
 else

--- a/src/lua/bcc/run.lua
+++ b/src/lua/bcc/run.lua
@@ -57,18 +57,21 @@ return function()
   local BPF = require("bcc.bpf")
   BPF.script_root(tracefile)
 
+  local USDT = require("bcc.usdt")
   local utils = {
     argparse = require("bcc.vendor.argparse"),
     posix = require("bcc.vendor.posix"),
+    USDT = USDT,
   }
 
   local command = dofile(tracefile)
   local res, err = xpcall(command, debug.traceback, BPF, utils)
 
-  if not res then
+  if not res and err ~= "interrupted!" then
     io.stderr:write("[ERROR] "..err.."\n")
   end
 
-  BPF.cleanup_probes()
+  BPF.cleanup()
+  USDT.cleanup()
   return res, err
 end

--- a/src/lua/bcc/usdt.lua
+++ b/src/lua/bcc/usdt.lua
@@ -1,0 +1,81 @@
+--[[
+Copyright 2016 GitHub, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+]]
+local ffi = require("ffi")
+ffi.cdef "void free(void *ptr);"
+
+local libbcc = require("bcc.libbcc")
+local Usdt = class("USDT")
+
+Usdt.static.open_contexts = {}
+
+function Usdt.static.cleanup()
+  for _, context in ipairs(Usdt.static.open_contexts) do
+    context:_cleanup()
+  end
+end
+
+function Usdt:initialize(args)
+  assert(args.pid or args.path)
+
+  if args.pid then
+    self.pid = args.pid
+    self.context = libbcc.bcc_usdt_new_frompid(args.pid)
+  elseif args.path then
+    self.path = args.path
+    self.context = libbcc.bcc_usdt_new_frompath(args.path)
+  end
+
+  assert(self.context ~= nil, "failed to create USDT context")
+  table.insert(Usdt.open_contexts, self)
+end
+
+function Usdt:enable_probe(args)
+  assert(args.probe and args.fn_name)
+  assert(libbcc.bcc_usdt_enable_probe(
+    self.context, args.probe, args.fn_name) == 0)
+end
+
+function Usdt:_cleanup()
+  libbcc.bcc_usdt_close(self.context)
+  self.context = nil
+end
+
+function Usdt:_get_text()
+  local argc = libbcc.bcc_usdt_genargs(self.context)
+  assert(argc ~= nil)
+
+  local text = ffi.string(argc)
+  ffi.C.free(argc)
+  return text
+end
+
+function Usdt:_attach_uprobes(bpf)
+  local uprobes = {}
+  local cb = ffi.cast("bcc_usdt_uprobe_cb",
+    function(binpath, fn_name, addr, pid)
+      table.insert(uprobes, {name=ffi.string(binpath),
+        addr=addr, fn_name=ffi.string(fn_name), pid=pid})
+    end)
+
+  libbcc.bcc_usdt_foreach_uprobe(self.context, cb)
+  cb:free()
+
+  for _, args in ipairs(uprobes) do
+    bpf:attach_uprobe(args)
+  end
+end
+
+return Usdt

--- a/src/lua/squishy
+++ b/src/lua/squishy
@@ -11,6 +11,7 @@ Module "bcc.sym" "bcc/sym.lua"
 Module "bcc.libbcc" "bcc/libbcc.lua"
 Module "bcc.tracerpipe" "bcc/tracerpipe.lua"
 Module "bcc.table" "bcc/table.lua"
+Module "bcc.usdt" "bcc/usdt.lua"
 
 Main "bcc/run.lua"
 Output "bcc.lua"

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -39,7 +39,7 @@ TEST_CASE("test finding a probe in our own process", "[usdt]") {
   REQUIRE(ctx.num_probes() >= 1);
 
   SECTION("our test probe") {
-	auto probe = ctx.get("sample_probe_1");
+    auto probe = ctx.get("sample_probe_1");
     REQUIRE(probe);
 
     REQUIRE(probe->in_shared_object() == false);

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -39,7 +39,7 @@ TEST_CASE("test finding a probe in our own process", "[usdt]") {
   REQUIRE(ctx.num_probes() >= 1);
 
   SECTION("our test probe") {
-    USDT::Probe *probe = ctx.find_probe("sample_probe_1");
+    USDT::Probe *probe = ctx.get("sample_probe_1");
     REQUIRE(probe != nullptr);
 
     REQUIRE(probe->in_shared_object() == false);
@@ -115,7 +115,7 @@ TEST_CASE("test listing all USDT probes in Ruby/MRI", "[usdt]") {
     mri_probe_count = ctx.num_probes();
 
     SECTION("GC static probe") {
-      USDT::Probe *probe = ctx.find_probe("gc__mark__begin");
+      USDT::Probe *probe = ctx.get("gc__mark__begin");
       REQUIRE(probe != nullptr);
 
       REQUIRE(probe->in_shared_object() == true);
@@ -129,7 +129,7 @@ TEST_CASE("test listing all USDT probes in Ruby/MRI", "[usdt]") {
     }
 
     SECTION("object creation probe") {
-      USDT::Probe *probe = ctx.find_probe("object__create");
+      USDT::Probe *probe = ctx.get("object__create");
       REQUIRE(probe != nullptr);
 
       REQUIRE(probe->in_shared_object() == true);
@@ -161,7 +161,7 @@ TEST_CASE("test listing all USDT probes in Ruby/MRI", "[usdt]") {
     }
 
     SECTION("array creation probe") {
-      USDT::Probe *probe = ctx.find_probe("array__create");
+      USDT::Probe *probe = ctx.get("array__create");
       REQUIRE(probe != nullptr);
       REQUIRE(probe->name() == "array__create");
 
@@ -203,7 +203,7 @@ TEST_CASE("test listing all USDT probes in Ruby/MRI", "[usdt]") {
     REQUIRE(ctx.num_probes() >= mri_probe_count);
 
     SECTION("get probe in running process") {
-      USDT::Probe *probe = ctx.find_probe("gc__mark__begin");
+      USDT::Probe *probe = ctx.get("gc__mark__begin");
       REQUIRE(probe != nullptr);
 
       REQUIRE(probe->in_shared_object() == true);

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -39,8 +39,8 @@ TEST_CASE("test finding a probe in our own process", "[usdt]") {
   REQUIRE(ctx.num_probes() >= 1);
 
   SECTION("our test probe") {
-    USDT::Probe *probe = ctx.get("sample_probe_1");
-    REQUIRE(probe != nullptr);
+	auto probe = ctx.get("sample_probe_1");
+    REQUIRE(probe);
 
     REQUIRE(probe->in_shared_object() == false);
     REQUIRE(probe->name() == "sample_probe_1");
@@ -108,8 +108,8 @@ TEST_CASE("test listing all USDT probes in Ruby/MRI", "[usdt]") {
     mri_probe_count = ctx.num_probes();
 
     SECTION("GC static probe") {
-      USDT::Probe *probe = ctx.get("gc__mark__begin");
-      REQUIRE(probe != nullptr);
+      auto probe = ctx.get("gc__mark__begin");
+      REQUIRE(probe);
 
       REQUIRE(probe->in_shared_object() == true);
       REQUIRE(probe->name() == "gc__mark__begin");
@@ -122,8 +122,8 @@ TEST_CASE("test listing all USDT probes in Ruby/MRI", "[usdt]") {
     }
 
     SECTION("object creation probe") {
-      USDT::Probe *probe = ctx.get("object__create");
-      REQUIRE(probe != nullptr);
+      auto probe = ctx.get("object__create");
+      REQUIRE(probe);
 
       REQUIRE(probe->in_shared_object() == true);
       REQUIRE(probe->name() == "object__create");
@@ -136,8 +136,8 @@ TEST_CASE("test listing all USDT probes in Ruby/MRI", "[usdt]") {
     }
 
     SECTION("array creation probe") {
-      USDT::Probe *probe = ctx.get("array__create");
-      REQUIRE(probe != nullptr);
+      auto probe = ctx.get("array__create");
+      REQUIRE(probe);
       REQUIRE(probe->name() == "array__create");
 
       REQUIRE(probe->num_locations() == 7);
@@ -158,8 +158,8 @@ TEST_CASE("test listing all USDT probes in Ruby/MRI", "[usdt]") {
     REQUIRE(ctx.num_probes() >= mri_probe_count);
 
     SECTION("get probe in running process") {
-      USDT::Probe *probe = ctx.get("gc__mark__begin");
-      REQUIRE(probe != nullptr);
+      auto probe = ctx.get("gc__mark__begin");
+      REQUIRE(probe);
 
       REQUIRE(probe->in_shared_object() == true);
       REQUIRE(probe->name() == "gc__mark__begin");

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -52,13 +52,6 @@ TEST_CASE("test finding a probe in our own process", "[usdt]") {
     REQUIRE(probe->need_enable() == false);
 
     REQUIRE(a_probed_function() != 0);
-
-    std::ostringstream case_stream;
-    REQUIRE(probe->usdt_cases(case_stream));
-
-    std::string cases = case_stream.str();
-    REQUIRE(cases.find("int32_t arg1") != std::string::npos);
-    REQUIRE(cases.find("uint64_t arg2") != std::string::npos);
   }
 }
 #endif  // HAVE_SDT_HEADER
@@ -140,24 +133,6 @@ TEST_CASE("test listing all USDT probes in Ruby/MRI", "[usdt]") {
       REQUIRE(probe->num_locations() == 1);
       REQUIRE(probe->num_arguments() == 3);
       REQUIRE(probe->need_enable() == true);
-
-      std::ostringstream thunks_stream;
-      REQUIRE(probe->usdt_thunks(thunks_stream, "ruby_usdt"));
-
-      std::string thunks = thunks_stream.str();
-      REQUIRE(std::count(thunks.begin(), thunks.end(), '\n') == 1);
-      REQUIRE(thunks.find("ruby_usdt_thunk_0") != std::string::npos);
-
-      std::ostringstream case_stream;
-      REQUIRE(probe->usdt_cases(case_stream));
-
-      std::string cases = case_stream.str();
-      REQUIRE(countsubs(cases, "arg1") == 2);
-      REQUIRE(countsubs(cases, "arg2") == 2);
-      REQUIRE(countsubs(cases, "arg3") == 2);
-
-      REQUIRE(countsubs(cases, "uint64_t") == 4);
-      REQUIRE(countsubs(cases, "int32_t") == 2);
     }
 
     SECTION("array creation probe") {
@@ -168,26 +143,6 @@ TEST_CASE("test listing all USDT probes in Ruby/MRI", "[usdt]") {
       REQUIRE(probe->num_locations() == 7);
       REQUIRE(probe->num_arguments() == 3);
       REQUIRE(probe->need_enable() == true);
-
-      std::ostringstream thunks_stream;
-      REQUIRE(probe->usdt_thunks(thunks_stream, "ruby_usdt"));
-
-      std::string thunks = thunks_stream.str();
-      REQUIRE(std::count(thunks.begin(), thunks.end(), '\n') == 7);
-      REQUIRE(thunks.find("ruby_usdt_thunk_0") != std::string::npos);
-      REQUIRE(thunks.find("ruby_usdt_thunk_6") != std::string::npos);
-      REQUIRE(thunks.find("ruby_usdt_thunk_7") == std::string::npos);
-
-      std::ostringstream case_stream;
-      REQUIRE(probe->usdt_cases(case_stream));
-
-      std::string cases = case_stream.str();
-      REQUIRE(countsubs(cases, "arg1") == 8);
-      REQUIRE(countsubs(cases, "arg2") == 8);
-      REQUIRE(countsubs(cases, "arg3") == 8);
-
-      REQUIRE(countsubs(cases, "__loc_id") == 7);
-      REQUIRE(cases.find("int64_t arg1 =") != std::string::npos);
     }
   }
 

--- a/tests/lua/test_uprobes.lua
+++ b/tests/lua/test_uprobes.lua
@@ -64,7 +64,7 @@ int count(struct pt_regs *ctx) {
 end
 
 function TestUprobes:teardown()
-  BPF.cleanup_probes()
+  BPF.cleanup()
 end
 
 suite("TestUprobes", TestUprobes)


### PR DESCRIPTION
Hey everyone,

Here's a proposal on what would a potential new USDT API look like. This is based on top off the C++ USDT code which I've previously written. I've implemented this API in Lua instead of Python because I find it easier to iterate the design like that, but if people think it's acceptable, I will port it to Python too.

### The existing API

The current interface for writing, attaching and working with USDT probes is a bit complex (*understatement.jpg*).

In https://github.com/iovisor/bcc/issues/327#issuecomment-215540322, @brendangregg writes a "hello world" USDT probe which highlights many shortcomings on the API. Namely:

1. You need to create a USDT reader to list/load the probes

2. You need to randomly insert two sections of "boilerplate" into your C text. The USDT reader generates this boilerplate in two phases: a set of wrapper functions for your actual C probe, which are used to notify your probe of the USDT calling location, and a "case" statement that assigns the arguments of the USDT probe to local variables named `argX`.

    This is IMO the biggest design flaw in the existing interface. Your C probe needs to be acutely aware of this implementation detail; you need to adjust your probe to take a magical `__loc_id` argument (which needs to be named exactly that), and you need to pick a place in the body of your probe to insert the argument cases.

3. Once you've generated your C probe with the boilerplate, there is no easy way to attach the corresponding UProbes. Again, the user needs to know the names of the magical wrappers generated by the USDT Reader, and attach those wrappers as UProbes. The user also needs to know that a probe can appear in different locations, and understand that we need to attach to specific addresses (i.e. the probe locations) instead to function names.

4. Last, but not least, the user must set up a signal handler to ensure that the probes that have been activated on a given PID are disabled once tracing is done.

### The proposal

As an alternative, I propose the following API, exemplified in a commented "hello world" example:

```lua
local program = [[
#include <uapi/linux/ptrace.h>
// C code for the probe; note that there's no reference to the probe location
// also note that there's no text replacement performed
int trace_method(struct pt_regs *ctx) {
    char fn_name[128] = {};
    // read the 2nd argument to the `method__entry` USDT probe
    // the `_p` variant of this helper dereferences the argument as a pointer
    // and reads its contents
    bpf_usdt_readarg_p(method__entry_2, ctx, &fn_name, sizeof(fn_name));

    // you can also call the following API (which is typesafe on its return value)
    int32_t line_number = bpf_usdt_readarg(method__entry_4, ctx);

    // print to the trace log as usual
    bpf_trace_printk("%s(...)\n", &fn_name);
    return 0;
};
]]

return function(BPF, util)
  -- create a USDT context for the given PID
  -- (you can also target a binary instead of a PID)
  local u = util.USDT:new{pid=tonumber(arg[1])}

  -- enable the `method__entry` USDT probe, calling the `trace_method` of our C text
  -- this will automagically do probe resolution and enabling of semaphores
  u:enable_probe{probe="method__entry", fn_name="trace_method"}

  -- now we create our BPF context, and pass our C text *and* the USDT context
  local b = BPF:new{text=program, usdt=u}

  -- we're ready. the BPF code has automatically attached to all the USDT probes
  -- which we enabled in our USDT context, and we can start tracing
  local pipe = b:pipe()
  while true do
    print(pipe:trace_fields())
  end

  -- the USDT semaphores will be automatically disabled when quitting
end
```

### The new codegen phase

Inquiring minds will probably notice that I've gotten rid of all text substitution for the C text, and instead any BPF program that has been attached to an USDT probe has access to generic, typesafe APIs to query the arguments for the probe, regardless of source location. How is this possible?

Well, let's take a look at the generated BPF program as it goes into the C compiler to understand this better:

```c
static inline uint64_t _bpf_readarg_method__entry_1(struct pt_regs *ctx) {
  uint64_t result = 0x0;
  switch(ctx->ip) {
  case 0x55c79eeed834ULL: result = (uint64_t)ctx->bx; break;
  case 0x55c79eef68f4ULL: result = (uint64_t)ctx->r13; break;
  }
  return result;
}
static inline uint64_t _bpf_readarg_method__entry_2(struct pt_regs *ctx) {
  uint64_t result = 0x0;
  switch(ctx->ip) {
  case 0x55c79eeed834ULL: result = (uint64_t)ctx->bp; break;
  case 0x55c79eef68f4ULL: { u64 __addr = ctx->sp + (8); uint64_t __res = 0x0; bpf_probe_read(&__res, sizeof(__res), (void *)__addr); result = __res; } break;
  }
  return result;
}
static inline uint64_t _bpf_readarg_method__entry_3(struct pt_regs *ctx) {
  uint64_t result = 0x0;
  switch(ctx->ip) {
  case 0x55c79eeed834ULL: result = (uint64_t)ctx->r12; break;
  case 0x55c79eef68f4ULL: result = (uint64_t)ctx->dx; break;
  }
  return result;
}
static inline int32_t _bpf_readarg_method__entry_4(struct pt_regs *ctx) {
  int32_t result = 0x0;
  switch(ctx->ip) {
  case 0x55c79eeed834ULL: result = (int32_t)ctx->ax; break;
  case 0x55c79eef68f4ULL: result = (int32_t)ctx->ax; break;
  }
  return result;
}
#include <uapi/linux/ptrace.h>
int trace_method(struct pt_regs *ctx) {
    char fn_name[128] = {};
    bpf_usdt_readarg_p(method__entry_2, ctx, &fn_name, sizeof(fn_name));
    bpf_trace_printk("%s(...)\n", &fn_name);
    return 0;
};
```

Oooh. That makes sense! We don't need to insert the argument parsing code throughout our C text; we can simply prepend a set of helpers to read each argument, and the helpers will be called magically by the `bpf_usdt_readarg` macro. This process is transparent to the user.

```c
#define bpf_usdt_readarg(probearg, ctx) _bpf_readarg_##probearg(ctx)
#define bpf_usdt_readarg_p(probearg, ctx, buf, len) {\
  u64 __addr = bpf_usdt_readarg(probearg, ctx); \
  bpf_probe_read(buf, len, (void *)__addr); }
```

Also note that there's no longer any magical wrappers for "probe location" or `__loc_id`. Instead, we can tell what's the location of an USDT probe because... well... we know where the probe is being called from. That's why `%rip` is there. :)

It is also worth noting that for the common case of probes with a single source location, the `%rip` check is skipped. Overall, very little code that generates typesafe and efficient APIs that IMO are a pleasure to use.

### Conclusion

That's what I'm proposing here today. I'm quite happy with this design. It can be integrated into a language wrapper with very few changes, and the surface of the C API is minimal, so I believe the abstraction level is quite adequate.

I'd love to hear your thoughts on this. The existing `examples/lua/ruby_usdt.lua` would be a good starting point for local testing.

cc @drzaeus77 @4ast @brendangregg 