### PR TITLE
Make bcc_symcache_new(tid) work with symbols from /tmp/perf-pid.map

### DIFF
--- a/src/cc/bcc_perf_map.c
+++ b/src/cc/bcc_perf_map.c
@@ -20,7 +20,7 @@
 
 #include "bcc_perf_map.h"
 
-int bcc_perf_map_nspid(int pid) {
+int bcc_perf_map_nstgid(int pid) {
   char status_path[64];
   FILE *status;
 
@@ -30,19 +30,22 @@ int bcc_perf_map_nspid(int pid) {
   if (!status)
     return -1;
 
-  // return the original PID if the NSpid line is missing
-  int nspid = pid;
+  // return the original PID if we fail to work out the TGID
+  int nstgid = pid;
 
   size_t size = 0;
   char *line = NULL;
   while (getline(&line, &size, status) != -1) {
-    if (strstr(line, "NSpid:") != NULL)
+    // check Tgid line first in case CONFIG_PID_NS is off
+    if (strstr(line, "Tgid:") != NULL)
+      nstgid = (int)strtol(strrchr(line, '\t'), NULL, 10);
+    if (strstr(line, "NStgid:") != NULL)
       // PID namespaces can be nested -- last number is innermost PID
-      nspid = (int)strtol(strrchr(line, '\t'), NULL, 10);
+      nstgid = (int)strtol(strrchr(line, '\t'), NULL, 10);
   }
   free(line);
 
-  return nspid;
+  return nstgid;
 }
 
 bool bcc_perf_map_path(char *map_path, size_t map_len, int pid) {
@@ -58,9 +61,9 @@ bool bcc_perf_map_path(char *map_path, size_t map_len, int pid) {
   if (strcmp(target, "/") == 0)
     target[0] = '\0';
 
-  int nspid = bcc_perf_map_nspid(pid);
+  int nstgid = bcc_perf_map_nstgid(pid);
 
-  snprintf(map_path, map_len, "%s/tmp/perf-%d.map", target, nspid);
+  snprintf(map_path, map_len, "%s/tmp/perf-%d.map", target, nstgid);
   return true;
 }
 

--- a/src/cc/bcc_perf_map.h
+++ b/src/cc/bcc_perf_map.h
@@ -27,7 +27,7 @@ extern "C" {
 typedef int (*bcc_perf_map_symcb)(const char *, uint64_t, uint64_t, int,
                                   void *);
 
-int bcc_perf_map_nspid(int pid);
+int bcc_perf_map_nstgid(int pid);
 bool bcc_perf_map_path(char *map_path, size_t map_len, int pid);
 int bcc_perf_map_foreach_sym(const char *path, bcc_perf_map_symcb callback,
                              void* payload);


### PR DESCRIPTION
This fixes #805 by making sure that the process ID is used when searching for `/tmp/perf-pid.map`, even if `bcc_symcache_new` was called with a thread ID. This makes resolving symbols from the perf map consistent with resolving them from symbol tables in binaries.

It also handles this case when `CONFIG_PID_NS` is not enabled by first trying to get the process ID from the `Tgid` line in `/proc/pid/status`. If `CONFIG_PID_NS` is enabled the value from `Tgid` will be overwritten with the process ID from whichever PID namespace the target process is in, consistent with existing behavior.