### PR TITLE
argdist: Cumulative mode (-c)

### DIFF
--- a/tools/argdist_example.txt
+++ b/tools/argdist_example.txt
@@ -10,7 +10,7 @@ various functions.
 For example, suppose you want to find what allocation sizes are common in
 your application:
 
-# ./argdist -p 2420 -C 'p:c:malloc(size_t size):size_t:size'
+# ./argdist -p 2420 -c -C 'p:c:malloc(size_t size):size_t:size'
 [01:42:29]
 p:c:malloc(size_t size):size_t:size
         COUNT      EVENT
@@ -43,7 +43,7 @@ probed and its value was 16, repeatedly.
 Now, suppose you wanted a histogram of buffer sizes passed to the write()
 function across the system:
 
-# ./argdist -H 'p:c:write(int fd, void *buf, size_t len):size_t:len'
+# ./argdist -c -H 'p:c:write(int fd, void *buf, size_t len):size_t:len'
 [01:45:22]
 p:c:write(int fd, void *buf, size_t len):size_t:len
      len                 : count     distribution
@@ -81,7 +81,7 @@ bytes, medium writes of 32-63 bytes, and larger writes of 64-127 bytes.
 But these are writes across the board -- what if you wanted to focus on writes
 to STDOUT?
 
-# ./argdist -H 'p:c:write(int fd, void *buf, size_t len):size_t:len:fd==1'
+# ./argdist -c -H 'p:c:write(int fd, void *buf, size_t len):size_t:len:fd==1'
 [01:47:17]
 p:c:write(int fd, void *buf, size_t len):size_t:len:fd==1
      len                 : count     distribution
@@ -232,7 +232,7 @@ multiple microseconds per byte.
 You could also group results by more than one field. For example, __kmalloc
 takes an additional flags parameter that describes how to allocate memory:
 
-# ./argdist -C 'p::__kmalloc(size_t size, gfp_t flags):gfp_t,size_t:flags,size'
+# ./argdist -c -C 'p::__kmalloc(size_t size, gfp_t flags):gfp_t,size_t:flags,size'
 [03:42:29]
 p::__kmalloc(size_t size, gfp_t flags):gfp_t,size_t:flags,size
         COUNT      EVENT
@@ -268,7 +268,7 @@ between kernel versions like function signatures tend to. For example, let's
 trace the net:net_dev_start_xmit tracepoint and print the interface name that
 is transmitting:
 
-# argdist -C 't:net:net_dev_start_xmit(void *a, void *b, struct net_device *c):char*:c->name' -n 2
+# argdist -c -C 't:net:net_dev_start_xmit(void *a, void *b, struct net_device *c):char*:c->name' -n 2
 [05:01:10]
 t:net:net_dev_start_xmit(void *a, void *b, struct net_device *c):char*:c->name
         COUNT      EVENT
@@ -286,7 +286,7 @@ tracepoint is defined in the include/trace/events/net.h header file.
 Here's a final example that finds how many write() system calls are performed
 by each process on the system:
 
-# argdist -C 'p:c:write():int:$PID;write per process' -n 2
+# argdist -c -C 'p:c:write():int:$PID;write per process' -n 2
 [06:47:18]
 write by process
         COUNT      EVENT
@@ -305,8 +305,8 @@ USAGE message:
 
 # argdist -h
 usage: argdist [-h] [-p PID] [-z STRING_SIZE] [-i INTERVAL] [-n COUNT] [-v]
-                  [-T TOP] [-H [specifier [specifier ...]]]
-                  [-C [specifier [specifier ...]]] [-I [header [header ...]]]
+               [-c] [-T TOP] [-H [specifier [specifier ...]]]
+               [-C [specifier [specifier ...]]] [-I [header [header ...]]]
 
 Trace a function and display a summary of its parameter values.
 
@@ -320,6 +320,7 @@ optional arguments:
   -n COUNT, --number COUNT
                         number of outputs
   -v, --verbose         print resulting BPF program code before executing
+  -c, --cumulative      do not clear histograms and freq counts at each interval
   -T TOP, --top TOP     number of top results to show (not applicable to
                         histograms)
   -H [specifier [specifier ...]], --histogram [specifier [specifier ...]]


### PR DESCRIPTION
By default, argdist now clears the histograms or freq
count maps after each display interval. The new `-c`
option enables cumulative mode, where maps are not
cleared at each interval. This fixes #718.