### PR TITLE
Add snapcraft script to package up bcc as a snap

### DIFF
--- a/snapcraft/Makefile
+++ b/snapcraft/Makefile
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2016 Canonical
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+
+#
+# Simple makefile to mangle version info in the yaml file
+#
+VERSION=$(shell git tag | tail -1 | cut -c2-)
+COMMITS=$(shell git log --oneline | wc -l)
+SHA=$(shell git log -1 --oneline | cut -d' ' -f1)
+DATE=$(shell date +'%Y%m%d')
+V=$(VERSION)-$(DATE)-$(COMMITS)-$(SHA)
+
+all: set_version
+	snapcraft
+
+set_version:
+	cat snapcraft.yaml | sed 's/version: .*/version: $(V)/' > snapcraft-tmp.yaml
+	mv snapcraft-tmp.yaml snapcraft.yaml
+
+install:
+	#
+	# Install latest snap
+	#
+	sudo snap install --devmode bcc_*.snap
+
+	#
+	# Connect up interfaces
+	#
+	sudo snap connect bcc:mount-observe
+	sudo snap connect bcc:system-observe
+	sudo snap connect bcc:system-trace
+
+remove:
+	sudo snap remove bcc
+
+clean:
+	snapcraft clean
+	rm -rf setup *.snap snapcraft

