### PR TITLE
Build debian packages in docker containers

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,14 @@
+FROM debian:jessie
+
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv 15CF4D18AF4F7421 && \
+    echo "deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main" > /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends build-essential fakeroot bison cmake debhelper devscripts flex git libedit-dev python zlib1g-dev libllvm3.8 llvm-3.8-dev libclang-3.8-dev libelf-dev luajit libluajit-5.1-dev && \
+    mkdir -p /usr/share/llvm-3.8 && \
+    ln -s /usr/lib/llvm-3.8/share/llvm/cmake /usr/share/llvm-3.8/cmake
+
+COPY ./ /root/bcc
+
+WORKDIR /root/bcc
+
+RUN ./scripts/build-deb.sh


### PR DESCRIPTION
I wanted to have deb packages for Debian Jessie, but I didn't want to pollute my system with all the build deps. I took `Dockerfile.ubuntu` and replaced pretty much everything in it.

Usage:

```
# docker build -t bcc:jessie -f Dockerfile.debian .
# docker run --rm -it -v $(pwd):$(pwd) bcc:jessie bash -c "cp *.deb $(pwd)"
```

Now I have questions:

* Is `Dockerfile.ubuntu` used anywhere? It looks broken to me. I can probably fix it.
* What do I do with my `Dockerfile`? Do we need it in this repo? Should it be mentioned in `INSTALL.md` as a way of producing packages?
* Is it possible to have publicly available builds for Debian Jessie like we have for Ubuntu?
* Domain name instead of IP and HTTPS would be nice for these builds.

Side note: build fails if you install `libluajit-5.1-dev`, but don't install `luajit`.