### PR TITLE
frontends/clang: Safety check for invalid opLoc in ProbeVisitor

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -89,7 +89,7 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
 // Do a depth-first search to rewrite all pointers that need to be probed
 class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
  public:
-  explicit ProbeVisitor(clang::Rewriter &rewriter);
+  explicit ProbeVisitor(clang::ASTContext &C, clang::Rewriter &rewriter);
   bool VisitVarDecl(clang::VarDecl *Decl);
   bool VisitCallExpr(clang::CallExpr *Call);
   bool VisitBinaryOperator(clang::BinaryOperator *E);
@@ -97,6 +97,10 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   bool VisitMemberExpr(clang::MemberExpr *E);
   void set_ptreg(clang::Decl *D) { ptregs_.insert(D); }
  private:
+  template <unsigned N>
+  clang::DiagnosticBuilder error(clang::SourceLocation loc, const char (&fmt)[N]);
+
+  clang::ASTContext &C;
   clang::Rewriter &rewriter_;
   std::set<clang::Decl *> fn_visited_;
   std::set<clang::Expr *> memb_visited_;

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -212,6 +212,20 @@ int trace_entry2(struct pt_regs *ctx, int unused, struct file *file) {
         fn = b.load_func("trace_entry1", BPF.KPROBE)
         fn = b.load_func("trace_entry2", BPF.KPROBE)
 
+    def test_probe_unnamed_union_deref(self):
+        text = """
+#include <linux/mm_types.h>
+int trace(struct pt_regs *ctx, struct page *page) {
+    void *p = page->mapping;
+    return p != NULL;
+}
+"""
+        # depending on llvm, compile may pass/fail, but at least shouldn't crash
+        try:
+            b = BPF(text=text)
+        except:
+            pass
+
     def test_probe_struct_assign(self):
         b = BPF(text = """
 #include <uapi/linux/ptrace.h>


### PR DESCRIPTION
As reported in #664:
In cases where the AST contains a MemberExpr with an invalid opLoc,
rewrite will fail but prior to this change would segfault. Fail a little
more gracefully, even though the program will still be rejected.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>