### PR TITLE
revert "Flag ${LLVM_INCLUDE_DIRS} as a system include directory"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NOT DEFINED BCC_KERNEL_MODULES_SUFFIX)
 endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -isystem ${LLVM_INCLUDE_DIRS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 endif()
 
 add_subdirectory(examples)


### PR DESCRIPTION
it breaks the build as:
"
c++: fatal error: no input files
compilation terminated.
/bin/sh: /w/llvm/bld/include: Is a directory
"

Signed-off-by: Alexei Starovoitov <ast@fb.com>