### PR TITLE
Expose destruction of SymbolCache in libbcc

### DIFF
--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -212,6 +212,13 @@ void *bcc_symcache_new(int pid) {
   return static_cast<void *>(new ProcSyms(pid));
 }
 
+void bcc_free_symcache(void *symcache, int pid) {
+  if (pid < 0)
+    delete static_cast<KSyms*>(symcache);
+  else
+    delete static_cast<ProcSyms*>(symcache);
+}
+
 int bcc_symcache_resolve(void *resolver, uint64_t addr,
                          struct bcc_symbol *sym) {
   SymbolCache *cache = static_cast<SymbolCache *>(resolver);
@@ -286,7 +293,7 @@ static int _list_sym(const char *symname, uint64_t addr, uint64_t end,
     return 0;
 
   SYM_CB cb = (SYM_CB) payload;
-  return cb(symname, addr); 
+  return cb(symname, addr);
 }
 
 int bcc_foreach_symbol(const char *module, SYM_CB cb) {

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -32,6 +32,8 @@ struct bcc_symbol {
 typedef int(* SYM_CB)(const char *symname, uint64_t addr);
 
 void *bcc_symcache_new(int pid);
+void bcc_free_symcache(void *symcache, int pid);
+
 int bcc_symcache_resolve(void *symcache, uint64_t addr, struct bcc_symbol *sym);
 int bcc_symcache_resolve_name(void *resolver, const char *name, uint64_t *addr);
 void bcc_symcache_refresh(void *resolver);

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -142,6 +142,9 @@ lib.bcc_foreach_symbol.argtypes = [ct.c_char_p, _SYM_CB_TYPE]
 lib.bcc_symcache_new.restype = ct.c_void_p
 lib.bcc_symcache_new.argtypes = [ct.c_int]
 
+lib.bcc_free_symcache.restype = ct.c_void_p
+lib.bcc_free_symcache.argtypes = [ct.c_void_p, ct.c_int]
+
 lib.bcc_symcache_resolve.restype = ct.c_int
 lib.bcc_symcache_resolve.argtypes = [ct.c_void_p, ct.c_ulonglong, ct.POINTER(bcc_symbol)]
 


### PR DESCRIPTION
This would be useful for cleaning up `SymbolCache` resources. Already used in #781 and other tools we are developing.
cc @jsedgwick @markdrayton 