### PR TITLE
Clean up bcc_exception.h

### DIFF
--- a/examples/cpp/CPUDistribution.cc
+++ b/examples/cpp/CPUDistribution.cc
@@ -61,15 +61,15 @@ int task_switch_event(struct pt_regs *ctx, struct task_struct *prev) {
 int main(int argc, char** argv) {
   ebpf::BPF bpf;
   auto init_res = bpf.init(BPF_PROGRAM);
-  if (std::get<0>(init_res) != 0) {
-    std::cerr << std::get<1>(init_res) << std::endl;
+  if (init_res.code() != 0) {
+    std::cerr << init_res.msg() << std::endl;
     return 1;
   }
 
   auto attach_res =
       bpf.attach_kprobe("finish_task_switch", "task_switch_event");
-  if (std::get<0>(attach_res) != 0) {
-    std::cerr << std::get<1>(attach_res) << std::endl;
+  if (attach_res.code() != 0) {
+    std::cerr << attach_res.msg() << std::endl;
     return 1;
   }
 
@@ -88,8 +88,8 @@ int main(int argc, char** argv) {
   }
 
   auto detach_res = bpf.detach_kprobe("finish_task_switch");
-  if (std::get<0>(detach_res) != 0) {
-    std::cerr << std::get<1>(detach_res) << std::endl;
+  if (detach_res.code() != 0) {
+    std::cerr << detach_res.msg() << std::endl;
     return 1;
   }
 

--- a/examples/cpp/HelloWorld.cc
+++ b/examples/cpp/HelloWorld.cc
@@ -20,8 +20,8 @@ int on_sys_clone(void *ctx) {
 int main() {
   ebpf::BPF bpf;
   auto init_res = bpf.init(BPF_PROGRAM);
-  if (std::get<0>(init_res) != 0) {
-    std::cerr << std::get<1>(init_res) << std::endl;
+  if (init_res.code() != 0) {
+    std::cerr << init_res.msg() << std::endl;
     return 1;
   }
 
@@ -29,8 +29,8 @@ int main() {
   std::string line;
 
   auto attach_res = bpf.attach_kprobe("sys_clone", "on_sys_clone");
-  if (std::get<0>(attach_res) != 0) {
-    std::cerr << std::get<1>(attach_res) << std::endl;
+  if (attach_res.code() != 0) {
+    std::cerr << attach_res.msg() << std::endl;
     return 1;
   }
 
@@ -39,8 +39,8 @@ int main() {
       std::cout << line << std::endl;
       // Detach the probe if we got at least one line.
       auto detach_res = bpf.detach_kprobe("sys_clone");
-      if (std::get<0>(detach_res) != 0) {
-        std::cerr << std::get<1>(detach_res) << std::endl;
+      if (detach_res.code() != 0) {
+        std::cerr << detach_res.msg() << std::endl;
         return 1;
       }
       break;

--- a/examples/cpp/RandomRead.cc
+++ b/examples/cpp/RandomRead.cc
@@ -70,21 +70,21 @@ void signal_handler(int s) {
 int main(int argc, char** argv) {
   bpf = new ebpf::BPF();
   auto init_res = bpf->init(BPF_PROGRAM);
-  if (std::get<0>(init_res) != 0) {
-    std::cerr << std::get<1>(init_res) << std::endl;
+  if (init_res.code() != 0) {
+    std::cerr << init_res.msg() << std::endl;
     return 1;
   }
 
   auto attach_res =
       bpf->attach_tracepoint("random:urandom_read", "on_urandom_read");
-  if (std::get<0>(attach_res) != 0) {
-    std::cerr << std::get<1>(attach_res) << std::endl;
+  if (attach_res.code() != 0) {
+    std::cerr << attach_res.msg() << std::endl;
     return 1;
   }
 
   auto open_res = bpf->open_perf_buffer("events", &handle_output);
-  if (std::get<0>(open_res) != 0) {
-    std::cerr << std::get<1>(open_res) << std::endl;
+  if (open_res.code() != 0) {
+    std::cerr << open_res.msg() << std::endl;
     return 1;
   }
 

--- a/examples/cpp/RecordMySQLQuery.cc
+++ b/examples/cpp/RecordMySQLQuery.cc
@@ -63,15 +63,15 @@ int main(int argc, char** argv) {
 
   ebpf::BPF bpf;
   auto init_res = bpf.init(BPF_PROGRAM);
-  if (std::get<0>(init_res) != 0) {
-    std::cerr << std::get<1>(init_res) << std::endl;
+  if (init_res.code() != 0) {
+    std::cerr << init_res.msg() << std::endl;
     return 1;
   }
 
   auto attach_res =
       bpf.attach_uprobe(mysql_path, ALLOC_QUERY_FUNC, "probe_mysql_query");
-  if (std::get<0>(attach_res) != 0) {
-    std::cerr << std::get<1>(attach_res) << std::endl;
+  if (attach_res.code() != 0) {
+    std::cerr << attach_res.msg() << std::endl;
     return 1;
   }
 
@@ -94,8 +94,8 @@ int main(int argc, char** argv) {
   }
 
   auto detach_res = bpf.detach_uprobe(mysql_path, ALLOC_QUERY_FUNC);
-  if (std::get<0>(detach_res) != 0) {
-    std::cerr << std::get<1>(detach_res) << std::endl;
+  if (detach_res.code() != 0) {
+    std::cerr << detach_res.msg() << std::endl;
     return 1;
   }
 

--- a/examples/cpp/TCPSendStack.cc
+++ b/examples/cpp/TCPSendStack.cc
@@ -58,14 +58,14 @@ struct stack_key_t {
 int main(int argc, char** argv) {
   ebpf::BPF bpf;
   auto init_res = bpf.init(BPF_PROGRAM);
-  if (std::get<0>(init_res) != 0) {
-    std::cerr << std::get<1>(init_res) << std::endl;
+  if (init_res.code() != 0) {
+    std::cerr << init_res.msg() << std::endl;
     return 1;
   }
 
   auto attach_res = bpf.attach_kprobe("tcp_sendmsg", "on_tcp_send");
-  if (std::get<0>(attach_res) != 0) {
-    std::cerr << std::get<1>(attach_res) << std::endl;
+  if (attach_res.code() != 0) {
+    std::cerr << attach_res.msg() << std::endl;
     return 1;
   }
 
@@ -105,8 +105,8 @@ int main(int argc, char** argv) {
   }
 
   auto detach_res = bpf.detach_kprobe("tcp_sendmsg");
-  if (std::get<0>(detach_res) != 0) {
-    std::cerr << std::get<1>(detach_res) << std::endl;
+  if (detach_res.code() != 0) {
+    std::cerr << detach_res.msg() << std::endl;
     return 1;
   }
 

--- a/src/cc/bcc_exception.h
+++ b/src/cc/bcc_exception.h
@@ -37,6 +37,10 @@ public:
     msg_ = std::string(buf);
   }
 
+  void append_msg(const std::string& msg) {
+    msg_ += msg;
+  }
+
   int code() { return ret_; }
 
   std::string msg() { return msg_; }

--- a/src/cc/bcc_exception.h
+++ b/src/cc/bcc_exception.h
@@ -16,12 +16,9 @@
 
 #pragma once
 
-#include <exception>
+#include <cstdio>
 #include <string>
 #include <tuple>
-#include <cstring>
-#include <cerrno>
-#include <cstdlib>
 #undef NDEBUG
 
 namespace ebpf {
@@ -48,14 +45,6 @@ static inline StatusTuple mkstatus(
 static inline StatusTuple mkstatus(int ret) {
   return std::make_tuple(ret, std::string());
 }
-
-#define TRY(CMD) \
-  do { \
-    int __status = (CMD); \
-    if (__status != 0) { \
-      return __status; \
-    } \
-  } while (0)
 
 #define TRY2(CMD) \
   do { \

--- a/src/cc/frontends/b/codegen_llvm.cc
+++ b/src/cc/frontends/b/codegen_llvm.cc
@@ -126,7 +126,7 @@ StatusTuple CodegenLLVM::visit_block_stmt_node(BlockStmtNode *n) {
   if (n->scope_)
     scopes_->pop_var();
 
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_if_stmt_node(IfStmtNode *n) {
@@ -159,7 +159,7 @@ StatusTuple CodegenLLVM::visit_if_stmt_node(IfStmtNode *n) {
 
   B.SetInsertPoint(label_end);
 
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_onvalid_stmt_node(OnValidStmtNode *n) {
@@ -192,7 +192,7 @@ StatusTuple CodegenLLVM::visit_onvalid_stmt_node(OnValidStmtNode *n) {
   }
 
   B.SetInsertPoint(label_end);
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_switch_stmt_node(SwitchStmtNode *n) {
@@ -213,7 +213,7 @@ StatusTuple CodegenLLVM::visit_switch_stmt_node(SwitchStmtNode *n) {
     B.SetInsertPoint(resolve_label("DONE"));
     label_end->eraseFromParent();
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_case_stmt_node(CaseStmtNode *n) {
@@ -236,7 +236,7 @@ StatusTuple CodegenLLVM::visit_case_stmt_node(CaseStmtNode *n) {
     if (!B.GetInsertBlock()->getTerminator())
       B.CreateBr(label_end);
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_ident_expr_node(IdentExprNode *n) {
@@ -308,7 +308,7 @@ StatusTuple CodegenLLVM::visit_ident_expr_node(IdentExprNode *n) {
       }
     }
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_assign_expr_node(AssignExprNode *n) {
@@ -343,7 +343,7 @@ StatusTuple CodegenLLVM::visit_assign_expr_node(AssignExprNode *n) {
       }
     }
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::lookup_var(Node *n, const string &name, Scopes::VarScope *scope,
@@ -353,7 +353,7 @@ StatusTuple CodegenLLVM::lookup_var(Node *n, const string &name, Scopes::VarScop
   auto it = vars_.find(*decl);
   if (it == vars_.end()) return mkstatus_(n, "unable to find %s memory location", name.c_str());
   *mem = it->second;
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_packet_expr_node(PacketExprNode *n) {
@@ -407,7 +407,7 @@ StatusTuple CodegenLLVM::visit_packet_expr_node(PacketExprNode *n) {
       return mkstatus_(n, "unsupported");
     }
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_integer_expr_node(IntegerExprNode *n) {
@@ -416,7 +416,7 @@ StatusTuple CodegenLLVM::visit_integer_expr_node(IntegerExprNode *n) {
   expr_ = ConstantInt::get(mod_->getContext(), val);
   if (n->bits_)
     expr_ = B.CreateIntCast(expr_, B.getIntNTy(n->bits_), false);
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_string_expr_node(StringExprNode *n) {
@@ -427,7 +427,7 @@ StatusTuple CodegenLLVM::visit_string_expr_node(StringExprNode *n) {
   B.CreateMemCpy(ptr, global, n->val_.size() + 1, 1);
   expr_ = ptr;
 
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::emit_short_circuit_and(BinopExprNode *n) {
@@ -454,7 +454,7 @@ StatusTuple CodegenLLVM::emit_short_circuit_and(BinopExprNode *n) {
   phi->addIncoming(pop_expr(), label_then);
   expr_ = phi;
 
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::emit_short_circuit_or(BinopExprNode *n) {
@@ -481,7 +481,7 @@ StatusTuple CodegenLLVM::emit_short_circuit_or(BinopExprNode *n) {
   phi->addIncoming(pop_expr(), label_then);
   expr_ = phi;
 
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_binop_expr_node(BinopExprNode *n) {
@@ -509,7 +509,7 @@ StatusTuple CodegenLLVM::visit_binop_expr_node(BinopExprNode *n) {
     case Tok::TLOR: expr_ = B.CreateOr(lhs, rhs); break;
     default: return mkstatus_(n, "unsupported binary operator");
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_unop_expr_node(UnopExprNode *n) {
@@ -519,11 +519,11 @@ StatusTuple CodegenLLVM::visit_unop_expr_node(UnopExprNode *n) {
     case Tok::TCMPL: expr_ = B.CreateNeg(pop_expr()); break;
     default: {}
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_bitop_expr_node(BitopExprNode *n) {
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_goto_expr_node(GotoExprNode *n) {
@@ -553,7 +553,7 @@ StatusTuple CodegenLLVM::visit_goto_expr_node(GotoExprNode *n) {
     }
   }
   B.CreateBr(resolve_label(jump_label));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_return_expr_node(ReturnExprNode *n) {
@@ -562,7 +562,7 @@ StatusTuple CodegenLLVM::visit_return_expr_node(ReturnExprNode *n) {
   Value *cast_1 = B.CreateIntCast(pop_expr(), parent->getReturnType(), true);
   B.CreateStore(cast_1, retval_);
   B.CreateBr(resolve_label("DONE"));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::emit_table_lookup(MethodCallExprNode *n) {
@@ -605,7 +605,7 @@ StatusTuple CodegenLLVM::emit_table_lookup(MethodCallExprNode *n) {
   } else {
     return mkstatus_(n, "lookup in table type %s unsupported", table->type_id()->c_str());
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::emit_table_update(MethodCallExprNode *n) {
@@ -636,7 +636,7 @@ StatusTuple CodegenLLVM::emit_table_update(MethodCallExprNode *n) {
   } else {
     return mkstatus_(n, "unsupported");
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::emit_table_delete(MethodCallExprNode *n) {
@@ -663,7 +663,7 @@ StatusTuple CodegenLLVM::emit_table_delete(MethodCallExprNode *n) {
   } else {
     return mkstatus_(n, "unsupported");
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::emit_log(MethodCallExprNode *n) {
@@ -684,13 +684,13 @@ StatusTuple CodegenLLVM::emit_log(MethodCallExprNode *n) {
                                          PointerType::getUnqual(printk_fn_type));
 
   expr_ = B.CreateCall(printk_fn, args);
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::emit_packet_rewrite_field(MethodCallExprNode *n) {
   TRY2(n->args_[1]->accept(this));
   TRY2(n->args_[0]->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::emit_atomic_add(MethodCallExprNode *n) {
@@ -701,7 +701,7 @@ StatusTuple CodegenLLVM::emit_atomic_add(MethodCallExprNode *n) {
   AtomicRMWInst *atomic_inst = B.CreateAtomicRMW(
       AtomicRMWInst::Add, lhs, rhs, AtomicOrdering::SequentiallyConsistent);
   atomic_inst->setVolatile(false);
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::emit_incr_cksum(MethodCallExprNode *n, size_t sz) {
@@ -738,11 +738,11 @@ StatusTuple CodegenLLVM::emit_incr_cksum(MethodCallExprNode *n, size_t sz) {
   Value *skb_ptr8 = B.CreateBitCast(skb_ptr, B.getInt8PtrTy());
 
   expr_ = B.CreateCall(csum_fn, vector<Value *>({skb_ptr8, offset, old_val, new_val, flags}));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::emit_get_usec_time(MethodCallExprNode *n) {
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_method_call_expr_node(MethodCallExprNode *n) {
@@ -768,7 +768,7 @@ StatusTuple CodegenLLVM::visit_method_call_expr_node(MethodCallExprNode *n) {
     return mkstatus_(n, "unsupported");
   }
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 /* result = lookup(key)
@@ -874,7 +874,7 @@ StatusTuple CodegenLLVM::visit_table_index_expr_node(TableIndexExprNode *n) {
   } else {
     expr_ = result;
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 /// on_match
@@ -907,7 +907,7 @@ StatusTuple CodegenLLVM::visit_match_decl_stmt_node(MatchDeclStmtNode *n) {
   }
 
   B.SetInsertPoint(label_end);
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 /// on_miss
@@ -935,7 +935,7 @@ StatusTuple CodegenLLVM::visit_miss_decl_stmt_node(MissDeclStmtNode *n) {
   }
 
   B.SetInsertPoint(label_end);
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_failure_decl_stmt_node(FailureDeclStmtNode *n) {
@@ -945,12 +945,12 @@ StatusTuple CodegenLLVM::visit_failure_decl_stmt_node(FailureDeclStmtNode *n) {
 StatusTuple CodegenLLVM::visit_expr_stmt_node(ExprStmtNode *n) {
   TRY2(n->expr_->accept(this));
   expr_ = nullptr;
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_struct_variable_decl_stmt_node(StructVariableDeclStmtNode *n) {
   if (n->struct_id_->name_ == "" || n->struct_id_->name_[0] == '_') {
-    return mkstatus(0);
+    return StatusTuple(0);
   }
 
   StructType *stype;
@@ -1004,12 +1004,12 @@ StatusTuple CodegenLLVM::visit_struct_variable_decl_stmt_node(StructVariableDecl
       }
     }
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_integer_variable_decl_stmt_node(IntegerVariableDeclStmtNode *n) {
   if (!B.GetInsertBlock())
-    return mkstatus(0);
+    return StatusTuple(0);
 
   // uintX var = init
   AllocaInst *ptr_a = new AllocaInst(B.getIntNTy(n->bit_width_), n->id_->name_, resolve_entry_stack());
@@ -1018,7 +1018,7 @@ StatusTuple CodegenLLVM::visit_integer_variable_decl_stmt_node(IntegerVariableDe
   // todo
   if (!n->init_.empty())
     TRY2(n->init_[0]->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_struct_decl_stmt_node(StructDeclStmtNode *n) {
@@ -1029,7 +1029,7 @@ StatusTuple CodegenLLVM::visit_struct_decl_stmt_node(StructDeclStmtNode *n) {
     fields.push_back(B.getIntNTy((*it)->bit_width_));
   struct_type->setBody(fields, n->is_packed());
   structs_[n] = struct_type;
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_parser_state_stmt_node(ParserStateStmtNode *n) {
@@ -1038,12 +1038,12 @@ StatusTuple CodegenLLVM::visit_parser_state_stmt_node(ParserStateStmtNode *n) {
   B.SetInsertPoint(label_entry);
   if (n->next_state_)
     TRY2(n->next_state_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_state_decl_stmt_node(StateDeclStmtNode *n) {
   if (!n->id_)
-    return mkstatus(0);
+    return StatusTuple(0);
   string jump_label = n->scoped_name();
   BasicBlock *label_entry = resolve_label(jump_label);
   B.SetInsertPoint(label_entry);
@@ -1067,7 +1067,7 @@ StatusTuple CodegenLLVM::visit_state_decl_stmt_node(StateDeclStmtNode *n) {
   }
 
   scopes_->pop_state();
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_table_decl_stmt_node(TableDeclStmtNode *n) {
@@ -1107,7 +1107,7 @@ StatusTuple CodegenLLVM::visit_table_decl_stmt_node(TableDeclStmtNode *n) {
   } else {
     return mkstatus_(n, "Table %s not implemented", n->table_type_->name_.c_str());
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::lookup_struct_type(StructDeclStmtNode *decl, StructType **stype) const {
@@ -1116,7 +1116,7 @@ StatusTuple CodegenLLVM::lookup_struct_type(StructDeclStmtNode *decl, StructType
     return mkstatus_(decl, "could not find IR for type %s", decl->id_->c_str());
   *stype = struct_it->second;
 
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::lookup_struct_type(VariableDeclStmtNode *n, StructType **stype,
@@ -1138,7 +1138,7 @@ StatusTuple CodegenLLVM::lookup_struct_type(VariableDeclStmtNode *n, StructType 
   if (decl)
     *decl = type;
 
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
@@ -1216,7 +1216,7 @@ StatusTuple CodegenLLVM::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
     B.CreateRet(B.CreateLoad(retval_));
   }
 
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::visit(Node* root, vector<TableDesc> &tables) {
@@ -1248,7 +1248,7 @@ StatusTuple CodegenLLVM::visit(Node* root, vector<TableDesc> &tables) {
       "", "",
     });
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple CodegenLLVM::print_header() {
@@ -1276,7 +1276,7 @@ StatusTuple CodegenLLVM::print_header() {
       continue;
     TRY2((*it)->accept(this));
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 int CodegenLLVM::get_table_fd(const string &name) const {

--- a/src/cc/frontends/b/loader.cc
+++ b/src/cc/frontends/b/loader.cc
@@ -20,7 +20,6 @@
 #include "loader.h"
 #include "table_desc.h"
 
-using std::get;
 using std::string;
 using std::unique_ptr;
 using std::vector;
@@ -57,8 +56,8 @@ int BLoader::parse(llvm::Module *mod, const string &filename, const string &prot
 
   ebpf::cc::TypeCheck type_check(parser_->scopes_.get(), proto_parser_->scopes_.get());
   auto ret = type_check.visit(parser_->root_node_);
-  if (get<0>(ret) != 0 || get<1>(ret).size()) {
-    fprintf(stderr, "Type error @line=%d: %s\n", get<0>(ret), get<1>(ret).c_str());
+  if (ret.code() != 0 || ret.msg().size()) {
+    fprintf(stderr, "Type error @line=%d: %s\n", ret.code(), ret.msg().c_str());
     return -1;
   }
 
@@ -66,9 +65,9 @@ int BLoader::parse(llvm::Module *mod, const string &filename, const string &prot
 
   codegen_ = ebpf::make_unique<ebpf::cc::CodegenLLVM>(mod, parser_->scopes_.get(), proto_parser_->scopes_.get());
   ret = codegen_->visit(parser_->root_node_, **tables);
-  if (get<0>(ret) != 0 || get<1>(ret).size()) {
-    fprintf(stderr, "Codegen error @line=%d: %s\n", get<0>(ret), get<1>(ret).c_str());
-    return get<0>(ret);
+  if (ret.code() != 0 || ret.msg().size()) {
+    fprintf(stderr, "Codegen error @line=%d: %s\n", ret.code(), ret.msg().c_str());
+    return ret.code();
   }
 
   return 0;

--- a/src/cc/frontends/b/node.h
+++ b/src/cc/frontends/b/node.h
@@ -115,19 +115,17 @@ class Node {
 
 template <typename... Args>
 StatusTuple mkstatus_(Node *n, const char *fmt, Args... args) {
-  char buf[2048];
-  snprintf(buf, sizeof(buf), fmt, args...);
-  string out_msg(buf);
+  StatusTuple status = StatusTuple(n->line_ ? n->line_ : -1, fmt, args...);
   if (n->line_ > 0)
-    out_msg += "\n" + n->text_;
-  return StatusTuple(n->line_ ? n->line_ : -1, out_msg);
+    status.append_msg("\n" + n->text_);
+  return status;
 }
 
 static inline StatusTuple mkstatus_(Node *n, const char *msg) {
-  string out_msg(msg);
+  StatusTuple status = StatusTuple(n->line_ ? n->line_ : -1, msg);
   if (n->line_ > 0)
-    out_msg += "\n" + n->text_;
-  return StatusTuple(n->line_ ? n->line_ : -1, out_msg);
+    status.append_msg("\n" + n->text_);
+  return status;
 }
 
 class StmtNode : public Node {

--- a/src/cc/frontends/b/node.h
+++ b/src/cc/frontends/b/node.h
@@ -114,20 +114,20 @@ class Node {
 };
 
 template <typename... Args>
-std::tuple<int, std::string> mkstatus_(Node *n, const char *fmt, Args... args) {
-  char buf[1024];
+StatusTuple mkstatus_(Node *n, const char *fmt, Args... args) {
+  char buf[2048];
   snprintf(buf, sizeof(buf), fmt, args...);
   string out_msg(buf);
   if (n->line_ > 0)
     out_msg += "\n" + n->text_;
-  return std::make_tuple(n->line_ ? n->line_ : -1, out_msg);
+  return StatusTuple(n->line_ ? n->line_ : -1, out_msg);
 }
 
-static inline std::tuple<int, std::string> mkstatus_(Node *n, const char *msg) {
+static inline StatusTuple mkstatus_(Node *n, const char *msg) {
   string out_msg(msg);
   if (n->line_ > 0)
     out_msg += "\n" + n->text_;
-  return std::make_tuple(n->line_ ? n->line_ : -1, out_msg);
+  return StatusTuple(n->line_ ? n->line_ : -1, out_msg);
 }
 
 class StmtNode : public Node {

--- a/src/cc/frontends/b/printer.cc
+++ b/src/cc/frontends/b/printer.cc
@@ -38,7 +38,7 @@ StatusTuple Printer::visit_block_stmt_node(BlockStmtNode* n) {
     --indent_;
   }
   fprintf(out_, "%*s}", indent_, "");
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_if_stmt_node(IfStmtNode* n) {
@@ -50,7 +50,7 @@ StatusTuple Printer::visit_if_stmt_node(IfStmtNode* n) {
     fprintf(out_, " else ");
     TRY2(n->false_block_->accept(this));
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_onvalid_stmt_node(OnValidStmtNode* n) {
@@ -62,7 +62,7 @@ StatusTuple Printer::visit_onvalid_stmt_node(OnValidStmtNode* n) {
     fprintf(out_, " else ");
     TRY2(n->else_block_->accept(this));
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_switch_stmt_node(SwitchStmtNode* n) {
@@ -70,7 +70,7 @@ StatusTuple Printer::visit_switch_stmt_node(SwitchStmtNode* n) {
   TRY2(n->cond_->accept(this));
   fprintf(out_, ") ");
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_case_stmt_node(CaseStmtNode* n) {
@@ -81,7 +81,7 @@ StatusTuple Printer::visit_case_stmt_node(CaseStmtNode* n) {
     fprintf(out_, "default");
   }
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_ident_expr_node(IdentExprNode* n) {
@@ -92,37 +92,37 @@ StatusTuple Printer::visit_ident_expr_node(IdentExprNode* n) {
   if (n->sub_name_.size()) {
     fprintf(out_, ".%s", n->sub_name_.c_str());
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_assign_expr_node(AssignExprNode* n) {
   TRY2(n->lhs_->accept(this));
   fprintf(out_, " = ");
   TRY2(n->rhs_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_packet_expr_node(PacketExprNode* n) {
   fprintf(out_, "$");
   TRY2(n->id_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_integer_expr_node(IntegerExprNode* n) {
   fprintf(out_, "%s:%zu", n->val_.c_str(), n->bits_);
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_string_expr_node(StringExprNode *n) {
   fprintf(out_, "%s", n->val_.c_str());
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_binop_expr_node(BinopExprNode* n) {
   TRY2(n->lhs_->accept(this));
   fprintf(out_, "%d", n->op_);
   TRY2(n->rhs_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_unop_expr_node(UnopExprNode* n) {
@@ -135,25 +135,25 @@ StatusTuple Printer::visit_unop_expr_node(UnopExprNode* n) {
   }
   fprintf(out_, "%s", s);
   TRY2(n->expr_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_bitop_expr_node(BitopExprNode* n) {
 
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_return_expr_node(ReturnExprNode* n) {
   fprintf(out_, "return ");
   TRY2(n->expr_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_goto_expr_node(GotoExprNode* n) {
   const char* s = n->is_continue_ ? "continue " : "goto ";
   fprintf(out_, "%s", s);
   TRY2(n->id_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_method_call_expr_node(MethodCallExprNode* n) {
@@ -177,19 +177,19 @@ StatusTuple Printer::visit_method_call_expr_node(MethodCallExprNode* n) {
     --indent_;
     fprintf(out_, "%*s}", indent_, "");
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_table_index_expr_node(TableIndexExprNode *n) {
   fprintf(out_, "%s[", n->id_->c_str());
   TRY2(n->index_->accept(this));
   fprintf(out_, "]");
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_expr_stmt_node(ExprStmtNode* n) {
   TRY2(n->expr_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_struct_variable_decl_stmt_node(StructVariableDeclStmtNode* n) {
@@ -207,7 +207,7 @@ StatusTuple Printer::visit_struct_variable_decl_stmt_node(StructVariableDeclStmt
     }
     fprintf(out_, "}");
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_integer_variable_decl_stmt_node(IntegerVariableDeclStmtNode* n) {
@@ -218,7 +218,7 @@ StatusTuple Printer::visit_integer_variable_decl_stmt_node(IntegerVariableDeclSt
     fprintf(out_, "; ");
     TRY2(n->init_[0]->accept(this));
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_struct_decl_stmt_node(StructDeclStmtNode* n) {
@@ -233,12 +233,12 @@ StatusTuple Printer::visit_struct_decl_stmt_node(StructDeclStmtNode* n) {
   }
   --indent_;
   fprintf(out_, "%*s}", indent_, "");
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_state_decl_stmt_node(StateDeclStmtNode* n) {
   if (!n->id_) {
-    return mkstatus(0);
+    return StatusTuple(0);
   }
   fprintf(out_, "state ");
   TRY2(n->id_->accept(this));
@@ -249,11 +249,11 @@ StatusTuple Printer::visit_state_decl_stmt_node(StateDeclStmtNode* n) {
   //  TRY2(n->id2_->accept(this));
   //}
   //TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_parser_state_stmt_node(ParserStateStmtNode* n) {
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_match_decl_stmt_node(MatchDeclStmtNode* n) {
@@ -268,7 +268,7 @@ StatusTuple Printer::visit_match_decl_stmt_node(MatchDeclStmtNode* n) {
   }
   fprintf(out_, ") ");
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_miss_decl_stmt_node(MissDeclStmtNode* n) {
@@ -283,7 +283,7 @@ StatusTuple Printer::visit_miss_decl_stmt_node(MissDeclStmtNode* n) {
   }
   fprintf(out_, ") ");
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_failure_decl_stmt_node(FailureDeclStmtNode* n) {
@@ -298,7 +298,7 @@ StatusTuple Printer::visit_failure_decl_stmt_node(FailureDeclStmtNode* n) {
   }
   fprintf(out_, ") ");
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_table_decl_stmt_node(TableDeclStmtNode* n) {
@@ -313,7 +313,7 @@ StatusTuple Printer::visit_table_decl_stmt_node(TableDeclStmtNode* n) {
   fprintf(out_, "> ");
   TRY2(n->id_->accept(this));
   fprintf(out_, "(%zu)", n->size_);
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple Printer::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
@@ -328,7 +328,7 @@ StatusTuple Printer::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
   }
   fprintf(out_, ") ");
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 }  // namespace cc

--- a/src/cc/frontends/b/type_check.cc
+++ b/src/cc/frontends/b/type_check.cc
@@ -37,7 +37,7 @@ StatusTuple TypeCheck::visit_block_stmt_node(BlockStmtNode *n) {
 
   if (n->scope_)
     scopes_->pop_var();
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_if_stmt_node(IfStmtNode *n) {
@@ -48,7 +48,7 @@ StatusTuple TypeCheck::visit_if_stmt_node(IfStmtNode *n) {
   if (n->false_block_) {
     TRY2(n->false_block_->accept(this));
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_onvalid_stmt_node(OnValidStmtNode *n) {
@@ -60,7 +60,7 @@ StatusTuple TypeCheck::visit_onvalid_stmt_node(OnValidStmtNode *n) {
   if (n->else_block_) {
     TRY2(n->else_block_->accept(this));
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_switch_stmt_node(SwitchStmtNode *n) {
@@ -71,7 +71,7 @@ StatusTuple TypeCheck::visit_switch_stmt_node(SwitchStmtNode *n) {
   for (auto it = n->block_->stmts_.begin(); it != n->block_->stmts_.end(); ++it) {
     /// @todo check for duplicates
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_case_stmt_node(CaseStmtNode *n) {
@@ -81,7 +81,7 @@ StatusTuple TypeCheck::visit_case_stmt_node(CaseStmtNode *n) {
       return mkstatus_(n, "Switch condition must be a numeric type");
   }
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_ident_expr_node(IdentExprNode *n) {
@@ -131,7 +131,7 @@ StatusTuple TypeCheck::visit_ident_expr_node(IdentExprNode *n) {
     n->bit_width_ = n->sub_decl_->bit_width_;
     n->flags_[ExprNode::WRITE] = true;
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_assign_expr_node(AssignExprNode *n) {
@@ -151,7 +151,7 @@ StatusTuple TypeCheck::visit_assign_expr_node(AssignExprNode *n) {
       return mkstatus_(n, "Right-hand side of assignment must be a numeric type");
   }
   n->typeof_ = ExprNode::VOID;
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_packet_expr_node(PacketExprNode *n) {
@@ -172,20 +172,20 @@ StatusTuple TypeCheck::visit_packet_expr_node(PacketExprNode *n) {
       n->bit_width_ = sub_decl->bit_width_;
   }
   n->flags_[ExprNode::WRITE] = true;
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_integer_expr_node(IntegerExprNode *n) {
   n->typeof_ = ExprNode::INTEGER;
   n->bit_width_ = n->bits_;
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_string_expr_node(StringExprNode *n) {
   n->typeof_ = ExprNode::STRING;
   n->flags_[ExprNode::IS_REF] = true;
   n->bit_width_ = n->val_.size() << 3;
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_binop_expr_node(BinopExprNode *n) {
@@ -207,7 +207,7 @@ StatusTuple TypeCheck::visit_binop_expr_node(BinopExprNode *n) {
     default:
       n->bit_width_ = std::max(n->lhs_->bit_width_, n->rhs_->bit_width_);
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_unop_expr_node(UnopExprNode *n) {
@@ -215,26 +215,26 @@ StatusTuple TypeCheck::visit_unop_expr_node(UnopExprNode *n) {
   if (n->expr_->typeof_ != ExprNode::INTEGER)
     return mkstatus_(n, "Unary operand must be a numeric type");
   n->copy_type(*n->expr_);
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_bitop_expr_node(BitopExprNode *n) {
   if (n->expr_->typeof_ != ExprNode::INTEGER)
     return mkstatus_(n, "Bitop [] can only operate on numeric types");
   n->typeof_ = ExprNode::INTEGER;
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_goto_expr_node(GotoExprNode *n) {
   //n->id_->accept(this);
   n->typeof_ = ExprNode::VOID;
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_return_expr_node(ReturnExprNode *n) {
   TRY2(n->expr_->accept(this));
   n->typeof_ = ExprNode::VOID;
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::expect_method_arg(MethodCallExprNode *n, size_t num, size_t num_def_args = 0) {
@@ -247,7 +247,7 @@ StatusTuple TypeCheck::expect_method_arg(MethodCallExprNode *n, size_t num, size
       return mkstatus_(n, "%s expected %d argument%s (%d default), %zu given", n->id_->sub_name_.c_str(),
                       num, num == 1 ? "" : "s", num_def_args, n->args_.size());
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::check_lookup_method(MethodCallExprNode *n) {
@@ -263,7 +263,7 @@ StatusTuple TypeCheck::check_lookup_method(MethodCallExprNode *n) {
     n->block_->scope_->add("_result", result.get());
     n->block_->stmts_.insert(n->block_->stmts_.begin(), move(result));
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::check_update_method(MethodCallExprNode *n) {
@@ -274,7 +274,7 @@ StatusTuple TypeCheck::check_update_method(MethodCallExprNode *n) {
     TRY2(expect_method_arg(n, 2));
   else if (table->type_id()->name_ == "LPM")
     TRY2(expect_method_arg(n, 3));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::check_delete_method(MethodCallExprNode *n) {
@@ -285,7 +285,7 @@ StatusTuple TypeCheck::check_delete_method(MethodCallExprNode *n) {
     TRY2(expect_method_arg(n, 1));
   else if (table->type_id()->name_ == "LPM")
     {}
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_method_call_expr_node(MethodCallExprNode *n) {
@@ -338,7 +338,7 @@ StatusTuple TypeCheck::visit_method_call_expr_node(MethodCallExprNode *n) {
       return mkstatus_(n, "%s does not allow trailing block statements", n->id_->full_name().c_str());
     TRY2(n->block_->accept(this));
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_table_index_expr_node(TableIndexExprNode *n) {
@@ -358,12 +358,12 @@ StatusTuple TypeCheck::visit_table_index_expr_node(TableIndexExprNode *n) {
     n->flags_[ExprNode::IS_REF] = true;
     n->struct_type_ = n->table_->leaf_type_;
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_expr_stmt_node(ExprStmtNode *n) {
   TRY2(n->expr_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_struct_variable_decl_stmt_node(StructVariableDeclStmtNode *n) {
@@ -398,7 +398,7 @@ StatusTuple TypeCheck::visit_struct_variable_decl_stmt_node(StructVariableDeclSt
       TRY2((*it)->accept(this));
     }
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_integer_variable_decl_stmt_node(IntegerVariableDeclStmtNode *n) {
@@ -406,7 +406,7 @@ StatusTuple TypeCheck::visit_integer_variable_decl_stmt_node(IntegerVariableDecl
   if (!n->init_.empty()) {
     TRY2(n->init_[0]->accept(this));
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_struct_decl_stmt_node(StructDeclStmtNode *n) {
@@ -414,16 +414,16 @@ StatusTuple TypeCheck::visit_struct_decl_stmt_node(StructDeclStmtNode *n) {
   for (auto it = n->stmts_.begin(); it != n->stmts_.end(); ++it) {
     TRY2((*it)->accept(this));
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_parser_state_stmt_node(ParserStateStmtNode *n) {
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_state_decl_stmt_node(StateDeclStmtNode *n) {
   if (!n->id_) {
-    return mkstatus(0);
+    return StatusTuple(0);
   }
   auto s1 = proto_scopes_->top_state()->lookup(n->id_->name_, true);
   if (s1) {
@@ -478,7 +478,7 @@ StatusTuple TypeCheck::visit_state_decl_stmt_node(StateDeclStmtNode *n) {
 
     scopes_->pop_state();
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_match_decl_stmt_node(MatchDeclStmtNode *n) {
@@ -487,7 +487,7 @@ StatusTuple TypeCheck::visit_match_decl_stmt_node(MatchDeclStmtNode *n) {
     TRY2((*it)->accept(this));
   }
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_miss_decl_stmt_node(MissDeclStmtNode *n) {
@@ -496,7 +496,7 @@ StatusTuple TypeCheck::visit_miss_decl_stmt_node(MissDeclStmtNode *n) {
     TRY2((*it)->accept(this));
   }
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_failure_decl_stmt_node(FailureDeclStmtNode *n) {
@@ -505,7 +505,7 @@ StatusTuple TypeCheck::visit_failure_decl_stmt_node(FailureDeclStmtNode *n) {
     TRY2((*it)->accept(this));
   }
   TRY2(n->block_->accept(this));
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_table_decl_stmt_node(TableDeclStmtNode *n) {
@@ -523,7 +523,7 @@ StatusTuple TypeCheck::visit_table_decl_stmt_node(TableDeclStmtNode *n) {
   }
   if (n->policy_id()->name_ != "AUTO" && n->policy_id()->name_ != "NONE")
     return mkstatus_(n, "Unsupported policy type %s", n->policy_id()->c_str());
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
@@ -538,7 +538,7 @@ StatusTuple TypeCheck::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
   scopes_->push_state(n->scope_);
   TRY2(n->block_->accept(this));
   scopes_->pop_state();
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 StatusTuple TypeCheck::visit(Node *root) {
@@ -549,14 +549,14 @@ StatusTuple TypeCheck::visit(Node *root) {
 
   // // packet data in bpf socket
   // if (scopes_->top_struct()->lookup("_skbuff", true)) {
-  //   return mkstatus(-1, "_skbuff already defined");
+  //   return StatusTuple(-1, "_skbuff already defined");
   // }
   // auto skb_type = make_unique<StructDeclStmtNode>(make_unique<IdentExprNode>("_skbuff"));
   // scopes_->top_struct()->add("_skbuff", skb_type.get());
   // b->stmts_.push_back(move(skb_type));
 
   // if (scopes_->current_var()->lookup("skb", true)) {
-  //   return mkstatus(-1, "skb already defined");
+  //   return StatusTuple(-1, "skb already defined");
   // }
   // auto skb = make_unique<StructVariableDeclStmtNode>(make_unique<IdentExprNode>("_skbuff"),
   //                                                    make_unique<IdentExprNode>("skb"));
@@ -577,9 +577,9 @@ StatusTuple TypeCheck::visit(Node *root) {
     for (auto it = errors_.begin(); it != errors_.end(); ++it) {
       fprintf(stderr, "%s\n", it->c_str());
     }
-    return mkstatus(-1, errors_.begin()->c_str());
+    return StatusTuple(-1, errors_.begin()->c_str());
   }
-  return mkstatus(0);
+  return StatusTuple(0);
 }
 
 }  // namespace cc


### PR DESCRIPTION
- Remove unused headers and Macros.
- Implement a `StatusTuple` class that has `code()` and `msg()` method, instead of using `std::get` and `std::tuple`, as suggested by @4ast and @drarmstr in #781.
- `clang-format -i` on the file.