### PR TITLE
Revert "Force lua main.c to include luajit headers"

### DIFF
--- a/src/lua/src/main.c
+++ b/src/lua/src/main.c
@@ -29,9 +29,9 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <luajit-2.0/lauxlib.h>
-#include <luajit-2.0/lua.h>
-#include <luajit-2.0/lualib.h>
+#include "lauxlib.h"
+#include "lua.h"
+#include "lualib.h"
 
 static lua_State *globalL = NULL;
 static const char *progname = NULL;


### PR DESCRIPTION
This reverts commit c21b9c036cba26e2927fbb5e46985faa73ef743e.

Instead, use `LUAJIT_DIR=/usr/include/luajit-2.0 cmake ..` or similar as
required.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>