### PR TITLE
distributed_bridge fixup

### DIFF
--- a/examples/networking/distributed_bridge/tunnel.c
+++ b/examples/networking/distributed_bridge/tunnel.c
@@ -29,7 +29,8 @@ int handle_ingress(struct __sk_buff *skb) {
   struct ethernet_t *ethernet = cursor_advance(cursor, sizeof(*ethernet));
 
   struct bpf_tunnel_key tkey = {};
-  bpf_skb_get_tunnel_key(skb, &tkey, sizeof(tkey), 0);
+  bpf_skb_get_tunnel_key(skb, &tkey,
+      offsetof(struct bpf_tunnel_key, remote_ipv6[1]), 0);
 
   int *ifindex = vni2if.lookup(&tkey.tunnel_id);
   if (ifindex) {
@@ -63,7 +64,8 @@ int handle_egress(struct __sk_buff *skb) {
     u32 zero = 0;
     tkey.tunnel_id = dst_host->tunnel_id;
     tkey.remote_ipv4 = dst_host->remote_ipv4;
-    bpf_skb_set_tunnel_key(skb, &tkey, sizeof(tkey), 0);
+    bpf_skb_set_tunnel_key(skb, &tkey,
+        offsetof(struct bpf_tunnel_key, remote_ipv6[1]), 0);
     lock_xadd(&dst_host->tx_pkts, 1);
   } else {
     struct bpf_tunnel_key tkey = {};
@@ -73,7 +75,8 @@ int handle_egress(struct __sk_buff *skb) {
       return 1;
     tkey.tunnel_id = dst_host->tunnel_id;
     tkey.remote_ipv4 = dst_host->remote_ipv4;
-    bpf_skb_set_tunnel_key(skb, &tkey, sizeof(tkey), 0);
+    bpf_skb_set_tunnel_key(skb, &tkey,
+        offsetof(struct bpf_tunnel_key, remote_ipv6[1]), 0);
   }
   bpf_clone_redirect(skb, cfg->tunnel_ifindex, 0/*egress*/);
   return 1;

--- a/examples/networking/distributed_bridge/tunnel_mesh.c
+++ b/examples/networking/distributed_bridge/tunnel_mesh.c
@@ -19,7 +19,8 @@ BPF_TABLE("hash", int, struct tunnel_key, if2tunkey, 1024);
 int handle_ingress(struct __sk_buff *skb) {
   struct bpf_tunnel_key tkey = {};
   struct tunnel_key key;
-  bpf_skb_get_tunnel_key(skb, &tkey, sizeof(tkey), 0);
+  bpf_skb_get_tunnel_key(skb, &tkey,
+      offsetof(struct bpf_tunnel_key, remote_ipv6[1]), 0);
 
   key.tunnel_id = tkey.tunnel_id;
   key.remote_ipv4 = tkey.remote_ipv4;
@@ -57,7 +58,8 @@ int handle_egress(struct __sk_buff *skb) {
   if (key_p) {
     tkey.tunnel_id = key_p->tunnel_id;
     tkey.remote_ipv4 = key_p->remote_ipv4;
-    bpf_skb_set_tunnel_key(skb, &tkey, sizeof(tkey), 0);
+    bpf_skb_set_tunnel_key(skb, &tkey,
+        offsetof(struct bpf_tunnel_key, remote_ipv6[1]), 0);
     bpf_clone_redirect(skb, cfg->tunnel_ifindex, 0/*egress*/);
   }
   return 1;


### PR DESCRIPTION
fix the issue in which distributed_bridge example wasn't working for kernel ver less than 4.5. #713 