### PR TITLE
Fix or hide a few warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NOT DEFINED BCC_KERNEL_MODULES_SUFFIX)
 endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -isystem ${LLVM_INCLUDE_DIRS}")
 endif()
 
 add_subdirectory(examples)

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -56,15 +56,6 @@ TEST_CASE("test finding a probe in our own process", "[usdt]") {
 }
 #endif  // HAVE_SDT_HEADER
 
-static size_t countsubs(const std::string &str, const std::string &sub) {
-  size_t count = 0;
-  for (size_t offset = str.find(sub); offset != std::string::npos;
-       offset = str.find(sub, offset + sub.length())) {
-    ++count;
-  }
-  return count;
-}
-
 class ChildProcess {
   pid_t pid_;
 


### PR DESCRIPTION
* mark ${LLVM_INCLUDE_DIRS} as a system include directory, so warnings therein can be ignored;
* fix a 'defined but not used' warning in the USDT probes test.