### PR TITLE
mysqld_slower: Fix breakage after USDT API change

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -544,7 +544,7 @@ Constructors.
 
 ### 1. BPF
 
-Syntax: ```BPF({text=BPF_program | src_file=filename} [, usdt=USDT_object])```
+Syntax: ```BPF({text=BPF_program | src_file=filename} [, usdt_contexts=[USDT_object, ...]])```
 
 Creates a BPF object. This is the main object for defining a BPF program, and interacting with its output.
 
@@ -569,7 +569,7 @@ b = BPF(src_file = "vfsreadlat.c")
 # include a USDT object:
 u = USDT(pid=int(pid))
 [...]
-b = BPF(text=bpf_text, usdt=u)
+b = BPF(text=bpf_text, usdt_contexts=[u])
 ```
 
 Examples in situ:
@@ -593,7 +593,7 @@ Examples:
 # include a USDT object:
 u = USDT(pid=int(pid))
 [...]
-b = BPF(text=bpf_text, usdt=u)
+b = BPF(text=bpf_text, usdt_contexts=[u])
 ```
 
 Examples in situ:

--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -629,7 +629,7 @@ u = USDT(pid=int(pid))
 u.enable_probe(probe="http__server__request", fn_name="do_trace")
 
 # initialize BPF
-b = BPF(text=bpf_text, usdt=u)
+b = BPF(text=bpf_text, usdt_contexts=[u])
 ```
 
 Things to learn:
@@ -638,7 +638,7 @@ Things to learn:
 1. ```bpf_probe_read(&path, sizeof(path), (void *)addr)```: Now the string ```addr``` points to into our ```path``` variable.
 1. ```u = USDT(pid=int(pid))```: Initialize USDT tracing for the given PID.
 1. ```u.enable_probe(probe="http__server__request", fn_name="do_trace")```: Attach our ```do_trace()``` BPF C function to the Node.js ```http__server__request``` USDT probe.
-1. ```b = BPF(text=bpf_text, usdt=u)```: Need to pass in our USDT object, ```u```, to BPF object creation.
+1. ```b = BPF(text=bpf_text, usdt_contexts=[u])```: Need to pass in our USDT object, ```u```, to BPF object creation.
 
 ### Lesson 16. task_switch.c
 

--- a/examples/tracing/mysqld_query.py
+++ b/examples/tracing/mysqld_query.py
@@ -46,7 +46,7 @@ if debug:
     print(bpf_text)
 
 # initialize BPF
-b = BPF(text=bpf_text, usdt=u)
+b = BPF(text=bpf_text, usdt_contexts=[u])
 
 # header
 print("%-18s %-16s %-6s %s" % ("TIME(s)", "COMM", "PID", "QUERY"))

--- a/examples/tracing/nodejs_http_server.py
+++ b/examples/tracing/nodejs_http_server.py
@@ -39,7 +39,7 @@ if debug:
     print(bpf_text)
 
 # initialize BPF
-b = BPF(text=bpf_text, usdt=u)
+b = BPF(text=bpf_text, usdt_contexts=[u])
 
 # header
 print("%-18s %-16s %-6s %s" % ("TIME(s)", "COMM", "PID", "ARGS"))

--- a/tools/mysqld_qslower.py
+++ b/tools/mysqld_qslower.py
@@ -102,7 +102,7 @@ if debug:
     print(bpf_text)
 
 # initialize BPF
-b = BPF(text=bpf_text, usdt=u)
+b = BPF(text=bpf_text, usdt_contexts=[u])
 
 # header
 print("Tracing MySQL server queries for PID %d slower than %s ms..." % (pid,


### PR DESCRIPTION
A recent PR to the USDT infrastructure changed the BPF
module constructor to accept an array of USDT contexts.
This commit updates `mysqld_slower` to use that new
constructor.