### PR TITLE
Add check for number of arguments

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -446,7 +446,7 @@ class BPF(object):
 
     @staticmethod
     def find_library(libname):
-        return lib.bcc_procutils_which_so(libname)
+        return lib.bcc_procutils_which_so(libname.encode("ascii")).decode()
 
     def attach_uprobe(self, name="", sym="", addr=None,
             fn_name="", pid=-1, cpu=0, group_fd=-1):

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -328,5 +328,15 @@ BPF_TABLE("hash", struct bpf_tunnel_key, int, t1, 1);
         t1 = b["t1"]
         print(t1.Key().remote_ipv4)
 
+    def test_too_many_args(self):
+        text = """
+#include <uapi/linux/ptrace.h>
+int many(struct pt_regs *ctx, int a, int b, int c, int d, int e, int f, int g) {
+    return 0;
+}
+"""
+        with self.assertRaises(Exception):
+            b = BPF(text=text)
+
 if __name__ == "__main__":
     main()

--- a/tests/python/test_stackid.py
+++ b/tests/python/test_stackid.py
@@ -47,7 +47,7 @@ int kprobe__htab_map_lookup_elem(struct pt_regs *ctx, struct bpf_map *map, u64 *
         stackid = stack_entries[k]
         self.assertIsNotNone(stackid)
         stack = stack_traces[stackid].ip
-        self.assertEqual(b.ksym(stack[0]), b"htab_map_lookup_elem")
+        self.assertEqual(b.ksym(stack[0]), "htab_map_lookup_elem")
 
 
 if __name__ == "__main__":

--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -673,8 +673,8 @@ struct __string_t { char s[%d]; };
                 except:
                         if self.args.verbose:
                                 traceback.print_exc()
-                        elif sys.exc_type is not SystemExit:
-                                print(sys.exc_value)
+                        elif sys.exc_info()[0] is not SystemExit:
+                                print(sys.exc_info()[1])
                 self._close_probes()
 
 if __name__ == "__main__":

--- a/tools/tplist.py
+++ b/tools/tplist.py
@@ -86,6 +86,6 @@ if __name__ == "__main__":
                 else:
                         print_tracepoints()
         except:
-                if sys.exc_type is not SystemExit:
-                        print(sys.exc_value)
+                if sys.exc_info()[0] is not SystemExit:
+                        print(sys.exc_info()[1])
 


### PR DESCRIPTION
There are two problems here:
 1. bcc is leaving the extra function parameters in the prototype, when
 these really just serve as an annotation on the method being traced.
 They aren't really passed into the function. LLVM lowering phase later
 errors out on such functions.
 2. bcc doesn't limit the size of the argument list, when currently it
 just supports up to the number of arguments held in registers (6).

Fix 1. by rewriting the arguments out of the prototype and into the
preamble where they are currently being initialized.
Fix 2. by enforcing the limit and returning a more meaningful error
message.

Added a test case.

Extra fix included for string type on python3.

Fixes: #497
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>