### PR TITLE
 BPF buffer log

### DIFF
--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -65,7 +65,6 @@ void * bpf_open_perf_buffer(perf_reader_raw_cb raw_cb, void *cb_cookie, int pid,
 int bpf_attach_xdp(const char *dev_name, int progfd);
 
 #define LOG_BUF_SIZE 65536
-extern char bpf_log_buf[LOG_BUF_SIZE];
 
 // Put non-static/inline functions in their own section with this prefix +
 // fn_name to enable discovery by the bcc library.

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -16,6 +16,8 @@ endif()
 
 add_test(NAME py_test_stat1_b WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_stat1_b namespace ${CMAKE_CURRENT_SOURCE_DIR}/test_stat1.py test_stat1.b proto.b)
+add_test(NAME py_test_bpf_log WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_bpf_prog namespace ${CMAKE_CURRENT_SOURCE_DIR}/test_bpf_log.py)
 add_test(NAME py_test_stat1_c WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_stat1_c namespace ${CMAKE_CURRENT_SOURCE_DIR}/test_stat1.py test_stat1.c)
 #add_test(NAME py_test_xlate1_b WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/python/test_bpf_log.py
+++ b/tests/python/test_bpf_log.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Copyright (c) PLUMgrid, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+from bcc import BPF
+from simulation import Simulation
+import sys
+import os
+import tempfile
+from unittest import main, TestCase
+
+
+error_msg = "R0 invalid mem access 'map_value_or_null'\n"
+
+text = """
+       #include <uapi/linux/ptrace.h>
+       #include <bcc/proto.h>
+       BPF_TABLE("hash", int, int, t1, 10);
+       int sim_port(struct __sk_buff *skb) {
+           int x = 0, *y;
+       """
+repeat = """
+           y = t1.lookup(&x);
+           if (!y) return 0;
+           x = *y;
+         """
+end = """
+           y = t1.lookup(&x);
+           x = *y;
+           return 0; 
+        }
+      """
+for i in range(0,300):
+    text += repeat
+text += end
+
+class TestBPFProgLoad(TestCase):
+
+    def setUp(self):
+        self.fp = tempfile.TemporaryFile()
+        os.dup2(self.fp.fileno(), sys.stderr.fileno())
+
+    def tearDown(self):
+        self.fp.close()
+        
+
+    def test_log_debug(self):
+        b = BPF(text=text, debug=2)
+        try:
+            ingress = b.load_func("sim_port",BPF.SCHED_CLS)
+        except Exception:
+            self.fp.flush()
+            self.fp.seek(0)
+            self.assertEqual(error_msg in self.fp.read(), True)
+
+
+    def test_log_no_debug(self):
+        b = BPF(text=text, debug=0)
+        try:
+            ingress = b.load_func("sim_port",BPF.SCHED_CLS)
+        except Exception:
+            self.fp.flush()
+            self.fp.seek(0)
+            self.assertEqual(error_msg in self.fp.read(), True)
+
+
+if __name__ == "__main__":
+    main()
+
+


### PR DESCRIPTION
This fix is addressing the buffer log  returned by bpf_prog_load api. The hard-coded value of 65k might not be large enough to contain all bpf program instruction. The new length is based on number of instruction times 128 bytes per instruction. 
In case the bpf program is bigger than 4096 instruction, kernel returns an error without filling up the the log buffer. A meaningful message is now returned, explaining the problem. 