### PR TITLE
Improve the structure of exception related header files

### DIFF
--- a/src/cc/BPF.cc
+++ b/src/cc/BPF.cc
@@ -25,7 +25,6 @@
 
 #include "bcc_syms.h"
 #include "bpf_module.h"
-#include "common.h"
 #include "exception.h"
 #include "libbpf.h"
 #include "perf_reader.h"

--- a/src/cc/BPF.cc
+++ b/src/cc/BPF.cc
@@ -23,9 +23,9 @@
 #include <sstream>
 #include <vector>
 
+#include "bcc_exception.h"
 #include "bcc_syms.h"
 #include "bpf_module.h"
-#include "exception.h"
 #include "libbpf.h"
 #include "perf_reader.h"
 

--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -23,7 +23,6 @@
 #include "BPFTable.h"
 #include "bcc_syms.h"
 #include "bpf_module.h"
-#include "common.h"
 #include "compat/linux/bpf.h"
 #include "libbpf.h"
 

--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "BPFTable.h"
+#include "bcc_exception.h"
 #include "bcc_syms.h"
 #include "bpf_module.h"
 #include "compat/linux/bpf.h"

--- a/src/cc/BPFTable.cc
+++ b/src/cc/BPFTable.cc
@@ -22,7 +22,6 @@
 #include "BPFTable.h"
 
 #include "bcc_syms.h"
-#include "common.h"
 #include "exception.h"
 #include "libbpf.h"
 #include "perf_reader.h"

--- a/src/cc/BPFTable.cc
+++ b/src/cc/BPFTable.cc
@@ -21,8 +21,8 @@
 
 #include "BPFTable.h"
 
+#include "bcc_exception.h"
 #include "bcc_syms.h"
-#include "exception.h"
 #include "libbpf.h"
 #include "perf_reader.h"
 

--- a/src/cc/BPFTable.h
+++ b/src/cc/BPFTable.h
@@ -24,7 +24,6 @@
 #include <vector>
 
 #include "bpf_module.h"
-#include "common.h"
 #include "libbpf.h"
 #include "perf_reader.h"
 

