### PR TITLE
Eliminate rpmlint errors and allow bcc srpm to build on Fedora koji b…

### DIFF
--- a/SPECS/bcc.spec
+++ b/SPECS/bcc.spec
@@ -1,3 +1,4 @@
+%bcond_with local_clang_static
 %define debug_package %{nil}
 
 Name:           bcc
@@ -11,12 +12,14 @@ URL:            https://github.com/iovisor/bcc
 Source0:        bcc.tar.gz
 
 ExclusiveArch: x86_64
-BuildRequires: bison cmake >= 2.8.7 flex
+BuildRequires: bison cmake >= 2.8.7 flex make
 BuildRequires: gcc gcc-c++ python2-devel elfutils-libelf-devel-static
 BuildRequires: luajit luajit-devel
+%if %{without local_clang_static}
 BuildRequires: llvm-devel llvm-static
 BuildRequires: clang-devel
-BuildRequires: pkgconfig
+%endif
+BuildRequires: pkgconfig ncurses-devel
 
 %description
 Python bindings for BPF Compiler Collection (BCC). Control a BPF program from
@@ -47,33 +50,40 @@ Requires: elfutils-libelf
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 
-%package -n libbcc-examples
-Summary: Examples for BPF Compiler Collection (BCC)
-%description -n libbcc-examples
-Examples for BPF Compiler Collection (BCC)
-
 %package -n python-bcc
 Summary: Python bindings for BPF Compiler Collection (BCC)
+Requires: libbcc = %{version}-%{release}
 %description -n python-bcc
 Python bindings for BPF Compiler Collection (BCC)
 
-%package -n bcc-tools
-Summary: Command line tools for BPF Compiler Collection (BCC)
-Requires: python-bcc
-%description -n bcc-tools
-Command line tools for BPF Compiler Collection (BCC)
-
 %package -n bcc-lua
 Summary: Standalone tool to run BCC tracers written in Lua
+Requires: libbcc = %{version}-%{release}
 %description -n bcc-lua
 Standalone tool to run BCC tracers written in Lua
 
