### PR TITLE
trace: Avoid passing -1 as the pid to USDT

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -157,7 +157,8 @@ class Probe(object):
                         self.function = parts[2]
 
         def _find_usdt_probe(self):
-                target = Probe.pid if Probe.pid else Probe.tgid
+                target = Probe.pid if Probe.pid and Probe.pid != -1 \
+                                   else Probe.tgid
                 self.usdt = USDT(path=self.library, pid=target)
                 for probe in self.usdt.enumerate_probes():
                         if probe.name == self.usdt_name:


### PR DESCRIPTION
When the `-p` switch is used with `trace`, it would set
the tgid to the value passed to `-p` and set the pid to
-1. The result would be incorrect logic that passed the -1
pid value to the `USDT` context constructor, which fails
for probes that require the pid to enable (because they
have a semaphore that needs a poke). This commit fixes it.