### PR TITLE
[tcpconnect] filter traced connection based on destination ports

### DIFF
--- a/man/man8/tcpconnect.8
+++ b/man/man8/tcpconnect.8
@@ -2,7 +2,7 @@
 .SH NAME
 tcpconnect \- Trace TCP active connections (connect()). Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B tcpconnect [\-h] [\-t] [\-x] [\-p PID]
+.B tcpconnect [\-h] [\-t] [\-x] [\-p PID] [-P PORT]
 .SH DESCRIPTION
 This tool traces active TCP connections (eg, via a connect() syscall;
 accept() are passive connections). This can be useful for general
@@ -27,6 +27,9 @@ Include a timestamp column.
 .TP
 \-p PID
 Trace this process ID only (filtered in-kernel).
+.TP
+\-P PORT
+Comma-separated list of destination ports to trace (filtered in-kernel).
 .SH EXAMPLES
 .TP
 Trace all active TCP connections:
@@ -40,6 +43,10 @@ Trace all TCP connects, and include timestamps:
 Trace PID 181 only:
 #
 .B tcpconnect \-p 181
+.TP
+Trace ports 80 and 81 only:
+#
+.B tcpconnect \-P 80,81
 .SH FIELDS
 .TP
 TIME(s)

--- a/tools/tcpconnect_example.txt
+++ b/tools/tcpconnect_example.txt
@@ -41,7 +41,7 @@ process to various other addresses. A few connections occur every minute.
 USAGE message:
 
 # ./tcpconnect -h
-usage: tcpconnect [-h] [-t] [-p PID]
+usage: tcpconnect [-h] [-t] [-p PID] [-P PORT]
 
 Trace TCP connects
 
@@ -49,8 +49,12 @@ optional arguments:
   -h, --help         show this help message and exit
   -t, --timestamp    include timestamp on output
   -p PID, --pid PID  trace this PID only
+  -P PORT, --port PORT
+                     comma-separated list of destination ports to trace.
 
 examples:
     ./tcpconnect           # trace all TCP connect()s
     ./tcpconnect -t        # include timestamps
     ./tcpconnect -p 181    # only trace PID 181
+    ./tcpconnect -P 80     # only trace port 80
+    ./tcpconnect -P 80,81  # only trace port 80 and 81


### PR DESCRIPTION
Test:
While running:
while [ 1 ]; do nc -w 1 100.127.0.1 80; nc -w 1 100.127.0.1 81; done

root@vagrant:/mnt/bcc# ./tools/tcpconnect.py
PID    COMM         IP SADDR            DADDR            DPORT
19978  nc           4  10.0.2.15        100.127.0.1      80
19979  nc           4  10.0.2.15        100.127.0.1      81
19980  nc           4  10.0.2.15        100.127.0.1      80
19981  nc           4  10.0.2.15        100.127.0.1      81
root@vagrant:/mnt/bcc# ./tools/tcpconnect.py  -P 80
PID    COMM         IP SADDR            DADDR            DPORT
19987  nc           4  10.0.2.15        100.127.0.1      80
19989  nc           4  10.0.2.15        100.127.0.1      80
19991  nc           4  10.0.2.15        100.127.0.1      80
19993  nc           4  10.0.2.15        100.127.0.1      80
19995  nc           4  10.0.2.15        100.127.0.1      80
root@vagrant:/mnt/bcc# ./tools/tcpconnect.py  -P 80 81
PID    COMM         IP SADDR            DADDR            DPORT
8725   nc           4  10.0.2.15        100.127.0.1      80
8726   nc           4  10.0.2.15        100.127.0.1      81
8727   nc           4  10.0.2.15        100.127.0.1      80
8728   nc           4  10.0.2.15        100.127.0.1      81
8729   nc           4  10.0.2.15        100.127.0.1      80

Fixes #681