### PR TITLE
[offcputime] allow for the speficication of a threshold for collection

### DIFF
--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -78,6 +78,9 @@ parser.add_argument("--stack-storage-size", default=1024,
 parser.add_argument("duration", nargs="?", default=99999999,
     type=positive_nonzero_int,
     help="duration of trace, in seconds")
+parser.add_argument("--min-block-time", default=1,
+    type=positive_nonzero_int,
+    help="the amount of time in microseconds over which we store traces (default 1)")
 args = parser.parse_args()
 if args.pid and args.tgid:
     parser.error("specify only one of -p and -t")
@@ -93,7 +96,7 @@ bpf_text = """
 #include <uapi/linux/ptrace.h>
 #include <linux/sched.h>
 
-#define MINBLOCK_US	1
+#define MINBLOCK_US    MINBLOCK_US_VALUE
 
 struct key_t {
     u32 pid;
@@ -170,6 +173,7 @@ bpf_text = bpf_text.replace('THREAD_FILTER', thread_filter)
 
 # set stack storage size
 bpf_text = bpf_text.replace('STACK_STORAGE_SIZE', str(args.stack_storage_size))
+bpf_text = bpf_text.replace('MINBLOCK_US_VALUE', str(args.min_block_time))
 
 # handle stack args
 kernel_stack_get = "stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID)"


### PR DESCRIPTION
There are situations, specially when using non-folded mode, where we are
interested only in very high latencies that happen due to blocking.

While we can certainly filter out the very small ones out of the output, it is a
lot more convenient to do this from the tool itself, as it would be difficult
from an external filter to do this in one pass.

But if we are to discard unused measurements, we can do even better: we can
change the bpf code itself not to grab those traces, and gain a bit of
efficiency in scenarios in which we are only concerned about peak latencies.