### PR TITLE
Update Clang download in INSTALL.md for FC

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -183,8 +183,13 @@ sudo pip install pyroute2
 ### Install binary clang
 
 ```
+# FC22
 wget http://llvm.org/releases/3.7.1/clang+llvm-3.7.1-x86_64-fedora22.tar.xz
 sudo tar xf clang+llvm-3.7.1-x86_64-fedora22.tar.xz -C /usr/local --strip 1
+
+# FC23 and FC24
+wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-fedora23.tar.xz
+sudo tar xf clang+llvm-3.9.0-x86_64-fedora23.tar.xz -C /usr/local --strip 1
 ```
 
 ### Install and compile BCC


### PR DESCRIPTION
FC23 and FC24 need Clang 3.9.0 because of ABI changes in the C++
runtime library. Split the installation instructions to FC22 and
FC23/24.

Resolves #721.