### PR TITLE
add CONFIG_FUNCTION_PROFILER for cachestat

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,6 +27,7 @@ CONFIG_BPF_JIT=y
 CONFIG_HAVE_BPF_JIT=y
 # [optional, for kprobes]
 CONFIG_BPF_EVENTS=y
+CONFIG_FUNCTION_PROFILER=y
 ```
 
 Kernel compile flags can usually be checked by looking at `/proc/config.gz` or


### PR DESCRIPTION
cachestat seems to need the CONFIG_FUNCTION_PROFILER=y kernel option.