### PR TITLE
Full tracepoint support in Clang front-end

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -451,5 +451,8 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 
 #define lock_xadd(ptr, val) ((void)__sync_fetch_and_add(ptr, val))
 
+#define TRACEPOINT_PROBE(category, event) \
+int tracepoint__##category##__##event(struct tracepoint__##category##__##event *args)
+
 #endif
 )********"

--- a/src/cc/frontends/clang/CMakeLists.txt
+++ b/src/cc/frontends/clang/CMakeLists.txt
@@ -4,4 +4,4 @@
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_DIR='\"${BCC_KERNEL_MODULES_DIR}\"'")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_SUFFIX='\"${BCC_KERNEL_MODULES_SUFFIX}\"'")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_HAS_SOURCE_DIR=${BCC_KERNEL_HAS_SOURCE_DIR}")
-add_library(clang_frontend loader.cc b_frontend_action.cc kbuild_helper.cc)
+add_library(clang_frontend loader.cc b_frontend_action.cc tp_frontend_action.cc kbuild_helper.cc)

--- a/src/cc/frontends/clang/tp_frontend_action.cc
+++ b/src/cc/frontends/clang/tp_frontend_action.cc
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2016 Sasha Goldshtein
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <linux/bpf.h>
+#include <linux/version.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <regex>
+
+#include <clang/AST/ASTConsumer.h>
+#include <clang/AST/ASTContext.h>
+#include <clang/AST/RecordLayout.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/MultiplexConsumer.h>
+#include <clang/Rewrite/Core/Rewriter.h>
+
+#include "tp_frontend_action.h"
+
+namespace ebpf {
+
+using std::map;
+using std::set;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+using std::regex;
+using std::smatch;
+using std::regex_search;
+using std::ifstream;
+using namespace clang;
+
+TracepointTypeVisitor::TracepointTypeVisitor(ASTContext &C, Rewriter &rewriter)
+    : C(C), diag_(C.getDiagnostics()), rewriter_(rewriter), out_(llvm::errs()) {
+}
+
+string TracepointTypeVisitor::GenerateTracepointStruct(
+    SourceLocation loc, string const& category, string const& event) {
+  static regex field_regex("field:([^;]*);.*size:\\d+;");
+  string format_file = "/sys/kernel/debug/tracing/events/" +
+    category + "/" + event + "/format";
+  ifstream input(format_file.c_str());
+  if (!input)
+    return "";
+
+  string tp_struct = "struct tracepoint__" + category + "__" + event + " {\n";
+  tp_struct += "\tu64 __do_not_use__;\n";
+  for (string line; getline(input, line); ) {
+    smatch field_match;
+    if (!regex_search(line, field_match, field_regex))
+      continue;
+
+    string field = field_match[1];
+    auto pos = field.find_last_of("\t ");
+    if (pos == string::npos)
+      continue;
+
+    string field_type = field.substr(0, pos);
+    string field_name = field.substr(pos + 1);
+    if (field_type.find("__data_loc") != string::npos)
+      continue;
+    if (field_name.find("common_") == 0)
+      continue;
+
+    tp_struct += "\t" + field_type + " " + field_name + ";\n";
+  }
+
+  tp_struct += "};\n";
+  return tp_struct;
+}
+
+bool TracepointTypeVisitor::VisitFunctionDecl(FunctionDecl *D) {
+  static regex type_regex("(?:struct|class)\\s+tracepoint__(\\S+)__(\\S+)");
+  if (D->isExternallyVisible() && D->hasBody()) {
+    // If this function has a tracepoint structure as an argument,
+    // add that structure declaration based on the structure name.
+    for (auto arg : D->params()) {
+      auto type = arg->getType();
+      if (type->isPointerType() &&
+          type->getPointeeType()->isStructureOrClassType()) {
+        auto type_name = QualType::getAsString(type.split());
+        smatch type_match;
+        if (regex_search(type_name, type_match, type_regex)) {
+          string tp_cat = type_match[1], tp_evt = type_match[2]; 
+          string tp_struct = GenerateTracepointStruct(
+              D->getLocStart(), tp_cat, tp_evt);
+
+          // Get the actual function declaration point (the macro instantiation
+          // point if using the TRACEPOINT_PROBE macro instead of the macro
+          // declaration point in bpf_helpers.h).
+          auto insert_loc = D->getLocStart();
+          insert_loc = rewriter_.getSourceMgr().getFileLoc(insert_loc);
+          rewriter_.InsertText(insert_loc, tp_struct);
+        }
+      }
+    }
+  }
+  return true;
+}
+
+TracepointTypeConsumer::TracepointTypeConsumer(ASTContext &C, Rewriter &rewriter)
+    : visitor_(C, rewriter) {
+}
+
+bool TracepointTypeConsumer::HandleTopLevelDecl(DeclGroupRef Group) {
+  for (auto D : Group)
+    visitor_.TraverseDecl(D);
+  return true;
+}
+
+TracepointFrontendAction::TracepointFrontendAction(llvm::raw_ostream &os)
+    : os_(os), rewriter_(new Rewriter) {
+}
+
+void TracepointFrontendAction::EndSourceFileAction() {
+  rewriter_->getEditBuffer(rewriter_->getSourceMgr().getMainFileID()).write(os_);
+  os_.flush();
+}
+
+unique_ptr<ASTConsumer> TracepointFrontendAction::CreateASTConsumer(
+        CompilerInstance &Compiler, llvm::StringRef InFile) {
+  rewriter_->setSourceMgr(Compiler.getSourceManager(), Compiler.getLangOpts());
+  return unique_ptr<ASTConsumer>(new TracepointTypeConsumer(
+              Compiler.getASTContext(), *rewriter_));
+}
+
+}

