### PR TITLE
C++ helper class for BCC

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 ---
 BasedOnStyle: Google
 AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
 IndentCaseLabels: false
 AccessModifierOffset: -2

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(EXAMPLE_PROGRAMS hello_world.py)
 install(PROGRAMS ${EXAMPLE_PROGRAMS} DESTINATION share/bcc/examples)
 
+add_subdirectory(cpp)
+add_subdirectory(lua)
 add_subdirectory(networking)
 add_subdirectory(tracing)
-add_subdirectory(lua)

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Facebook, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+include_directories(${CMAKE_SOURCE_DIR}/src/cc)
+
+add_executable(HelloWorld HelloWorld.cc)
+target_link_libraries(HelloWorld bcc-static)
+install (TARGETS HelloWorld DESTINATION share/bcc/examples/cpp)
+
+add_executable(CPUDistribution CPUDistribution.cc)
+target_link_libraries(CPUDistribution bcc-static)
+install (TARGETS CPUDistribution DESTINATION share/bcc/examples/cpp)
+
+add_executable(RecordMySQLQuery RecordMySQLQuery.cc)
+target_link_libraries(RecordMySQLQuery bcc-static)
+install (TARGETS RecordMySQLQuery DESTINATION share/bcc/examples/cpp)
+
+add_executable(TCPSendStack TCPSendStack.cc)
+target_link_libraries(TCPSendStack bcc-static)
+install (TARGETS TCPSendStack DESTINATION share/bcc/examples/cpp)
+
+add_executable(RandomRead RandomRead.cc)
+target_link_libraries(RandomRead bcc-static)
+install (TARGETS RandomRead DESTINATION share/bcc/examples/cpp)

