### PR TITLE
trace: Add %K and %U format specifiers

### DIFF
--- a/man/man8/trace.8
+++ b/man/man8/trace.8
@@ -92,6 +92,12 @@ number of arguments as there are placeholders in the format string. The
 format specifier replacements may be any C expressions, and may refer to the
 same special keywords as in the predicate (arg1, arg2, etc.).
 
+In addition to the above format specifiers, you can also use %K and %U when
+the expression is an address that potentially points to executable code (i.e.,
+a symbol). trace will resolve %K specifiers to a kernel symbol, such as
+vfs__read, and will resolve %U specifiers to a user-space symbol in that
+process, such as sprintf.
+
 In tracepoints, both the predicate and the arguments may refer to the tracepoint
 format structure, which is stored in the special "args" variable. For example, the
 block:block_rq_complete tracepoint can print or filter by args->nr_sector. To 

--- a/tools/trace_example.txt
+++ b/tools/trace_example.txt
@@ -105,6 +105,37 @@ block:block_rq_complete
 This output tells you that you can use "args->dev", "args->sector", etc. in your
 predicate and trace arguments.
 
+
+More and more high-level libraries are instrumented with USDT probe support.
+These probes can be traced by trace just like kernel tracepoints. For example,
+trace new threads being created and their function name:
+
+# trace 'u:pthread:pthread_create "%U", arg3'
+TIME     PID    COMM         FUNC             -
+02:07:29 4051   contentions  pthread_create   primes_thread+0x0
+02:07:29 4051   contentions  pthread_create   primes_thread+0x0
+02:07:29 4051   contentions  pthread_create   primes_thread+0x0
+02:07:29 4051   contentions  pthread_create   primes_thread+0x0
+^C
+
+The "%U" format specifier tells trace to resolve arg3 as a user-space symbol,
+if possible. Similarly, use "%K" for kernel symbols.
+
+Ruby, Node, and OpenJDK are also instrumented with USDT. For example, let's
+trace Ruby methods being called (this requires a version of Ruby built with 
+the --enable-dtrace configure flag):
+
+# trace 'u:ruby:method__entry "%s.%s", arg1, arg2' -p $(pidof irb)
+TIME     PID    COMM         FUNC             -
+12:08:43 18420  irb          method__entry    IRB::Context.verbose?
+12:08:43 18420  irb          method__entry    RubyLex.ungetc
+12:08:43 18420  irb          method__entry    RuxyLex.debug?
+^C
+
+In the previous invocation, arg1 and arg2 are the class name and method name
+for the Ruby method being invoked.
+
+
 As a final example, let's trace open syscalls for a specific process. By 
 default, tracing is system-wide, but the -p switch overrides this:
 


### PR DESCRIPTION
The %K and %U format specifiers can be used in a trace
format string to resolve kernel and user symbols,
respectively. For example, the pthread_create USDT probe
has an argument pointing to the new thread's function.
To trace pthread_create and print the symbolic name of
the new thread's function, use:

```
trace 'u:pthread:pthread_create "%U", arg3'
```

The %U specifier resolves addresses in the event's process,
while the %K specifier resolves kernel addresses.