### PR TITLE
Try to demangle C++ symbols

### DIFF
--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -24,6 +24,7 @@ extern "C" {
 
 struct bcc_symbol {
   const char *name;
+  const char *demangle_name;
   const char *module;
   uint64_t offset;
 };

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -101,6 +101,7 @@ void perf_reader_set_fd(struct perf_reader *reader, int fd);
 ffi.cdef[[
 struct bcc_symbol {
 	const char *name;
+	const char *demangle_name;
 	const char *module;
 	uint64_t offset;
 };

--- a/src/lua/bcc/sym.lua
+++ b/src/lua/bcc/sym.lua
@@ -25,7 +25,7 @@ local function create_cache(pid)
       if libbcc.bcc_symcache_resolve(self._CACHE, addr, sym) < 0 then
         return "[unknown]", 0x0
       end
-      return ffi.string(sym[0].name), sym[0].offset
+      return ffi.string(sym[0].demangle_name), sym[0].offset
     end
   }
 end

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -54,7 +54,7 @@ class SymbolCache(object):
         psym = ct.pointer(sym)
         if lib.bcc_symcache_resolve(self.cache, addr, psym) < 0:
             return "[unknown]", 0
-        return sym.name.decode(), sym.offset
+        return sym.demangle_name.decode(), sym.offset
 
     def resolve_name(self, name):
         addr = ct.c_ulonglong()

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -115,6 +115,7 @@ lib.bpf_attach_xdp.argtypes = [ct.c_char_p, ct.c_int]
 class bcc_symbol(ct.Structure):
     _fields_ = [
             ('name', ct.c_char_p),
+            ('demangle_name', ct.c_char_p),
             ('module', ct.c_char_p),
             ('offset', ct.c_ulonglong),
         ]


### PR DESCRIPTION
For C++ programs, this would make outputted stack traces look nicer.
Example: http://pastebin.com/LqT0nP67