### PR TITLE
cc: Support glob+offset format in USDT arguments

### DIFF
--- a/src/cc/usdt_args.cc
+++ b/src/cc/usdt_args.cc
@@ -146,6 +146,9 @@ ssize_t ArgumentParser::parse_expr(ssize_t pos, Argument *dest) {
   } else {
     dest->deref_offset_ = 0;
     pos = parse_identifier(pos, &dest->deref_ident_);
+    if (arg_[pos] == '+' || arg_[pos] == '-') {
+      pos = parse_number(pos, &dest->deref_offset_);
+    }
   }
 
   if (arg_[pos] != '(')
@@ -184,10 +187,12 @@ bool ArgumentParser::parse(Argument *dest) {
   ssize_t res = parse_1(cur_pos_, dest);
   if (res < 0) {
     print_error(-res);
+    cur_pos_ = -res;
     return false;
   }
   if (!isspace(arg_[res]) && arg_[res] != '\0') {
     print_error(res);
+    cur_pos_ = res;
     return false;
   }
   while (isspace(arg_[res])) res++;


### PR DESCRIPTION
Modern versions of USDT probes (such as what's found in
PostgreSQL when compiled with `--enable-dtrace`) may have
the offset listed after the global symbol for USDT
arguments of the format `4@symbol+8(%rip)`. This commit
extends the argument parser to support these cases, adds
tests for these cases, and makes sure that in case of a
parse error, the parser always moves forward and consumes
at least one character. Presently, the parser would get
stuck on the problematic position and enter an infinite
loop.