### PR TITLE
Disable static-libstdc++ when clang is linked dynamically

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -19,8 +19,10 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs=A
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 
+# only turn on static-libstdc++ if also linking statically against clang
+string(REGEX MATCH ".*[.]a$" LIBCLANG_ISSTATIC "${libclangBasic}")
 # if gcc 4.9 or higher is used, static libstdc++ is a good option
-if (CMAKE_COMPILER_IS_GNUCC)
+if (CMAKE_COMPILER_IS_GNUCC AND LIBCLANG_ISSTATIC)
   execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
   if (GCC_VERSION VERSION_GREATER 4.9 OR GCC_VERSION VERSION_EQUAL 4.9)
     execute_process(COMMAND ${CMAKE_C_COMPILER} -print-libgcc-file-name OUTPUT_VARIABLE GCC_LIB)


### PR DESCRIPTION
Based on the bug report in
https://bugs.gentoo.org/show_bug.cgi?id=582770, mixing static+non-static
libstdc++ can lead to crashes. Disable such combinations. Choosing to
leave out the llvm check, since in practice clang is less likely to be
provided statically, so the check should cover both cases.

Fixes: #633
Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>