### PR TITLE
ProcSyms: deduplicate symbol names

### DIFF
--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <sys/types.h>
@@ -63,9 +64,9 @@ public:
 
 class ProcSyms : SymbolCache {
   struct Symbol {
-    Symbol(const char *name, uint64_t start, uint64_t size, int flags = 0)
+    Symbol(const std::string *name, uint64_t start, uint64_t size, int flags = 0)
         : name(name), start(start), size(size), flags(flags) {}
-    std::string name;
+    const std::string *name;
     uint64_t start;
     uint64_t size;
     int flags;
@@ -81,6 +82,7 @@ class ProcSyms : SymbolCache {
     std::string name_;
     uint64_t start_;
     uint64_t end_;
+    std::unordered_set<std::string> symnames_;
     std::vector<Symbol> syms_;
 
     void load_sym_table();


### PR DESCRIPTION
`/tmp/perf-pid.map` files can contain the same function name on many lines. Often this is because the map is written by a JIT which compiles parts of a function as it needs them, writing each to a different memory location. Currently `ProcSyms` just reads them all in and creates a `Symbol` for every line, regardless of whether the name is duplicate. This can easily add up to a lot of RAM. I saw cases in which a large, heavily duplicated map and this simple example would use nearly 400MB RAM:

    struct bcc_symbol sym
    void *resolver = bcc_symcache_new(pid);
    bcc_symcache_resolve(resolver, 0xf00, &sym);

This is enough to make tools which themselves have a negative impact on the system they're observing.

This PR deduplicates the symbol names by putting names an `unordered_set` and storing pointers to the values instead of string copies. This is safe — references aren't invalidated during insertion (http://en.cppreference.com/w/cpp/container/unordered_set/emplace) — but doesn't feel very clean. Suggestions for improvement are welcome.

The same test program is now 130MB RSS. I'll try to work out if there is more to save.