### PR TITLE
Fix argdist, trace, tplist to use the libbcc USDT support

### DIFF
--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -26,6 +26,18 @@ void *bcc_usdt_new_frompid(int pid);
 void *bcc_usdt_new_frompath(const char *path);
 void bcc_usdt_close(void *usdt);
 
+struct bcc_usdt {
+    const char *provider;
+    const char *name;
+    const char *bin_path;
+    uint64_t semaphore;
+    int num_locations;
+    int num_arguments;
+};
+
+typedef void (*bcc_usdt_cb)(struct bcc_usdt *);
+void bcc_usdt_foreach(void *usdt, bcc_usdt_cb callback);
+
 int bcc_usdt_enable_probe(void *, const char *, const char *);
 const char *bcc_usdt_genargs(void *);
 

--- a/src/cc/usdt.cc
+++ b/src/cc/usdt.cc
@@ -24,6 +24,7 @@
 #include "bcc_proc.h"
 #include "usdt.h"
 #include "vendor/tinyformat.hpp"
+#include "bcc_usdt.h"
 
 namespace USDT {
 
@@ -255,6 +256,19 @@ bool Context::enable_probe(const std::string &probe_name,
   return p && p->enable(fn_name);
 }
 
+void Context::each(each_cb callback) {
+  for (const auto &probe : probes_) {
+    struct bcc_usdt info = {0};
+    info.provider = probe->provider().c_str();
+    info.bin_path = probe->bin_path().c_str();
+    info.name = probe->name().c_str();
+    info.semaphore = probe->semaphore();
+    info.num_locations = probe->num_locations();
+    info.num_arguments = probe->num_arguments();
+    callback(&info);
+  }
+}
+
 void Context::each_uprobe(each_uprobe_cb callback) {
   for (auto &p : probes_) {
     if (!p->enabled())
@@ -288,7 +302,6 @@ Context::~Context() {
 }
 
 extern "C" {
-#include "bcc_usdt.h"
 
 void *bcc_usdt_new_frompid(int pid) {
   USDT::Context *ctx = new USDT::Context(pid);
@@ -329,6 +342,11 @@ const char *bcc_usdt_genargs(void *usdt) {
 
   storage_ = stream.str();
   return storage_.c_str();
+}
+
+void bcc_usdt_foreach(void *usdt, bcc_usdt_cb callback) {
+  USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
+  ctx->each(callback);
 }
 
 void bcc_usdt_foreach_uprobe(void *usdt, bcc_usdt_uprobe_cb callback) {

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -23,6 +23,8 @@
 #include "syms.h"
 #include "vendor/optional.hpp"
 
+struct bcc_usdt;
+
 namespace USDT {
 
 using std::experimental::optional;
@@ -148,6 +150,7 @@ public:
 
   size_t num_locations() const { return locations_.size(); }
   size_t num_arguments() const { return locations_.front().arguments_.size(); }
+  uint64_t semaphore()   const { return semaphore_; }
 
   uint64_t address(size_t n = 0) const { return locations_[n].address_; }
   bool usdt_getarg(std::ostream &stream);
@@ -193,6 +196,9 @@ public:
 
   bool enable_probe(const std::string &probe_name, const std::string &fn_name);
   bool generate_usdt_args(std::ostream &stream);
+
+  typedef void (*each_cb)(struct bcc_usdt *);
+  void each(each_cb callback);
 
   typedef void (*each_uprobe_cb)(const char *, const char *, uint64_t, int);
   void each_uprobe(each_uprobe_cb callback);

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -149,7 +149,7 @@ class BPF(object):
         return None
 
     def __init__(self, src_file="", hdr_file="", text=None, cb=None, debug=0,
-            cflags=[], usdt=None):
+            cflags=[], usdt_contexts=[]):
         """Create a a new BPF module with the given source code.
 
         Note:
@@ -179,7 +179,15 @@ class BPF(object):
         self.tables = {}
         cflags_array = (ct.c_char_p * len(cflags))()
         for i, s in enumerate(cflags): cflags_array[i] = s.encode("ascii")
-        if usdt and text: text = usdt.get_text() + text
+        if text:
+            for usdt_context in usdt_contexts:
+                usdt_text = usdt_context.get_text()
+                if usdt_text is None:
+                    raise Exception("can't generate USDT probe arguments; " +
+                                    "possible cause is missing pid when a " +
+                                    "probe in a shared object has multiple " +
+                                    "locations")
+                text = usdt_context.get_text() + text
 
         if text:
             self.module = lib.bpf_module_create_c_from_string(text.encode("ascii"),
@@ -197,7 +205,8 @@ class BPF(object):
         if not self.module:
             raise Exception("Failed to compile BPF module %s" % src_file)
 
-        if usdt: usdt.attach_uprobes(self)
+        for usdt_context in usdt_contexts:
+            usdt_context.attach_uprobes(self)
 
         # If any "kprobe__" or "tracepoint__" prefixed functions were defined,
         # they will be loaded and attached here.

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -157,7 +157,23 @@ lib.bcc_usdt_enable_probe.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_char_p]
 lib.bcc_usdt_genargs.restype = ct.c_char_p
 lib.bcc_usdt_genargs.argtypes = [ct.c_void_p]
 
-_USDT_CB = ct.CFUNCTYPE(None, ct.c_char_p, ct.c_char_p, ct.c_ulonglong, ct.c_int)
+class bcc_usdt(ct.Structure):
+    _fields_ = [
+            ('provider', ct.c_char_p),
+            ('name', ct.c_char_p),
+            ('bin_path', ct.c_char_p),
+            ('semaphore', ct.c_ulonglong),
+            ('num_locations', ct.c_int),
+            ('num_arguments', ct.c_int),
+        ]
+
+_USDT_CB = ct.CFUNCTYPE(None, ct.POINTER(bcc_usdt))
+
+lib.bcc_usdt_foreach.restype = None
+lib.bcc_usdt_foreach.argtypes = [ct.c_void_p, _USDT_CB]
+
+_USDT_PROBE_CB = ct.CFUNCTYPE(None, ct.c_char_p, ct.c_char_p,
+                              ct.c_ulonglong, ct.c_int)
 
 lib.bcc_usdt_foreach_uprobe.restype = None
-lib.bcc_usdt_foreach_uprobe.argtypes = [ct.c_void_p, _USDT_CB]
+lib.bcc_usdt_foreach_uprobe.argtypes = [ct.c_void_p, _USDT_PROBE_CB]

--- a/src/python/bcc/tracepoint.py
+++ b/src/python/bcc/tracepoint.py
@@ -16,6 +16,7 @@ import ctypes as ct
 import multiprocessing
 import os
 import re
+from .perf import Perf
 
 class Tracepoint(object):
         enabled_tracepoints = []

--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -48,7 +48,9 @@ class USDT(object):
 
     def enable_probe(self, probe, fn_name):
         if lib.bcc_usdt_enable_probe(self.context, probe, fn_name) != 0:
-            raise Exception("failed to enable probe '%s'" % probe)
+            raise Exception(("failed to enable probe '%s'; a possible cause " +
+                            "can be that the probe requires a pid to enable") %
+                            probe)
 
     def get_text(self):
         return lib.bcc_usdt_genargs(self.context)

--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -12,7 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .libbcc import lib, _USDT_CB
+from .libbcc import lib, _USDT_CB, _USDT_PROBE_CB
+
+class USDTProbe(object):
+    def __init__(self, usdt):
+        self.provider = usdt.provider
+        self.name = usdt.name
+        self.bin_path = usdt.bin_path
+        self.semaphore = usdt.semaphore
+        self.num_locations = usdt.num_locations
+        self.num_arguments = usdt.num_arguments
+
+    def __str__(self):
+        return "%s %s:%s [sema 0x%x]\n  %d location(s)\n  %d argument(s)" % \
+               (self.bin_path, self.provider, self.name, self.semaphore,
+                self.num_locations, self.num_arguments)
 
 class USDT(object):
     def __init__(self, pid=None, path=None):
@@ -20,12 +34,14 @@ class USDT(object):
             self.pid = pid
             self.context = lib.bcc_usdt_new_frompid(pid)
             if self.context == None:
-                raise Exception("USDT failed to instrument PID %d" % pid) 
+                raise Exception("USDT failed to instrument PID %d" % pid)
         elif path:
             self.path = path
             self.context = lib.bcc_usdt_new_frompath(path)
             if self.context == None:
-                raise Exception("USDT failed to instrument path %s" % path) 
+                raise Exception("USDT failed to instrument path %s" % path)
+        else:
+            raise Exception("either a pid or a binary path must be specified")
 
     def enable_probe(self, probe, fn_name):
         if lib.bcc_usdt_enable_probe(self.context, probe, fn_name) != 0:
@@ -34,12 +50,24 @@ class USDT(object):
     def get_text(self):
         return lib.bcc_usdt_genargs(self.context)
 
+    def enumerate_probes(self):
+        probes = []
+        def _add_probe(probe):
+            probes.append(USDTProbe(probe.contents))
+
+        lib.bcc_usdt_foreach(self.context, _USDT_CB(_add_probe))
+        return probes
+
+    # This is called by the BPF module's __init__ when it realizes that there
+    # is a USDT context and probes need to be attached.
     def attach_uprobes(self, bpf):
         probes = []
         def _add_probe(binpath, fn_name, addr, pid):
             probes.append((binpath, fn_name, addr, pid))
 
-        lib.bcc_usdt_foreach_uprobe(self.context, _USDT_CB(_add_probe))
+        lib.bcc_usdt_foreach_uprobe(self.context, _USDT_PROBE_CB(_add_probe))
 
         for (binpath, fn_name, addr, pid) in probes:
-            bpf.attach_uprobe(name=binpath, fn_name=fn_name, addr=addr, pid=pid)
+            bpf.attach_uprobe(name=binpath, fn_name=fn_name,
+                              addr=addr, pid=pid)
+

--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -28,9 +28,12 @@ class USDTProbe(object):
                (self.bin_path, self.provider, self.name, self.semaphore,
                 self.num_locations, self.num_arguments)
 
+    def short_name(self):
+        return "%s:%s" % (self.provider, self.name)
+
 class USDT(object):
     def __init__(self, pid=None, path=None):
-        if pid:
+        if pid and pid != -1:
             self.pid = pid
             self.context = lib.bcc_usdt_new_frompid(pid)
             if self.context == None:

--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -175,8 +175,8 @@ u64 __time = bpf_ktime_get_ns();
                         self._bail("no exprs specified")
                 self.exprs = exprs.split(',')
 
-        def __init__(self, bpf, type, specifier):
-                self.pid = bpf.args.pid
+        def __init__(self, tool, type, specifier):
+                self.pid = tool.args.pid
                 self.raw_spec = specifier
                 self._validate_specifier()
 
@@ -200,8 +200,8 @@ u64 __time = bpf_ktime_get_ns();
                         self.library = parts[1]
                         self.probe_func_name = "%s_probe%d" % \
                                 (self.function, Probe.next_probe_index)
-                        bpf.enable_usdt_probe(self.function,
-                                        fn_name=self.probe_func_name)
+                        tool.enable_usdt_probe(self.library, self.function,
+                                               self.probe_func_name)
                 else:
                         self.library = parts[1]
                 self.is_user = len(self.library) > 0
@@ -265,7 +265,7 @@ u64 __time = bpf_ktime_get_ns();
         def _generate_field_assignment(self, i):
                 text = ""
                 if self.probe_type == "u" and self.exprs[i][0:3] == "arg":
-                    text = ("        u64 %s;\n" + 
+                    text = ("        u64 %s;\n" +
                            "        bpf_usdt_readarg(%s, ctx, &%s);\n") % \
                            (self.exprs[i], self.exprs[i][3], self.exprs[i])
                 if self._is_string(self.expr_types[i]):
@@ -590,9 +590,9 @@ argdist -p 2780 -z 120 \\
                         print("at least one specifier is required")
                         exit()
 
-        def enable_usdt_probe(self, probe_name, fn_name):
+        def enable_usdt_probe(self, library, probe_name, fn_name):
                 if not self.usdt_ctx:
-                        self.usdt_ctx = USDT(pid=self.args.pid)
+                        self.usdt_ctx = USDT(path=library, pid=self.args.pid)
                 self.usdt_ctx.enable_probe(probe_name, fn_name)
 
         def _generate_program(self):

--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -612,7 +612,8 @@ struct __string_t { char s[%d]; };
                 if self.args.verbose:
                         if self.usdt_ctx: print(self.usdt_ctx.get_text())
                         print(bpf_source)
-                self.bpf = BPF(text=bpf_source, usdt=self.usdt_ctx)
+                # TODO Support multiple USDT probes!!!
+                self.bpf = BPF(text=bpf_source, usdt_contexts=[self.usdt_ctx])
 
         def _attach(self):
                 Tracepoint.attach(self.bpf)

--- a/tools/tplist.py
+++ b/tools/tplist.py
@@ -13,7 +13,7 @@ import os
 import re
 import sys
 
-from bcc import USDTReader
+from bcc import USDT
 
 trace_root = "/sys/kernel/debug/tracing"
 event_root = os.path.join(trace_root, "events")
@@ -21,7 +21,7 @@ event_root = os.path.join(trace_root, "events")
 parser = argparse.ArgumentParser(description=
                 "Display kernel tracepoints or USDT probes and their formats.",
                 formatter_class=argparse.RawDescriptionHelpFormatter)
-parser.add_argument("-p", "--pid", type=int, default=-1, help=
+parser.add_argument("-p", "--pid", type=int, default=None, help=
                 "List USDT probes in the specified process")
 parser.add_argument("-l", "--lib", default="", help=
                 "List USDT probes in the specified library or executable")
@@ -65,23 +65,23 @@ def print_tracepoints():
                                 print_tpoint(category, event)
 
 def print_usdt(pid, lib):
-        reader = USDTReader(bin_path=lib, pid=pid)
+        reader = USDT(path=lib, pid=pid)
         probes_seen = []
-        for probe in reader.probes:
+        for probe in reader.enumerate_probes():
                 probe_name = "%s:%s" % (probe.provider, probe.name)
                 if not args.filter or fnmatch.fnmatch(probe_name, args.filter):
                         if probe_name in probes_seen:
                                 continue
                         probes_seen.append(probe_name)
                         if args.variables:
-                                print(probe.display_verbose())
+                                print(probe)
                         else:
                                 print("%s %s:%s" % (probe.bin_path,
-                                        probe.provider, probe.name))
+                                                    probe.provider, probe.name))
 
 if __name__ == "__main__":
         try:
-                if args.pid != -1 or args.lib != "":
+                if args.pid or args.lib != "":
                         print_usdt(args.pid, args.lib)
                 else:
                         print_tracepoints()

--- a/tools/tplist.py
+++ b/tools/tplist.py
@@ -68,7 +68,7 @@ def print_usdt(pid, lib):
         reader = USDT(path=lib, pid=pid)
         probes_seen = []
         for probe in reader.enumerate_probes():
-                probe_name = "%s:%s" % (probe.provider, probe.name)
+                probe_name = probe.short_name()
                 if not args.filter or fnmatch.fnmatch(probe_name, args.filter):
                         if probe_name in probes_seen:
                                 continue

--- a/tools/tplist_example.txt
+++ b/tools/tplist_example.txt
@@ -17,25 +17,18 @@ $ tplist -l basic_usdt
 /home/vagrant/basic_usdt basic_usdt:loop_iter
 /home/vagrant/basic_usdt basic_usdt:end_main
 
-The loop_iter probe sounds interesting. What are the locations of that
-probe, and which variables are available?
+The loop_iter probe sounds interesting. How many arguments are available?
 
 $ tplist '*loop_iter' -l basic_usdt -v
 /home/vagrant/basic_usdt basic_usdt:loop_iter [sema 0x601036]
-  location 0x400550 raw args: -4@$42 8@%rax
-    4   signed bytes @ constant 42
-    8 unsigned bytes @ register %rax
-  location 0x40056f raw args: 8@-8(%rbp) 8@%rax
-    8 unsigned bytes @ -8(%rbp)
-    8 unsigned bytes @ register %rax
+  2 location(s)
+  2 argument(s)
 
 This output indicates that the loop_iter probe is used in two locations
-in the basic_usdt executable. The first location passes a constant value,
-42, to the probe. The second location passes a variable value located at
-an offset from the %rbp register. Don't worry -- you don't have to trace
-the register values yourself. The argdist and trace tools understand the
-probe format and can print out the arguments automatically -- you can
-refer to them as arg1, arg2, and so on.
+in the basic_usdt executable, and that it has two arguments. Fortunately,
+the argdist and trace tools understand the probe format and can print out
+the arguments automatically -- you can refer to them as arg1, arg2, and
+so on.
 
 Try to explore with some common libraries on your system and see if they
 contain UDST probes. Here are two examples you might find interesting:


### PR DESCRIPTION
UPDATED: The task list below is pretty much done, and I think that's the pieces we need to update the three tools to the new USDT support. Any comments and feedback will be appreciated. From my side, it's ready to merge.

So, here's the task list:

- [x] Fix argdist so that it fully supports USDT probes, including when no pid is specified
- [x] Add API to libbcc that returns a list of the USDT probes in a process or binary
- [x] Fix tplist to print USDT probe information on processes or binaries
- [x] Fix trace so that it doesn't bail for kprobes, uprobes, and tracepoints (not including USDT)
- [x] Migrate trace to the new libbcc USDT support
- [x] Modify `BPF` Python class to allow multiple USDT contexts
- [x] Fix trace to support multiple USDT probes
- [x] Fix argdist to support multiple USDT probes