### PR TITLE
ext4slower: fix getting kallsyms address

### DIFF
--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -245,6 +245,7 @@ with open(kallsyms) as syms:
     ops = ''
     for line in syms:
         (addr, size, name) = line.rstrip().split(" ", 2)
+        name = name.split("\t")[0]
         if name == "ext4_file_operations":
             ops = "0x" + addr
             break


### PR DESCRIPTION
It didn't work on `Linux 4.6.0-1-amd64 #1 SMP Debian 4.6.1-1 (2016-06-06) x86_64 GNU/Linux` out of the box, because of fourth field : 
```
$ grep ext4_file_operations /proc/kallsyms
ffffffffc0331340 r ext4_file_operations	[ext4]
```