### PR TITLE
trace: add pid/tid filtering, fix symbolizing, misc nits

### DIFF
--- a/man/man8/trace.8
+++ b/man/man8/trace.8
@@ -2,7 +2,9 @@
 .SH NAME
 trace \- Trace a function and print its arguments or return value, optionally evaluating a filter. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B trace [-h] [-p PID] [-v] [-Z STRING_SIZE] [-S] [-M MAX_EVENTS] [-o] [-K] [-U] [-I header] probe [probe ...]
+.B trace [-h] [-p PID] [-t TID] [-v] [-Z STRING_SIZE] [-S]
+         [-M MAX_EVENTS] [-o] [-K] [-U] [-I header]
+         probe [probe ...]
 .SH DESCRIPTION
 trace probes functions you specify and displays trace messages if a particular
 condition is met. You can control the message format to display function 
@@ -18,6 +20,9 @@ Print usage message.
 .TP
 \-p PID
 Trace only functions in the process PID.
+.TP
+\-t TID
+Trace only functions in the thread TID.
 .TP
 \-v
 Display the generated BPF program, for debugging purposes.

--- a/tools/trace_example.txt
+++ b/tools/trace_example.txt
@@ -171,8 +171,9 @@ libraries and then accessing the /home/vagrant directory listing.
 USAGE message:
 
 # trace -h
-usage: trace.py [-h] [-p PID] [-v] [-Z STRING_SIZE] [-S] [-M MAX_EVENTS] [-o]
-                probe [probe ...]
+usage: trace [-h] [-p PID] [-t TID] [-v] [-Z STRING_SIZE] [-S]
+             [-M MAX_EVENTS] [-o] [-K] [-U] [-I header]
+             probe [probe ...]
 
 Attach to functions and print trace messages.
 
@@ -182,6 +183,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -p PID, --pid PID     id of the process to trace (optional)
+  -t TID, --tid TID     id of the thread to trace (optional)
   -v, --verbose         print resulting BPF program code before executing
   -Z STRING_SIZE, --string-size STRING_SIZE
                         maximum size to read from strings
@@ -202,8 +204,8 @@ trace 'do_sys_open "%s", arg2'
         Trace the open syscall and print the filename being opened
 trace 'sys_read (arg3 > 20000) "read %d bytes", arg3'
         Trace the read syscall and print a message for reads >20000 bytes
-trace r::do_sys_return
-        Trace the return from the open syscall
+trace 'r::do_sys_return "%llx", retval'
+        Trace the return from the open syscall and print the return value
 trace 'c:open (arg2 == 42) "%s %d", arg1, arg2'
         Trace the open() call from libc only if the flags (arg2) argument is 42
 trace 'c:malloc "size = %d", arg1'
@@ -218,4 +220,3 @@ trace 't:block:block_rq_complete "sectors=%d", args->nr_sector'
         Trace the block_rq_complete kernel tracepoint and print # of tx sectors
 trace 'u:pthread:pthread_create (arg4 != 0)'
         Trace the USDT probe pthread_create when its 4th argument is non-zero
-


### PR DESCRIPTION
`trace` is an excellent exploratory tool but it has a few shortcomings when dealing with multithreaded applications. This PR fixes up the issues I run into most often.

* support filtering by process ID (-p) or thread ID (-t); previously -p
  actually filtered on thread ID (aka "pid" in kernel-speak)
* include process and thread ID in output
* flip order of user and kernel stacks to flow more naturally
* resolve symbols using process ID instead of thread ID so only one symbol
  cache is instantiated per process
* misc aesthetic fixes here and there

Output before:

```
# trace -UK -p 28047 osq_lock
TIME     PID    COMM         FUNC
10:02:36 28047  load-monitor osq_lock         
    User Stack Trace:
        00000000024e966b get_cpu
        [..snipped..]
        00007fa2739677f1 start_thread
        00007fa272f7846d __clone
    Kernel Stack Trace:
        ffffffff810ac881 osq_lock
        ffffffff8177667b __mutex_lock_slowpath
        ffffffff8177676b mutex_lock
        ffffffff810b34ec kstat_irqs_usr
        ffffffff8122743a show_stat
        ffffffff811db22a seq_read
        ffffffff8121e0fd proc_reg_read
        ffffffff811b8a10 __vfs_read
        ffffffff811b8ad6 vfs_read
        ffffffff811b8bd6 sys_read
        ffffffff81778232 system_call_fastpath
```

After:

```
# trace -UK -t 28047 osq_lock
TIME     PID    TID    COMM         FUNC
10:03:26 28041  28047  load-monitor osq_lock         
        ffffffff810ac881 osq_lock
        ffffffff8177667b __mutex_lock_slowpath
        ffffffff8177676b mutex_lock
        ffffffff810b34ec kstat_irqs_usr
        ffffffff8122743a show_stat
        ffffffff811db22a seq_read
        ffffffff8121e0fd proc_reg_read
        ffffffff811b8a10 __vfs_read
        ffffffff811b8ad6 vfs_read
        ffffffff811b8bd6 sys_read
        ffffffff81778232 system_call_fastpath
        00000000024e966b get_cpu
        [..snipped..]
        00007fa2739677f1 start_thread
        00007fa272f7846d __clone
```