--- a/src/cc/BPFTable.h
+++ b/src/cc/BPFTable.h
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "bcc_exception.h"
 #include "bpf_module.h"
 #include "libbpf.h"
 #include "perf_reader.h"

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(bcc-static b_frontend clang_frontend bcc-loader-static ${c
 
 install(TARGETS bcc-shared LIBRARY COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES bpf_common.h bpf_module.h bcc_syms.h common.h exception.h libbpf.h perf_reader.h BPF.h BPFTable.h COMPONENT libbcc
+install(FILES bpf_common.h bpf_module.h bcc_syms.h exception.h libbpf.h perf_reader.h BPF.h BPFTable.h COMPONENT libbcc
   DESTINATION include/bcc)
 install(DIRECTORY compat/linux/ COMPONENT libbcc
   DESTINATION include/bcc/compat/linux

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(bcc-static b_frontend clang_frontend bcc-loader-static ${c
 
 install(TARGETS bcc-shared LIBRARY COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES bpf_common.h bpf_module.h bcc_syms.h exception.h libbpf.h perf_reader.h BPF.h BPFTable.h COMPONENT libbcc
+install(FILES bpf_common.h bpf_module.h bcc_syms.h bcc_exception.h libbpf.h perf_reader.h BPF.h BPFTable.h COMPONENT libbcc
   DESTINATION include/bcc)
 install(DIRECTORY compat/linux/ COMPONENT libbcc
   DESTINATION include/bcc/compat/linux

--- a/src/cc/bcc_exception.h
+++ b/src/cc/bcc_exception.h
@@ -29,23 +29,23 @@ namespace ebpf {
 typedef std::tuple<int, std::string> StatusTuple;
 
 template <typename... Args>
-std::tuple<int, std::string> mkstatus(int ret, const char *fmt, Args... args) {
+StatusTuple mkstatus(int ret, const char *fmt, Args... args) {
   char buf[1024];
   snprintf(buf, sizeof(buf), fmt, args...);
   return std::make_tuple(ret, std::string(buf));
 }
 
-static inline std::tuple<int, std::string> mkstatus(int ret, const char *msg) {
+static inline StatusTuple mkstatus(int ret, const char *msg) {
   return std::make_tuple(ret, std::string(msg));
 }
 
-static inline std::tuple<int, std::string> mkstatus(
+static inline StatusTuple mkstatus(
   int ret, const std::string& msg
 ) {
   return std::make_tuple(ret, msg);
 }
 
-static inline std::tuple<int, std::string> mkstatus(int ret) {
+static inline StatusTuple mkstatus(int ret) {
   return std::make_tuple(ret, std::string());
 }
 
@@ -59,7 +59,7 @@ static inline std::tuple<int, std::string> mkstatus(int ret) {
 
 #define TRY2(CMD) \
   do { \
-    std::tuple<int, std::string> __stp = (CMD); \
+    StatusTuple __stp = (CMD); \
     if (std::get<0>(__stp) != 0) { \
       return __stp; \
     } \

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -44,7 +44,7 @@
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <llvm-c/Transforms/IPO.h>
 
-#include "exception.h"
+#include "bcc_exception.h"
 #include "frontends/b/loader.h"
 #include "frontends/clang/loader.h"
 #include "frontends/clang/b_frontend_action.h"

--- a/src/cc/common.h
+++ b/src/cc/common.h
@@ -28,6 +28,4 @@ make_unique(Args &&... args) {
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-typedef std::tuple<int, std::string> StatusTuple;
-
 }  // namespace ebpf

--- a/src/cc/exception.h
+++ b/src/cc/exception.h
@@ -26,6 +26,8 @@
 
 namespace ebpf {
 
+typedef std::tuple<int, std::string> StatusTuple;
+
 template <typename... Args>
 std::tuple<int, std::string> mkstatus(int ret, const char *fmt, Args... args) {
   char buf[1024];

--- a/src/cc/frontends/b/codegen_llvm.cc
+++ b/src/cc/frontends/b/codegen_llvm.cc
@@ -33,7 +33,7 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 
-#include "exception.h"
+#include "bcc_exception.h"
 #include "codegen_llvm.h"
 #include "lexer.h"
 #include "table_desc.h"

--- a/src/cc/frontends/b/node.h
+++ b/src/cc/frontends/b/node.h
@@ -24,7 +24,7 @@
 #include <stdint.h>
 
 #include "common.h"
-#include "exception.h"
+#include "bcc_exception.h"
 #include "scope.h"
 
 #define REVISION_MASK 0xfff

--- a/src/cc/frontends/b/node.h
+++ b/src/cc/frontends/b/node.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include "common.h"
+#include "exception.h"
 #include "scope.h"
 
 #define REVISION_MASK 0xfff

--- a/src/cc/frontends/b/parser.cc
+++ b/src/cc/frontends/b/parser.cc
@@ -16,7 +16,7 @@
 
 #include <algorithm>
 #include <assert.h>
-#include "exception.h"
+#include "bcc_exception.h"
 #include "parser.h"
 #include "type_helper.h"
 

--- a/src/cc/frontends/b/printer.cc
+++ b/src/cc/frontends/b/printer.cc
@@ -16,7 +16,7 @@
 
 #include "printer.h"
 #include "lexer.h"
-#include "exception.h"
+#include "bcc_exception.h"
 
 namespace ebpf {
 namespace cc {

--- a/src/cc/frontends/b/type_check.cc
+++ b/src/cc/frontends/b/type_check.cc
@@ -16,7 +16,7 @@
 
 #include <set>
 #include <algorithm>
-#include "exception.h"
+#include "bcc_exception.h"
 #include "type_check.h"
 #include "lexer.h"
 

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -47,7 +47,7 @@
 #include <llvm/IR/Module.h>
 
 #include "common.h"
-#include "exception.h"
+#include "bcc_exception.h"
 #include "exported_files.h"
 #include "kbuild_helper.h"
 #include "b_frontend_action.h"


### PR DESCRIPTION
- Move definition of `StatusTuple` from `common.h` to `exception.h`. It is used in frontend code and C++ API effectively as exception, and the entire `exception.h` is built to operate on `StatusTuple`. It makes sense for the definition to move to the same file. It also allows us to not install `common.h`.

- Rename `exception.h` to `bcc_exception.h`. The original name was too common for an externally-installed header file, and doesn't match naming convention of other installed headers.