### PR TITLE
Add vxlan gbp header

### DIFF
--- a/src/cc/export/proto.h
+++ b/src/cc/export/proto.h
@@ -127,4 +127,19 @@ struct vxlan_t {
   unsigned int key:24;
   unsigned int rsv4:8;
 } BPF_PACKET_HEADER;
+
+struct vxlan_gbp_t {
+  unsigned int gflag:1;
+  unsigned int rsv1:3;
+  unsigned int iflag:1;
+  unsigned int rsv2:3;
+  unsigned int rsv3:1;
+  unsigned int dflag:1;
+  unsigned int rsv4:1;
+  unsigned int aflag:1;
+  unsigned int rsv5:3;
+  unsigned int tag:16;
+  unsigned int key:24;
+  unsigned int rsv6:8;
+} BPF_PACKET_HEADER;
 )********"


### PR DESCRIPTION
Adding vxlan gbp header to proto.h, this is used by some iomodules
Signed-off-by: Deepa Kalani <dkalani@plumgrid.com>