### PR TITLE
Fix warnings covered by -Wdelete-non-virtual-dtor

### DIFF
--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -36,6 +36,8 @@ public:
 
 class SymbolCache {
 public:
+  virtual ~SymbolCache() = default;
+
   virtual void refresh() = 0;
   virtual bool resolve_addr(uint64_t addr, struct bcc_symbol *sym) = 0;
   virtual bool resolve_name(const char *module, const char *name,


### PR DESCRIPTION
The warnings were:

 src/cc/bcc_syms.cc: In function ‘void bcc_free_symcache(void*, int)’:
 src/cc/bcc_syms.cc:217:40: warning: deleting object of polymorphic class type ‘KSyms’
                            which has non-virtual destructor might cause undefined behaviour
                            [-Wdelete-non-virtual-dtor]
     delete static_cast<KSyms*>(symcache);
                                        ^
 src/cc/bcc_syms.cc:219:43: warning: deleting object of polymorphic class type ‘ProcSyms’
                            which has non-virtual destructor might cause undefined behaviour
                            [-Wdelete-non-virtual-dtor]
     delete static_cast<ProcSyms*>(symcache);
                                           ^

Fix the warnings by defining a virtual destructor for the base class SymbolCache.

Of course this solution works only for C++11 and above, but i think we don't support earlier standards, right?