### PR TITLE
set use_errno to True for libbcc.so

### DIFF
--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -14,7 +14,7 @@
 
 import ctypes as ct
 
-lib = ct.CDLL("libbcc.so.0")
+lib = ct.CDLL("libbcc.so.0", use_errno=True)
 
 # keep in sync with bpf_common.h
 lib.bpf_module_create_b.restype = ct.c_void_p


### PR DESCRIPTION
Currently, errno could not be accessed by libbcc.py, like:
```
binding socket to 'eth0'
cannot create raw socket: Operation not permitted
Traceback (most recent call last):
  File "/home/ryan/Software/bcc/examples/networking/http_filter/http-parse-simple.py", line 73, in <module>
    BPF.attach_raw_socket(function_http_filter, interface)
  File "/usr/lib/python2.7/site-packages/bcc/__init__.py", line 330, in attach_raw_socket
    raise Exception("Failed to open raw device %s: %s" % (dev, errstr))
Exception: Failed to open raw device eth0: Success
```
The exception prints the errno as `Success`, instead of `EPERM`.

This patch would fix this problem.

Signed-off-by: Jincheng Miao <jincheng.miao@gmail.com>