### PR TITLE
Fix tools still referencing ProcUtils

### DIFF
--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -371,7 +371,7 @@ int PROBENAME(struct pt_regs *ctx SIGNATURE)
         def _attach_u(self):
                 libpath = BPF.find_library(self.library)
                 if libpath is None:
-                        libpath = ProcUtils.which(self.library)
+                        libpath = BPF._find_exe(self.library)
                 if libpath is None or len(libpath) == 0:
                         self._bail("unable to find library %s" % self.library)
 

--- a/tools/trace.py
+++ b/tools/trace.py
@@ -9,7 +9,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 # Copyright (C) 2016 Sasha Goldshtein.
 
-from bcc import BPF, Tracepoint, Perf, ProcUtils, USDT
+from bcc import BPF, Tracepoint, Perf, USDT
 from time import sleep, strftime
 import argparse
 import re
@@ -416,7 +416,7 @@ BPF_PERF_OUTPUT(%s);
                 libpath = BPF.find_library(self.library)
                 if libpath is None:
                         # This might be an executable (e.g. 'bash')
-                        libpath = ProcUtils.which(self.library)
+                        libpath = BPF._find_exe(self.library)
                 if libpath is None or len(libpath) == 0:
                         self._bail("unable to find library %s" % self.library)
 


### PR DESCRIPTION
Recent [change](https://github.com/iovisor/bcc/commit/4f88a9401357d7b75e917abd994aa6ea97dda4d3) removed `procstat.py`, but the `tools/argdist.py` and `tools/trace.py` are still referencing it. This Diff moves the only method (`ProcUtils.which()`) that is still being used to those tools.

Also, make `BPF.find_library()` not to call `decode()` on `None`.