### PR TITLE
Fix for C++ api change in LLVM 3.9

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -265,7 +265,8 @@ bool BTypeVisitor::VisitFunctionDecl(FunctionDecl *D) {
     // remember the arg names of the current function...first one is the ctx
     fn_args_.clear();
     string preamble = "{";
-    for (auto arg : D->params()) {
+    for (auto arg_it = D->param_begin(); arg_it != D->param_end(); arg_it++) {
+      auto arg = *arg_it;
       if (arg->getName() == "") {
         error(arg->getLocEnd(), "arguments to BPF program definition must be named");
         return false;


### PR DESCRIPTION
Upstream, params() was renamed to parameters(). In order to support both
old and new LLVM, use the unchanged param_begin and param_end API.

Fixes: #597
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>