### PR TITLE
stackcount: Support uprobes, tracepoints, and USDT

### DIFF
--- a/man/man8/stackcount.8
+++ b/man/man8/stackcount.8
@@ -1,11 +1,12 @@
 .TH stackcount 8  "2016-01-14" "USER COMMANDS"
 .SH NAME
-stackcount \- Count kernel function calls and their stack traces. Uses Linux eBPF/bcc.
+stackcount \- Count function calls and their stack traces. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B stackcount [\-h] [\-p PID] [\-i INTERVAL] [\-T] [\-r] pattern
+.B stackcount [\-h] [\-p PID] [\-i INTERVAL] [\-T] [\-r] [\-s]
+              [\-l LIBRARY] pattern
 .SH DESCRIPTION
-stackcount traces kernel functions and frequency counts them with their entire
-kernel stack trace, summarized in-kernel for efficiency. This allows higher
+stackcount traces functions and frequency counts them with their entire
+stack trace, summarized in-kernel for efficiency. This allows higher
 frequency events to be studied. The output consists of unique stack traces,
 and their occurrence counts.
 
@@ -41,8 +42,11 @@ Summary interval, in seconds.
 \-p PID
 Trace this process ID only (filtered in-kernel).
 .TP
+\-l LIBRARY
+Trace user-space functions in this library or executable.
+.TP
 pattern
-A kernel function name, or a search pattern. Can include wildcards ("*"). If the
+A function name, or a search pattern. Can include wildcards ("*"). If the
 \-r option is used, can include regular expressions.
 .SH EXAMPLES
 .TP
@@ -77,6 +81,10 @@ Output every 5 seconds, with timestamps:
 Only count stacks when PID 185 is on-CPU:
 #
 .B stackcount -p 185 ip_output
+.TP
+Count user stacks for dynamic heap allocations with malloc in PID 185:
+#
+.B stackcount -l c -p 185 malloc
 .SH OVERHEAD
 This summarizes unique stack traces in-kernel for efficiency, allowing it to
 trace a higher rate of function calls than methods that post-process in user

--- a/man/man8/stackcount.8
+++ b/man/man8/stackcount.8
@@ -3,12 +3,13 @@
 stackcount \- Count function calls and their stack traces. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B stackcount [\-h] [\-p PID] [\-i INTERVAL] [\-T] [\-r] [\-s]
-              [\-l LIBRARY] pattern
+              [\-P] [\-v] [\-d] pattern
 .SH DESCRIPTION
 stackcount traces functions and frequency counts them with their entire
 stack trace, summarized in-kernel for efficiency. This allows higher
 frequency events to be studied. The output consists of unique stack traces,
-and their occurrence counts.
+and their occurrence counts. In addition to kernel and user functions, kernel
+tracepoints and USDT tracepoint are also supported.
 
 The pattern is a string with optional '*' wildcards, similar to file globbing.
 If you'd prefer to use regular expressions, use the \-r option.
@@ -36,14 +37,15 @@ Include a timestamp with interval output.
 \-v
 Show raw addresses.
 .TP
+\-d
+Print the source of the BPF program when loading it (for debugging purposes).
+.TP
 \-i interval
 Summary interval, in seconds.
 .TP
 \-p PID
 Trace this process ID only (filtered in-kernel).
 .TP
-\-l LIBRARY
-Trace user-space functions in this library or executable.
 .TP
 pattern
 A function name, or a search pattern. Can include wildcards ("*"). If the
@@ -84,7 +86,15 @@ Only count stacks when PID 185 is on-CPU:
 .TP
 Count user stacks for dynamic heap allocations with malloc in PID 185:
 #
-.B stackcount -l c -p 185 malloc
+.B stackcount -p 185 c:malloc
+.TP
+Count user stacks for thread creation (USDT tracepoint) in PID 185:
+#
+.B stackcount -p 185 u:pthread:pthread_create
+.TP
+Count kernel stacks for context switch events using a kernel tracepoint:
+#
+.B stackcount t:sched:sched_switch
 .SH OVERHEAD
 This summarizes unique stack traces in-kernel for efficiency, allowing it to
 trace a higher rate of function calls than methods that post-process in user
@@ -107,6 +117,6 @@ Linux
 .SH STABILITY
 Unstable - in development.
 .SH AUTHOR