--- a/snapcraft/README.md
+++ b/snapcraft/README.md
@@ -1,0 +1,44 @@
+# bcc snap
+
+This is an unconfined snap of the BPF Compiler Collection (BCC), a toolkit for
+creating efficient kernel tracing and manipulation programs.
+
+First, install snapcraft, e.g. on Ubuntu:
+
+sudo apt install snapcraft
+
+Clone the bcc repo (if you haven't done so already) and create the snap:
+
+git clone https://github.com/iovisor/bcc.git
+cd snapcraft
+make
+
+Note: running `make` just gets the version from the current bcc gito
+repository and uses this in the snapcraft yaml file to version the bcc
+snap. The Makefile basically runs snapcraft to snap up bcc.
+
+Install the snap by running:
+
+sudo snap install --devmode bcc_*.snap
+
+One may need to ensure the snap plugins are enabled for the snap using:
+
+sudo snap connect bcc:mount-observe
+sudo snap connect bcc:system-observe
+sudo snap connect bcc:system-trace
+
+Now run a bcc tool, for example, to run opensnoop use:
+
+sudo bcc.opensnoop
+
+Note that this may fail to build and run if you do not have the kernel
+headers installed or perhaps the kernel config is not set up correctly.
+
+This snap has been tested using the mainly 4.8 and 4.9 kernels built
+with the Ubuntu Yakkety and Zesty kernel configs as well as the default
+Ubuntu 4.8 Yakkey and 4.9 Zesty kernels.
+
+Contact Colin Ian King <colin.king@canonical.com> for support on this
+bcc snap.
+
+Thu 15 Dec 17:08:29 GMT 2016

--- a/snapcraft/snapcraft.yaml
+++ b/snapcraft/snapcraft.yaml
@@ -1,0 +1,169 @@
+#
+# Copyright (C) 2016 Canonical
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+name: bcc
+version: 0.2.0-20161215-1402-7151673
+summary: BPF Compiler Collection (BCC)
+description: A toolkit for creating efficient kernel tracing and manipulation programs
+confinement: strict
+grade: stable
+plugs:
+    mount-observe: null
+    system-observe: null
+    system-trace: null
+apps:
+    argdist:
+        command: wrapper argdist
+    bashreadline:
+        command: wrapper bashreadline
+    biolatency:
+        command: wrapper biolatency
+    biosnoop:
+        command: wrapper biosnoop
+    biotop:
+        command: wrapper biotop
+    bitesize:
+        command: wrapper bitesize
+    btrfsdist:
+        command: wrapper btrfsdist
+    btrfsslower:
+        command: wrapper btrfsslower
+    cachestat:
+        command: wrapper cachestat
+    cachetop:
+        command: wrapper cachetop
+    cpudist:
+        command: wrapper cpudist
+    dcsnoop:
+        command: wrapper dcsnoop
+    dcstat:
+        command: wrapper dcstat
+    execsnoop:
+        command: wrapper execsnoop
+    ext4dist:
+        command: wrapper ext4dist
+    ext4slower:
+        command: wrapper ext4slower
+    filelife:
+        command: wrapper filelife
+    fileslower:
+        command: wrapper fileslower
+    filetop:
+        command: wrapper filetop
+    funccount:
+        command: wrapper funccount
+    funclatency:
+        command: wrapper funclatency
+    gethostlatency:
+        command: wrapper gethostlatency
+    hardirqs:
+        command: wrapper hardirqs
+    killsnoop:
+        command: wrapper killsnoop
+    mdflush:
+        command: wrapper mdflush
+    memleak:
+        command: wrapper memleak
+    offcputime:
+        command: wrapper offcputime
+    offwaketime:
+        command: wrapper offwaketime
+    oomkill:
+        command: wrapper oomkill
+    opensnoop:
+        command: wrapper opensnoop
+    pidpersec:
+        command: wrapper pidpersec
+    runqlat:
+        command: wrapper runqlat
+    slabratetop:
+        command: wrapper slabratetop
+    softirqs:
+        command: wrapper softirqs
+    sslsniff:
+        command: wrapper sslsniff
+    stackcount:
+        command: wrapper stackcount
+    stacksnoop:
+        command: wrapper stacksnoop
+    statsnoop:
+        command: wrapper statsnoop
+    syncsnoop:
+        command: wrapper syncsnoop
+    tcpaccept:
+        command: wrapper tcpaccept
+    tcpconnect:
+        command: wrapper tcpconnect
+    tcpconnlat:
+        command: wrapper tcpconnlat
+    tcplife:
+        command: wrapper tcplife
+    tcpretrans:
+        command: wrapper tcpretrans
+    tcptop:
+        command: wrapper tcptop
+    ttysnoop:
+        command: wrapper ttysnop
+    trace:
+        command: wrapper trace
+    vfscount:
+        command: wrapper vfscount
+    vfsstat:
+        command: wrapper vfsstat
+    wakeuptime:
+        command: wrapper wakeuptime
+    xfsdist:
+        command: wrapper xfsdist
+    xfsslower:
+        command: wrapper xfsslower
+    zfsdist:
+        command: wrapper zfsdist
+    zfsslower:
+        command: wrapper zfsslower
+parts:
+    bcc:
+        plugin: cmake
+        configflags:
+            - -DCMAKE_INSTALL_PREFIX=/usr
+        source: ..
+        build-packages:
+            - bison
+            - build-essential
+            - cmake
+            - flex
+            - libedit-dev
+            - libllvm3.7
+            - llvm-3.7-dev
+            - libclang-3.7-dev
+            - python
+            - zlib1g-dev
+            - libelf-dev
+        stage-packages:
+            - python
+        snap:
+            - usr/bin/python*
+            - usr/share/bcc/tools
+            - usr/lib/*/lib*.so*
+            - usr/lib/python2.7
+            - -usr/share/bcc/tools/doc
+    wrapper:
+        source: .
+        plugin: copy
+        files:
+            wrapper: bin/wrapper
+
+# vim: set ai et sts=4 tabstop=4 sw=4:

--- a/snapcraft/wrapper
+++ b/snapcraft/wrapper
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+# Snappy does not yet support CAP_SYS_ADMIN for unconfined snaps, thus sudo:
+# https://bugs.launchpad.net/snappy/+bug/1586581
+# stdout isn't set to line buffered mode:
+# https://bugs.launchpad.net/snappy/+bug/1587675
+
+cmd="$1"
+if [ `id -u` = 0 ] ; then
+	shift
+	stdbuf -oL $SNAP/usr/bin/python "$SNAP/usr/share/bcc/tools/$cmd" $@
+else
+	echo "Need to run $cmd as root (use sudo $@)"
+	exit 1
+fi


### PR DESCRIPTION
This supports packaging using snapcraft; to create a snap
install snapcraft and in the snapcraft directory run
snapcraft to generate a snap.  This script was originally
written by Evan Dandrea and updated by Colin King.

Signed-off-by: Colin Ian King <colin.king@canonical.com>