-%files -n python-bcc
-%{python_sitelib}/bcc*
+%package -n libbcc-examples
+Summary: Examples for BPF Compiler Collection (BCC)
+Requires: python-bcc = %{version}-%{release}
+Requires: bcc-lua = %{version}-%{release}
+%description -n libbcc-examples
+Examples for BPF Compiler Collection (BCC)
+
+%package -n bcc-tools
+Summary: Command line tools for BPF Compiler Collection (BCC)
+Requires: python-bcc = %{version}-%{release}
+%description -n bcc-tools
+Command line tools for BPF Compiler Collection (BCC)
 
 %files -n libbcc
 /usr/lib64/*
 /usr/include/bcc/*
+
+%files -n python-bcc
+%{python_sitelib}/bcc*
+
+%files -n bcc-lua
+/usr/bin/bcc-lua
 
 %files -n libbcc-examples
 /usr/share/bcc/examples/*
@@ -87,9 +97,6 @@ Standalone tool to run BCC tracers written in Lua
 %files -n bcc-tools
 /usr/share/bcc/tools/*
 /usr/share/bcc/man/*
-
-%files -n bcc-lua
-/usr/bin/bcc-lua
 
 %post -n libbcc -p /sbin/ldconfig
 

--- a/SPECS/bcc.spec
+++ b/SPECS/bcc.spec
@@ -10,8 +10,13 @@ License:        ASL 2.0
 URL:            https://github.com/iovisor/bcc
 Source0:        bcc.tar.gz
 
-BuildArch:      x86_64
-BuildRequires:  bison, cmake >= 2.8.7, flex, gcc, gcc-c++, python2-devel, elfutils-libelf-devel-static
+ExclusiveArch: x86_64
+BuildRequires: bison cmake >= 2.8.7 flex
+BuildRequires: gcc gcc-c++ python2-devel elfutils-libelf-devel-static
+BuildRequires: luajit luajit-devel
+BuildRequires: llvm-devel llvm-static
+BuildRequires: clang-devel
+BuildRequires: pkgconfig
 
 %description
 Python bindings for BPF Compiler Collection (BCC). Control a BPF program from
@@ -19,32 +24,22 @@ userspace.
 
 
 %prep
-%setup -n bcc
+%setup -q -n bcc
 
 %build
 
 mkdir build
 pushd build
-cmake .. -DREVISION_LAST=%{version} -DREVISION=%{version} -DCMAKE_INSTALL_PREFIX=/usr
+cmake .. -DREVISION_LAST=%{version} -DREVISION=%{version} \
+      -DCMAKE_INSTALL_PREFIX=/usr \
+      -DLUAJIT_INCLUDE_DIR=`pkg-config --variable=includedir luajit` \
+      -DLUAJIT_LIBRARIES=`pkg-config --variable=libdir luajit`/lib`pkg-config --variable=libname luajit`.so
 make %{?_smp_mflags}
 popd
 
 %install
 pushd build
 make install/strip DESTDIR=%{buildroot}
-
-%changelog
-* Mon Apr 04 2016 Vicent Marti <vicent@github.com> - 0.1.4-1
-- Add bcc-lua package
-
-* Sun Nov 29 2015 Brenden Blanco <bblanco@plumgrid.com> - 0.1.3-1
-- Add bcc-tools package
-
-* Mon Oct 12 2015 Brenden Blanco <bblanco@plumgrid.com> - 0.1.2-1
-- Add better version numbering into libbcc.so
-
-* Fri Jul 03 2015 Brenden Blanco <bblanco@plumgrid.com> - 0.1.1-2
-- Initial RPM Release
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)
@@ -54,13 +49,11 @@ Shared Library for BPF Compiler Collection (BCC)
 
 %package -n libbcc-examples
 Summary: Examples for BPF Compiler Collection (BCC)
-Requires: libbcc
 %description -n libbcc-examples
 Examples for BPF Compiler Collection (BCC)
 
 %package -n python-bcc
 Summary: Python bindings for BPF Compiler Collection (BCC)
-Requires: libbcc
 %description -n python-bcc
 Python bindings for BPF Compiler Collection (BCC)
 
@@ -72,7 +65,6 @@ Command line tools for BPF Compiler Collection (BCC)
 
 %package -n bcc-lua
 Summary: Standalone tool to run BCC tracers written in Lua
-Requires: libbcc
 %description -n bcc-lua
 Standalone tool to run BCC tracers written in Lua
 
@@ -98,3 +90,23 @@ Standalone tool to run BCC tracers written in Lua
 
 %files -n bcc-lua
 /usr/bin/bcc-lua
+
+%post -n libbcc -p /sbin/ldconfig
+
+%postun -n libbcc -p /sbin/ldconfig
+
+%changelog
+* Mon Nov 21 2016 William Cohen <wcohen@redhat.com> - 0.2.0-1
+- Revise bcc.spec to address rpmlint issues and build properly in Fedora koji.
+
+* Mon Apr 04 2016 Vicent Marti <vicent@github.com> - 0.1.4-1
+- Add bcc-lua package
+
+* Sun Nov 29 2015 Brenden Blanco <bblanco@plumgrid.com> - 0.1.3-1
+- Add bcc-tools package
+
+* Mon Oct 12 2015 Brenden Blanco <bblanco@plumgrid.com> - 0.1.2-1
+- Add better version numbering into libbcc.so
+
+* Fri Jul 03 2015 Brenden Blanco <bblanco@plumgrid.com> - 0.1.1-2
+- Initial RPM Release


### PR DESCRIPTION
…uild system

The nightly bcc srpm does not build as-is on Fedora 24. To get the
build to work the following changes were made in the bcc.spec file:

-Specify where to find luajit headers and libraries
-Correctly limit the build to the x86_64 architecture
-Add needed build requires so the srpm can build on Fedora koji
-Run ldconfig so shared library information is updated
-Follow spec conventions by putting %changelog at the end of the spec file