### PR TITLE
tplist: Print USDT locations and arguments

### DIFF
--- a/man/man8/tplist.8
+++ b/man/man8/tplist.8
@@ -22,7 +22,8 @@ Display the USDT probes from the specified library or executable. If the librar
 or executable can be found in the standard paths, a full path is not required.
 .TP
 \-v
-Display the variables associated with the tracepoint or USDT probe.
+Increase the verbosity level. Can be used to display the variables, locations,
+and arguments of tracepoints and USDT probes.
 .TP
 [filter]
 A wildcard expression that specifies which tracepoints or probes to print.
@@ -45,6 +46,10 @@ $
 Print all USDT probes in process 4717 from the libc provider:
 $
 .B tplist -p 4717 'libc:*'
+.TP
+Print all the USDT probes in the node executable:
+$
+.B tplist -l node
 .SH SOURCE
 This is from bcc.
 .IP

--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -35,8 +35,32 @@ struct bcc_usdt {
     int num_arguments;
 };
 
+struct bcc_usdt_location {
+    uint64_t address;
+};
+
+#define BCC_USDT_ARGUMENT_NONE          0x0
+#define BCC_USDT_ARGUMENT_CONSTANT      0x1
+#define BCC_USDT_ARGUMENT_DEREF_OFFSET  0x2
+#define BCC_USDT_ARGUMENT_DEREF_IDENT   0x4
+#define BCC_USDT_ARGUMENT_REGISTER_NAME 0x8
+
+struct bcc_usdt_argument {
+    int size;
+    int valid;
+    int constant;
+    int deref_offset;
+    const char *deref_ident;
+    const char *register_name;
+};
+
 typedef void (*bcc_usdt_cb)(struct bcc_usdt *);
 void bcc_usdt_foreach(void *usdt, bcc_usdt_cb callback);
+int bcc_usdt_get_location(void *usdt, const char *probe_name,
+                          int index, struct bcc_usdt_location *location);
+int bcc_usdt_get_argument(void *usdt, const char *probe_name,
+                          int location_index, int argument_index,
+                          struct bcc_usdt_argument *argument);
 
 int bcc_usdt_enable_probe(void *, const char *, const char *);
 const char *bcc_usdt_genargs(void *);

