### PR TITLE
Powerpc support v2

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -44,7 +44,7 @@ set_target_properties(bcc-static PROPERTIES OUTPUT_NAME bcc)
 # BPF is still experimental otherwise it should be available
 #llvm_map_components_to_libnames(llvm_libs bpf mcjit irreader passes)
 llvm_map_components_to_libnames(llvm_libs bitwriter bpfcodegen irreader linker
-  mcjit objcarcopts option passes x86codegen)
+  mcjit objcarcopts option passes nativecodegen)
 llvm_expand_dependencies(expanded_libs ${llvm_libs})
 
 # order is important

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -35,8 +35,14 @@ namespace ebpf {
 const char *calling_conv_regs_x86[] = {
   "di", "si", "dx", "cx", "r8", "r9"
 };
+const char *calling_conv_regs_ppc[] = {"gpr[3]", "gpr[4]", "gpr[5]",
+                                       "gpr[6]", "gpr[7]", "gpr[8]"};
 // todo: support more archs
+#if defined(__powerpc__)
+const char **calling_conv_regs = calling_conv_regs_ppc;
+#else
 const char **calling_conv_regs = calling_conv_regs_x86;
+#endif
 
 using std::map;
 using std::set;

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -128,7 +128,11 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
   DiagnosticsEngine diags(DiagID, &*diag_opts, diag_client);
 
   // set up the command line argument wrapper
+#if defined(__powerpc64__)
+  driver::Driver drv("", "ppc64le-unknown-linux-gnu", diags);
+#else
   driver::Driver drv("", "x86_64-unknown-linux-gnu", diags);
+#endif
   drv.setTitle("bcc-clang-driver");
   drv.setCheckInputsExist(false);
 

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -39,7 +39,11 @@
 // TODO: remove these defines when linux-libc-dev exports them properly
 
 #ifndef __NR_bpf
+#if defined(__powerpc64__)
+#define __NR_bpf 361
+#else
 #define __NR_bpf 321
+#endif
 #endif
 
 #ifndef SO_ATTACH_BPF

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -43,8 +43,8 @@ TEST_CASE("binary resolution with `which`", "[c_api]") {
 static void _test_ksym(const char *sym, uint64_t addr, void *_) {
   if (!strcmp(sym, "startup_64")) {
     REQUIRE(addr == 0xffffffff81000000ull);
-  } else if (!strcmp(sym, "__per_cpu_start"))
-    REQUIRE(addr == 0x0);
+  } else if (!strcmp(sym, "system_reset_pSeries"))
+    REQUIRE(addr == 0xc000000000000100ull);
 }
 
 TEST_CASE("list all kernel symbols", "[c_api]") {

--- a/tests/python/test_trace2.py
+++ b/tests/python/test_trace2.py
@@ -15,7 +15,11 @@ struct Counters { u64 stat1; };
 BPF_TABLE("hash", struct Ptr, struct Counters, stats, 1024);
 
 int count_sched(struct pt_regs *ctx) {
+#if defined(__powerpc__)
+  struct Ptr key = {.ptr=ctx->gpr[3]};
+#else
   struct Ptr key = {.ptr=ctx->bx};
+#endif
   struct Counters zleaf = {0};
   stats.lookup_or_init(&key, &zleaf)->stat1++;
   return 0;

--- a/tests/python/test_trace3.c
+++ b/tests/python/test_trace3.c
@@ -28,14 +28,22 @@ static u32 log2l(u64 v) {
 }
 
 int probe_blk_start_request(struct pt_regs *ctx) {
+#if defined(__powerpc__)
+  struct Request rq = {.rq = ctx->gpr[3]};
+#else
   struct Request rq = {.rq = ctx->di};
+#endif
   struct Time tm = {.start = bpf_ktime_get_ns()};
   requests.update(&rq, &tm);
   return 0;
 }
 
 int probe_blk_update_request(struct pt_regs *ctx) {
+#if defined(__powerpc__)
+  struct Request rq = {.rq = ctx->gpr[3]};
+#else
   struct Request rq = {.rq = ctx->di};
+#endif
   struct Time *tm = requests.lookup(&rq);
   if (!tm) return 0;
   u64 delta = bpf_ktime_get_ns() - tm->start;


### PR DESCRIPTION
This addresses review comments on #513. We now use 'nativecodegen' instead of including arch-specific llvm codegen components.