### PR TITLE
Fixup test errors in clang, c api

### DIFF
--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -44,10 +44,8 @@ TEST_CASE("binary resolution with `which`", "[c_api]") {
 }
 
 static void _test_ksym(const char *sym, uint64_t addr, void *_) {
-  if (!strcmp(sym, "startup_64")) {
-    REQUIRE(addr == 0xffffffff81000000ull);
-  } else if (!strcmp(sym, "system_reset_pSeries"))
-    REQUIRE(addr == 0xc000000000000100ull);
+  if (!strcmp(sym, "startup_64"))
+    REQUIRE(addr != 0x0ull);
 }
 
 TEST_CASE("list all kernel symbols", "[c_api]") {

--- a/tests/lua/test_clang.lua
+++ b/tests/lua/test_clang.lua
@@ -269,9 +269,9 @@ function TestClang:test_unop_probe_read()
   local text = [[
 #include <linux/blkdev.h>
 int trace_entry(struct pt_regs *ctx, struct request *req) {
-    if (!(req->bio->bi_rw & 1))
+    if (!(req->bio->bi_flags & 1))
         return 1;
-    if (((req->bio->bi_rw)))
+    if (((req->bio->bi_flags)))
         return 1;
     return 0;
 }

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -284,9 +284,9 @@ int kprobe____kmalloc(struct pt_regs *ctx, size_t size) {
         text = """
 #include <linux/blkdev.h>
 int trace_entry(struct pt_regs *ctx, struct request *req) {
-    if (!(req->bio->bi_rw & 1))
+    if (!(req->bio->bi_flags & 1))
         return 1;
-    if (((req->bio->bi_rw)))
+    if (((req->bio->bi_flags)))
         return 1;
     return 0;
 }


### PR DESCRIPTION
Some errors seem to have cropped up due to updating kernels and clang
library versions.
1. test_c_api fails on kernels (seen on fedora 4.9) where startup_64
doesn't start at a particular address. Simplify the test to hopefully
work in more systems.
2. The lua and python test_clang did a dereference on a particular bio
field, which has been removed. Pick a different field that is more
uniquitous.
3. test_xlate1 was generating code where the verified pointer spilled.
Rewrite the example to store the result on the stack.

Signed-off-by: Brenden Blanco <bblanco@plumgrid.com>