--- a/src/cc/usdt.cc
+++ b/src/cc/usdt.cc
@@ -28,7 +28,7 @@
 
 namespace USDT {
 
-Probe::Location::Location(uint64_t addr, const char *arg_fmt) : address_(addr) {
+Location::Location(uint64_t addr, const char *arg_fmt) : address_(addr) {
   ArgumentParser_x64 parser(arg_fmt);
   while (!parser.done()) {
     Argument arg;
@@ -274,7 +274,7 @@ void Context::each_uprobe(each_uprobe_cb callback) {
     if (!p->enabled())
       continue;
 
-    for (Probe::Location &loc : p->locations_) {
+    for (Location &loc : p->locations_) {
       callback(p->bin_path_.c_str(), p->attached_to_->c_str(), loc.address_,
                pid_.value_or(-1));
     }
@@ -355,6 +355,52 @@ const char *bcc_usdt_get_probe_argctype(
 void bcc_usdt_foreach(void *usdt, bcc_usdt_cb callback) {
   USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
   ctx->each(callback);
+}
+
+int bcc_usdt_get_location(void *usdt, const char *probe_name,
+                          int index, struct bcc_usdt_location *location) {
+    USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
+    USDT::Probe *probe = ctx->get(probe_name);
+    if (!probe)
+        return -1;
+    if (index < 0 || (size_t)index >= probe->num_locations())
+        return -1;
+    location->address = probe->address(index);
+    return 0;
+}
+
+int bcc_usdt_get_argument(void *usdt, const char *probe_name,
+                          int location_index, int argument_index,
+                          struct bcc_usdt_argument *argument) {
+    USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
+    USDT::Probe *probe = ctx->get(probe_name);
+    if (!probe)
+        return -1;
+    if (argument_index < 0 || (size_t)argument_index >= probe->num_arguments())
+        return -1;
+    if (location_index < 0 || (size_t)location_index >= probe->num_locations())
+        return -1;
+    auto const &location = probe->location(location_index);
+    auto const &arg = location.arguments_[argument_index];
+    argument->size = arg.arg_size();
+    argument->valid = BCC_USDT_ARGUMENT_NONE;
+    if (arg.constant()) {
+        argument->valid |= BCC_USDT_ARGUMENT_CONSTANT;
+        argument->constant = *(arg.constant());
+    }
+    if (arg.deref_offset()) {
+        argument->valid |= BCC_USDT_ARGUMENT_DEREF_OFFSET;
+        argument->deref_offset = *(arg.deref_offset());
+    }
+    if (arg.deref_ident()) {
+        argument->valid |= BCC_USDT_ARGUMENT_DEREF_IDENT;
+        argument->deref_ident = arg.deref_ident()->c_str();
+    }
+    if (arg.register_name()) {
+        argument->valid |= BCC_USDT_ARGUMENT_REGISTER_NAME;
+        argument->register_name = arg.register_name()->c_str();
+    }
+    return 0;
 }
 
 void bcc_usdt_foreach_uprobe(void *usdt, bcc_usdt_uprobe_cb callback) {

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -117,17 +117,17 @@ public:
   ArgumentParser_x64(const char *arg) : ArgumentParser(arg) {}
 };
 
+struct Location {
+  uint64_t address_;
+  std::vector<Argument> arguments_;
+  Location(uint64_t addr, const char *arg_fmt);
+};
+
 class Probe {
   std::string bin_path_;
   std::string provider_;
   std::string name_;
   uint64_t semaphore_;
-
-  struct Location {
-    uint64_t address_;
-    std::vector<Argument> arguments_;
-    Location(uint64_t addr, const char *arg_fmt);
-  };
 
   std::vector<Location> locations_;
 
@@ -153,6 +153,7 @@ public:
   uint64_t semaphore()   const { return semaphore_; }
 
   uint64_t address(size_t n = 0) const { return locations_[n].address_; }
+  const Location &location(size_t n) const { return locations_[n]; }
   bool usdt_getarg(std::ostream &stream);
   std::string get_arg_ctype(int arg_index) {
     return largest_arg_type(arg_index);

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -174,10 +174,40 @@ class bcc_usdt(ct.Structure):
             ('num_arguments', ct.c_int),
         ]
 
+class bcc_usdt_location(ct.Structure):
+    _fields_ = [
+            ('address', ct.c_ulonglong)
+        ]
+
+class BCC_USDT_ARGUMENT_FLAGS(object):
+    NONE = 0x0
+    CONSTANT = 0x1
+    DEREF_OFFSET = 0x2
+    DEREF_IDENT = 0x4
+    REGISTER_NAME = 0x8
+
+class bcc_usdt_argument(ct.Structure):
+    _fields_ = [
+            ('size', ct.c_int),
+            ('valid', ct.c_int),
+            ('constant', ct.c_int),
+            ('deref_offset', ct.c_int),
+            ('deref_ident', ct.c_char_p),
+            ('register_name', ct.c_char_p)
+        ]
+
 _USDT_CB = ct.CFUNCTYPE(None, ct.POINTER(bcc_usdt))
 
 lib.bcc_usdt_foreach.restype = None
 lib.bcc_usdt_foreach.argtypes = [ct.c_void_p, _USDT_CB]
+
+lib.bcc_usdt_get_location.restype = ct.c_int
+lib.bcc_usdt_get_location.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_int,
+                                      ct.POINTER(bcc_usdt_location)]
+
+lib.bcc_usdt_get_argument.restype = ct.c_int
+lib.bcc_usdt_get_argument.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_int,
+                                      ct.c_int, ct.POINTER(bcc_usdt_argument)]
 
 _USDT_PROBE_CB = ct.CFUNCTYPE(None, ct.c_char_p, ct.c_char_p,
                               ct.c_ulonglong, ct.c_int)

--- a/tools/tplist_example.txt
+++ b/tools/tplist_example.txt
@@ -88,6 +88,31 @@ The dev, sector, nr_sector, etc. variables can now all be used in probes
 you specify with argdist or trace.
 
 
+For debugging USDT probes, it is sometimes useful to see the exact locations
+and arguments of the probes, including the registers or global variables from
+which their values are coming from. In super-verbose mode, tplist will print
+this information (note the -vv):
+
+$ tplist -vv -l c *alloc*
+/lib64/libc.so.6 libc:memory_malloc_retry [sema 0x0]
+  location #0 0x835c0
+    argument #0 8 unsigned bytes @ bp
+  location #1 0x83778
+    argument #0 8 unsigned bytes @ bp
+  location #2 0x85a50
+    argument #0 8 unsigned bytes @ bp
+/lib64/libc.so.6 libc:memory_realloc_retry [sema 0x0]
+  location #0 0x84b90
+    argument #0 8 unsigned bytes @ r13
+    argument #1 8 unsigned bytes @ bp
+  location #1 0x85cf0
+    argument #0 8 unsigned bytes @ r13
+    argument #1 8 unsigned bytes @ bp
+/lib64/libc.so.6 libc:memory_calloc_retry [sema 0x0]
+  location #0 0x850f0
+    argument #0 8 unsigned bytes @ bp
+
+
 USAGE message:
 
 $ tplist -h
@@ -102,5 +127,5 @@ optional arguments:
   -h, --help         show this help message and exit
   -p PID, --pid PID  List USDT probes in the specified process
   -l LIB, --lib LIB  List USDT probes in the specified library or executable
-  -v                 Print the format (available variables)
+  -v                 Increase verbosity level (print variables, arguments, etc.)
 


### PR DESCRIPTION
This adds support in libbcc (on the C++ and Python side) and in tplist for printing USDT probe locations and arguments in super-verbose (`-vv`) mode, as requested by @4ast.

Example:

```
# ./tplist.py -vv -l c *mmap*
/lib64/libc.so.6 libc:memory_mallopt_mmap_max [sema 0x0]
  location #0 0x85448
    argument #0 4 signed   bytes @ bp
    argument #1 4 signed   bytes @ *(&mp_ + 44)
    argument #2 4 signed   bytes @ *(&mp_ + 52)
/lib64/libc.so.6 libc:memory_mallopt_mmap_threshold [sema 0x0]
  location #0 0x8546e
    argument #0 4 signed   bytes @ bp
    argument #1 8 unsigned bytes @ *(&mp_ + 16)
    argument #2 4 signed   bytes @ *(&mp_ + 52)
```

Resolves #711.