### PR TITLE
Remove debug flag override in bcc_exception.h

### DIFF
--- a/src/cc/bcc_exception.h
+++ b/src/cc/bcc_exception.h
@@ -18,7 +18,6 @@
 
 #include <cstdio>
 #include <string>
-#undef NDEBUG
 
 namespace ebpf {
 

--- a/src/cc/frontends/b/codegen_llvm.cc
+++ b/src/cc/frontends/b/codegen_llvm.cc
@@ -17,7 +17,6 @@
 #include <set>
 #include <algorithm>
 #include <sstream>
-#include <assert.h>
 
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/CallingConv.h>

--- a/src/cc/frontends/b/parser.cc
+++ b/src/cc/frontends/b/parser.cc
@@ -15,7 +15,6 @@
  */
 
 #include <algorithm>
-#include <assert.h>
 #include "bcc_exception.h"
 #include "parser.h"
 #include "type_helper.h"


### PR DESCRIPTION
`bcc_exception.h` has an override `#undef NDEBUG`. Now that the file is an installed header, it may alter user's code's behavior. I checked @drzaeus77 who introduced this in the first place a few weeks ago and we thought it is probably irrelevant now.

The only files that both have `assert.h` and `bcc_exception.h` are `frontends/b/codegen_llvm.cc` and `frontends/b/parser.cc`, but there aren't any asserts in them at all @_@

Built BCC and randomly checked on things, no notable behavior change. Any suggestion on where to test in particular?