### PR TITLE
Update opensnoop to filter by PID and TID

### DIFF
--- a/man/man8/opensnoop.8
+++ b/man/man8/opensnoop.8
@@ -2,7 +2,7 @@
 .SH NAME
 opensnoop \- Trace open() syscalls. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B opensnoop [\-h] [\-t] [\-x] [\-p PID] [\-n name]
+.B opensnoop [\-h] [\-T] [\-x] [\-p PID] [\-t TID] [\-n name]
 .SH DESCRIPTION
 opensnoop traces the open() syscall, showing which processes are attempting
 to open which files. This can be useful for determining the location of config
@@ -24,7 +24,7 @@ CONFIG_BPF and bcc.
 \-h
 Print usage message.
 .TP
-\-t
+\-T
 Include a timestamp column.
 .TP
 \-x
@@ -32,6 +32,9 @@ Only print failed opens.
 .TP
 \-p PID
 Trace this process ID only (filtered in-kernel).
+.TP
+\-t TID
+Trace this thread ID only (filtered in-kernel).
 .TP
 \-n name
 Only print processes where its name partially matches 'name'
@@ -43,7 +46,7 @@ Trace all open() syscalls:
 .TP
 Trace all open() syscalls, and include timestamps:
 #
-.B opensnoop \-t
+.B opensnoop \-T
 .TP
 Trace only open() syscalls that failed:
 #
@@ -63,6 +66,9 @@ Time of the call, in seconds.
 .TP
 PID
 Process ID
+.TP
+TID
+Thread ID
 .TP
 COMM
 Process name

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -4,7 +4,7 @@
 # opensnoop Trace open() syscalls.
 #           For Linux, uses BCC, eBPF. Embedded C.
 #
-# USAGE: opensnoop [-h] [-T] [-x] [-p PID] [-t TID]
+# USAGE: opensnoop [-h] [-T] [-x] [-p PID] [-t TID] [-n NAME]
 #
 # Copyright (c) 2015 Brendan Gregg.
 # Licensed under the Apache License, Version 2.0 (the "License")

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -4,13 +4,14 @@
 # opensnoop Trace open() syscalls.
 #           For Linux, uses BCC, eBPF. Embedded C.
 #
-# USAGE: opensnoop [-h] [-t] [-x] [-p PID] [-t TID]
+# USAGE: opensnoop [-h] [-T] [-x] [-p PID] [-t TID]
 #
 # Copyright (c) 2015 Brendan Gregg.
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
 # 17-Sep-2015   Brendan Gregg   Created this.
-# 29-Apr-2016   Allan McAleavy updated for BPF_PERF_OUTPUT
+# 29-Apr-2016   Allan McAleavy  Updated for BPF_PERF_OUTPUT.
+# 08-Oct-2016   Dina Goldshtein Support filtering by PID and TID.
 
 from __future__ import print_function
 from bcc import BPF
@@ -20,7 +21,7 @@ import ctypes as ct
 # arguments
 examples = """examples:
     ./opensnoop           # trace all open() syscalls
-    ./opensnoop -t        # include timestamps
+    ./opensnoop -T        # include timestamps
     ./opensnoop -x        # only show failed opens
     ./opensnoop -p 181    # only trace PID 181
     ./opensnoop -n main   # only print process names containing "main"
@@ -29,7 +30,7 @@ parser = argparse.ArgumentParser(
     description="Trace open() syscalls",
     formatter_class=argparse.RawDescriptionHelpFormatter,
     epilog=examples)
-parser.add_argument("-t", "--timestamp", action="store_true",
+parser.add_argument("-T", "--timestamp", action="store_true",
     help="include timestamp on output")
 parser.add_argument("-x", "--failed", action="store_true",
     help="only show failed opens")

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -111,8 +111,8 @@ int trace_return(struct pt_regs *ctx)
     return 0;
 }
 """
