### PR TITLE
Correct link to Ubuntu binary section

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 * [Kernel Configuration](#kernel-configuration)
 * [Packages](#packages)
-  - [Ubuntu](#ubuntu---binary)
+  - [Ubuntu](#ubuntu-xenial---binary)
   - [Fedora](#fedora---binary)
   - [Arch](#arch---aur)
 * [Source](#source)


### PR DESCRIPTION
I found that the Ubuntu link was not working in the TOC (to navigate to the relevant section in the doc). Updated to link to the first Ubuntu binary heading (Xenial).