### PR TITLE
cc, python: Clean up BPF module and tables

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -120,6 +120,8 @@ BPFModule::~BPFModule() {
     for (auto table : *tables_) {
       if (table.is_shared)
         SharedTables::instance()->remove_fd(table.name);
+      else
+        close(table.fd);
     }
   }
 }

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1049,6 +1049,10 @@ class BPF(object):
             self.detach_perf_event(ev_type, ev_config)
         if self.tracefile:
             self.tracefile.close()
+            self.tracefile = None
+        if self.module:
+            lib.bpf_module_destroy(self.module)
+            self.module = None
 
 
 from .usdt import USDT


### PR DESCRIPTION
When the `BPFModule` object is destroyed, shared tables
were closed, but non-shared tables were not. Add `close`
call to close non-shared tables in `~BPFModule`.

Make sure the `BPF.cleanup` function in the Python module
calls `bpf_module_destroy` to clean up the module. Otherwise,
we have hanging table fds that aren't destroyed.

Fixes #806. This would have been an issue for any tool
that repeatedly runs a BPF program with new maps. It's just
that most tools we have haven't exhibited this behavior.