### PR TITLE
Probe registration fixes

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -364,7 +364,6 @@ class BPF(object):
     def attach_kprobe(self, event="", fn_name="", event_re="",
             pid=-1, cpu=0, group_fd=-1):
 
-        assert isinstance(event, str), "event must be a string"
         # allow the caller to glob multiple functions together
         if event_re:
             for line in self._get_kprobe_functions(event_re):
@@ -375,6 +374,7 @@ class BPF(object):
                     pass
             return
 
+        event = str(event)
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
         ev_name = "p_" + event.replace("+", "_").replace(".", "_")
@@ -389,7 +389,7 @@ class BPF(object):
         return self
 
     def detach_kprobe(self, event):
-        assert isinstance(event, str), "event must be a string"
+        event = str(event)
         ev_name = "p_" + event.replace("+", "_").replace(".", "_")
         if ev_name not in self.open_kprobes:
             raise Exception("Kprobe %s is not attached" % event)
@@ -403,7 +403,6 @@ class BPF(object):
     def attach_kretprobe(self, event="", fn_name="", event_re="",
             pid=-1, cpu=0, group_fd=-1):
 
-        assert isinstance(event, str), "event must be a string"
         # allow the caller to glob multiple functions together
         if event_re:
             for line in self._get_kprobe_functions(event_re):
@@ -414,6 +413,7 @@ class BPF(object):
                     pass
             return
 
+        event = str(event)
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
         ev_name = "r_" + event.replace("+", "_").replace(".", "_")
@@ -428,7 +428,7 @@ class BPF(object):
         return self
 
     def detach_kretprobe(self, event):
-        assert isinstance(event, str), "event must be a string"
+        event = str(event)
         ev_name = "r_" + event.replace("+", "_").replace(".", "_")
         if ev_name not in self.open_kprobes:
             raise Exception("Kretprobe %s is not attached" % event)
@@ -527,6 +527,7 @@ class BPF(object):
                  BPF(text).attach_uprobe("/usr/bin/python", "main")
         """
 
+        name = str(name)
         (path, addr) = BPF._check_path_symbol(name, sym, addr)
 
         self._check_probe_quota(1)
@@ -549,6 +550,7 @@ class BPF(object):
         or binary 'name'.
         """
 
+        name = str(name)
         (path, addr) = BPF._check_path_symbol(name, sym, addr)
         ev_name = "p_%s_0x%x" % (self._probe_repl.sub("_", path), addr)
         if ev_name not in self.open_uprobes:
@@ -570,6 +572,7 @@ class BPF(object):
         meaning of additional parameters.
         """
 
+        name = str(name)
         (path, addr) = BPF._check_path_symbol(name, sym, addr)
 
         self._check_probe_quota(1)
@@ -592,6 +595,7 @@ class BPF(object):
         or binary 'name'.
         """
 
+        name = str(name)
         (path, addr) = BPF._check_path_symbol(name, sym, addr)
         ev_name = "r_%s_0x%x" % (self._probe_repl.sub("_", path), addr)
         if ev_name not in self.open_uprobes:


### PR DESCRIPTION
The first diff fixes the py3 incompatibilities @drzaeus77 pointed out in https://github.com/iovisor/bcc/commit/8fa8c0e8a0daeb4ab9eb2cc5fb308f996351965a. In testing (which I did using Ubuntu's [alternatives](https://linuxconfig.org/how-to-change-from-default-to-alternative-python-version-on-debian-linux) support) I found a couple of other things that needed fixing too.

The second removes the asserts that force `str` names for kprobes (#623). I'm on the fence on this one. On one hand I think it's better to make sure all the probes have string keys, particularly as we use the type to decide which probes to remove, but on the other hand it makes the API unforgiving if you use py2's unicode_literals, or you try to register a probe with a unicode string you already had to hand. @drzaeus77 any opinion here?