### PR TITLE
[cachetop] fix stats computation per processes.

### DIFF
--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -139,24 +139,16 @@ while 1:
     for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
 
         if re.match('mark_page_accessed', b.ksym(k.ip)) is not None:
-            mpa = v.value
-            if mpa < 0:
-                mpa = 0
+            mpa = max(0, v.value)
 
         if re.match('mark_buffer_dirty', b.ksym(k.ip)) is not None:
-            mbd = v.value
-            if mbd < 0:
-                mbd = 0
+            mbd = max(0, v.value)
 
         if re.match('add_to_page_cache_lru', b.ksym(k.ip)) is not None:
-            apcl = v.value
-            if apcl < 0:
-                apcl = 0
+            apcl = max(0, v.value)
 
         if re.match('account_page_dirtied', b.ksym(k.ip)) is not None:
-            apd = v.value
-            if apd < 0:
-                apd = 0
+            apd = max(0, v.value)
 
         # access = total cache access incl. reads(mpa) and writes(mbd)
         # misses = total of add to lru which we do when we write(mbd)

--- a/tools/cachetop.py
+++ b/tools/cachetop.py
@@ -69,17 +69,6 @@ def get_processes_stats(
     cached
     list of tuple with per process cache stats
     '''
-    rtaccess = 0
-    wtaccess = 0
-    mpa = 0
-    mbd = 0
-    apcl = 0
-    apd = 0
-    access = 0
-    misses = 0
-    rhits = 0
-    whits = 0
-
     counts = bpf.get_table("counts")
     stats = defaultdict(lambda: defaultdict(int))
     for k, v in counts.items():
@@ -87,26 +76,29 @@ def get_processes_stats(
     stats_list = []
 
     for pid, count in sorted(stats.items(), key=lambda stat: stat[0]):
+        rtaccess = 0
+        wtaccess = 0
+        mpa = 0
+        mbd = 0
+        apcl = 0
+        apd = 0
+        access = 0
+        misses = 0
+        rhits = 0
+        whits = 0
+
         for k, v in count.items():
             if re.match('mark_page_accessed', bpf.ksym(k)) is not None:
-                mpa = v
-                if mpa < 0:
-                    mpa = 0
+                mpa = max(0, v)
 
             if re.match('mark_buffer_dirty', bpf.ksym(k)) is not None:
-                mbd = v
-                if mbd < 0:
-                    mbd = 0
+                mbd = max(0, v)
 
             if re.match('add_to_page_cache_lru', bpf.ksym(k)) is not None:
-                apcl = v
-                if apcl < 0:
-                    apcl = 0
+                apcl = max(0, v)
 
             if re.match('account_page_dirtied', bpf.ksym(k)) is not None:
-                apd = v
-                if apd < 0:
-                    apd = 0
+                apd = max(0, v)
 
             # access = total cache access incl. reads(mpa) and writes(mbd)
             # misses = total of add to lru which we do when we write(mbd)


### PR DESCRIPTION
The current logic was only initializing page accesses, mark dirty.. at
the beginning of the method, preventing counters to be ever reset for
each PIDs.

Piggyback https://github.com/iovisor/bcc/pull/615#discussion_r71056842

Tested by running both tools manually.