### PR TITLE
filelife: use d_name.name and d_name.len instead of d_iname

### DIFF
--- a/tools/filelife.py
+++ b/tools/filelife.py
@@ -82,13 +82,14 @@ int trace_unlink(struct pt_regs *ctx, struct inode *dir, struct dentry *dentry)
     delta = (bpf_ktime_get_ns() - *tsp) / 1000000;
     birth.delete(&dentry);
 
-    if (dentry->d_iname[0] == 0)
+    if (dentry->d_name.len == 0)
         return 0;
 
     if (bpf_get_current_comm(&data.comm, sizeof(data.comm)) == 0) {
         data.pid = pid;
         data.delta = delta;
-        bpf_probe_read(&data.fname, sizeof(data.fname), dentry->d_iname);
+        bpf_probe_read(&data.fname, sizeof(data.fname),
+            (void *)dentry->d_name.name);
     }
 
     events.perf_submit(ctx, &data, sizeof(data));


### PR DESCRIPTION
This is similar in spirit to what was done in PR #677 to fix the problem reported in #609.

filelife.py is now converted to use the right struct field.