### PR TITLE
Remove unnecessary delete() in sync_timing.py

### DIFF
--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -162,7 +162,7 @@ Things to learn:
 1. ```BPF_HASH(last)```: Creates a BPF map object that is a hash (associative array), called "last". We didn't specify any further arguments, so it defaults to key and value types of u64.
 1. ```key = 0```: We'll only store one key/value pair in this hash, where the key is hardwired to zero.
 1. ```last.lookup(&key)```: Lookup the key in the hash, and return a pointer to its value if it exists, else NULL. We pass the key in as an address to a pointer.
-1. ```last.delete(&key)```: Delete the key from the hash.
+1. ```last.delete(&key)```: Delete the key from the hash. This is currently required because of [a kernel bug in `.update()`](https://git.kernel.org/cgit/linux/kernel/git/davem/net.git/commit/?id=a6ed3ea65d9868fdf9eff84e6fe4f666b8d14b02).
 1. ```last.update(&key)```: Set the key to equal the value in the 2nd argument. This records the timestamp.
 
 ### Lesson 5. sync_count.py


### PR DESCRIPTION
This pull request removes an unnecessary `.delete(&key)` in `sync_timing.py` and updates the tutorial accordingly.