-if args.tid: # TID trumps PID
-    bpf_text = bpf_text.replace('FILTER', 
+if args.tid:  # TID trumps PID
+    bpf_text = bpf_text.replace('FILTER',
         'if (tid != %s) { return 0; }' % args.tid)
 elif args.pid:
     bpf_text = bpf_text.replace('FILTER',
@@ -144,7 +144,8 @@ initial_ts = 0
 # header
 if args.timestamp:
     print("%-14s" % ("TIME(s)"), end="")
-print("%-6s %-16s %4s %3s %s" % ("TID" if args.tid else "PID", "COMM", "FD", "ERR", "PATH"))
+print("%-6s %-16s %4s %3s %s" %
+      ("TID" if args.tid else "PID", "COMM", "FD", "ERR", "PATH"))
 
 # process event
 def print_event(cpu, data, size):
@@ -172,8 +173,8 @@ def print_event(cpu, data, size):
         delta = event.ts - initial_ts
         print("%-14.9f" % (float(delta) / 1000000), end="")
 
-    print("%-6d %-16s %4d %3d %s" % 
-          (event.id & 0xffffffff if args.tid else event.id >> 32, 
+    print("%-6d %-16s %4d %3d %s" %
+          (event.id & 0xffffffff if args.tid else event.id >> 32,
            event.comm, fd_s, err, event.fname))
 
 # loop with callback to print_event

--- a/tools/opensnoop_example.txt
+++ b/tools/opensnoop_example.txt
@@ -123,16 +123,17 @@ to the '-n' option.
 USAGE message:
 
 # ./opensnoop -h
-usage: opensnoop [-h] [-T] [-x] [-p PID] [-t TID]
+usage: opensnoop [-h] [-T] [-x] [-p PID] [-t TID] [-n NAME]
 
 Trace open() syscalls
 
 optional arguments:
-  -h, --help         show this help message and exit
-  -T, --timestamp    include timestamp on output
-  -x, --failed       only show failed opens
-  -p PID, --pid PID  trace this PID only
-  -t TID, --tid TID  trace this TID only
+  -h, --help            show this help message and exit
+  -T, --timestamp       include timestamp on output
+  -x, --failed          only show failed opens
+  -p PID, --pid PID     trace this PID only
+  -t TID, --tid TID     trace this TID only
+  -n NAME, --name NAME  only print process names containing this name
 
 examples:
     ./opensnoop           # trace all open() syscalls
@@ -140,3 +141,4 @@ examples:
     ./opensnoop -x        # only show failed opens
     ./opensnoop -p 181    # only trace PID 181
     ./opensnoop -t 123    # only trace TID 123
+    ./opensnoop -n main   # only print process names containing "main"

--- a/tools/opensnoop_example.txt
+++ b/tools/opensnoop_example.txt
@@ -48,9 +48,9 @@ during application startup.
 
 
 The -p option can be used to filter on a PID, which is filtered in-kernel. Here
-I've used it with -t to print timestamps:
+I've used it with -T to print timestamps:
 
- ./opensnoop -tp 1956
+ ./opensnoop -Tp 1956
 TIME(s)       PID    COMM               FD ERR PATH
 0.000000000   1956   supervise           9   0 supervise/status.new
 0.000289999   1956   supervise           9   0 supervise/status.new
@@ -123,18 +123,20 @@ to the '-n' option.
 USAGE message:
 
 # ./opensnoop -h
-usage: opensnoop [-h] [-t] [-x] [-p PID]
+usage: opensnoop [-h] [-T] [-x] [-p PID] [-t TID]
 
 Trace open() syscalls
 
 optional arguments:
   -h, --help         show this help message and exit
-  -t, --timestamp    include timestamp on output
+  -T, --timestamp    include timestamp on output
   -x, --failed       only show failed opens
   -p PID, --pid PID  trace this PID only
+  -t TID, --tid TID  trace this TID only
 
 examples:
     ./opensnoop           # trace all open() syscalls
-    ./opensnoop -t        # include timestamps
+    ./opensnoop -T        # include timestamps
     ./opensnoop -x        # only show failed opens
     ./opensnoop -p 181    # only trace PID 181
+    ./opensnoop -t 123    # only trace TID 123


### PR DESCRIPTION
I updated opensnoop in to support #547: 
* Now supports passing TID and PID as filters where PID is the actual process ID and TID is the thread ID (note that this is a change on the behavior which currently used -p to filter by thread ID!)
* Output displays PID or TID according to the input parameters
* Added some missing documentation about the -n parameter

```
$ sudo ./opensnoop.py -Tt 2359
TIME(s)       TID    COMM               FD ERR PATH
0.000000000   2359   opens               3   0 /tmp/myfile.txt
```


If this looks good, I can update other tools similarly. @brendangregg 