### PR TITLE
Add support for reading symbols from /tmp/perf-pid.map

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -33,11 +33,11 @@ if (CMAKE_COMPILER_IS_GNUCC)
   endif()
 endif()
 
-add_library(bcc-shared SHARED bpf_common.cc bpf_module.cc libbpf.c perf_reader.c shared_table.cc exported_files.cc bcc_elf.c bcc_proc.c bcc_syms.cc usdt_args.cc usdt.cc)
+add_library(bcc-shared SHARED bpf_common.cc bpf_module.cc libbpf.c perf_reader.c shared_table.cc exported_files.cc bcc_elf.c bcc_perf_map.c bcc_proc.c bcc_syms.cc usdt_args.cc usdt.cc)
 set_target_properties(bcc-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
 set_target_properties(bcc-shared PROPERTIES OUTPUT_NAME bcc)
 
-add_library(bcc-loader-static libbpf.c perf_reader.c bcc_elf.c bcc_proc.c)
+add_library(bcc-loader-static libbpf.c perf_reader.c bcc_elf.c bcc_perf_map.c bcc_proc.c)
 add_library(bcc-static STATIC bpf_common.cc bpf_module.cc shared_table.cc exported_files.cc bcc_syms.cc usdt_args.cc usdt.cc)
 set_target_properties(bcc-static PROPERTIES OUTPUT_NAME bcc)
 

--- a/src/cc/bcc_perf_map.c
+++ b/src/cc/bcc_perf_map.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "bcc_perf_map.h"
+
+int bcc_perf_map_nspid(int pid) {
+  char status_path[64];
+  FILE *status;
+
+  snprintf(status_path, sizeof(status_path), "/proc/%d/status", pid);
+  status = fopen(status_path, "r");
+
+  if (!status)
+    return -1;
+
+  // return the original PID if the NSpid line is missing
+  int nspid = pid;
+
+  size_t size;
+  char *line = NULL;
+  while (getline(&line, &size, status) != -1)
+    if (strstr(line, "NSpid:") != NULL)
+      // PID namespaces can be nested -- last number is innermost PID
+      nspid = (int)strtol(strrchr(line, '\t'), NULL, 10);
+  free(line);
+
+  return nspid;
+}
+
+bool bcc_perf_map_path(char *map_path, size_t map_len, int pid) {
+  char source[64];
+  snprintf(source, sizeof(source), "/proc/%d/root", pid);
+
+  char target[4096];
+  ssize_t target_len = readlink(source, target, sizeof(target) - 1);
+  if (target_len == -1)
+    return false;
+
+  target[target_len] = '\0';
+  if (strcmp(target, "/") == 0)
+    target[0] = '\0';
+
+  int nspid = bcc_perf_map_nspid(pid);
+
+  snprintf(map_path, map_len, "%s/tmp/perf-%d.map", target, nspid);
+  return true;
+}
+
+int bcc_perf_map_foreach_sym(const char *path, bcc_perf_map_symcb callback,
+                             void* payload) {
+  FILE* file = fopen(path, "r");
+  if (!file)
+    return -1;
+
+  char *line = NULL;
+  size_t size;
+  long long begin, len;
+  while (getline(&line, &size, file) != -1) {
+    char *cursor = line;
+    char *newline, *sep;
+
+    begin = strtoull(cursor, &sep, 16);
+    if (*sep != ' ' || (sep == cursor && begin == 0))
+      continue;
+    cursor = sep;
+    while (*cursor && isspace(*cursor)) cursor++;
+
+    len = strtoull(cursor, &sep, 16);
+    if (*sep != ' ' || (sep == cursor && begin == 0))
+      continue;
+    cursor = sep;
+    while (*cursor && isspace(*cursor)) cursor++;
+
+    newline = strchr(cursor, '\n');
+    if (newline)
+        newline[0] = '\0';
+
+    callback(cursor, begin, len - 1, 0, payload);
+  }
+
+  free(line);
+  fclose(file);
+
+  return 0;
+}

--- a/src/cc/bcc_perf_map.h
+++ b/src/cc/bcc_perf_map.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef LIBBCC_PERF_MAP_H
+#define LIBBCC_PERF_MAP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+typedef int (*bcc_perf_map_symcb)(const char *, uint64_t, uint64_t, int,
+                                  void *);
+
+int bcc_perf_map_nspid(int pid);
+bool bcc_perf_map_path(char *map_path, size_t map_len, int pid);
+int bcc_perf_map_foreach_sym(const char *path, bcc_perf_map_symcb callback,
+                             void* payload);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -20,6 +20,7 @@
 #include <unistd.h>
 
 #include "bcc_elf.h"
+#include "bcc_perf_map.h"
 #include "bcc_proc.h"
 #include "bcc_syms.h"
 
@@ -139,11 +140,18 @@ bool ProcSyms::Module::is_so() const {
   return strstr(name_.c_str(), ".so") != nullptr;
 }
 
+bool ProcSyms::Module::is_perf_map() const {
+  return strstr(name_.c_str(), ".map") != nullptr;
+}
+
 void ProcSyms::Module::load_sym_table() {
   if (syms_.size())
     return;
 
-  bcc_elf_foreach_sym(name_.c_str(), _add_symbol, this);
+  if (is_perf_map())
+    bcc_perf_map_foreach_sym(name_.c_str(), _add_symbol, this);
+  else
+    bcc_elf_foreach_sym(name_.c_str(), _add_symbol, this);
 }
 
 bool ProcSyms::Module::find_name(const char *symname, uint64_t *addr) {

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -83,6 +83,7 @@ class ProcSyms : SymbolCache {
     bool find_addr(uint64_t addr, struct bcc_symbol *sym);
     bool find_name(const char *symname, uint64_t *addr);
     bool is_so() const;
+    bool is_perf_map() const;
 
     static int _add_symbol(const char *symname, uint64_t start, uint64_t end,
                            int flags, void *p);


### PR DESCRIPTION
For #548, this adds basic support for reading symbols from `/tmp/perf-pid.map` (e.g., from a JIT or other code relocation). To cope with processes in containers, it supports:

* mapping from BCC's PID namespace to the target process's PID namespace
  using `/proc/pid/status`
* resolving a target process's root filesystem using `/proc/pid/root`

Note that mapping to a target's PID in a separate namespace requires a `NSpid:` line in `/proc/pid/status`. IIRC this was added sometime in 4.0 but I can't remember exactly when.