### PR TITLE
edit optional info in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,13 +91,6 @@ sudo python /usr/share/bcc/examples/hello_world.py
 sudo python /usr/share/bcc/examples/tracing/task_switch.py
 ```
 
-(Optional) Install pyroute2 for additional networking features
-```bash
-git clone https://github.com/svinota/pyroute2
-cd pyroute2; sudo make install
-sudo python /usr/share/bcc/examples/simple_tc.py
-```
-
 ## Fedora - Binary
 
 Install a 4.2+ kernel from
@@ -164,6 +157,13 @@ mkdir bcc/build; cd bcc/build
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr
 make
 sudo make install
+```
+
+(Optional) Install pyroute2 for additional networking features
+```bash
+git clone https://github.com/svinota/pyroute2
+cd pyroute2; sudo make install
+sudo python ./bcc/examples/networking/simple_tc.py
 ```
 
 ## Fedora - Source


### PR DESCRIPTION
While I installed IO Visor following INSTALL.md document, I found something to be fixed about pyroute2 example.

Currently, there are some script about installation of pyroute2 and testing example like below.

---

(Optional) Install pyroute2 for additional networking features

```
git clone https://github.com/svinota/pyroute2
cd pyroute2; sudo make install
sudo python /usr/share/bcc/examples/simple_tc.py
```

---

But there is no `simple_tc.py` file in /usr/share/bcc/examples/ directory.
`simple_tc.py` is included in 'Source' step, not 'Packages' step in INSTALL.md

And also we can find that file in `bcc/examples/networking/simple_tc.py` after 'Source' step in INSTALL.md

So, I suggest that optional information about pyroute2 would be included in 'Source' step.
I think It will be more clearly.

---

Apart from that, the example `simple_tc.py` does not operate properly.
When I executed `simple_tc.py`, this error was occured.

`No handlers could be found for logger "pyroute2.iproute"
BPF tc functionality - SCHED_CLS: OK`

Although I can't understand source code in `simple_tc.py`, It has some problem.
I will study hard and fix source code as well as docs.

---