--- a/examples/cpp/CPUDistribution.cc
+++ b/examples/cpp/CPUDistribution.cc
@@ -1,0 +1,97 @@
+/*
+ * CPUDistribution Show load distribution across CPU cores during a period of
+ *                 time. For Linux, uses BCC, eBPF. Embedded C.
+ *
+ * Basic example of BCC and kprobes.
+ *
+ * USAGE: CPUDistribution [duration]
+ *
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <unistd.h>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include "BPF.h"
+
+const std::string BPF_PROGRAM = R"(
+#include <linux/sched.h>
+#include <uapi/linux/ptrace.h>
+
+BPF_HASH(pid_to_cpu, pid_t, int);
+BPF_HASH(pid_to_ts, pid_t, uint64_t);
+BPF_HASH(cpu_time, int, uint64_t);
+
+int task_switch_event(struct pt_regs *ctx, struct task_struct *prev) {
+  pid_t prev_pid = prev->pid;
+  int* prev_cpu = pid_to_cpu.lookup(&prev_pid);
+  uint64_t* prev_ts = pid_to_ts.lookup(&prev_pid);
+
+  pid_t cur_pid = bpf_get_current_pid_tgid();
+  int cur_cpu = bpf_get_smp_processor_id();
+  uint64_t cur_ts = bpf_ktime_get_ns();
+
+  uint64_t this_cpu_time = 0;
+  if (prev_ts) {
+    pid_to_ts.delete(&prev_pid);
+    this_cpu_time = (cur_ts - *prev_ts);
+  }
+  if (prev_cpu) {
+    pid_to_cpu.delete(&prev_pid);
+    if (this_cpu_time > 0) {
+      int cpu_key = *prev_cpu;
+      uint64_t* history_time = cpu_time.lookup(&cpu_key);
+      if (history_time)
+        this_cpu_time += *history_time;
+      cpu_time.update(&cpu_key, &this_cpu_time);
+    }
+  }
+
+  pid_to_cpu.update(&cur_pid, &cur_cpu);
+  pid_to_ts.update(&cur_pid, &cur_ts);
+
+  return 0;
+}
+)";
+
+int main(int argc, char** argv) {
+  ebpf::BPF bpf;
+  auto init_res = bpf.init(BPF_PROGRAM);
+  if (std::get<0>(init_res) != 0) {
+    std::cerr << std::get<1>(init_res) << std::endl;
+    return 1;
+  }
+
+  auto attach_res =
+      bpf.attach_kprobe("finish_task_switch", "task_switch_event");
+  if (std::get<0>(attach_res) != 0) {
+    std::cerr << std::get<1>(attach_res) << std::endl;
+    return 1;
+  }
+
+  int probe_time = 10;
+  if (argc == 2) {
+    probe_time = atoi(argv[1]);
+  }
+  std::cout << "Probing for " << probe_time << " seconds" << std::endl;
+  sleep(probe_time);
+
+  auto table = bpf.get_hash_table<int, uint64_t>("cpu_time");
+  auto num_cores = sysconf(_SC_NPROCESSORS_ONLN);
+  for (int i = 0; i < num_cores; i++) {
+    std::cout << "CPU " << std::setw(2) << i << " worked for ";
+    std::cout << (table[i] / 1000000.0) << " ms." << std::endl;
+  }
+
+  auto detach_res = bpf.detach_kprobe("finish_task_switch");
+  if (std::get<0>(detach_res) != 0) {
+    std::cerr << std::get<1>(detach_res) << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/examples/cpp/HelloWorld.cc
+++ b/examples/cpp/HelloWorld.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <unistd.h>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "BPF.h"
+
+const std::string BPF_PROGRAM = R"(
+int on_sys_clone(void *ctx) {
+  bpf_trace_printk("Hello, World! Here I did a sys_clone call!\n");
+  return 0;
+}
+)";
+
+int main() {
+  ebpf::BPF bpf;
+  auto init_res = bpf.init(BPF_PROGRAM);
+  if (std::get<0>(init_res) != 0) {
+    std::cerr << std::get<1>(init_res) << std::endl;
+    return 1;
+  }
+
+  std::ifstream pipe("/sys/kernel/debug/tracing/trace_pipe");
+  std::string line;
+
+  auto attach_res = bpf.attach_kprobe("sys_clone", "on_sys_clone");
+  if (std::get<0>(attach_res) != 0) {
+    std::cerr << std::get<1>(attach_res) << std::endl;
+    return 1;
+  }
+
+  while (true) {
+    if (std::getline(pipe, line)) {
+      std::cout << line << std::endl;
+      // Detach the probe if we got at least one line.
+      auto detach_res = bpf.detach_kprobe("sys_clone");
+      if (std::get<0>(detach_res) != 0) {
+        std::cerr << std::get<1>(detach_res) << std::endl;
+        return 1;
+      }
+      break;
+    } else {
+      std::cout << "Waiting for a sys_clone event" << std::endl;
+      sleep(1);
+    }
+  }
+
+  return 0;
+}

--- a/examples/cpp/RandomRead.cc
+++ b/examples/cpp/RandomRead.cc
@@ -1,0 +1,97 @@
+/*
+ * RandomRead Monitor random number read events.
+ *            For Linux, uses BCC, eBPF. Embedded C.
+ *
+ * Basic example of BCC Tracepoint and perf buffer.
+ *
+ * USAGE: RandomRead
+ *
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <signal.h>
+#include <iostream>
+
+#include "BPF.h"
+
+const std::string BPF_PROGRAM = R"(
+#include <linux/sched.h>
+#include <uapi/linux/ptrace.h>
+
+struct urandom_read_args {
+  // See /sys/kernel/debug/tracing/events/random/urandom_read/format
+  uint64_t common__unused;
+  int got_bits;
+  int pool_left;
+  int input_left;
+};
+
+struct event_t {
+  int pid;
+  char comm[16];
+  int got_bits;
+};
+
+BPF_PERF_OUTPUT(events);
+
+int on_urandom_read(struct urandom_read_args* attr) {
+  struct event_t event = {};
+  event.pid = bpf_get_current_pid_tgid();
+  bpf_get_current_comm(&event.comm, sizeof(event.comm));
+  event.got_bits = attr->got_bits;
+
+  events.perf_submit(attr, &event, sizeof(event));
+  return 0;
+}
+)";
+
+// Define the same struct to use in user space.
+struct event_t {
+  int pid;
+  char comm[16];
+  int got_bits;
+};
+
+void handle_output(void* cb_cookie, void* data, int data_size) {
+  auto event = static_cast<event_t*>(data);
+  std::cout << "PID: " << event->pid << " (" << event->comm << ") "
+            << "Read " << event->got_bits << " bits" << std::endl;
+}
+
+ebpf::BPF* bpf;
+
+void signal_handler(int s) {
+  std::cerr << "Terminating..." << std::endl;
+  delete bpf;
+  exit(0);
+}
+
+int main(int argc, char** argv) {
+  bpf = new ebpf::BPF();
+  auto init_res = bpf->init(BPF_PROGRAM);
+  if (std::get<0>(init_res) != 0) {
+    std::cerr << std::get<1>(init_res) << std::endl;
+    return 1;
+  }
+
+  auto attach_res =
+      bpf->attach_tracepoint("random:urandom_read", "on_urandom_read");
+  if (std::get<0>(attach_res) != 0) {
+    std::cerr << std::get<1>(attach_res) << std::endl;
+    return 1;
+  }
+
+  auto open_res = bpf->open_perf_buffer("events", &handle_output);
+  if (std::get<0>(open_res) != 0) {
+    std::cerr << std::get<1>(open_res) << std::endl;
+    return 1;
+  }
+
+  signal(SIGINT, signal_handler);
+  std::cout << "Started tracing, hit Ctrl-C to terminate." << std::endl;
+  while (true)
+    bpf->poll_perf_buffer("events");
+
+  return 0;
+}

--- a/examples/cpp/RecordMySQLQuery.cc
+++ b/examples/cpp/RecordMySQLQuery.cc
@@ -1,0 +1,103 @@
+/*
+ * RecordMySQLQuery Record MySQL queries by probing the alloc_query() function
+ *                  in mysqld. For Linux, uses BCC, eBPF. Embedded C.
+ *
+ * Basic example of BCC and uprobes.
+ *
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <unistd.h>
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "BPF.h"
+
+const std::string BPF_PROGRAM = R"(
+#include <linux/ptrace.h>
+
+struct query_probe_t {
+  uint64_t ts;
+  pid_t pid;
+  char query[100];
+};
+
+BPF_HASH(queries, struct query_probe_t, int);
+
+int probe_mysql_query(struct pt_regs *ctx, void* thd, char* query, size_t len) {
+  if (query) {
+    struct query_probe_t key = {};
+
+    key.ts = bpf_ktime_get_ns();
+    key.pid = bpf_get_current_pid_tgid();
+
+    bpf_probe_read(&key.query, sizeof(key.query), query);
+
+    int one = 1;
+    queries.update(&key, &one);
+  }
+  return 0;
+}
+)";
+const std::string ALLOC_QUERY_FUNC = "_Z11alloc_queryP3THDPKcj";
+
+// Define the same struct to use in user space.
+struct query_probe_t {
+  uint64_t ts;
+  pid_t pid;
+  char query[100];
+};
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cout << "USAGE: RecordMySQLQuery PATH_TO_MYSQLD [duration]"
+              << std::endl;
+    exit(1);
+  }
+
+  std::string mysql_path(argv[1]);
+  std::cout << "Using mysqld path: " << mysql_path << std::endl;
+
+  ebpf::BPF bpf;
+  auto init_res = bpf.init(BPF_PROGRAM);
+  if (std::get<0>(init_res) != 0) {
+    std::cerr << std::get<1>(init_res) << std::endl;
+    return 1;
+  }
+
+  auto attach_res =
+      bpf.attach_uprobe(mysql_path, ALLOC_QUERY_FUNC, "probe_mysql_query");
+  if (std::get<0>(attach_res) != 0) {
+    std::cerr << std::get<1>(attach_res) << std::endl;
+    return 1;
+  }
+
+  int probe_time = 10;
+  if (argc >= 3)
+    probe_time = atoi(argv[2]);
+  std::cout << "Probing for " << probe_time << " seconds" << std::endl;
+  sleep(probe_time);
+
+  auto table_handle = bpf.get_hash_table<query_probe_t, int>("queries");
+  auto table = table_handle.get_table_offline();
+  std::sort(table.begin(), table.end(), [](std::pair<query_probe_t, int> a,
+                                           std::pair<query_probe_t, int> b) {
+    return a.first.ts < b.first.ts;
+  });
+  std::cout << table.size() << " queries recorded:" << std::endl;
+  for (auto it : table) {
+    std::cout << "Time: " << it.first.ts << " PID: " << it.first.pid
+              << " Query: " << it.first.query << std::endl;
+  }
+
+  auto detach_res = bpf.detach_uprobe(mysql_path, ALLOC_QUERY_FUNC);
+  if (std::get<0>(detach_res) != 0) {
+    std::cerr << std::get<1>(detach_res) << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/examples/cpp/TCPSendStack.cc
+++ b/examples/cpp/TCPSendStack.cc
@@ -1,0 +1,114 @@
+/*
+ * TCPSendStack Summarize tcp_sendmsg() calling stack traces.
+ *              For Linux, uses BCC, eBPF. Embedded C.
+ *
+ * Basic example of BCC in-kernel stack trace dedup.
+ *
+ * USAGE: TCPSendStack [duration]
+ *
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <unistd.h>
+#include <algorithm>
+#include <iostream>
+
+#include "BPF.h"
+
+const std::string BPF_PROGRAM = R"(
+#include <linux/sched.h>
+#include <uapi/linux/ptrace.h>
+
+struct stack_key_t {
+  int pid;
+  char name[16];
+  int user_stack;
+  int kernel_stack;
+};
+
+BPF_STACK_TRACE(stack_traces, 10240)
+BPF_HASH(counts, struct stack_key_t, uint64_t);
+
+int on_tcp_send(struct pt_regs *ctx) {
+  struct stack_key_t key = {};
+  key.pid = bpf_get_current_pid_tgid();
+  bpf_get_current_comm(&key.name, sizeof(key.name));
+  key.kernel_stack = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
+  key.user_stack = stack_traces.get_stackid(
+    ctx, BPF_F_REUSE_STACKID | BPF_F_USER_STACK
+  );
+
+  u64 zero = 0, *val;
+  val = counts.lookup_or_init(&key, &zero);
+  (*val)++;
+
+  return 0;
+}
+)";
+
+// Define the same struct to use in user space.
+struct stack_key_t {
+  int pid;
+  char name[16];
+  int user_stack;
+  int kernel_stack;
+};
+
+int main(int argc, char** argv) {
+  ebpf::BPF bpf;
+  auto init_res = bpf.init(BPF_PROGRAM);
+  if (std::get<0>(init_res) != 0) {
+    std::cerr << std::get<1>(init_res) << std::endl;
+    return 1;
+  }
+
+  auto attach_res = bpf.attach_kprobe("tcp_sendmsg", "on_tcp_send");
+  if (std::get<0>(attach_res) != 0) {
+    std::cerr << std::get<1>(attach_res) << std::endl;
+    return 1;
+  }
+
+  int probe_time = 10;
+  if (argc == 2) {
+    probe_time = atoi(argv[1]);
+  }
+  std::cout << "Probing for " << probe_time << " seconds" << std::endl;
+  sleep(probe_time);
+
+  auto table =
+      bpf.get_hash_table<stack_key_t, uint64_t>("counts").get_table_offline();
+  std::sort(table.begin(), table.end(), [](std::pair<stack_key_t, uint64_t> a,
+                                           std::pair<stack_key_t, uint64_t> b) {
+    return a.second < b.second;
+  });
+  auto stacks = bpf.get_stack_table("stack_traces");
+
+  for (auto it : table) {
+    std::cout << "PID: " << it.first.pid << " (" << it.first.name << ") "
+              << "made " << it.second
+              << " TCP sends on following stack: " << std::endl;
+    std::cout << "  Kernel Stack:" << std::endl;
+    if (it.first.kernel_stack >= 0) {
+      auto syms = stacks.get_stack_symbol(it.first.kernel_stack, -1);
+      for (auto sym : syms)
+        std::cout << "    " << sym << std::endl;
+    } else
+      std::cout << "    " << it.first.kernel_stack << std::endl;
+    std::cout << "  User Stack:" << std::endl;
+    if (it.first.user_stack >= 0) {
+      auto syms = stacks.get_stack_symbol(it.first.user_stack, it.first.pid);
+      for (auto sym : syms)
+        std::cout << "    " << sym << std::endl;
+    } else
+      std::cout << "    " << it.first.user_stack << std::endl;
+  }
+
+  auto detach_res = bpf.detach_kprobe("tcp_sendmsg");
+  if (std::get<0>(detach_res) != 0) {
+    std::cerr << std::get<1>(detach_res) << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/src/cc/BPF.cc
+++ b/src/cc/BPF.cc
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <linux/bpf.h>
+#include <unistd.h>
+#include <cstdio>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+#include "bcc_syms.h"
+#include "bpf_module.h"
+#include "common.h"
+#include "exception.h"
+#include "libbpf.h"
+#include "perf_reader.h"
+
+#include "BPF.h"
+
+namespace ebpf {
+
+std::string uint_to_hex(uint64_t value) {
+  std::stringstream ss;
+  ss << std::hex << value;
+  return ss.str();
+}
+
+std::string sanitize_str(std::string str, bool (*validator)(char),
+                         char replacement = '_') {
+  for (size_t i = 0; i < str.length(); i++)
+    if (!validator(str[i]))
+      str[i] = replacement;
+  return str;
+}
+
+StatusTuple BPF::init(const std::string& bpf_program,
+                      std::vector<std::string> cflags) {
+  auto flags_len = cflags.size();
+  const char* flags[flags_len];
+  for (size_t i = 0; i < flags_len; i++)
+    flags[i] = cflags[i].c_str();
+  if (bpf_module_->load_string(bpf_program, flags, flags_len) != 0)
+    return mkstatus(-1, "Unable to initialize BPF program");
+  return mkstatus(0);
+};
+
+BPF::~BPF() {
+  auto res = detach_all();
+  if (std::get<0>(res) != 0)
+    std::cerr << "Failed to detach all probes on destruction: " << std::endl
+              << std::get<1>(res) << std::endl;
+}
+
+StatusTuple BPF::detach_all() {
+  bool has_error = false;
+  std::string error_msg;
+
+  for (auto it : kprobes_) {
+    auto res = detach_kprobe_event(it.first, it.second);
+    if (std::get<0>(res) != 0) {
+      error_msg += "Failed to detach kprobe event " + it.first + ": ";
+      error_msg += std::get<1>(res) + "\n";
+      has_error = true;
+    }
+  }
+
+  for (auto it : uprobes_) {
+    auto res = detach_uprobe_event(it.first, it.second);
+    if (std::get<0>(res) != 0) {
+      error_msg += "Failed to detach uprobe event " + it.first + ": ";
+      error_msg += std::get<1>(res) + "\n";
+      has_error = true;
+    }
+  }
+
+  for (auto it : tracepoints_) {
+    auto res = detach_tracepoint_event(it.first, it.second);
+    if (std::get<0>(res) != 0) {
+      error_msg += "Failed to detach Tracepoint " + it.first + ": ";
+      error_msg += std::get<1>(res) + "\n";
+      has_error = true;
+    }
+  }
+
+  for (auto it : perf_buffers_) {
+    auto res = it.second->close();
+    if (std::get<0>(res) != 0) {
+      error_msg += "Failed to close perf buffer " + it.first + ": ";
+      error_msg += std::get<1>(res) + "\n";
+      has_error = true;
+    }
+    delete it.second;
+  }
+
+  if (has_error)
+    return mkstatus(-1, error_msg);
+  else
+    return mkstatus(0);
+}
+
+StatusTuple BPF::attach_kprobe(const std::string& kernel_func,
+                               const std::string& probe_func,
+                               bpf_attach_type attach_type,
+                               pid_t pid, int cpu, int group_fd,
+                               perf_reader_cb cb, void* cb_cookie) {
+  int probe_fd;
+  TRY2(load_func(probe_func, BPF_PROG_TYPE_KPROBE, probe_fd));
+
+  std::string probe_event = get_kprobe_event(kernel_func, attach_type);
+  if (kprobes_.find(probe_event) != kprobes_.end()) {
+    TRY2(unload_func(probe_func));
+    return mkstatus(-1, "kprobe %s already attached", probe_event.c_str());
+  }
+
+  std::string probe_event_desc = attach_type_prefix(attach_type);
+  probe_event_desc += ":kprobes/" + probe_event + " " + kernel_func;
+
+  void* res =
+      bpf_attach_kprobe(probe_fd, probe_event.c_str(), probe_event_desc.c_str(),
+                        pid, cpu, group_fd, cb, cb_cookie);
+
+  if (!res) {
+    TRY2(unload_func(probe_func));
+    return mkstatus(-1, "Unable to attach %skprobe for %s using %s",
+                    attach_type_debug(attach_type).c_str(), kernel_func.c_str(),
+                    probe_func.c_str());
+  }
+
+  open_probe_t p = {};
+  p.reader_ptr = res;
+  p.func = probe_func;
+  kprobes_[probe_event] = std::move(p);
+  return mkstatus(0);
+}
+
+StatusTuple BPF::attach_uprobe(const std::string& binary_path,
+                               const std::string& symbol,
+                               const std::string& probe_func,
+                               uint64_t symbol_addr,
+                               bpf_attach_type attach_type,
+                               pid_t pid, int cpu, int group_fd,
+                               perf_reader_cb cb, void* cb_cookie) {
+  int probe_fd;
+  TRY2(load_func(probe_func, BPF_PROG_TYPE_KPROBE, probe_fd));
+
+  bcc_symbol sym = bcc_symbol();
+  TRY2(check_binary_symbol(binary_path, symbol, symbol_addr, &sym));
+
+  std::string probe_event =
+      get_uprobe_event(sym.module, sym.offset, attach_type);
+  if (uprobes_.find(probe_event) != uprobes_.end()) {
+    TRY2(unload_func(probe_func));
+    return mkstatus(-1, "uprobe %s already attached", probe_event.c_str());
+  }
+
+  std::string probe_event_desc = attach_type_prefix(attach_type);
+  probe_event_desc += ":uprobes/" + probe_event + " ";
+  probe_event_desc += binary_path + ":0x" + uint_to_hex(sym.offset);
+
+  void* res =
+      bpf_attach_uprobe(probe_fd, probe_event.c_str(), probe_event_desc.c_str(),
+                        pid, cpu, group_fd, cb, cb_cookie);
+
+  if (!res) {
+    TRY2(unload_func(probe_func));
+    return mkstatus(
+        -1,
+        "Unable to attach %suprobe for binary %s symbol %s addr %lx using %s\n",
+        attach_type_debug(attach_type).c_str(), binary_path.c_str(),
+        symbol.c_str(), symbol_addr, probe_func.c_str());
+  }
+
+  open_probe_t p = {};
+  p.reader_ptr = res;
+  p.func = probe_func;
+  uprobes_[probe_event] = std::move(p);
+  return mkstatus(0);
+}
+
+StatusTuple BPF::attach_tracepoint(const std::string& tracepoint,
+                                   const std::string& probe_func,
+                                   pid_t pid, int cpu, int group_fd,
+                                   perf_reader_cb cb, void* cb_cookie) {
+  int probe_fd;
+  TRY2(load_func(probe_func, BPF_PROG_TYPE_TRACEPOINT, probe_fd));
+
+  if (tracepoints_.find(tracepoint) != tracepoints_.end())
+    return mkstatus(-1, "Tracepoint %s already attached", tracepoint.c_str());
+
+  auto pos = tracepoint.find(":");
+  if ((pos == std::string::npos) || (pos != tracepoint.rfind(":")))
+    return mkstatus(-1, "Unable to parse Tracepoint %s", tracepoint.c_str());
+  std::string tp_category = tracepoint.substr(0, pos);
+  std::string tp_name = tracepoint.substr(pos + 1);
+
+  void* res =
+      bpf_attach_tracepoint(probe_fd, tp_category.c_str(), tp_name.c_str(), pid,
+                            cpu, group_fd, cb, cb_cookie);
+
+  if (!res) {
+    TRY2(unload_func(probe_func));
+    return mkstatus(-1, "Unable to attach Tracepoint %s using %s",
+                    tracepoint.c_str(), probe_func.c_str());
+  }
+
+  open_probe_t p = {};
+  p.reader_ptr = res;
+  p.func = probe_func;
+  tracepoints_[tracepoint] = std::move(p);
+  return mkstatus(0);
+}
+
+StatusTuple BPF::detach_kprobe(const std::string& kernel_func,
+                               bpf_attach_type attach_type) {
+  std::string event = get_kprobe_event(kernel_func, attach_type);
+
+  auto it = kprobes_.find(event);
+  if (it == kprobes_.end())
+    return mkstatus(-1, "No open %skprobe for %s",
+                    attach_type_debug(attach_type).c_str(),
+                    kernel_func.c_str());
+
+  TRY2(detach_kprobe_event(it->first, it->second));
+  kprobes_.erase(it);
+  return mkstatus(0);
+}
+
+StatusTuple BPF::detach_uprobe(const std::string& binary_path,
+                               const std::string& symbol, uint64_t symbol_addr,
+                               bpf_attach_type attach_type) {
+  bcc_symbol sym = bcc_symbol();
+  TRY2(check_binary_symbol(binary_path, symbol, symbol_addr, &sym));
+
+  std::string event = get_uprobe_event(sym.module, sym.offset, attach_type);
+  auto it = uprobes_.find(event);
+  if (it == uprobes_.end())
+    return mkstatus(-1, "No open %suprobe for binary %s symbol %s addr %lx",
+                    attach_type_debug(attach_type).c_str(), binary_path.c_str(),
+                    symbol.c_str(), symbol_addr);
+
+  TRY2(detach_uprobe_event(it->first, it->second));
+  uprobes_.erase(it);
+  return mkstatus(0);
+}
+
+StatusTuple BPF::detach_tracepoint(const std::string& tracepoint) {
+  auto it = tracepoints_.find(tracepoint);
+  if (it == tracepoints_.end())
+    return mkstatus(-1, "No open Tracepoint %s", tracepoint.c_str());
+
+  TRY2(detach_tracepoint_event(it->first, it->second));
+  tracepoints_.erase(it);
+  return mkstatus(0);
+}
+
+StatusTuple BPF::open_perf_buffer(const std::string& name,
+                                  perf_reader_raw_cb cb, void* cb_cookie) {
+  if (perf_buffers_.find(name) == perf_buffers_.end())
+    perf_buffers_[name] = new BPFPerfBuffer(bpf_module_.get(), name);
+  auto table = perf_buffers_[name];
+  TRY2(table->open(cb, cb_cookie));
+  return mkstatus(0);
+}
+
+StatusTuple BPF::close_perf_buffer(const std::string& name) {
+  auto it = perf_buffers_.find(name);
+  if (it == perf_buffers_.end())
+    return mkstatus(-1, "Perf buffer for %s not open", name.c_str());
+  TRY2(it->second->close());
+  return mkstatus(0);
+}
+
+void BPF::poll_perf_buffer(const std::string& name, int timeout) {
+  auto it = perf_buffers_.find(name);
+  if (it == perf_buffers_.end())
+    return;
+  it->second->poll(timeout);
+}
+
+StatusTuple BPF::load_func(const std::string& func_name,
+                           enum bpf_prog_type type, int& fd) {
+  if (funcs_.find(func_name) != funcs_.end()) {
+    fd = funcs_[func_name];
+    return mkstatus(0);
+  }
+
+  uint8_t* func_start = bpf_module_->function_start(func_name);
+  if (!func_start)
+    return mkstatus(-1, "Can't find start of function %s", func_name.c_str());
+  size_t func_size = bpf_module_->function_size(func_name);
+
+  fd = bpf_prog_load(type, reinterpret_cast<struct bpf_insn*>(func_start),
+                     func_size, bpf_module_->license(),
+                     bpf_module_->kern_version(), nullptr,
+                     0  // BPFModule will handle error printing
+                     );
+
+  if (fd < 0)
+    return mkstatus(-1, "Failed to load %s: %d", func_name.c_str(), fd);
+  funcs_[func_name] = fd;
+  return mkstatus(0);
+}
+
+StatusTuple BPF::unload_func(const std::string& func_name) {
+  auto it = funcs_.find(func_name);
+  if (it == funcs_.end())
+    return mkstatus(-1, "Probe function %s not loaded", func_name.c_str());
+
+  int res = close(it->second);
+  if (res != 0)
+    return mkstatus(-1, "Can't close FD for %s: %d", it->first.c_str(), res);
+
+  funcs_.erase(it);
+  return mkstatus(0);
+}
+
+StatusTuple BPF::check_binary_symbol(const std::string& binary_path,
+                                     const std::string& symbol,
+                                     uint64_t symbol_addr, bcc_symbol* output) {
+  int res = bcc_resolve_symname(binary_path.c_str(), symbol.c_str(),
+                                symbol_addr, output);
+  if (res < 0)
+    return mkstatus(-1,
+                    "Unable to find offset for binary %s symbol %s address %lx",
+                    binary_path.c_str(), symbol.c_str(), symbol_addr);
+  return mkstatus(0);
+}
+
+std::string BPF::get_kprobe_event(const std::string& kernel_func,
+                                  bpf_attach_type type) {
+  std::string res = attach_type_prefix(type) + "_";
+  res += sanitize_str(kernel_func, &BPF::kprobe_event_validator);
+  return res;
+}
+
+std::string BPF::get_uprobe_event(const std::string& binary_path,
+                                  uint64_t offset, bpf_attach_type type) {
+  std::string res = attach_type_prefix(type) + "_";
+  res += sanitize_str(binary_path, &BPF::uprobe_path_validator);
+  res += "_0x" + uint_to_hex(offset);
+  return res;
+}
+
+StatusTuple BPF::detach_kprobe_event(const std::string& event,
+                                     open_probe_t& attr) {
+  if (attr.reader_ptr) {
+    perf_reader_free(attr.reader_ptr);
+    attr.reader_ptr = nullptr;
+  }
+  TRY2(unload_func(attr.func));
+  std::string detach_event = "-:kprobes/" + event;
+  if (bpf_detach_kprobe(detach_event.c_str()) < 0)
+    return mkstatus(-1, "Unable to detach kprobe %s", event.c_str());
+  return mkstatus(0);
+}
+
+StatusTuple BPF::detach_uprobe_event(const std::string& event,
+                                     open_probe_t& attr) {
+  if (attr.reader_ptr) {
+    perf_reader_free(attr.reader_ptr);
+    attr.reader_ptr = nullptr;
+  }
+  TRY2(unload_func(attr.func));
+  std::string detach_event = "-:uprobes/" + event;
+  if (bpf_detach_uprobe(detach_event.c_str()) < 0)
+    return mkstatus(-1, "Unable to detach uprobe %s", event.c_str());
+  return mkstatus(0);
+}
+
+StatusTuple BPF::detach_tracepoint_event(const std::string& tracepoint,
+                                         open_probe_t& attr) {
+  if (attr.reader_ptr) {
+    perf_reader_free(attr.reader_ptr);
+    attr.reader_ptr = nullptr;
+  }
+  TRY2(unload_func(attr.func));
+
+  // TODO: bpf_detach_tracepoint currently does nothing.
+  return mkstatus(0);
+}
+
+}  // namespace ebpf

--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cctype>
+#include <memory>
+#include <string>
+
+#include "BPFTable.h"
+#include "bcc_syms.h"
+#include "bpf_module.h"
+#include "common.h"
+#include "compat/linux/bpf.h"
+#include "libbpf.h"
+
+namespace ebpf {
+
+enum class bpf_attach_type {
+  probe_entry,
+  probe_return
+};
+
+struct open_probe_t {
+  void* reader_ptr;
+  std::string func;
+};
+
+class BPF {
+public:
+  static const int BPF_MAX_STACK_DEPTH = 127;
+
+  explicit BPF(unsigned int flag = 0) : bpf_module_(new BPFModule(flag)) {}
+  StatusTuple init(const std::string& bpf_program,
+                   std::vector<std::string> cflags = {});
+
+  ~BPF();
+  StatusTuple detach_all();
+
+  StatusTuple attach_kprobe(
+      const std::string& kernel_func, const std::string& probe_func,
+      bpf_attach_type attach_type = bpf_attach_type::probe_entry,
+      pid_t pid = -1, int cpu = 0, int group_fd = -1,
+      perf_reader_cb cb = nullptr, void* cb_cookie = nullptr);
+  StatusTuple detach_kprobe(
+      const std::string& kernel_func,
+      bpf_attach_type attach_type = bpf_attach_type::probe_entry);
+
+  StatusTuple attach_uprobe(
+      const std::string& binary_path, const std::string& symbol,
+      const std::string& probe_func, uint64_t symbol_addr = 0,
+      bpf_attach_type attach_type = bpf_attach_type::probe_entry,
+      pid_t pid = -1, int cpu = 0, int group_fd = -1,
+      perf_reader_cb cb = nullptr, void* cb_cookie = nullptr);
+  StatusTuple detach_uprobe(
+      const std::string& binary_path, const std::string& symbol,
+      uint64_t symbol_addr = 0,
+      bpf_attach_type attach_type = bpf_attach_type::probe_entry);
+
+  StatusTuple attach_tracepoint(const std::string& tracepoint,
+                                const std::string& probe_func,
+                                pid_t pid = -1, int cpu = 0, int group_fd = -1,
+                                perf_reader_cb cb = nullptr,
+                                void* cb_cookie = nullptr);
+  StatusTuple detach_tracepoint(const std::string& tracepoint);
+
+  template <class KeyType, class ValueType>
+  BPFHashTable<KeyType, ValueType> get_hash_table(const std::string& name) {
+    return BPFHashTable<KeyType, ValueType>(bpf_module_.get(), name);
+  }
+
+  BPFStackTable get_stack_table(const std::string& name) {
+    return BPFStackTable(bpf_module_.get(), name);
+  }
+
+  StatusTuple open_perf_buffer(const std::string& name, perf_reader_raw_cb cb,
+                               void* cb_cookie = nullptr);
+  StatusTuple close_perf_buffer(const std::string& name);
+  void poll_perf_buffer(const std::string& name, int timeout = -1);
+
+private:
+  StatusTuple load_func(const std::string& func_name, enum bpf_prog_type type,
+                        int& fd);
+  StatusTuple unload_func(const std::string& func_name);
+
+  std::string get_kprobe_event(const std::string& kernel_func,
+                               bpf_attach_type type);
+  std::string get_uprobe_event(const std::string& binary_path, uint64_t offset,
+                               bpf_attach_type type);
+
+  StatusTuple detach_kprobe_event(const std::string& event, open_probe_t& attr);
+  StatusTuple detach_uprobe_event(const std::string& event, open_probe_t& attr);
+  StatusTuple detach_tracepoint_event(const std::string& tracepoint,
+                                      open_probe_t& attr);
+
+  std::string attach_type_debug(bpf_attach_type type) {
+    switch (type) {
+    case bpf_attach_type::probe_entry:
+      return "";
+    case bpf_attach_type::probe_return:
+      return "return ";
+    }
+    return "ERROR";
+  }
+
+  std::string attach_type_prefix(bpf_attach_type type) {
+    switch (type) {
+    case bpf_attach_type::probe_entry:
+      return "p";
+    case bpf_attach_type::probe_return:
+      return "r";
+    }
+    return "ERROR";
+  }
+
+  static bool kprobe_event_validator(char c) {
+    return (c != '+') && (c != '.');
+  }
+
+  static bool uprobe_path_validator(char c) {
+    return std::isalpha(c) || std::isdigit(c) || (c == '_');
+  }
+
+  StatusTuple check_binary_symbol(const std::string& binary_path,
+                                  const std::string& symbol,
+                                  uint64_t symbol_addr, bcc_symbol* output);
+
+  std::unique_ptr<BPFModule> bpf_module_;
+
+  std::map<std::string, int> funcs_;
+
+  std::map<std::string, open_probe_t> kprobes_;
+  std::map<std::string, open_probe_t> uprobes_;
+  std::map<std::string, open_probe_t> tracepoints_;
+  std::map<std::string, BPFPerfBuffer*> perf_buffers_;
+};
+
+}  // namespace ebpf

--- a/src/cc/BPFTable.cc
+++ b/src/cc/BPFTable.cc
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <unistd.h>
+#include <cstring>
+#include <iostream>
+
+#include "BPFTable.h"
+
+#include "bcc_syms.h"
+#include "common.h"
+#include "exception.h"
+#include "libbpf.h"
+#include "perf_reader.h"
+
+namespace ebpf {
+
+BPFStackTable::~BPFStackTable() {
+  for (auto it : pid_sym_)
+    bcc_free_symcache(it.second, it.first);
+}
+
+std::vector<intptr_t> BPFStackTable::get_stack_addr(int stack_id) {
+  std::vector<intptr_t> res;
+  stacktrace_t stack;
+  if (!lookup(&stack_id, &stack))
+    return res;
+  for (int i = 0; (i < BPF_MAX_STACK_DEPTH) && (stack.ip[i] != 0); i++)
+    res.push_back(stack.ip[i]);
+  return res;
+}
+
+std::vector<std::string> BPFStackTable::get_stack_symbol(int stack_id,
+                                                         int pid) {
+  auto addresses = get_stack_addr(stack_id);
+  std::vector<std::string> res;
+  res.reserve(addresses.size());
+
+  if (pid < 0)
+    pid = -1;
+  if (pid_sym_.find(pid) == pid_sym_.end())
+    pid_sym_[pid] = bcc_symcache_new(pid);
+  void* cache = pid_sym_[pid];
+
+  bcc_symbol symbol;
+  for (auto addr : addresses)
+    if (bcc_symcache_resolve(cache, addr, &symbol) != 0)
+      res.push_back("[UNKNOWN]");
+    else
+      res.push_back(symbol.demangle_name);
+
+  return res;
+}
+
+StatusTuple BPFPerfBuffer::open_on_cpu(perf_reader_raw_cb cb, int cpu,
+                                       void* cb_cookie) {
+  if (cpu_readers_.find(cpu) != cpu_readers_.end())
+    return mkstatus(-1, "Perf buffer already open on CPU %d", cpu);
+  auto reader =
+      static_cast<perf_reader*>(bpf_open_perf_buffer(cb, cb_cookie, -1, cpu));
+  if (reader == nullptr)
+    return mkstatus(-1, "Unable to construct perf reader");
+  int reader_fd = perf_reader_fd(reader);
+  if (!update(&cpu, &reader_fd)) {
+    perf_reader_free(static_cast<void*>(reader));
+    return mkstatus(-1, "Unable to open perf buffer on CPU %d: %s", cpu,
+                    strerror(errno));
+  }
+  cpu_readers_[cpu] = static_cast<perf_reader*>(reader);
+  return mkstatus(0);
+}
+
+StatusTuple BPFPerfBuffer::open(perf_reader_raw_cb cb, void* cb_cookie) {
+  for (int i = 0; i < sysconf(_SC_NPROCESSORS_ONLN); i++)
+    TRY2(open_on_cpu(cb, i, cb_cookie));
+  return mkstatus(0);
+}
+
+StatusTuple BPFPerfBuffer::close_on_cpu(int cpu) {
+  auto it = cpu_readers_.find(cpu);
+  if (it == cpu_readers_.end())
+    return mkstatus(0);
+  perf_reader_free(static_cast<void*>(it->second));
+  if (!remove(const_cast<int*>(&(it->first))))
+    return mkstatus(-1, "Unable to close perf buffer on CPU %d", it->first);
+  cpu_readers_.erase(it);
+  return mkstatus(0);
+}
+
+StatusTuple BPFPerfBuffer::close() {
+  std::string errors;
+  bool has_error = false;
+  for (int i = 0; i < sysconf(_SC_NPROCESSORS_ONLN); i++) {
+    auto res = close_on_cpu(i);
+    if (std::get<0>(res) != 0) {
+      errors += "Failed to close CPU" + std::to_string(i) + " perf buffer: ";
+      errors += std::get<1>(res) + "\n";
+      has_error = true;
+    }
+  }
+  if (has_error)
+    return mkstatus(-1, errors);
+  return mkstatus(0);
+}
+
+void BPFPerfBuffer::poll(int timeout) {
+  perf_reader* readers[cpu_readers_.size()];
+  int i = 0;
+  for (auto it : cpu_readers_)
+    readers[i++] = it.second;
+  perf_reader_poll(cpu_readers_.size(), readers, timeout);
+}
+
+BPFPerfBuffer::~BPFPerfBuffer() {
+  auto res = close();
+  if (std::get<0>(res) != 0)
+    std::cerr << "Failed to close all perf buffer on destruction: "
+              << std::get<1>(res) << std::endl;
+}
+
+}  // namespace ebpf

--- a/src/cc/BPFTable.h
+++ b/src/cc/BPFTable.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <exception>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "bpf_module.h"
+#include "common.h"
+#include "libbpf.h"
+#include "perf_reader.h"
+
+namespace ebpf {
+
+template <class KeyType, class ValueType>
+class BPFTableBase {
+public:
+  size_t capacity() { return capacity_; }
+
+protected:
+  BPFTableBase(BPFModule* bpf_module, const std::string& name) {
+    size_t id_ = bpf_module->table_id(name);
+    if (id_ >= bpf_module->num_tables())
+      throw std::invalid_argument("Table " + name + " does not exist");
+    fd_ = bpf_module->table_fd(id_);
+    capacity_ = bpf_module->table_max_entries(id_);
+  };
+
+  bool lookup(KeyType* key, ValueType* value) {
+    return bpf_lookup_elem(fd_, static_cast<void*>(key),
+                           static_cast<void*>(value)) >= 0;
+  }
+
+  bool next(KeyType* key, KeyType* next_key) {
+    return bpf_get_next_key(fd_, static_cast<void*>(key),
+                            static_cast<void*>(next_key)) >= 0;
+  }
+
+  bool update(KeyType* key, ValueType* value) {
+    return bpf_update_elem(fd_, static_cast<void*>(key),
+                           static_cast<void*>(value), 0) >= 0;
+  }
+
+  bool remove(KeyType* key) {
+    return bpf_delete_elem(fd_, static_cast<void*>(key)) >= 0;
+  }
+
+  int fd_;
+  size_t capacity_;
+};
+
+template <class KeyType, class ValueType>
+class BPFHashTable : protected BPFTableBase<KeyType, ValueType> {
+public:
+  BPFHashTable(BPFModule* bpf_module, const std::string& name)
+      : BPFTableBase<KeyType, ValueType>(bpf_module, name) {}
+
+  ValueType get_value(const KeyType& key) {
+    ValueType res;
+    if (!this->lookup(const_cast<KeyType*>(&key), &res))
+      throw std::invalid_argument("Key does not exist in the table");
+    return res;
+  }
+
+  ValueType operator[](const KeyType& key) { return get_value(key); }
+
+  std::vector<std::pair<KeyType, ValueType>> get_table_offline() {
+    std::vector<std::pair<KeyType, ValueType>> res;
+
+    KeyType cur, nxt;
+    ValueType value;
+
+    while (true) {
+      if (!this->next(&cur, &nxt))
+        break;
+      if (!this->lookup(&nxt, &value))
+        break;
+      res.emplace_back(nxt, value);
+      std::swap(cur, nxt);
+    }
+
+    return res;
+  }
+};
+
+// From src/cc/export/helpers.h
+static const int BPF_MAX_STACK_DEPTH = 127;
+struct stacktrace_t {
+  intptr_t ip[BPF_MAX_STACK_DEPTH];
+};
+
+class BPFStackTable : protected BPFTableBase<int, stacktrace_t> {
+public:
+  BPFStackTable(BPFModule* bpf_module, const std::string& name)
+      : BPFTableBase<int, stacktrace_t>(bpf_module, name) {}
+  ~BPFStackTable();
+
+  std::vector<intptr_t> get_stack_addr(int stack_id);
+  std::vector<std::string> get_stack_symbol(int stack_id, int pid);
+
+private:
+  std::map<int, void*> pid_sym_;
+};
+
+class BPFPerfBuffer : protected BPFTableBase<int, int> {
+public:
+  BPFPerfBuffer(BPFModule* bpf_module, const std::string& name)
+      : BPFTableBase<int, int>(bpf_module, name) {}
+  ~BPFPerfBuffer();
+
+  StatusTuple open(perf_reader_raw_cb cb, void* cb_cookie);
+  StatusTuple close();
+  void poll(int timeout);
+
+private:
+  StatusTuple open_on_cpu(perf_reader_raw_cb cb, int cpu, void* cb_cookie);
+  StatusTuple close_on_cpu(int cpu);
+
+  std::map<int, perf_reader*> cpu_readers_;
+};
+
+}  // namespace ebpf

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(bcc-static b_frontend clang_frontend bcc-loader-static ${c
 
 install(TARGETS bcc-shared LIBRARY COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES bpf_common.h bpf_module.h bcc_syms.h libbpf.h perf_reader.h COMPONENT libbcc
+install(FILES bpf_common.h bpf_module.h bcc_syms.h common.h exception.h libbpf.h perf_reader.h COMPONENT libbcc
   DESTINATION include/bcc)
 install(DIRECTORY compat/linux/ COMPONENT libbcc
   DESTINATION include/bcc/compat/linux

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -35,12 +35,12 @@ if (CMAKE_COMPILER_IS_GNUCC AND LIBCLANG_ISSTATIC)
   endif()
 endif()
 
-add_library(bcc-shared SHARED bpf_common.cc bpf_module.cc libbpf.c perf_reader.c shared_table.cc exported_files.cc bcc_elf.c bcc_perf_map.c bcc_proc.c bcc_syms.cc usdt_args.cc usdt.cc)
+add_library(bcc-shared SHARED bpf_common.cc bpf_module.cc libbpf.c perf_reader.c shared_table.cc exported_files.cc bcc_elf.c bcc_perf_map.c bcc_proc.c bcc_syms.cc usdt_args.cc usdt.cc BPF.cc BPFTable.cc)
 set_target_properties(bcc-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
 set_target_properties(bcc-shared PROPERTIES OUTPUT_NAME bcc)
 
 add_library(bcc-loader-static libbpf.c perf_reader.c bcc_elf.c bcc_perf_map.c bcc_proc.c)
-add_library(bcc-static STATIC bpf_common.cc bpf_module.cc shared_table.cc exported_files.cc bcc_syms.cc usdt_args.cc usdt.cc)
+add_library(bcc-static STATIC bpf_common.cc bpf_module.cc shared_table.cc exported_files.cc bcc_syms.cc usdt_args.cc usdt.cc BPF.cc BPFTable.cc)
 set_target_properties(bcc-static PROPERTIES OUTPUT_NAME bcc)
 
 set(llvm_raw_libs bitwriter bpfcodegen irreader linker
@@ -63,7 +63,7 @@ target_link_libraries(bcc-static b_frontend clang_frontend bcc-loader-static ${c
 
 install(TARGETS bcc-shared LIBRARY COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES bpf_common.h bpf_module.h bcc_syms.h common.h exception.h libbpf.h perf_reader.h COMPONENT libbcc
+install(FILES bpf_common.h bpf_module.h bcc_syms.h common.h exception.h libbpf.h perf_reader.h BPF.h BPFTable.h COMPONENT libbcc
   DESTINATION include/bcc)
 install(DIRECTORY compat/linux/ COMPONENT libbcc
   DESTINATION include/bcc/compat/linux

--- a/src/cc/exception.h
+++ b/src/cc/exception.h
@@ -37,6 +37,12 @@ static inline std::tuple<int, std::string> mkstatus(int ret, const char *msg) {
   return std::make_tuple(ret, std::string(msg));
 }
 
+static inline std::tuple<int, std::string> mkstatus(
+  int ret, const std::string& msg
+) {
+  return std::make_tuple(ret, msg);
+}
+
 static inline std::tuple<int, std::string> mkstatus(int ret) {
   return std::make_tuple(ret, std::string());
 }


### PR DESCRIPTION
We have pretty good helper class available in Python and Lua. However, for C++ developers, they would need to go into the details of `libbpf` and `bcc_module` to figure out what needs to be done to attach their probes. This Diff adds some basics of a C++ helper class, that includes:
- Basic attaching and detaching of kprobes, uprobes and tracepoints.
- Reading of hash table and stack trace table.
- A few examples to demonstrate how to use the APIs.

```
$ sudo ./HelloWorld
The BPF Program is:

int probe_sys_clone(void *ctx) {
  bpf_trace_printk("Hello, World!");
  return 0;
}
           <...>-1105667 [010] d... 555825.171913: : Hello, World!           <...>-1105668 [009] d... 555825.173268: : Hello, World!           <...>-1105668 [014] d... 555825.174373: : Hello, World!           <...>-1105670 [022] d... 555825.174582: : Hello, World!           <...>-1105670 [022] d... 555825.174698: : Hello, World!           <...>-1105668 [000] d... 555825.176054: : Hello, World!           <...>-1105673 [028] d... 555825.176271: : Hello, World!           <...>-1105673 [028] d... 555825.176392: : Hello, World!           <...>-1105668 [014] d... 555825.177785: : Hello, World!           <...>-1105676 [022] d... 555825.177996: : Hello, World!           <...>-1105676 [022] d... 555825.178099: : Hello, World!           <...>-1105668 [000] d... 555825.179444: : Hello, World!           <...>-1105668 [013] d... 555825.180261: : Hello, World!           <...>-1105668 [013] d... 555825.180339: : Hello, World!           <...>-1105681 [007] d... 555825.187444: : Hello, World!           <...>-1105681 [007] d.
```

```
$ sudo ./CPUDistribution
Probing for 10 seconds
CPU  0 worked for 465.048 ms.
CPU  1 worked for 2083.19 ms.
CPU  2 worked for 494.222 ms.
CPU  3 worked for 438.929 ms.
CPU  4 worked for 520.142 ms.
CPU  5 worked for 484.19 ms.
CPU  6 worked for 321.532 ms.
CPU  7 worked for 418.621 ms.
CPU  8 worked for 919.519 ms.
CPU  9 worked for 785.386 ms.
CPU 10 worked for 753.927 ms.
CPU 11 worked for 1942.52 ms.
CPU 12 worked for 716.44 ms.
CPU 13 worked for 817.163 ms.
CPU 14 worked for 915.345 ms.
CPU 15 worked for 1357.1 ms.
CPU 16 worked for 16.329 ms.
CPU 17 worked for 9.93461 ms.
CPU 18 worked for 8.63813 ms.
CPU 19 worked for 12.4068 ms.
CPU 20 worked for 41.3855 ms.
CPU 21 worked for 14.8725 ms.
CPU 22 worked for 5.20463 ms.
CPU 23 worked for 17.3686 ms.
CPU 24 worked for 15.5483 ms.
CPU 25 worked for 59.5226 ms.
CPU 26 worked for 114.46 ms.
CPU 27 worked for 285.454 ms.
CPU 28 worked for 22.2104 ms.
CPU 29 worked for 20.6931 ms.
CPU 30 worked for 11.7063 ms.
CPU 31 worked for 20.1535 ms.
```

```
$ sudo ./TCPSendStack 1
Probing for 1 seconds
[...]
PID: 5357 (IOThreadPool0) made 6 TCP sends on following stack:
  Kernel Stack:
    tcp_sendmsg
    do_sock_sendmsg
    ___sys_sendmsg
    __sys_sendmsg
    sys_sendmsg
    system_call_fastpath
  User Stack:
    [UNKNOWN]
    folly::AsyncSocket::performWrite(iovec const*, unsigned int, folly::WriteFlags, unsigned int*, unsigned int*)
    folly::AsyncSSLSocket::performWrite(iovec const*, unsigned int, folly::WriteFlags, unsigned int*, unsigned int*)
    folly::AsyncSocket::writeImpl(folly::AsyncWriter::WriteCallback*, iovec const*, unsigned long, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >&&, folly::WriteFlags)
    folly::AsyncSocket::writeChain(folly::AsyncWriter::WriteCallback*, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >&&, folly::WriteFlags)
    apache::thrift::TAsyncTransportHandler::write(wangle::HandlerContext<folly::IOBufQueue&, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> > >*, std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >)
    wangle::ContextImpl<apache::thrift::TAsyncTransportHandler>::write(std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >)
    wangle::OutboundContextImpl<wangle::OutputBufferingHandler>::fireWrite(std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >)
    wangle::OutputBufferingHandler::runLoopCallback()
    folly::EventBase::runLoopCallbacks()
    folly::EventBase::loopBody(int)
    folly::EventBase::loopForever()
    wangle::IOThreadPoolExecutor::threadRun(std::shared_ptr<wangle::ThreadPoolExecutor::Thread>)
    void folly::detail::function::FunctionTraits<void ()>::callBig<std::_Bind<std::_Mem_fn<void (wangle::ThreadPoolExecutor::*)(std::shared_ptr<wangle::ThreadPoolExecutor::Thread>)> (wangle::ThreadPoolExecutor*, std::shared_ptr<wangle::ThreadPoolExecutor::Thread>)> >(folly::detail::function::Data&)
    execute_native_thread_routine
    start_thread
    __clone
```

```
$ sudo ./RecordMySQLQuery [...]/mysqld 25
Using mysqld path: [...]/mysqld
Probing for 25 seconds
9 queries recorded:
Time: 556598409159660 PID: 723991 Query: SET SQL_SAFE_UPDATES=1,SQL_SELECT_LIMIT=1000,MAX_JOIN_SIZE=1000000
Time: 556598425292767 PID: 723991 Query: select USER()
Time: 556602820110928 PID: 723991 Query: show processlist
Time: 556605435971397 PID: 723991 Query: show databases
Time: 556607386278462 PID: 539142 Query: /* /usr/local/bin/dbatool:base.pyc */ SHOW GLOBAL VARIABLES
Time: 556607410458669 PID: 539264 Query: /* /usr/local/bin/dbatool:base.pyc */ SHOW GLOBAL VARIABLES
Time: 556609363724478 PID: 723991 Query: SELECT DATABASE()
Time: 556611171660239 PID: 723991 Query: show tables
Time: 556614523422863 PID: 723991 Query: describe INNODB_FT_CONFIG
```

```
$ sudo ./RandomRead
Started tracing, hit Ctrl-C to terminate.
PID: 5830 (SREventBase3) Read 128 bits
PID: 5831 (SREventBase4) Read 128 bits
PID: 5828 (SREventBase1) Read 96 bits
PID: 5829 (SREventBase2) Read 128 bits
PID: 5830 (SREventBase3) Read 128 bits
PID: 5831 (SREventBase4) Read 96 bits
PID: 6079 (SREventBase3) Read 96 bits
PID: 6132 (sasl-thread-32) Read 32 bits
PID: 6132 (sasl-thread-32) Read 256 bits
PID: 6132 (sasl-thread-32) Read 128 bits
PID: 6079 (SREventBase3) Read 96 bits
PID: 955806 (hhvm.node.0) Read 24 bits
PID: 955806 (hhvm.node.0) Read 16 bits
PID: 955806 (hhvm.node.0) Read 24 bits
PID: 955806 (hhvm.node.0) Read 16 bits
PID: 949264 (SREventBase2) Read 96 bits
PID: 5970 (sasl-thread-21) Read 32 bits
PID: 5970 (sasl-thread-21) Read 256 bits
PID: 5970 (sasl-thread-21) Read 128 bits
PID: 5979 (sasl-thread-30) Read 32 bits
```