### PR TITLE
Support filtering by process ID in the filesystem slower tools

### DIFF
--- a/tools/btrfsslower.py
+++ b/tools/btrfsslower.py
@@ -22,6 +22,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
 # 15-Feb-2016   Brendan Gregg   Created this.
+# 16-Oct-2016   Dina Goldshtein -p to filter by process ID.
 
 from __future__ import print_function
 from bcc import BPF
@@ -87,7 +88,7 @@ struct data_t {
     char file[DNAME_INLINE_LEN];
 };
 
-BPF_HASH(entryinfo, pid_t, struct val_t);
+BPF_HASH(entryinfo, u64, struct val_t);
 BPF_PERF_OUTPUT(events);
 
 //
@@ -99,8 +100,9 @@ BPF_PERF_OUTPUT(events);
 // I do by checking file->f_op.
 int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 {
-    u32 pid;
-    pid = bpf_get_current_pid_tgid();
+    u64 id =  bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+
     if (FILTER_PID)
         return 0;
 
@@ -115,7 +117,7 @@ int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
     val.fp = fp;
     val.offset = iocb->ki_pos;
     if (val.fp)
-        entryinfo.update(&pid, &val);
+        entryinfo.update(&id, &val);
 
     return 0;
 }
@@ -123,18 +125,19 @@ int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 // btrfs_file_write_iter():
 int trace_write_entry(struct pt_regs *ctx, struct kiocb *iocb)
 {
-    u32 pid;
-    pid = bpf_get_current_pid_tgid();
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+
     if (FILTER_PID)
         return 0;
 
-    // store filep and timestamp by pid
+    // store filep and timestamp by id
     struct val_t val = {};
     val.ts = bpf_ktime_get_ns();
     val.fp = iocb->ki_filp;
     val.offset = iocb->ki_pos;
     if (val.fp)
-        entryinfo.update(&pid, &val);
+        entryinfo.update(&id, &val);
 
     return 0;
 }
@@ -144,8 +147,9 @@ int trace_write_entry(struct pt_regs *ctx, struct kiocb *iocb)
 int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
     struct file *file)
 {
-    u32 pid;
-    pid = bpf_get_current_pid_tgid();
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+
     if (FILTER_PID)
         return 0;
 
@@ -153,13 +157,13 @@ int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
     if ((u64)file->f_op != BTRFS_FILE_OPERATIONS)
         return 0;
 
-    // store filep and timestamp by pid
+    // store filep and timestamp by id
     struct val_t val = {};
     val.ts = bpf_ktime_get_ns();
     val.fp = file;
     val.offset = 0;
     if (val.fp)
-        entryinfo.update(&pid, &val);
+        entryinfo.update(&id, &val);
 
     return 0;
 }
@@ -167,18 +171,19 @@ int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
 // btrfs_sync_file():
 int trace_fsync_entry(struct pt_regs *ctx, struct file *file)
 {
-    u32 pid;
-    pid = bpf_get_current_pid_tgid();
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+
     if (FILTER_PID)
         return 0;
 
-    // store filep and timestamp by pid
+    // store filep and timestamp by id
     struct val_t val = {};
     val.ts = bpf_ktime_get_ns();
     val.fp = file;
     val.offset = 0;
     if (val.fp)
-        entryinfo.update(&pid, &val);
+        entryinfo.update(&id, &val);
 
     return 0;
 }
