### PR TITLE
Add bcc_syms.h to C++ install

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -61,7 +61,7 @@ target_link_libraries(bcc-static b_frontend clang_frontend bcc-loader-static ${c
 
 install(TARGETS bcc-shared LIBRARY COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES bpf_common.h bpf_module.h ../libbpf.h COMPONENT libbcc
+install(FILES bpf_common.h bpf_module.h bcc_syms.h ../libbpf.h COMPONENT libbcc
   DESTINATION include/bcc)
 install(DIRECTORY compat/linux/ COMPONENT libbcc
   DESTINATION include/bcc/compat/linux


### PR DESCRIPTION
Expose `bcc_syms.h` to the C++ install. It is very useful in lookup / converting between symbols and addresses.