### PR TITLE
killsnoop: s/failed opens/failed kill syscalls/

### DIFF
--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -31,7 +31,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument("-t", "--timestamp", action="store_true",
     help="include timestamp on output")
 parser.add_argument("-x", "--failed", action="store_true",
-    help="only show failed opens")
+    help="only show failed kill syscalls")
 parser.add_argument("-p", "--pid",
     help="trace this PID only")
 args = parser.parse_args()

--- a/tools/killsnoop_example.txt
+++ b/tools/killsnoop_example.txt
@@ -26,7 +26,7 @@ Trace signals issued by the kill() syscall
 optional arguments:
   -h, --help         show this help message and exit
   -t, --timestamp    include timestamp on output
-  -x, --failed       only show failed opens
+  -x, --failed       only show failed kill syscalls
   -p PID, --pid PID  trace this PID only
 
 examples:


### PR DESCRIPTION
I think this is a bad copy/paste from opensnoop, if I'm not mistaken.