### PR TITLE
Force lua main.c to include luajit headers

### DIFF
--- a/src/lua/src/main.c
+++ b/src/lua/src/main.c
@@ -29,9 +29,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "lauxlib.h"
-#include "lua.h"
-#include "lualib.h"
+#include <luajit-2.0/lauxlib.h>
+#include <luajit-2.0/lua.h>
+#include <luajit-2.0/lualib.h>
 
 static lua_State *globalL = NULL;
 static const char *progname = NULL;


### PR DESCRIPTION
On my system, when both lua and luajit are installed, multiple headers
exist in /usr/include. However, my lua installation is 5.3, which has
some api-breaking changes, which means that the standard lua.h must not
be included.

Simply force lua.h to come from luajit-2.0 directory.

Cc: @vmg 