### PR TITLE
lua: Allow LuaJIT parameterized types in `open_perf_buffer`

### DIFF
--- a/src/lua/bcc/table.lua
+++ b/src/lua/bcc/table.lua
@@ -254,9 +254,9 @@ function PerfEventArray:_open_perf_buffer(cpu, callback, ctype)
   self._callbacks[cpu] = _cb
 end
 
-function PerfEventArray:open_perf_buffer(callback, data_type)
+function PerfEventArray:open_perf_buffer(callback, data_type, ...)
   assert(data_type, "a data type is needed for callback conversion")
-  local ctype = ffi.typeof(data_type.."*")
+  local ctype = ffi.typeof(data_type.."*", ...)
   for i = 0, Posix.cpu_count() - 1 do
     self:_open_perf_buffer(i, callback, ctype)
   end

--- a/tools/stacksnoop.lua
+++ b/tools/stacksnoop.lua
@@ -100,12 +100,8 @@ return function(BPF, utils)
 
   local TASK_COMM_LEN = 16 -- linux/sched.h
 
-  bpf:get_table("events"):open_perf_buffer(print_event, [[
-    struct {
-      uint64_t stack_id;
-      uint32_t pid;
-      char comm[%d];
-    }
-  ]] % {TASK_COMM_LEN})
+  bpf:get_table("events"):open_perf_buffer(print_event,
+    "struct { uint64_t stack_id; uint32_t pid; char comm[$]; }",
+    TASK_COMM_LEN)
   bpf:kprobe_poll_loop()
 end


### PR DESCRIPTION
Following up on @4ast's comment at https://github.com/iovisor/bcc/pull/550#discussion_r64417493:

> imo the c->lua binding are less verbose and cleaner than c->py. 

WHY THANK YOU. 😍

> Just curious luajit dislikes 'char comm[TASK_COMM_LEN]' because the macro is undefined? any other way to pass it down to lua other than this '%' approach?

That's right. The argument to `open_perf_buffer` is not going through BCC (since BCC has already compiled the original program), but to LuaJIT's builtin C type parser. This is a feature of LuaJIT that lets us JIT-compile types to be used on the FFI, and it's the magic that makes the whole callback API so efficient.

...Obviously, since this is a custom parser in LuaJIT, it does not have access to the system's headers, so it cannot lookup `TASK_COMM_LEN` anywhere. Fortunately, LuaJIT provides what they call "parameterized types" (http://luajit.org/ext_ffi_semantics.html#param), allowing us to "template" parts of a type definition in a typesafe way (e.g. LuaJIT will now check that the `TASK_COM_LEN` variable is a number, since it's meant to template the size of an array).

This tiny PR changes the `open_perf_buffer` API to take a variable number or args so you can safely parametrize your types. No string replacements required. 😄