-Brendan Gregg
+Brendan Gregg, Sasha Goldshtein
 .SH SEE ALSO
 stacksnoop(8), funccount(8)

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -282,26 +282,28 @@ struct sym_search_t {
 
 static int _list_sym(const char *symname, uint64_t addr, uint64_t end,
                      int flags, void *payload) {
-  if (!ELF_TYPE_IS_FUNCTION(flags))
+  if (!ELF_TYPE_IS_FUNCTION(flags) || addr == 0)
     return 0;
 
   struct sym_search_t *sym_search = (struct sym_search_t *)payload;
-  sym_search->start -= 1;
-  if (sym_search->start > 0)
+  if (sym_search->start > 0) {
+    sym_search->start -= 1;
     return 0;   // skipping the first 'start' symbols
+  }
 
   struct bcc_symbol *sym = &sym_search->syms[*sym_search->actual];
   sym->name = symname;
   sym->offset = addr;  
   *sym_search->actual += 1;
-  if (sym_search->requested == *sym_search->actual)
+  if (sym_search->requested == *sym_search->actual) {
     return -1;  // stop the enumeration, we're done
+  }
   return 0;
 }
 
 int bcc_list_symbols(const char *module, struct bcc_symbol *syms,
                      int start, int requested, int *actual) {
-  if (syms == 0)
+  if (syms == 0 || actual == 0)
     return -1;
   if (requested == 0)
     return 0;

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -36,6 +36,8 @@ void bcc_symcache_refresh(void *resolver);
 
 int bcc_resolve_global_addr(int pid, const char *module, const uint64_t address,
                             uint64_t *global);
+int bcc_list_symbols(const char *module, struct bcc_symbol *syms,
+                     int start, int requested, int *actual);
 int bcc_find_symbol_addr(struct bcc_symbol *sym);
 int bcc_resolve_symname(const char *module, const char *symname,
                         const uint64_t addr, struct bcc_symbol *sym);

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -29,6 +29,8 @@ struct bcc_symbol {
   uint64_t offset;
 };
 
+typedef int(* SYM_CB)(const char *symname, uint64_t addr);
+
 void *bcc_symcache_new(int pid);
 int bcc_symcache_resolve(void *symcache, uint64_t addr, struct bcc_symbol *sym);
 int bcc_symcache_resolve_name(void *resolver, const char *name, uint64_t *addr);
@@ -36,8 +38,7 @@ void bcc_symcache_refresh(void *resolver);
 
 int bcc_resolve_global_addr(int pid, const char *module, const uint64_t address,
                             uint64_t *global);
-int bcc_list_symbols(const char *module, struct bcc_symbol *syms,
-                     int start, int requested, int *actual);
+int bcc_foreach_symbol(const char *module, SYM_CB cb);
 int bcc_find_symbol_addr(struct bcc_symbol *sym);
 int bcc_resolve_symname(const char *module, const char *symname,
                         const uint64_t addr, struct bcc_symbol *sym);

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -799,6 +799,17 @@ class BPF(object):
         return name
 
     @staticmethod
+    def symaddr(addr, pid):
+        """symaddr(addr, pid)
+
+        Translate a memory address into a function name plus the instruction
+        offset as a hexadecimal number, which is returned as a string.
+        A pid of less than zero will access the kernel symbol cache.
+        """
+        name, offset = BPF._sym_cache(pid).resolve(addr)
+        return "%s+0x%x" % (name, offset)
+
+    @staticmethod
     def ksym(addr):
         """ksym(addr)
 
@@ -815,8 +826,7 @@ class BPF(object):
         instruction offset as a hexidecimal number, which is returned as a
         string.
         """
-        name, offset = BPF._sym_cache(-1).resolve(addr)
-        return "%s+0x%x" % (name, offset)
+        return BPF.symaddr(addr, -1)
 
     @staticmethod
     def ksymname(name):
@@ -834,6 +844,14 @@ class BPF(object):
         perf_events readers.
         """
         return len([k for k in self.open_kprobes.keys() if isinstance(k, str)])
+
+    @staticmethod
+    def num_open_uprobes():
+        """num_open_uprobes()
+
+        Get the number of open U[ret]probes.
+        """
+        return len(open_uprobes)
 
     def kprobe_poll(self, timeout = -1):
         """kprobe_poll(self)

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -906,21 +906,19 @@ class BPF(object):
         """
         return len([k for k in self.open_kprobes.keys() if isinstance(k, str)])
 
-    @staticmethod
-    def num_open_uprobes():
+    def num_open_uprobes(self):
         """num_open_uprobes()
 
         Get the number of open U[ret]probes.
         """
-        return len(open_uprobes)
+        return len(self.open_uprobes)
 
-    @staticmethod
-    def num_open_tracepoints():
+    def num_open_tracepoints(self):
         """num_open_tracepoints()
 
         Get the number of open tracepoints.
         """
-        return len(open_tracepoints)
+        return len(self.open_tracepoints)
 
     def kprobe_poll(self, timeout = -1):
         """kprobe_poll(self)

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -129,10 +129,9 @@ lib.bcc_resolve_symname.restype = ct.c_int
 lib.bcc_resolve_symname.argtypes = [
     ct.c_char_p, ct.c_char_p, ct.c_ulonglong, ct.POINTER(bcc_symbol)]
 
-lib.bcc_list_symbols.restype = ct.c_int
-lib.bcc_list_symbols.argtypes = [
-    ct.c_char_p, ct.POINTER(bcc_symbol), ct.c_int, ct.c_int,
-    ct.POINTER(ct.c_int)]
+_SYM_CB_TYPE = ct.CFUNCTYPE(ct.c_int, ct.c_char_p, ct.c_ulonglong)
+lib.bcc_foreach_symbol.restype = ct.c_int
+lib.bcc_foreach_symbol.argtypes = [ct.c_char_p, _SYM_CB_TYPE]
 
 lib.bcc_symcache_new.restype = ct.c_void_p
 lib.bcc_symcache_new.argtypes = [ct.c_int]

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -129,6 +129,11 @@ lib.bcc_resolve_symname.restype = ct.c_int
 lib.bcc_resolve_symname.argtypes = [
     ct.c_char_p, ct.c_char_p, ct.c_ulonglong, ct.POINTER(bcc_symbol)]
 
+lib.bcc_list_symbols.restype = ct.c_int
+lib.bcc_list_symbols.argtypes = [
+    ct.c_char_p, ct.POINTER(bcc_symbol), ct.c_int, ct.c_int,
+    ct.POINTER(ct.c_int)]
+
 lib.bcc_symcache_new.restype = ct.c_void_p
 lib.bcc_symcache_new.argtypes = [ct.c_int]
 

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -242,7 +242,7 @@ class Tool(object):
             self.comm_cache[pid] = comm
             return comm
         except:
-            return "    PID %d" % pid
+            return "    unknown process [%d]" % pid
 
     def run(self):
         self.probe.load()
@@ -267,10 +267,11 @@ class Tool(object):
             self.comm_cache = {}
             for k, v in sorted(counts.items(),
                                key=lambda counts: counts[1].value):
-                if k.pid != 0xffffffff:
-                    print(self._comm_for_pid(k.pid))
                 for addr in stack_traces.walk(k.stackid):
-                    self._print_frame(addr, k.pid)
+                    pid = -1 if self.probe.is_kernel_probe() else k.pid
+                    self._print_frame(addr, pid)
+                if not self.args.pid and k.pid != 0xffffffff:
+                    print(self._comm_for_pid(k.pid))
                 print("    %d\n" % v.value)
             counts.clear()
 

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# stackcount    Count function calls and their stack traces.
+# stackcount    Count events and their stack traces.
 #               For Linux, uses BCC, eBPF.
 #
 # USAGE: stackcount [-h] [-p PID] [-i INTERVAL] [-T] [-r] [-s]
@@ -13,7 +13,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
 # 12-Jan-2016	Brendan Gregg	    Created this.
-# 09-Jul-2016   Sasha Goldshtein    Added user-space function support.
+# 09-Jul-2016   Sasha Goldshtein    Generalized for uprobes and tracepoints.
 
 from __future__ import print_function
 from bcc import BPF
@@ -23,8 +23,10 @@ import signal
 import traceback
 import sys
 
+debug = True
+
 class Probe(object):
-    def __init__(self, pattern, use_regex):
+    def __init__(self, pattern, use_regex, pid):
         """Init a new probe.
 
         Init the probe from the pattern provided by the user. The supported
@@ -33,19 +35,20 @@ class Probe(object):
 
             func            -- probe a kernel function
             lib:func        -- probe a user-space function in the library 'lib'
+            p::func         -- same thing as 'func'
+            p:lib:func      -- same thing as 'lib:func'
             t:cat:event     -- probe a kernel tracepoint
-            u:lib:event     -- probe a user-space USDT tracepoint
         """
         parts = pattern.split(':')
         if len(parts) == 1:
-            parts = ["f", "", parts[0]]
+            parts = ["p", "", parts[0]]
         elif len(parts) == 2:
-            parts = ["f", parts[0], parts[1]]
+            parts = ["p", parts[0], parts[1]]
         elif len(parts) == 3:
             if parts[0] == "t":
                 parts = ["t", "", "%s:%s" % tuple(parts[1:])]
-            if parts[0] not in ["f", "t", "u"]:
-                raise Exception("Type must be 'f', 't', or 'u', but got %s" %
+            if parts[0] not in ["p", "t"]:
+                raise Exception("Type must be 'p' or 't', but got %s" %
                                 parts[0])
         else:
             raise Exception("Too many ':'-separated components in pattern %s" %
@@ -56,46 +59,94 @@ class Probe(object):
             self.pattern = self.pattern.replace('*', '.*')
             self.pattern = '^' + self.pattern + '$'
 
-        if self.type == "f" and self.library:
+        if self.type == "p" and self.library:
             self.library = BPF.find_library(self.library)
 
-    def is_kernel_probe(self):
-        return self.type == "t" or (self.type == "f" and self.library == "")
+        self.pid = pid
+        # TODO Remove this limitation, which is only there because we need the
+        # pid to resolve symbols. If we maintain a stack cache per pid, we can
+        # resolve the right symbols on the fly. We will need to merge the stacks
+        # in user-space, however -- we could have the same functions called with
+        # the same stacks across multiple processes. Maybe print the pids in
+        # that case, or make it an option to join pids or print each pid's stack
+        # separately.
+        if not self.pid and not self.is_kernel_probe():
+            raise Exception("pid must be specified when tracing user-space")
 
-    def attach(self, bpf, fn_name):
-        if self.type == "f":
+    def is_kernel_probe(self):
+        return self.type == "t" or (self.type == "p" and self.library == "")
+
+    def attach(self):
+        if self.type == "p":
             if self.library:
-                bpf.attach_uprobe(name=self.library, sym_re=self.pattern,
-                                  fn_name=fn_name)
-                self.matched = bpf.num_open_uprobes()
+                self.bpf.attach_uprobe(name=self.library, sym_re=self.pattern,
+                                       fn_name="trace_count", pid=self.pid)
+                self.matched = self.bpf.num_open_uprobes()
             else:
-                bpf.attach_kprobe(event_re=pattern, fn_name=fn_name)
-                self.matched = bpf.num_open_kprobes()
+                self.bpf.attach_kprobe(event_re=pattern, fn_name="trace_count",
+                                       pid=self.pid)
+                self.matched = self.bpf.num_open_kprobes()
         elif self.type == "t":
-            bpf.attach_tracepoint(tp_re=self.pattern, fn_name=fn_name)
-            self.matched = bpf.num_open_tracepoints()
-        elif self.type == "u":
-            # TODO
-            raise Exception("USDT probes are not yet supported")
+            self.bpf.attach_tracepoint(tp_re=self.pattern,
+                                       fn_name="trace_count", pid=self.pid)
+            self.matched = self.bpf.num_open_tracepoints()
 
         if self.matched == 0:
             raise Exception("No functions matched by pattern %s" % self.pattern)
+
+    def load(self):
+        bpf_text = """#include <uapi/linux/ptrace.h>
+
+BPF_HASH(counts, int);
+BPF_STACK_TRACE(stack_traces, 1024);
+
+int trace_count(void *ctx) {
+    FILTER
+    int key = stack_traces.get_stackid(ctx, STACK_FLAGS);
+    u64 zero = 0;
+    u64 *val = counts.lookup_or_init(&key, &zero);
+    (*val)++;
+    return 0;
+}
+        """
+
+        # We really mean the tgid from the kernel's perspective, which is in
+        # the top 32 bits of bpf_get_current_pid_tgid().
+        # TODO Why do we even need this when we call attach_nnn with the pid,
+        # which eventually calls perf_event_open with that pid? Is it ignored?
+        # It works for uprobes, why not for kprobes/tracepoints?
+        if self.is_kernel_probe() and self.pid:
+            bpf_text = bpf_text.replace('FILTER',
+                ('u32 pid; pid = bpf_get_current_pid_tgid() >> 32; ' +
+                'if (pid != %d) { return 0; }') % (self.pid))
+        else:
+            bpf_text = bpf_text.replace('FILTER', '')
+
+        stack_flags = 'BPF_F_REUSE_STACKID'
+        if not self.is_kernel_probe():
+            stack_flags += '| BPF_F_USER_STACK' # can't do both U *and* K
+        bpf_text = bpf_text.replace('STACK_FLAGS', stack_flags)
+
+        if debug:
+            print(bpf_text)
+        self.bpf = BPF(text=bpf_text)
 
 class Tool(object):
     def __init__(self):
         examples = """examples:
     ./stackcount submit_bio          # count kernel stack traces for submit_bio
-    ./stackcount ip_output           # count kernel stack traces for ip_output
     ./stackcount -s ip_output        # show symbol offsets
     ./stackcount -sv ip_output       # show offsets and raw addresses (verbose)
     ./stackcount 'tcp_send*'         # count stacks for funcs matching tcp_send*
     ./stackcount -r '^tcp_send.*'    # same as above, using regular expressions
     ./stackcount -Ti 5 ip_output     # output every 5 seconds, with timestamps
     ./stackcount -p 185 ip_output    # count ip_output stacks for PID 185 only
-    ./stackcount -p 185 -l c malloc  # count stacks for malloc in PID 185
+    ./stackcount -p 185 c:malloc     # count stacks for malloc in PID 185
+    ./stackcount t:sched:sched_fork  # count stacks for the sched_fork tracepoint
+    ./stackcount -p 185 u:node:*     # count stacks for all USDT probes in node
         """
         parser = argparse.ArgumentParser(
-            description="Count function calls and their stack traces",
+            description="Count events and their stack traces",
             formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog=examples)
         parser.add_argument("-p", "--pid", type=int,
@@ -111,59 +162,27 @@ class Tool(object):
         parser.add_argument("-v", "--verbose", action="store_true",
             help="show raw addresses")
         parser.add_argument("pattern",
-            help="search expression for functions")
+            help="search expression for events")
         self.args = parser.parse_args()
-        self.probe = Probe(self.args.pattern, self.args.regexp)
-        if not self.args.pid and not self.probe.is_kernel_probe():
-            raise Exception("pid must be specified when tracing user-space")
-
-    def load(self):
-        bpf_text = """#include <uapi/linux/ptrace.h>
-
-        BPF_HASH(counts, int);
-        BPF_STACK_TRACE(stack_traces, 1024);
-
-        int trace_count(void *ctx) {
-            FILTER
-            int key = stack_traces.get_stackid(ctx, STACK_FLAGS);
-            u64 zero = 0;
-            u64 *val = counts.lookup_or_init(&key, &zero);
-            (*val)++;
-            return 0;
-        }
-        """
-
-        # We really mean the tgid from the kernel's perspective, which is in
-        # the top 32 bits of bpf_get_current_pid_tgid().
-        if self.args.pid:
-            bpf_text = bpf_text.replace('FILTER',
-                ('u32 pid; pid = bpf_get_current_pid_tgid() >> 32; ' +
-                'if (pid != %d) { return 0; }') % (self.args.pid))
-        else:
-            bpf_text = bpf_text.replace('FILTER', '')
-
-        stack_flags = 'BPF_F_REUSE_STACKID'
-        if not self.probe.is_kernel_probe():
-            stack_flags += '| BPF_F_USER_STACK'
-        bpf_text = bpf_text.replace('STACK_FLAGS', stack_flags)
-
-        self.bpf = BPF(text=bpf_text)
+        self.probe = Probe(self.args.pattern, self.args.regexp, self.args.pid)
 
     def _print_frame(self, addr):
+        pid_for_syms = None if self.probe.is_kernel_probe() else self.args.pid
         print("  ", end="")
         if self.args.verbose:
             print("%-16x " % addr, end="")
         if self.args.offset:
-            print("%s" % self.bpf.symaddr(addr, self.args.pid or -1))
+            print("%s" % self.probe.bpf.symaddr(addr, pid_for_syms))
         else:
-            print("%s" % self.bpf.sym(addr, self.args.pid or -1))
+            print("%s" % self.probe.bpf.sym(addr, pid_for_syms))
 
     @staticmethod
     def _signal_ignore(signal, frame):
         print()
 
     def run(self):
-        self.probe.attach(self.bpf, fn_name="trace_count")
+        self.probe.load()
+        self.probe.attach()
         print("Tracing %d functions for \"%s\"... Hit Ctrl-C to end." %
               (self.probe.matched, self.args.pattern))
         exiting = 0 if self.args.interval else 1
@@ -179,8 +198,8 @@ class Tool(object):
             if self.args.timestamp:
                 print("%-8s\n" % strftime("%H:%M:%S"), end="")
 
-            counts = self.bpf["counts"]
-            stack_traces = self.bpf["stack_traces"]
+            counts = self.probe.bpf["counts"]
+            stack_traces = self.probe.bpf["stack_traces"]
             for k, v in sorted(counts.items(),
                                key=lambda counts: counts[1].value):
                 for addr in stack_traces.walk(k.value):
@@ -194,9 +213,10 @@ class Tool(object):
 
 if __name__ == "__main__":
     try:
-        tool = Tool()
-        tool.load()
-        tool.run()
+        Tool().run()
     except Exception:
-        traceback.print_exc() # TODO print this only in -DEBUG mode
+        if debug:
+            traceback.print_exc()
+        elif sys.exc_info()[0] is not SystemExit:
+            print(sys.exc_info()[1])
 

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -4,7 +4,7 @@
 #               For Linux, uses BCC, eBPF.
 #
 # USAGE: stackcount [-h] [-p PID] [-i INTERVAL] [-T] [-r] [-s]
-#                   [-l LIBRARY] [-v] pattern
+#                   [-v] pattern
 #
 # The pattern is a string with optional '*' wildcards, similar to file
 # globbing. If you'd prefer to use regular expressions, use the -r option.
@@ -20,9 +20,70 @@ from bcc import BPF
 from time import sleep, strftime
 import argparse
 import signal
+import traceback
+import sys
 
-# arguments
-examples = """examples:
+class Probe(object):
+    def __init__(self, pattern, use_regex):
+        """Init a new probe.
+
+        Init the probe from the pattern provided by the user. The supported
+        patterns mimic the 'trace' and 'argdist' tools, but are simpler because
+        we don't have to distinguish between probes and retprobes.
+
+            func            -- probe a kernel function
+            lib:func        -- probe a user-space function in the library 'lib'
+            t:cat:event     -- probe a kernel tracepoint
+            u:lib:event     -- probe a user-space USDT tracepoint
+        """
+        parts = pattern.split(':')
+        if len(parts) == 1:
+            parts = ["f", "", parts[0]]
+        elif len(parts) == 2:
+            parts = ["f", parts[0], parts[1]]
+        elif len(parts) == 3:
+            if parts[0] == "t":
+                parts = ["t", "", "%s:%s" % tuple(parts[1:])]
+            if parts[0] not in ["f", "t", "u"]:
+                raise Exception("Type must be 'f', 't', or 'u', but got %s" %
+                                parts[0])
+        else:
+            raise Exception("Too many ':'-separated components in pattern %s" %
+                            pattern)
+
+        (self.type, self.library, self.pattern) = parts
+        if not use_regex:
+            self.pattern = self.pattern.replace('*', '.*')
+            self.pattern = '^' + self.pattern + '$'
+
+        if self.type == "f" and self.library:
+            self.library = BPF.find_library(self.library)
+
+    def is_kernel_probe(self):
+        return self.type == "t" or (self.type == "f" and self.library == "")
+
+    def attach(self, bpf, fn_name):
+        if self.type == "f":
+            if self.library:
+                bpf.attach_uprobe(name=self.library, sym_re=self.pattern,
+                                  fn_name=fn_name)
+                self.matched = bpf.num_open_uprobes()
+            else:
+                bpf.attach_kprobe(event_re=pattern, fn_name=fn_name)
+                self.matched = bpf.num_open_kprobes()
+        elif self.type == "t":
+            bpf.attach_tracepoint(tp_re=self.pattern, fn_name=fn_name)
+            self.matched = bpf.num_open_tracepoints()
+        elif self.type == "u":
+            # TODO
+            raise Exception("USDT probes are not yet supported")
+
+        if self.matched == 0:
+            raise Exception("No functions matched by pattern %s" % self.pattern)
+
+class Tool(object):
+    def __init__(self):
+        examples = """examples:
     ./stackcount submit_bio          # count kernel stack traces for submit_bio
     ./stackcount ip_output           # count kernel stack traces for ip_output
     ./stackcount -s ip_output        # show symbol offsets
@@ -32,127 +93,110 @@ examples = """examples:
     ./stackcount -Ti 5 ip_output     # output every 5 seconds, with timestamps
     ./stackcount -p 185 ip_output    # count ip_output stacks for PID 185 only
     ./stackcount -p 185 -l c malloc  # count stacks for malloc in PID 185
-"""
-parser = argparse.ArgumentParser(
-    description="Count function calls and their stack traces",
-    formatter_class=argparse.RawDescriptionHelpFormatter,
-    epilog=examples)
-parser.add_argument("-p", "--pid", type=int,
-    help="trace this PID only")
-parser.add_argument("-i", "--interval", default=99999999,
-    help="summary interval, seconds")
-parser.add_argument("-T", "--timestamp", action="store_true",
-    help="include timestamp on output")
-parser.add_argument("-r", "--regexp", action="store_true",
-    help="use regular expressions. Default is \"*\" wildcards only.")
-parser.add_argument("-s", "--offset", action="store_true",
-    help="show address offsets")
-parser.add_argument("-l", "--library",
-    help="trace user-space functions from this library or executable")
-parser.add_argument("-v", "--verbose", action="store_true",
-    help="show raw addresses")
-parser.add_argument("pattern",
-    help="search expression for functions")
+        """
+        parser = argparse.ArgumentParser(
+            description="Count function calls and their stack traces",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=examples)
+        parser.add_argument("-p", "--pid", type=int,
+            help="trace this PID only")
+        parser.add_argument("-i", "--interval", default=99999999,
+            help="summary interval, seconds")
+        parser.add_argument("-T", "--timestamp", action="store_true",
+            help="include timestamp on output")
+        parser.add_argument("-r", "--regexp", action="store_true",
+            help="use regular expressions. Default is \"*\" wildcards only.")
+        parser.add_argument("-s", "--offset", action="store_true",
+            help="show address offsets")
+        parser.add_argument("-v", "--verbose", action="store_true",
+            help="show raw addresses")
+        parser.add_argument("pattern",
+            help="search expression for functions")
+        self.args = parser.parse_args()
+        self.probe = Probe(self.args.pattern, self.args.regexp)
+        if not self.args.pid and not self.probe.is_kernel_probe():
+            raise Exception("pid must be specified when tracing user-space")
 
-args = parser.parse_args()
-pattern = args.pattern
-if not args.regexp and not args.library:
-    pattern = pattern.replace('*', '.*')
-    pattern = '^' + pattern + '$'
-if args.library and not args.pid:
-    print("pid must be specified when tracing user-space functions")
-    exit(1)
-if args.library and (args.regexp or ('*' in args.pattern)):
-    print("regexes and patterns are not supported for user-space functions")
-    exit(1)
-offset = args.offset
-verbose = args.verbose
-debug = 0
+    def load(self):
+        bpf_text = """#include <uapi/linux/ptrace.h>
 
-# signal handler
-def signal_ignore(signal, frame):
-    print()
+        BPF_HASH(counts, int);
+        BPF_STACK_TRACE(stack_traces, 1024);
 
-# load BPF program
-bpf_text = """
-#include <uapi/linux/ptrace.h>
+        int trace_count(void *ctx) {
+            FILTER
+            int key = stack_traces.get_stackid(ctx, STACK_FLAGS);
+            u64 zero = 0;
+            u64 *val = counts.lookup_or_init(&key, &zero);
+            (*val)++;
+            return 0;
+        }
+        """
 
-BPF_HASH(counts, int);
-BPF_STACK_TRACE(stack_traces, 1024);
+        # We really mean the tgid from the kernel's perspective, which is in
+        # the top 32 bits of bpf_get_current_pid_tgid().
+        if self.args.pid:
+            bpf_text = bpf_text.replace('FILTER',
+                ('u32 pid; pid = bpf_get_current_pid_tgid() >> 32; ' +
+                'if (pid != %d) { return 0; }') % (self.args.pid))
+        else:
+            bpf_text = bpf_text.replace('FILTER', '')
 
-int trace_count(struct pt_regs *ctx) {
-    FILTER
-    int key = stack_traces.get_stackid(ctx, STACK_FLAGS);
-    u64 zero = 0;
-    u64 *val = counts.lookup_or_init(&key, &zero);
-    (*val)++;
-    return 0;
-}
-"""
+        stack_flags = 'BPF_F_REUSE_STACKID'
+        if not self.probe.is_kernel_probe():
+            stack_flags += '| BPF_F_USER_STACK'
+        bpf_text = bpf_text.replace('STACK_FLAGS', stack_flags)
 
-if args.pid:
-    bpf_text = bpf_text.replace('FILTER',
-        ('u32 pid; pid = bpf_get_current_pid_tgid(); ' +
-        'if (pid != %d) { return 0; }') % (args.pid))
-else:
-    bpf_text = bpf_text.replace('FILTER', '')
+        self.bpf = BPF(text=bpf_text)
 
-stack_flags = 'BPF_F_REUSE_STACKID'
-if args.library:
-    stack_flags += '| BPF_F_USER_STACK'
-bpf_text = bpf_text.replace('STACK_FLAGS', stack_flags)
+    def _print_frame(self, addr):
+        print("  ", end="")
+        if self.args.verbose:
+            print("%-16x " % addr, end="")
+        if self.args.offset:
+            print("%s" % self.bpf.symaddr(addr, self.args.pid or -1))
+        else:
+            print("%s" % self.bpf.sym(addr, self.args.pid or -1))
 
-if debug:
-    print(bpf_text)
+    @staticmethod
+    def _signal_ignore(signal, frame):
+        print()
 
-b = BPF(text=bpf_text)
+    def run(self):
+        self.probe.attach(self.bpf, fn_name="trace_count")
+        print("Tracing %d functions for \"%s\"... Hit Ctrl-C to end." %
+              (self.probe.matched, self.args.pattern))
+        exiting = 0 if self.args.interval else 1
+        while True:
+            try:
+                sleep(int(self.args.interval))
+            except KeyboardInterrupt:
+                exiting = 1
+                # as cleanup can take many seconds, trap Ctrl-C:
+                signal.signal(signal.SIGINT, Tool._signal_ignore)
 
-if args.library:
-    b.attach_uprobe(name=args.library, sym=pattern, fn_name="trace_count")
-    matched = b.num_open_uprobes()
-else:
-    b.attach_kprobe(event_re=pattern, fn_name="trace_count")
-    matched = b.num_open_kprobes()
+            print()
+            if self.args.timestamp:
+                print("%-8s\n" % strftime("%H:%M:%S"), end="")
 
-if matched == 0:
-    print("0 functions matched by \"%s\". Exiting." % args.pattern)
-    exit()
+            counts = self.bpf["counts"]
+            stack_traces = self.bpf["stack_traces"]
+            for k, v in sorted(counts.items(),
+                               key=lambda counts: counts[1].value):
+                for addr in stack_traces.walk(k.value):
+                    self._print_frame(addr)
+                print("    %d\n" % v.value)
+            counts.clear()
 
-# header
-print("Tracing %d functions for \"%s\"... Hit Ctrl-C to end." %
-    (matched, args.pattern))
+            if exiting:
+                print("Detaching...")
+                exit()
 
-def print_frame(addr):
-    print("  ", end="")
-    if verbose:
-        print("%-16x " % addr, end="")
-    if offset:
-        print("%s" % b.symaddr(addr, args.pid or -1))
-    else:
-        print("%s" % b.sym(addr, args.pid or -1))
-
-# output
-exiting = 0 if args.interval else 1
-while (1):
+if __name__ == "__main__":
     try:
-        sleep(int(args.interval))
-    except KeyboardInterrupt:
-        exiting = 1
-        # as cleanup can take many seconds, trap Ctrl-C:
-        signal.signal(signal.SIGINT, signal_ignore)
+        tool = Tool()
+        tool.load()
+        tool.run()
+    except Exception:
+        traceback.print_exc() # TODO print this only in -DEBUG mode
 
-    print()
-    if args.timestamp:
-        print("%-8s\n" % strftime("%H:%M:%S"), end="")
-
-    counts = b["counts"]
-    stack_traces = b["stack_traces"]
-    for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
-        for addr in stack_traces.walk(k.value):
-            print_frame(addr)
-        print("    %d\n" % v.value)
-    counts.clear()
-
-    if exiting:
-        print("Detaching...")
-        exit()

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -1,23 +1,19 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
-# stackcount    Count kernel function calls and their stack traces.
+# stackcount    Count function calls and their stack traces.
 #               For Linux, uses BCC, eBPF.
 #
-# USAGE: stackcount [-h] [-p PID] [-i INTERVAL] [-T] [-r] pattern
+# USAGE: stackcount [-h] [-p PID] [-i INTERVAL] [-T] [-r] [-s]
+#                   [-l LIBRARY] [-v] pattern
 #
 # The pattern is a string with optional '*' wildcards, similar to file
 # globbing. If you'd prefer to use regular expressions, use the -r option.
 #
-# The current implementation uses an unrolled loop for x86_64, and was written
-# as a proof of concept. This implementation should be replaced in the future
-# with an appropriate bpf_ call, when available.
-#
-# Currently limited to a stack trace depth of 11 (maxdepth + 1).
-#
 # Copyright 2016 Netflix, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
-# 12-Jan-2016	Brendan Gregg	Created this.
+# 12-Jan-2016	Brendan Gregg	    Created this.
+# 09-Jul-2016   Sasha Goldshtein    Added user-space function support.
 
 from __future__ import print_function
 from bcc import BPF
@@ -27,20 +23,21 @@ import signal
 
 # arguments
 examples = """examples:
-    ./stackcount submit_bio       # count kernel stack traces for submit_bio
-    ./stackcount ip_output        # count kernel stack traces for ip_output
-    ./stackcount -s ip_output     # show symbol offsets
-    ./stackcount -sv ip_output    # show offsets and raw addresses (verbose)
-    ./stackcount 'tcp_send*'      # count stacks for funcs matching tcp_send*
-    ./stackcount -r '^tcp_send.*' # same as above, using regular expressions
-    ./stackcount -Ti 5 ip_output  # output every 5 seconds, with timestamps
-    ./stackcount -p 185 ip_output # count ip_output stacks for PID 185 only
+    ./stackcount submit_bio          # count kernel stack traces for submit_bio
+    ./stackcount ip_output           # count kernel stack traces for ip_output
+    ./stackcount -s ip_output        # show symbol offsets
+    ./stackcount -sv ip_output       # show offsets and raw addresses (verbose)
+    ./stackcount 'tcp_send*'         # count stacks for funcs matching tcp_send*
+    ./stackcount -r '^tcp_send.*'    # same as above, using regular expressions
+    ./stackcount -Ti 5 ip_output     # output every 5 seconds, with timestamps
+    ./stackcount -p 185 ip_output    # count ip_output stacks for PID 185 only
+    ./stackcount -p 185 -l c malloc  # count stacks for malloc in PID 185
 """
 parser = argparse.ArgumentParser(
-    description="Count kernel function calls and their stack traces",
+    description="Count function calls and their stack traces",
     formatter_class=argparse.RawDescriptionHelpFormatter,
     epilog=examples)
-parser.add_argument("-p", "--pid",
+parser.add_argument("-p", "--pid", type=int,
     help="trace this PID only")
 parser.add_argument("-i", "--interval", default=99999999,
     help="summary interval, seconds")
@@ -50,19 +47,27 @@ parser.add_argument("-r", "--regexp", action="store_true",
     help="use regular expressions. Default is \"*\" wildcards only.")
 parser.add_argument("-s", "--offset", action="store_true",
     help="show address offsets")
+parser.add_argument("-l", "--library",
+    help="trace user-space functions from this library or executable")
 parser.add_argument("-v", "--verbose", action="store_true",
     help="show raw addresses")
 parser.add_argument("pattern",
-    help="search expression for kernel functions")
+    help="search expression for functions")
+
 args = parser.parse_args()
 pattern = args.pattern
-if not args.regexp:
+if not args.regexp and not args.library:
     pattern = pattern.replace('*', '.*')
     pattern = '^' + pattern + '$'
+if args.library and not args.pid:
+    print("pid must be specified when tracing user-space functions")
+    exit(1)
+if args.library and (args.regexp or ('*' in args.pattern)):
+    print("regexes and patterns are not supported for user-space functions")
+    exit(1)
 offset = args.offset
 verbose = args.verbose
 debug = 0
-maxdepth = 10    # and MAXDEPTH
 
 # signal handler
 def signal_ignore(signal, frame):
@@ -77,24 +82,38 @@ BPF_STACK_TRACE(stack_traces, 1024);
 
 int trace_count(struct pt_regs *ctx) {
     FILTER
-    int key = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
+    int key = stack_traces.get_stackid(ctx, STACK_FLAGS);
     u64 zero = 0;
     u64 *val = counts.lookup_or_init(&key, &zero);
     (*val)++;
     return 0;
 }
 """
+
 if args.pid:
     bpf_text = bpf_text.replace('FILTER',
         ('u32 pid; pid = bpf_get_current_pid_tgid(); ' +
-        'if (pid != %s) { return 0; }') % (args.pid))
+        'if (pid != %d) { return 0; }') % (args.pid))
 else:
     bpf_text = bpf_text.replace('FILTER', '')
+
+stack_flags = 'BPF_F_REUSE_STACKID'
+if args.library:
+    stack_flags += '| BPF_F_USER_STACK'
+bpf_text = bpf_text.replace('STACK_FLAGS', stack_flags)
+
 if debug:
     print(bpf_text)
+
 b = BPF(text=bpf_text)
-b.attach_kprobe(event_re=pattern, fn_name="trace_count")
-matched = b.num_open_kprobes()
+
+if args.library:
+    b.attach_uprobe(name=args.library, sym=pattern, fn_name="trace_count")
+    matched = b.num_open_uprobes()
+else:
+    b.attach_kprobe(event_re=pattern, fn_name="trace_count")
+    matched = b.num_open_kprobes()
+
 if matched == 0:
     print("0 functions matched by \"%s\". Exiting." % args.pattern)
     exit()
@@ -108,9 +127,9 @@ def print_frame(addr):
     if verbose:
         print("%-16x " % addr, end="")
     if offset:
-        print("%s" % b.ksymaddr(addr))
+        print("%s" % b.symaddr(addr, args.pid or -1))
     else:
-        print("%s" % b.ksym(addr))
+        print("%s" % b.sym(addr, args.pid or -1))
 
 # output
 exiting = 0 if args.interval else 1

--- a/tools/stackcount_example.txt
+++ b/tools/stackcount_example.txt
@@ -296,6 +296,48 @@ with frame-pointer omission (-fomit-frame-pointer), which makes it impossible
 to reliably obtain the stack trace.
 
 
+In addition to kernel and user-space functions, kernel tracepoints and USDT
+tracepoints are also supported. 
+
+For example, to determine where threads are being created in a particular 
+process, use the pthread_create USDT tracepoint:
+
+# ./stackcount -p $(pidof parprimes) u:pthread:pthread_create
+Tracing 1 functions for "u:pthread:pthread_create"... Hit Ctrl-C to end.
+^C
+
+    parprimes [11923]
+  pthread_create@@GLIBC_2.2.5
+  main
+  __libc_start_main
+  [unknown]
+    7
+
+Similarly, to determine where context switching is happening in the kernel, 
+use the sched:sched_switch kernel tracepoint:
+
+# ./stackcount t:sched:sched_switch
+... (omitted for brevity)
+
+  __schedule
+  schedule
+  schedule_hrtimeout_range_clock
+  schedule_hrtimeout_range
+  poll_schedule_timeout
+  do_select
+  core_sys_select
+  SyS_select
+  entry_SYSCALL_64_fastpath
+    40
+
+  __schedule
+  schedule
+  schedule_preempt_disabled
+  cpu_startup_entry
+  start_secondary
+    85
+
+
 A -i option can be used to set an output interval, and -T to include a
 timestamp. For example:
 
@@ -463,7 +505,7 @@ USAGE message:
 
 # ./stackcount -h
 usage: stackcount [-h] [-p PID] [-i INTERVAL] [-T] [-r] [-s]
-                  [-l LIBRARY] [-v] pattern
+                  [-l LIBRARY] [-v] [-d] pattern
 
 Count function calls and their stack traces
 
@@ -481,6 +523,7 @@ optional arguments:
   -s, --offset          show address offsets
   -l, --library         trace user-space functions from this library or executable
   -v, --verbose         show raw addresses
+  -d, --debug           print BPF program before starting (for debugging purposes)
 
 examples:
     ./stackcount submit_bio          # count kernel stack traces for submit_bio
@@ -492,3 +535,5 @@ examples:
     ./stackcount -Ti 5 ip_output     # output every 5 seconds, with timestamps
     ./stackcount -p 185 ip_output    # count ip_output stacks for PID 185 only
     ./stackcount -p 185 -l c malloc  # count stacks for malloc in PID 185
+    ./stackcount t:sched:sched_fork  # count stacks for the sched_fork tracepoint
+    ./stackcount -p 185 u:node:*     # count stacks for all USDT probes in node

--- a/tools/stackcount_example.txt
+++ b/tools/stackcount_example.txt
@@ -1,8 +1,8 @@
 Demonstrations of stackcount, the Linux eBPF/bcc version.
 
 
-This program traces kernel functions and frequency counts them with their entire
-kernel stack trace, summarized in-kernel for efficiency. For example, counting
+This program traces functions and frequency counts them with their entire
+stack trace, summarized in-kernel for efficiency. For example, counting
 stack traces that led to submit_bio(), which creates block device I/O:
 
 # ./stackcount submit_bio
@@ -268,6 +268,34 @@ As may be obvious, this is a great tool for quickly understanding kernel code
 flow.
 
 
+User-space functions can also be traced if a library name is provided. For
+example, to quickly identify code locations that allocate heap memory:
+
+# ./stackcount -l c -p 4902 malloc
+Tracing 1 functions for "malloc"... Hit Ctrl-C to end.
+^C
+  malloc
+  rbtree_new
+  main
+  [unknown]
+    12
+
+  malloc
+  _rbtree_node_new_internal
+  _rbtree_node_insert
+  rbtree_insert
+  main
+  [unknown]
+    1189
+
+Detaching...
+
+Note that user-space uses of stackcount can be somewhat more limited because
+a lot of user-space libraries and binaries are compiled without debuginfo, or
+with frame-pointer omission (-fomit-frame-pointer), which makes it impossible
+to reliably obtain the stack trace.
+
+
 A -i option can be used to set an output interval, and -T to include a
 timestamp. For example:
 
@@ -434,12 +462,13 @@ Use -r to allow regular expressions.
 USAGE message:
 
 # ./stackcount -h
-usage: stackcount [-h] [-p PID] [-i INTERVAL] [-T] [-r] [-s] [-v] pattern
+usage: stackcount [-h] [-p PID] [-i INTERVAL] [-T] [-r] [-s]
+                  [-l LIBRARY] [-v] pattern
 
-Count kernel function calls and their stack traces
+Count function calls and their stack traces
 
 positional arguments:
-  pattern               search expression for kernel functions
+  pattern               search expression for functions
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -450,14 +479,16 @@ optional arguments:
   -r, --regexp          use regular expressions. Default is "*" wildcards
                         only.
   -s, --offset          show address offsets
+  -l, --library         trace user-space functions from this library or executable
   -v, --verbose         show raw addresses
 
 examples:
-    ./stackcount submit_bio       # count kernel stack traces for submit_bio
-    ./stackcount ip_output        # count kernel stack traces for ip_output
-    ./stackcount -s ip_output     # show symbol offsets
-    ./stackcount -sv ip_output    # show offsets and raw addresses (verbose)
-    ./stackcount 'tcp_send*'      # count stacks for funcs matching tcp_send*
-    ./stackcount -r '^tcp_send.*' # same as above, using regular expressions
-    ./stackcount -Ti 5 ip_output  # output every 5 seconds, with timestamps
-    ./stackcount -p 185 ip_output # count ip_output stacks for PID 185 only
+    ./stackcount submit_bio          # count kernel stack traces for submit_bio
+    ./stackcount ip_output           # count kernel stack traces for ip_output
+    ./stackcount -s ip_output        # show symbol offsets
+    ./stackcount -sv ip_output       # show offsets and raw addresses (verbose)
+    ./stackcount 'tcp_send*'         # count stacks for funcs matching tcp_send*
+    ./stackcount -r '^tcp_send.*'    # same as above, using regular expressions
+    ./stackcount -Ti 5 ip_output     # output every 5 seconds, with timestamps
+    ./stackcount -p 185 ip_output    # count ip_output stacks for PID 185 only
+    ./stackcount -p 185 -l c malloc  # count stacks for malloc in PID 185


### PR DESCRIPTION
`stackcount` now supports uprobes, tracepoints, and USDT probes (using the bcc/BPF native tracepoint and USDT support). Examples and man page updated. Also fixed a minor bug in symbol enumeration (bcc).

Resolves #580.

A couple of highlights to try:

```
stackcount t:sched:sched_switch
stackcount -p $(pidof node) u:node:gc__start
stackcount -p $(pidof ruby) u:ruby:object__create # not great stacks though
stackcount u:pthread:pthread_create
```