### PR TITLE
trace: Initialize USDT arguments to 0 before reading

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -303,7 +303,7 @@ BPF_PERF_OUTPUT(%s);
                 expr = self.values[idx].strip()
                 text = ""
                 if self.probe_type == "u" and expr[0:3] == "arg":
-                        text = ("        u64 %s;\n" +
+                        text = ("        u64 %s = 0;\n" +
                                 "        bpf_usdt_readarg(%s, ctx, &%s);\n") % \
                                 (expr, expr[3], expr)
 


### PR DESCRIPTION
Fixes #722, in which a USDT probe that has more than
one location and the type of the argument is a string
caused trace to potentially access an uninitialized
stack variable, thereby not passing BPF program
verification at load time.

(Note that `argdist` already had the right behavior, it's
just `trace` that wasn't updated accordingly.)