### PR TITLE
trace: Print USDT arg helpers in verbose mode

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -576,6 +576,8 @@ trace 'u:pthread:pthread_create (arg4 != 0)'
                         # uprobe is being attached.
                         probe.usdt.enable_probe(
                                 probe.usdt_name, probe.probe_name)
+                        if self.args.verbose:
+                                print(probe.usdt.get_text())
                         usdt_contexts.append(probe.usdt)
                 self.bpf = BPF(text=self.program, usdt_contexts=usdt_contexts)
                 Tracepoint.attach(self.bpf)


### PR DESCRIPTION
When verbose mode is enabled, ask all USDT helper
objects to print out the argument helper functions,
which help retrieve the argument values for each
individual probe location. This can be useful for
debugging probes; the helper functions are part of
the loaded BPF program, so they need to be printed
in verbose mode.