### PR TITLE
Fix trace.py USDT argument filtering

### DIFF
--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -40,6 +40,9 @@ void bcc_usdt_foreach(void *usdt, bcc_usdt_cb callback);
 
 int bcc_usdt_enable_probe(void *, const char *, const char *);
 const char *bcc_usdt_genargs(void *);
+const char *bcc_usdt_get_probe_argctype(
+  void *ctx, const char* probe_name, const int arg_index
+);
 
 typedef void (*bcc_usdt_uprobe_cb)(const char *, const char *, uint64_t, int);
 void bcc_usdt_foreach_uprobe(void *usdt, bcc_usdt_uprobe_cb callback);

--- a/src/cc/usdt.cc
+++ b/src/cc/usdt.cc
@@ -344,6 +344,14 @@ const char *bcc_usdt_genargs(void *usdt) {
   return storage_.c_str();
 }
 
+const char *bcc_usdt_get_probe_argctype(
+  void *ctx, const char* probe_name, const int arg_index
+) {
+  USDT::Probe *p = static_cast<USDT::Context *>(ctx)->get(probe_name);
+  std::string res = p ? p->get_arg_ctype(arg_index) : "";
+  return res.c_str();
+}
+
 void bcc_usdt_foreach(void *usdt, bcc_usdt_cb callback) {
   USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
   ctx->each(callback);

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -154,6 +154,9 @@ public:
 
   uint64_t address(size_t n = 0) const { return locations_[n].address_; }
   bool usdt_getarg(std::ostream &stream);
+  std::string get_arg_ctype(int arg_index) {
+    return largest_arg_type(arg_index);
+  }
 
   bool need_enable() const { return semaphore_ != 0x0; }
   bool enable(const std::string &fn_name);

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -157,6 +157,9 @@ lib.bcc_usdt_enable_probe.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_char_p]
 lib.bcc_usdt_genargs.restype = ct.c_char_p
 lib.bcc_usdt_genargs.argtypes = [ct.c_void_p]
 
+lib.bcc_usdt_get_probe_argctype.restype = ct.c_char_p
+lib.bcc_usdt_get_probe_argctype.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_int]
+
 class bcc_usdt(ct.Structure):
     _fields_ = [
             ('provider', ct.c_char_p),

--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -55,6 +55,10 @@ class USDT(object):
     def get_text(self):
         return lib.bcc_usdt_genargs(self.context)
 
+    def get_probe_arg_ctype(self, probe_name, arg_index):
+        return lib.bcc_usdt_get_probe_argctype(
+            self.context, probe_name, arg_index)
+
     def enumerate_probes(self):
         probes = []
         def _add_probe(probe):


### PR DESCRIPTION
@goldshtn fixed general USDT support in `trace.py` in #698 . However, filtering is still not able to function since we are not reading the arguments correctly.

This Diffs replaces `argX` variables in filtering conditions to `argX_filter`, and use the `bpf_readarg_N` macros to read argument values into `argX_filter` variables. 

In order to define the variables correctly, this Diff also exposes the ability to get USDT argument type (i.e., size) in Python `USDT` class. I think this would be useful elsewhere as well.

Tested by defining an USDT probe with two parameters in my test binary and run
```
trace.py 'u:pathToBinary:theProbeName (arg1!=0) "Arg1 %lld Arg2 %s", arg1, arg2'
```
Generated BPF program looks like:
```
int probe_contextSwitch_1(struct pt_regs *ctx)
{

        u32 __pid = bpf_get_current_pid_tgid();
        if (__pid == 3787616) { return 0; }

        uint64_t arg1_filter;
        bpf_usdt_readarg(1, ctx, &arg1_filter);

        if (!((arg1_filter!=0))) return 0;

        struct probe_contextSwitch_1_data_t __data = {0};
        __data.timestamp_ns = bpf_ktime_get_ns();
        __data.pid = bpf_get_current_pid_tgid();
        bpf_get_current_comm(&__data.comm, sizeof(__data.comm));
        u64 arg1;
        bpf_usdt_readarg(1, ctx, &arg1);
        __data.v0 = (long long)arg1;
        u64 arg2;
        bpf_usdt_readarg(2, ctx, &arg2);

        if (arg2 != 0) {
                bpf_probe_read(&__data.v1, sizeof(__data.v1), (void *)arg2);
        }

        probe_contextSwitch_1_events.perf_submit(ctx, &__data, sizeof(__data));
        return 0;
}
```
