### PR TITLE
bcc: Tracepoint support in libbpf and BPF

### DIFF
--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -54,6 +54,11 @@ void * bpf_attach_uprobe(int progfd, const char *event, const char *event_desc,
                          void *cb_cookie);
 int bpf_detach_uprobe(const char *event_desc);
 
+void * bpf_attach_tracepoint(int progfd, const char *tp_category,
+                             const char *tp_name, int pid, int cpu,
+                             int group_fd, perf_reader_cb cb, void *cb_cookie);
+int bpf_detach_tracepoint(const char *tp_category, const char *tp_name);
+
 void * bpf_open_perf_buffer(perf_reader_raw_cb raw_cb, void *cb_cookie, int pid, int cpu);
 
 #define LOG_BUF_SIZE 65536

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -50,6 +50,8 @@ add_test(NAME py_uprobes WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_uprobes sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_uprobes.py)
 add_test(NAME py_test_stackid WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_stackid sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_stackid.py)
+add_test(NAME py_test_tracepoint WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_test_tracepoint sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_tracepoint.py)
 
 add_test(NAME py_test_dump_func WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_dump_func simple ${CMAKE_CURRENT_SOURCE_DIR}/test_dump_func.py)

--- a/tests/python/test_tracepoint.py
+++ b/tests/python/test_tracepoint.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# Copyright (c) Sasha Goldshtein
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+import bcc
+import unittest
+from time import sleep
+import distutils.version
+import os
+
+def kernel_version_ge(major, minor):
+    # True if running kernel is >= X.Y
+    version = distutils.version.LooseVersion(os.uname()[2]).version
+    if version[0] > major:
+        return True
+    if version[0] < major:
+        return False
+    if minor and version[1] < minor:
+        return False
+    return True
+
+@unittest.skipUnless(kernel_version_ge(4,7), "requires kernel >= 4.7")
+class TestTracepoint(unittest.TestCase):
+    def test_tracepoint(self):
+        text = """#include <linux/ptrace.h>
+        struct tp_args {
+            unsigned long long __unused__;
+            char prev_comm[16];
+            pid_t prev_pid;
+            int prev_prio;
+            long prev_state;
+            char next_comm[16];
+            pid_t next_pid;
+            int next_prio;
+        };
+        BPF_HASH(switches, u32, u64);
+        int probe_switch(struct tp_args *args) {
+            if (args == 0)
+                return 0;
+            u64 val = 0;
+            u32 pid = args->next_pid;
+            u64 *existing = switches.lookup_or_init(&pid, &val);
+            (*existing)++;
+            return 0;
+        }
+        """
+        b = bcc.BPF(text=text)
+        b.attach_tracepoint("sched:sched_switch", "probe_switch")
+        sleep(1)
+        total_switches = 0
+        for k, v in b["switches"].items():
+            total_switches += v.value
+        self.assertNotEqual(0, total_switches)
+        b.detach_tracepoint("sched:sched_switch")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduce tracepoint support in libbpf via new `bpf_attach_tracepoint`
API, which takes the tracepoint category and name (e.g. "sched",
"sched_switch"). Attach the tracing program to the tracepoint's id
and proceed as usual.

Add `attach_tracepoint` API to Python BPF module, which takes the
tracepoint description as a single string (e.g. "sched:sched_switch").
Load the BPF program with bpf_prog_type set to TRACEPOINT and then
call `bpf_attach_tracepoint` to attach it.

Simple test:

```python
#!/usr/bin/env python

from bcc import BPF
from time import sleep

bpf = BPF(text="""
#include <linux/ptrace.h>

struct tp_args {
    unsigned long long __do_not_use__;
    int irq;
};

BPF_HASH(count, u32, u32);

int probe(struct tp_args *args) {
    u32 key = args->irq;
    u32 val = 0;
    u32 *existing_val = count.lookup_or_init(&key, &val);
    (*existing_val)++;
    return 0;
}
""")

bpf.attach_tracepoint("irq:irq_handler_entry", "probe")

print("Counting interrupts, Ctrl-C to quit...")
try:
    sleep(999999)
except KeyboardInterrupt:
    pass

print("")
counts = bpf["count"]
print("%-8s %-8s" % ("IRQ", "COUNT"))
for k, v in counts.items():
    print("%-8d %-8d" % (k.value, v.value))
```

Test output:

```
# ./test_bcc_tp.py
Counting interrupts, Ctrl-C to quit...
^C
IRQ      COUNT
24       2
27       4
```

Partially closes #587 -- no rewriter support for generating the tracepoint
structure yet, it needs to be provided manually.