### PR TITLE
change the file name in CONTRIBUTING-SCRIPTS.md

### DIFF
--- a/CONTRIBUTING-SCRIPTS.md
+++ b/CONTRIBUTING-SCRIPTS.md
@@ -15,7 +15,7 @@ More detail for each below.
 
 ## Examples
 
-These are grouped into subdirectories (networking, tracing). Your example can either be a Python program with embedded C (eg, tracing/strlen_count.py), or separate Python and C files (eg, tracing/bitehist.*).
+These are grouped into subdirectories (networking, tracing). Your example can either be a Python program with embedded C (eg, tracing/strlen_count.py), or separate Python and C files (eg, tracing/vfsreadlat.*).
 
 As said earlier: keep it short, neat, and documented (code comments).
 


### PR DESCRIPTION
I found something to need to be update in CONTRIBUTING-SCRIPTS.md.

This documents said that tracing/strlen_count.py is a Python program with embedded C, and tracing/bitehist.* are separate Python and C files.
But I can't find the bitehist.c file. I think that the source file that named by bitehist.py is also a Python program with embedded C such as strlen_count.py.

So I changed the filename, bitehist.* to vfsreadlat.*


PS. I'm really expect it will be my first contribution point for opensource projects.