### PR TITLE
Fix argument type for increment() in documentation

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -509,7 +509,7 @@ Examples in situ:
 
 ### 10. map.increment()
 
-Syntax: ```map.increment(&key)```
+Syntax: ```map.increment(key)```
 
 Increments the key's value by one. Used for histograms.
 


### PR DESCRIPTION
`map.increment()` actually takes the key itself and not a reference to it.
