### PR TITLE
handle ENOMEM in tools/offcputime

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -175,12 +175,19 @@ static int (*bpf_perf_event_output)(void *ctx, void *map, u32 index, void *data,
   (void *) BPF_FUNC_perf_event_output;
 static int (*bpf_skb_load_bytes)(void *ctx, int offset, void *to, u32 len) =
   (void *) BPF_FUNC_skb_load_bytes;
+
+/* bpf_get_stackid will return a negative value in the case of an error
+ *
+ * BPF_STACK_TRACE(_name, _size) will allocate space for _size stack traces.
+ *  -ENOMEM will be returned when this limit is reached.
+ */
 static int (*bpf_get_stackid_)(void *ctx, void *map, u64 flags) =
   (void *) BPF_FUNC_get_stackid;
 static inline __attribute__((always_inline))
 int bpf_get_stackid(uintptr_t map, void *ctx, u64 flags) {
   return bpf_get_stackid_(ctx, (void *)map, flags);
 }
+
 static int (*bpf_csum_diff)(void *from, u64 from_size, void *to, u64 to_size, u64 seed) =
   (void *) BPF_FUNC_csum_diff;
 

--- a/tools/offcputime_example.txt
+++ b/tools/offcputime_example.txt
@@ -11,7 +11,7 @@ Here is some example output. To explain what we are seeing: the very first
 stack trace looks like a page fault (do_page_fault() etc) from the "chmod"
 command, and in total was off-CPU for 13 microseconds.
 
-# ./offcputime 
+# ./offcputime
 Tracing off-CPU time (us) by kernel stack... Hit Ctrl-C to end.
 ^C
     schedule
@@ -644,7 +644,7 @@ Tracing off-CPU time (us) by kernel stack for 5 secs.
 Here, dd was blocked for 4.4 seconds out of 5. Or put differently, likely
 on-CPU for about 12% of the time. Which matches the ratio seen by time(1):
 
-# time dd if=/dev/md0 iflag=direct of=/dev/null bs=1k 
+# time dd if=/dev/md0 iflag=direct of=/dev/null bs=1k
 ^C108115+0 records in
 108114+0 records out
 110708736 bytes (111 MB) copied, 13.7565 s, 8.0 MB/s
@@ -718,19 +718,24 @@ creating your "off-CPU time flame graphs".
 USAGE message:
 
 # ./offcputime -h
-usage: offcputime [-h] [-u] [-p PID] [-v] [-f] [duration]
+usage: offcputime.py [-h] [-u | -p PID] [-v] [-f]
+                     [--stack-storage-size STACK_STORAGE_SIZE]
+                     [duration]
 
 Summarize off-CPU time by kernel stack trace
 
 positional arguments:
-  duration           duration of trace, in seconds
+  duration              duration of trace, in seconds
 
 optional arguments:
-  -h, --help         show this help message and exit
-  -u, --useronly     user threads only (no kernel threads)
-  -p PID, --pid PID  trace this PID only
-  -v, --verbose      show raw addresses
-  -f, --folded       output folded format
+  -h, --help            show this help message and exit
+  -u, --useronly        user threads only (no kernel threads)
+  -p PID, --pid PID     trace this PID only
+  -v, --verbose         show raw addresses
+  -f, --folded          output folded format
+  --stack-storage-size STACK_STORAGE_SIZE
+                        the number of unique stack traces that can be stored
+                        and displayed (default 1024)
 
 examples:
     ./offcputime             # trace off-CPU stack time until Ctrl-C

--- a/tools/offcputime_example.txt
+++ b/tools/offcputime_example.txt
@@ -586,8 +586,6 @@ Tracing off-CPU time (us) by kernel stack... Hit Ctrl-C to end.
     supervise
         81670888
 
-Detaching...
-
 The last few stack traces aren't very interesting, since they are threads that
 are ofter blocked off-CPU waiting for work.
 
@@ -619,8 +617,6 @@ Tracing off-CPU time (us) by kernel stack... Hit Ctrl-C to end.
     dd
         2405710
 
-Detaching...
-
 The stack trace shows "dd" is blocked waiting on disk I/O, as expected, for a
 total of 2.4 seconds during tracing.
 
@@ -644,8 +640,6 @@ Tracing off-CPU time (us) by kernel stack for 5 secs.
     entry_SYSCALL_64_fastpath
     dd
         4413909
-
-Detaching...
 
 Here, dd was blocked for 4.4 seconds out of 5. Or put differently, likely
 on-CPU for about 12% of the time. Which matches the ratio seen by time(1):


### PR DESCRIPTION
`BPF_STACK_TRACE(_name, _size)` will allocate space for _size stack traces
(see [here](https://github.com/torvalds/linux/blob/master/kernel/bpf/stackmap.c#L30-L50)).

If we've already used all of this space, subsequent calls to `bpf_get_stackid()` will return -ENOMEM
(see [here](https://github.com/torvalds/linux/blob/master/kernel/bpf/stackmap.c#L173-L176)).

This causes our BPF bytecode to store this value in `key_t.stack_id` and subsequently causes our
python application to crash due to a `KeyError` when invoking `stack_traces.walk(k.stack_id)`.

Let's avoid calling stack_traces.walk(k.stack_id) with bad stackid's

We should also handle this edge case in the other tools that use `bpf_get_stackid()`:
```
devbig680[bcc](tools): grep -r get_stackid . | grep tools
./tools/memleak.py:        info.stack_id = stack_traces.get_stackid(ctx, STACK_FLAGS);
./tools/stackcount.py:    int key = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
./tools/stacksnoop.py:    int stack_id = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
./tools/offcputime.py:    key.stack_id = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
```

Test Plan:
Run offcputime.py in an extreme case; with space for only a single stack trace per core
```
devbig680[bcc](tools): sed_in_file 's/BPF_STACK_TRACE(stack_traces, 1024)/BPF_STACK_TRACE(stack_traces, 1)/' tools/offcputime.py && \
> ~/bcc_run_tool.sh offcputime -f 5; \
> git reset --hard HEAD
swapper/30;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 496
swapper/26;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 553
swapper/28;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 604
swapper/31;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 692
swapper/23;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 713
swapper/18;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 919
swapper/16;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 1051
swapper/20;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 1056
swapper/21;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 1585
swapper/24;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 1597
swapper/27;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 1610
swapper/17;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 1674
swapper/22;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 2390
swapper/25;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 2574
swapper/19;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 2589
swapper/29;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 8428
swapper/8;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 15272
swapper/15;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 15591
swapper/11;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 17934
swapper/9;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 18100
swapper/14;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 18266
swapper/10;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 20124
swapper/12;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 20887
swapper/13;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 23453
swapper/3;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 27296
swapper/5;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 29094
swapper/6;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 29799
swapper/7;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 31522
swapper/1;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 32269
swapper/4;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 35585
swapper/2;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 37627
WARNING: 249 stack traces could not be displayed. Consider increasing stack trace storage size.
HEAD is now at d3365e9 [RFC] handle ENOMEM in tools/offcputime`
```