### PR TITLE
cmake: fix build when LLVM_INCLUDE_DIRS includes multiple directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,12 @@ if(NOT DEFINED BCC_KERNEL_MODULES_SUFFIX)
 endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -isystem ${LLVM_INCLUDE_DIRS}")
+# iterate over all available directories in LLVM_INCLUDE_DIRS to
+# generate a correctly tokenized list of parameters
+foreach(ONE_LLVM_INCLUDE_DIR ${LLVM_INCLUDE_DIRS})
+  set(CXX_ISYSTEM_DIRS "${CXX_ISYSTEM_DIRS} -isystem ${ONE_LLVM_INCLUDE_DIR}")
+endforeach()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall ${CXX_ISYSTEM_DIRS}")
 endif()
 
 add_subdirectory(examples)


### PR DESCRIPTION
If LLVM_INCLUDE_DIRS includes multiple directories, separated by
semicolon, the string would be incorrectly propagated all the way down
to the shell, that would interpret such semicolon as a command
separator. E.g. we would have:

 c++ ... -isystem /w/llvm/include;/w/llvm/bld/include ...

Instead, we need to parse the string as a CMake list (that are defined
as strings composed by semicolon-separated tokens) and build a string
in the form:

 c++ ... -isystem /w/llvm/include -isystem /w/llvm/bld/include ...

This bug was introduced in d19e0cb.
This commit fixes #707.

Signed-off-by: Marco Leogrande <marcol@plumgrid.com>