### PR TITLE
trace: Specifying a pid with a kernel probe now works

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -314,7 +314,7 @@ BPF_PERF_OUTPUT(%s);
                         pid_filter = """
         u32 __pid = bpf_get_current_pid_tgid();
         if (__pid != %d) { return 0; }
-"""             % pid
+"""             % Probe.pid
                 elif not include_self:
                         pid_filter = """
         u32 __pid = bpf_get_current_pid_tgid();


### PR DESCRIPTION
Due to an incorrectly referenced global variable, specifying a pid
to filter with a kernel probe produced an error. This is now fixed,
for example:

```
TIME     PID    COMM         FUNC
23:46:00 29967  bash         sched_switch
23:46:01 29967  bash         sched_switch
23:46:01 29967  bash         sched_switch
^C
```