### PR TITLE
[easy] bpf_common.cc include style

### DIFF
--- a/src/cc/bpf_common.cc
+++ b/src/cc/bpf_common.cc
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "cc/bpf_module.h"
-#include "cc/bpf_common.h"
+#include "bpf_common.h"
+#include "bpf_module.h"
 
 extern "C" {
 void * bpf_module_create_b(const char *filename, const char *proto_filename, unsigned flags) {


### PR DESCRIPTION
Make it consistent with reset of the files in the directory to `include "xxx.h"` directly instead of `#include "cc/xxx.h"`