### PR TITLE
Use header files from BCC in installed headers

### DIFF
--- a/src/cc/compat/linux/bpf.h
+++ b/src/cc/compat/linux/bpf.h
@@ -8,7 +8,7 @@
 #define _UAPI__LINUX_BPF_H__
 
 #include <linux/types.h>
-#include <linux/bpf_common.h>
+#include "bpf_common.h"
 
 /* Extended instruction set based on top of classic BPF */
 

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -18,7 +18,7 @@
 #ifndef LIBBPF_H
 #define LIBBPF_H
 
-#include <linux/bpf.h>
+#include "compat/linux/bpf.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
For people who would use `libbcc` directly (as well as the future C++ API to be introduced in #781 ), they would probably reference some installed header files (like `libbpf.h`) directly or indirectly. If those files are referencing to the ones in system platform (like `#include <linux/bpf.h>`), they would risk to use an outdated header file, or duplication under some circumstance.

This Diff changes all externally installed header files to include headers from BCC instead of system.