### PR TITLE
Edit some sentences in INSTALL.md more clearly

### DIFF
--- a/CONTRIBUTING-SCRIPTS.md
+++ b/CONTRIBUTING-SCRIPTS.md
@@ -15,7 +15,7 @@ More detail for each below.
 
 ## Examples
 
-These are grouped into subdirectories (networking, tracing). Your example can either be a Python program with embedded C (eg, tracing/strlen_count.py), or separate Python and C files (eg, tracing/bitehist.*).
+These are grouped into subdirectories (networking, tracing). Your example can either be a Python program with embedded C (eg, tracing/strlen_count.py), or separate Python and C files (eg, tracing/vfsreadlat.*).
 
 As said earlier: keep it short, neat, and documented (code comments).
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,6 @@ sudo python /usr/share/bcc/examples/tracing/task_switch.py
 ```bash
 git clone https://github.com/svinota/pyroute2
 cd pyroute2; sudo make install
-sudo python /usr/share/bcc/examples/simple_tc.py
 ```
 
 ## Fedora - Binary

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -150,13 +150,6 @@ sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
 sudo apt-get -y install luajit luajit-5.1-dev
 ```
 
-(Optional) Install pyroute2 for additional networking features
-```bash
-git clone https://github.com/svinota/pyroute2
-cd pyroute2; sudo make install
-sudo python bcc/examples/networking/simple_tc.py
-```
-
 ### Install and compile BCC
 ```
 git clone https://github.com/iovisor/bcc.git
@@ -164,6 +157,13 @@ mkdir bcc/build; cd bcc/build
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr
 make
 sudo make install
+```
+
+(Optional) Install pyroute2 for additional networking features
+```bash
+git clone https://github.com/svinota/pyroute2
+cd pyroute2; sudo make install
+sudo python bcc/examples/networking/simple_tc.py
 ```
 
 ## Fedora - Source

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,12 +91,6 @@ sudo python /usr/share/bcc/examples/hello_world.py
 sudo python /usr/share/bcc/examples/tracing/task_switch.py
 ```
 
-(Optional) Install pyroute2 for additional networking features
-```bash
-git clone https://github.com/svinota/pyroute2
-cd pyroute2; sudo make install
-```
-
 ## Fedora - Binary
 
 Install a 4.2+ kernel from
@@ -154,6 +148,13 @@ sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
 
 # For Lua support
 sudo apt-get -y install luajit luajit-5.1-dev
+```
+
+(Optional) Install pyroute2 for additional networking features
+```bash
+git clone https://github.com/svinota/pyroute2
+cd pyroute2; sudo make install
+sudo python bcc/examples/networking/simple_tc.py
 ```
 
 ### Install and compile BCC


### PR DESCRIPTION
While I installed IO Visor following INSTALL.md document, I found something to be fixed about pyroute2 example.


Currently, there are some script about installation of pyroute2 and testing example like below.

---
(Optional) Install pyroute2 for additional networking features
```
git clone https://github.com/svinota/pyroute2
cd pyroute2; sudo make install
sudo python /usr/share/bcc/examples/simple_tc.py
```
---

But there is no ```simple_tc.py``` file in /usr/share/bcc/examples/ directory.
```simple_tc.py``` is included in 'Source' step, not 'Packages' step in INSTALL.md

And also we can find that file in ```bcc/examples/networking/simple_tc.py``` after 'Source' step in INSTALL.md

So, I suggest that optional information about pyroute2 would be included in 'Source' step.
I think It will be more clearly.

---

Apart from that, the example ```simple_tc.py``` does not operate properly.
When I executed ```simple_tc.py```, this error was occured.

```No handlers could be found for logger "pyroute2.iproute"
BPF tc functionality - SCHED_CLS: OK```

Although I can't understand source code in ```simple_tc.py```, It has some problem.
I will study hard and fix source code as well as docs.

---