### PR TITLE
argdist, trace: Support naked executable names in probes

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -120,9 +120,9 @@ class BPF(object):
         return filename
 
     @staticmethod
-    def _find_exe(cls, bin_path):
+    def find_exe(bin_path):
         """
-        _find_exe(bin_path)
+        find_exe(bin_path)
 
         Traverses the PATH environment variable, looking for the first
         directory that contains an executable file named bin_path, and

--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -379,7 +379,7 @@ int PROBENAME(struct pt_regs *ctx SIGNATURE)
         def _attach_u(self):
                 libpath = BPF.find_library(self.library)
                 if libpath is None:
-                        libpath = BPF._find_exe(self.library)
+                        libpath = BPF.find_exe(self.library)
                 if libpath is None or len(libpath) == 0:
                         self._bail("unable to find library %s" % self.library)
 

--- a/tools/trace.py
+++ b/tools/trace.py
@@ -472,7 +472,7 @@ int %s(%s)
                 libpath = BPF.find_library(self.library)
                 if libpath is None:
                         # This might be an executable (e.g. 'bash')
-                        libpath = BPF._find_exe(self.library)
+                        libpath = BPF.find_exe(self.library)
                 if libpath is None or len(libpath) == 0:
                         self._bail("unable to find library %s" % self.library)
 


### PR DESCRIPTION
Fixes the error message from `BPF._find_exe` which would
occur if argdist or trace had a naked executable name
not qualified with a path, such as:

```
trace 'r:bash:readline "%s", retval'
```

This is now supported again, and fixes #565.