### PR TITLE
Fix negative delta time

### DIFF
--- a/tools/btrfsslower.py
+++ b/tools/btrfsslower.py
@@ -202,7 +202,7 @@ static int trace_return(struct pt_regs *ctx, int type)
     u64 ts = bpf_ktime_get_ns();
     u64 delta_us = (ts - valp->ts) / 1000;
     entryinfo.delete(&pid);
-    if (FILTER_US)
+    if (FILTER_US || ts < valp->ts)
         return 0;
 
     // workaround (rewriter should handle file to d_iname in one step):


### PR DESCRIPTION
While investigating slow Btrfs operations, I noticed a very high latency range that didn't seem right:

```
    2251799813685248 -> 4503599627370495     : 0        |                    |
    4503599627370496 -> 9007199254740991     : 0        |                    |
    9007199254740992 -> 18014398509481983    : 0        |                    |
   18014398509481984 -> 36028797018963967    : 1206     |*                   |
```

It seems that the start time is after the end time, leading to negative elapse time. I didn't have time to investigate more and I only have Btrfs on this laptop so I only submitted a quick fix for this filesystem, but it may impacts others.

Did it happen to anyone else? Do you have any idea to investigate further? I was thinking about tracing all events with their occurrence time to see if I can find something.

Also, I am using a 4.8 kernel with custom config (Gentoo), so maybe I forgot some debugging options. Do you have any idea which one I can check?