### PR TITLE
libbpf.c: Prepend BPF syscall error to log_bug when debug is enabled.

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -211,7 +211,7 @@ class BPF(object):
             print(log_buf.value.decode(), file=sys.stderr)
 
         if fd < 0:
-            if self.debug & DEBUG_BPF and not log_buf.value:
+            if self.debug & DEBUG_BPF:
                 errstr = os.strerror(ct.get_errno())
                 raise Exception("Failed to load BPF program %s: %s" %
                                 (func_name, errstr))

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -207,11 +207,16 @@ class BPF(object):
                 lib.bpf_module_kern_version(self.module),
                 log_buf, ct.sizeof(log_buf) if log_buf else 0)
 
-        if self.debug & DEBUG_BPF:
+        if self.debug & DEBUG_BPF and log_buf.value:
             print(log_buf.value.decode(), file=sys.stderr)
 
         if fd < 0:
-            raise Exception("Failed to load BPF program %s" % func_name)
+            if self.debug & DEBUG_BPF and not log_buf.value:
+                errstr = os.strerror(ct.get_errno())
+                raise Exception("Failed to load BPF program %s: %s" %
+                                (func_name, errstr))
+            else:
+                raise Exception("Failed to load BPF program %s" % func_name)
 
         fn = BPF.Function(self, func_name, fd)
         self.funcs[func_name] = fn


### PR DESCRIPTION
Commit 759029fea8066b41b54be5447137db95cb1313c4 provided an option to store the output from BPF syscall into a buffer (and not to print it systematically to standard output) on program load in libbpf.c.

But doing so, it only stores the content of attr.log_buf, while the error string resulting from a failed BPF syscall is no more displayed when the DEBUG_BPF flag is used in the Python script responsible to
convert and to inject the code.

The commit in this PR proposes a fix to this bug by prepending the error string to the log_buf buffer when the latter exists, so that the error can also be displayed when DEBUG_BPF flag has been set to true.
When no buffer is provided to bpf_prog_load(), the message error is prepended during the second (recursive) call and then displayed to stderr once this second call has returned.

----

To reproduce the bug, one can use the following snippet to call a BPF filter:

    #!/usr/bin/env python
    # Run with e.g. `./my_script.py my_bpf_prog.c`

    from bcc import BPF, DEBUG_BPF
    import sys

    b = BPF(src_file=sys.argv[1], debug=DEBUG_BPF)
    fn = b.load_func("ebpf_filter", BPF.SCHED_CLS)

If one tries to run this code without root permission,
- *Without* flag DEBUG_BPF: `bpf: Operation not permitted` is displayed.
- *With* flag DEBUG_BPF: nothing (only the Python backtrace). This is
  because a specific log_buf buffer is passed to the C function
  bpf_prog_load(), where the error string is displayed only if no buffer
  has been provided.

----

Note: It might be simpler / cleaner to append the error string to the buffer instead of prepending it. I chose to display the information (error string and then buffer filled in the kernel) in the same order as
it was before, but maybe we can rearrange it.