### PR TITLE
Avoid unexpected log message on BPF program load error

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -201,6 +201,7 @@ int bpf_prog_load(enum bpf_prog_type prog_type,
                      strerror(errno));
              return ret;
          }
+         bpf_log_buffer[0] = 0;
 
          attr.log_buf = ptr_to_u64(bpf_log_buffer);
          attr.log_size = buffer_size;


### PR DESCRIPTION
The `BPF_PROG_LOAD` sys call doesn't really write to (or do anything with) `attr.log_buf` on [a lot of error scenarios](https://github.com/torvalds/linux/blob/master/kernel/bpf/syscall.c#L723). Only verifier errors would write information to the log buffer. However, here we [always print the buffer to `stderr`](https://github.com/iovisor/bcc/blob/master/src/cc/libbpf.c#L219), which may lead to gibberish output.

This Diff clears out the buffer before passing it into the sys call. I'm not sure if this is the best solution. @4ast: Would it be better to have kernel side to clear, or at least to set a leading `\0` to, the log buffer?