--- a/src/cc/frontends/clang/tp_frontend_action.h
+++ b/src/cc/frontends/clang/tp_frontend_action.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016 Sasha Goldshtein
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Rewrite/Core/Rewriter.h>
+
+namespace clang {
+class ASTConsumer;
+class ASTContext;
+class CompilerInstance;
+}
+
+namespace llvm {
+class raw_ostream;
+class StringRef;
+}
+
+namespace ebpf {
+
+// Visit functions that have a tracepoint argument structure in their signature
+// and automatically generate the structure on-the-fly.
+class TracepointTypeVisitor :
+  public clang::RecursiveASTVisitor<TracepointTypeVisitor> {
+ public:
+  explicit TracepointTypeVisitor(clang::ASTContext &C,
+                                 clang::Rewriter &rewriter);
+  bool VisitFunctionDecl(clang::FunctionDecl *D);
+
+ private:
+  std::string GenerateTracepointStruct(clang::SourceLocation loc,
+          std::string const& category, std::string const& event);
+
+  clang::ASTContext &C;
+  clang::DiagnosticsEngine &diag_;
+  clang::Rewriter &rewriter_;
+  llvm::raw_ostream &out_; 
+};
+
+class TracepointTypeConsumer : public clang::ASTConsumer {
+ public:
+  explicit TracepointTypeConsumer(clang::ASTContext &C,
+                                  clang::Rewriter &rewriter);
+  bool HandleTopLevelDecl(clang::DeclGroupRef Group) override;
+ private:
+  TracepointTypeVisitor visitor_;
+};
+
+class TracepointFrontendAction : public clang::ASTFrontendAction {
+ public:
+  TracepointFrontendAction(llvm::raw_ostream &os);
+
+  void EndSourceFileAction() override;
+
+  std::unique_ptr<clang::ASTConsumer>
+      CreateASTConsumer(clang::CompilerInstance &Compiler, llvm::StringRef InFile) override;
+
+ private:
+  llvm::raw_ostream &os_;
+  std::unique_ptr<clang::Rewriter> rewriter_;
+};
+
+}  // namespace visitor

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -182,8 +182,8 @@ class BPF(object):
         if not self.module:
             raise Exception("Failed to compile BPF module %s" % src_file)
 
-        # If any "kprobe__" prefixed functions were defined, they will be
-        # loaded and attached here.
+        # If any "kprobe__" or "tracepoint__" prefixed functions were defined,
+        # they will be loaded and attached here.
         self._trace_autoload()
 
     def load_funcs(self, prog_type=KPROBE):
@@ -620,9 +620,6 @@ class BPF(object):
                 fn = self.load_func(func_name, BPF.TRACEPOINT)
                 tp = fn.name[len("tracepoint__"):].replace("__", ":")
                 self.attach_tracepoint(tp=tp, fn_name=fn.name)
-        # It would be nice to automatically generate the tracepont
-        # structure here, but once we passed the load of the BPF program,
-        # we can't do that anymore. It will have to go in the clang rewriter.
 
     def trace_open(self, nonblocking=False):
         """trace_open(nonblocking=False)

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -610,10 +610,10 @@ class BPF(object):
     def _trace_autoload(self):
         for i in range(0, lib.bpf_num_functions(self.module)):
             func_name = lib.bpf_function_name(self.module, i).decode()
-            if func_name.startswith("kprobe__"):
+            if len(open_kprobes) == 0 and func_name.startswith("kprobe__"):
                 fn = self.load_func(func_name, BPF.KPROBE)
                 self.attach_kprobe(event=fn.name[8:], fn_name=fn.name)
-            elif func_name.startswith("kretprobe__"):
+            elif len(open_kprobes) == 0 and func_name.startswith("kretprobe__"):
                 fn = self.load_func(func_name, BPF.KPROBE)
                 self.attach_kretprobe(event=fn.name[11:], fn_name=fn.name)
             elif func_name.startswith("tracepoint__"):


### PR DESCRIPTION
This should close #587 by providing full support for tracepoints in the Clang front-end. Namely, probe functions for tracepoints can now be defined using the `TRACEPOINT_PROBE` macro. For example:

```c
TRACEPOINT_PROBE(sched, sched_switch) {
  bpf_trace_printk("%d -> %d\n", args->prev_pid, args->next_pid);
  return 0;
}
```