@@ -190,9 +195,10 @@ int trace_fsync_entry(struct pt_regs *ctx, struct file *file)
 static int trace_return(struct pt_regs *ctx, int type)
 {
     struct val_t *valp;
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
 
-    valp = entryinfo.lookup(&pid);
+    valp = entryinfo.lookup(&id);
     if (valp == 0) {
         // missed tracing issue or filtered
         return 0;
@@ -201,7 +207,7 @@ static int trace_return(struct pt_regs *ctx, int type)
     // calculate delta
     u64 ts = bpf_ktime_get_ns();
     u64 delta_us = (ts - valp->ts) / 1000;
-    entryinfo.delete(&pid);
+    entryinfo.delete(&id);
     if (FILTER_US)
         return 0;
 

--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -22,6 +22,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
 # 11-Feb-2016   Brendan Gregg   Created this.
+# 15-Oct-2016   Dina Goldshtein -p to filter by process ID.
 
 from __future__ import print_function
 from bcc import BPF
@@ -87,7 +88,7 @@ struct data_t {
     char file[DNAME_INLINE_LEN];
 };
 
-BPF_HASH(entryinfo, pid_t, struct val_t);
+BPF_HASH(entryinfo, u64, struct val_t);
 BPF_PERF_OUTPUT(events);
 
 //
@@ -99,8 +100,9 @@ BPF_PERF_OUTPUT(events);
 // which I do by checking file->f_op.
 int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 {
-    u32 pid;
-    pid = bpf_get_current_pid_tgid();
+    u64 id =  bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+
     if (FILTER_PID)
         return 0;
 
@@ -109,13 +111,13 @@ int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
     if ((u64)fp->f_op != EXT4_FILE_OPERATIONS)
         return 0;
 
-    // store filep and timestamp by pid
+    // store filep and timestamp by id
     struct val_t val = {};
     val.ts = bpf_ktime_get_ns();
     val.fp = fp;
     val.offset = iocb->ki_pos;
     if (val.fp)
-        entryinfo.update(&pid, &val);
+        entryinfo.update(&id, &val);
 
     return 0;
 }
@@ -123,18 +125,19 @@ int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 // ext4_file_write_iter():
 int trace_write_entry(struct pt_regs *ctx, struct kiocb *iocb)
 {
-    u32 pid;
-    pid = bpf_get_current_pid_tgid();
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+
     if (FILTER_PID)
         return 0;
 
-    // store filep and timestamp by pid
+    // store filep and timestamp by id
     struct val_t val = {};
     val.ts = bpf_ktime_get_ns();
     val.fp = iocb->ki_filp;
     val.offset = iocb->ki_pos;
     if (val.fp)
-        entryinfo.update(&pid, &val);
+        entryinfo.update(&id, &val);
 
     return 0;
 }
@@ -143,18 +146,19 @@ int trace_write_entry(struct pt_regs *ctx, struct kiocb *iocb)
 int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
     struct file *file)
 {
-    u32 pid;
-    pid = bpf_get_current_pid_tgid();
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+
     if (FILTER_PID)
         return 0;
 
-    // store filep and timestamp by pid
+    // store filep and timestamp by id
     struct val_t val = {};
     val.ts = bpf_ktime_get_ns();
     val.fp = file;
     val.offset = 0;
     if (val.fp)
-        entryinfo.update(&pid, &val);
+        entryinfo.update(&id, &val);
 
     return 0;
 }
@@ -162,18 +166,19 @@ int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
 // ext4_sync_file():
 int trace_fsync_entry(struct pt_regs *ctx, struct file *file)
 {
-    u32 pid;
-    pid = bpf_get_current_pid_tgid();
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+
     if (FILTER_PID)
         return 0;
 
-    // store filep and timestamp by pid
+    // store filep and timestamp by id
     struct val_t val = {};
     val.ts = bpf_ktime_get_ns();
     val.fp = file;
     val.offset = 0;
     if (val.fp)
-        entryinfo.update(&pid, &val);
+        entryinfo.update(&id, &val);
 
     return 0;
 }
@@ -185,9 +190,10 @@ int trace_fsync_entry(struct pt_regs *ctx, struct file *file)
 static int trace_return(struct pt_regs *ctx, int type)
 {
     struct val_t *valp;
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
 
-    valp = entryinfo.lookup(&pid);
+    valp = entryinfo.lookup(&id);
     if (valp == 0) {
         // missed tracing issue or filtered
         return 0;
@@ -196,7 +202,7 @@ static int trace_return(struct pt_regs *ctx, int type)
     // calculate delta
     u64 ts = bpf_ktime_get_ns();
     u64 delta_us = (ts - valp->ts) / 1000;
-    entryinfo.delete(&pid);
+    entryinfo.delete(&id);
     if (FILTER_US)
         return 0;
 


### PR DESCRIPTION
Changed the -p parameter to filter by real process ID rather than just first thread in the following tools:
* ext4slower.py
* btrfsslower.py
* xfsslower.py
* zfsslower.py

@brendangregg 