### PR TITLE
add --kernel-threads-only to tools/offcputime

### DIFF
--- a/tools/offcputime_example.txt
+++ b/tools/offcputime_example.txt
@@ -718,7 +718,7 @@ creating your "off-CPU time flame graphs".
 USAGE message:
 
 # ./offcputime -h
-usage: offcputime.py [-h] [-u | -p PID] [-v] [-f]
+usage: offcputime.py [-h] [-p PID | -k | -u] [-f]
                      [--stack-storage-size STACK_STORAGE_SIZE]
                      [duration]
 
@@ -729,9 +729,11 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -u, --useronly        user threads only (no kernel threads)
   -p PID, --pid PID     trace this PID only
-  -v, --verbose         show raw addresses
+  -k, --kernel-threads-only
+                        kernel threads only (no user threads)
+  -u, --user-threads-only
+                        user threads only (no kernel threads)
   -f, --folded          output folded format
   --stack-storage-size STACK_STORAGE_SIZE
                         the number of unique stack traces that can be stored
@@ -741,5 +743,6 @@ examples:
     ./offcputime             # trace off-CPU stack time until Ctrl-C
     ./offcputime 5           # trace for 5 seconds only
     ./offcputime -f 5        # 5 seconds, and output in folded format
-    ./offcputime -u          # don't include kernel threads (user only)
-    ./offcputime -p 185      # trace for PID 185 only
+    ./offcputime -p 185      # only trace threads for PID 185
+    ./offcputime -u          # only trace user threads (no kernel)
+    ./offcputime -k          # only trace kernel threads (no user)


### PR DESCRIPTION
Summary:
Adds `--kernel-threads-only` arg
The kernel-threads-only arg is exclusive with pid/user-threads-only via `parser.add_mutually_exclusive_group`.
The output message now indicates what we are tracing (pid/user threads/kernel threads/all threads).
Removed the --verbose arg (unused).

Test Plan:
Run with combinations of the args; validate output looks sane:

// test mutually exclusive group
```
devbig680[bcc](abirchall_dev): ~/bcc_run_tool.sh offcputime -k -u 1
[Running] /data/users/abirchall/bcc/tools/offcputime.py -k -u 1
usage: offcputime.py [-h] [-p PID | -k | -u] [-v] [-f] [duration]
offcputime.py: error: argument -u/--user-threads-only: not allowed with argument -k/--kernel-threads-only
```

// kernel threads only
```
devbig680[bcc](abirchall_dev): ~/bcc_run_tool.sh offcputime -f -k 1
[Running] /data/users/abirchall/bcc/tools/offcputime.py -f -k 1
swapper/21;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 11
swapper/16;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 19
swapper/22;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 20
swapper/31;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 20
swapper/23;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 67
swapper/25;start_secondary;cpu_startup_entry;schedule_preempt_disabled;schedule 74
...
```
`~/bcc_run_tool.sh offcputime -f --kernel-threads-only 1`

// user threads only
`~/bcc_run_tool.sh offcputime -f --user-threads-only 1`
`~/bcc_run_tool.sh offcputime -f -u 1`

// specific pid
`~/bcc_run_tool.sh offcputime -f -p $(pidof hphpi) 1`
```
devbig680[bcc](abirchall_dev): ~/bcc_run_tool.sh offcputime --pid $(pidof mcrouter) 10 | head
[Running] /data/users/abirchall/bcc/tools/offcputime.py --pid 95929 10
Tracing off-CPU time (us) of PID 95929 by kernel stack for 10 secs.
```

Note that this last case (specific PID) doesn't appear to be working; I can debug that in a follow up commit.