### PR TITLE
offcputime improvements: use less RAM, add PID/TID support

### DIFF
--- a/man/man8/offcputime.8
+++ b/man/man8/offcputime.8
@@ -40,6 +40,9 @@ Print output in folded stack format.
 \-p PID
 Trace this process ID only (filtered in-kernel).
 .TP
+\-t TID
+Trace this thread ID only (filtered in-kernel).
+.TP
 \-u
 Only trace user threads (no kernel threads).
 .TP
@@ -51,6 +54,15 @@ Show stacks from user space only (no kernel space stacks).
 .TP
 \-K
 Show stacks from kernel space only (no user space stacks).
+.TP
+\-d
+Insert delimiter between kernel/user stacks.
+.TP
+\-f
+Output folded format.
+.TP
+\-\-stack-storage-size STACK_STORAGE_SIZE
+Change the number of unique stack traces that can be stored and displayed.
 .TP
 duration
 Duration to trace, in seconds.

--- a/tools/offcputime_example.txt
+++ b/tools/offcputime_example.txt
@@ -719,7 +719,7 @@ creating your "off-CPU time flame graphs".
 USAGE message:
 
 # ./offcputime -h
-usage: offcputime.py [-h] [-p PID | -k | -u] [-K | -U] [-f]
+usage: offcputime.py [-h] [-p PID | -t TID | -u | -k] [-U | -K] [-d] [-f]
                      [--stack-storage-size STACK_STORAGE_SIZE]
                      [duration]
 
@@ -731,6 +731,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -p PID, --pid PID     trace this PID only
+  -t TID, --tid TID     trace this TID only
   -u, --user-threads-only
                         user threads only (no kernel threads)
   -k, --kernel-threads-only
@@ -741,6 +742,7 @@ optional arguments:
   -K, --kernel-stacks-only
                         show stacks from kernel space only (no user space
                         stacks)
+  -d, --delimited       insert delimiter between kernel/user stacks
   -f, --folded          output folded format
   --stack-storage-size STACK_STORAGE_SIZE
                         the number of unique stack traces that can be stored
@@ -751,6 +753,7 @@ examples:
     ./offcputime 5           # trace for 5 seconds only
     ./offcputime -f 5        # 5 seconds, and output in folded format
     ./offcputime -p 185      # only trace threads for PID 185
+    ./offcputime -t 188      # only trace thread 188
     ./offcputime -u          # only trace user threads (no kernel)
     ./offcputime -k          # only trace kernel threads (no user)
     ./offcputime -U          # only show user space stacks (no kernel)


### PR DESCRIPTION
This PR adds support for filtering by thread or process ID to `offcputime`. Since "thread" and "process" mean different things in userspace and the kernel I went for `-t` and `-p` as the command options but mapped them to `pid` and `tgid` in the code to make it less confusing (see #547 as well).

It also instantiates only one symbol cache per process instead of one per thread. One per thread can add up to gigabytes of RAM in a multithreaded process with a lot of code.

Lastly, I fixed up the man page, example and a few aesthetic things here and there.