### PR TITLE
Determine kernel dirs at runtime (fix #743)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,24 +49,6 @@ endif()
 
 find_package(LibElf REQUIRED)
 
-# Set to non-zero if system installs kernel headers with split source and build
-# directories in /lib/modules/`uname -r`/. This is the case for debian and
-# suse, to the best of my knowledge.
-
-if(EXISTS "${ROOT}/lib/modules/${CMAKE_SYSTEM_VERSION}/build" AND EXISTS "${ROOT}/lib/modules/${CMAKE_SYSTEM_VERSION}/source")
-  message("Building for a split build/source kernel headers package")
-  set(BCC_KERNEL_HAS_SOURCE_DIR 1)
-  set(BCC_KERNEL_MODULES_SUFFIX "source")
-else()
-  set(BCC_KERNEL_HAS_SOURCE_DIR 0)
-endif()
-
-# Similar to above, set to custom value if kernel headers in
-# /lib/modules/`uname -r` sit in a different location than build/.
-if(NOT DEFINED BCC_KERNEL_MODULES_SUFFIX)
-  set(BCC_KERNEL_MODULES_SUFFIX "build")
-endif()
-
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 # As reported in issue #735, GCC 6 has some behavioral problems when

--- a/src/cc/frontends/clang/CMakeLists.txt
+++ b/src/cc/frontends/clang/CMakeLists.txt
@@ -2,6 +2,4 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_DIR='\"${BCC_KERNEL_MODULES_DIR}\"'")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_SUFFIX='\"${BCC_KERNEL_MODULES_SUFFIX}\"'")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_HAS_SOURCE_DIR=${BCC_KERNEL_HAS_SOURCE_DIR}")
 add_library(clang_frontend loader.cc b_frontend_action.cc tp_frontend_action.cc kbuild_helper.cc)

--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -22,7 +22,8 @@ namespace ebpf {
 using std::string;
 using std::vector;
 
-KBuildHelper::KBuildHelper(const std::string &kdir) : kdir_(kdir) {
+KBuildHelper::KBuildHelper(const std::string &kdir, bool has_source_dir) : kdir_(kdir),
+                                                                           has_source_dir_(has_source_dir) {
 }
 
 // read the flags from cache or learn
@@ -60,7 +61,7 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
   cflags->push_back("/virtual/lib/clang/include");
 
   // some module build directories split headers between source/ and build/
-  if (KERNEL_HAS_SOURCE_DIR) {
+  if (has_source_dir_) {
     cflags->push_back("-I" + kdir_ + "/build/arch/"+arch+"/include");
     cflags->push_back("-I" + kdir_ + "/build/arch/"+arch+"/include/generated/uapi");
     cflags->push_back("-I" + kdir_ + "/build/arch/"+arch+"/include/generated");

--- a/src/cc/frontends/clang/kbuild_helper.h
+++ b/src/cc/frontends/clang/kbuild_helper.h
@@ -92,10 +92,11 @@ class TmpDir {
 //  case we eventually support non-root user programs, cache in $HOME.
 class KBuildHelper {
  public:
-  explicit KBuildHelper(const std::string &kdir);
+  explicit KBuildHelper(const std::string &kdir, bool has_source_dir);
   int get_flags(const char *uname_machine, std::vector<std::string> *cflags);
  private:
   std::string kdir_;
+  bool has_source_dir_;
 };
 
 }  // namespace ebpf


### PR DESCRIPTION
As some module build directories split headers between `source/` and
`build/` and this varies between distributions, determine the location
at runtime.