### PR TITLE
Add support for aarch64

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -448,6 +448,18 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #define PT_REGS_RC(ctx)		((ctx)->ax)
 #define PT_REGS_IP(ctx)		((ctx)->ip)
 #define PT_REGS_SP(ctx)		((ctx)->sp)
+#elif defined(__aarch64__)
+#define PT_REGS_PARM1(x)	((x)->regs[0])
+#define PT_REGS_PARM2(x)	((x)->regs[1])
+#define PT_REGS_PARM3(x)	((x)->regs[2])
+#define PT_REGS_PARM4(x)	((x)->regs[3])
+#define PT_REGS_PARM5(x)	((x)->regs[4])
+#define PT_REGS_PARM6(x)	((x)->regs[5])
+#define PT_REGS_RET(x)		((x)->regs[30])
+#define PT_REGS_FP(x)		((x)->regs[29]) /*  Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_RC(x)		((x)->regs[0])
+#define PT_REGS_SP(x)		((x)->sp)
+#define PT_REGS_IP(x)		((x)->pc)
 #else
 #error "bcc does not support this platform yet"
 #endif

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -38,9 +38,13 @@ const char *calling_conv_regs_x86[] = {
 };
 const char *calling_conv_regs_ppc[] = {"gpr[3]", "gpr[4]", "gpr[5]",
                                        "gpr[6]", "gpr[7]", "gpr[8]"};
+const char *calling_conv_regs_arm64[] = {"regs[0]", "regs[1]", "regs[2]",
+                                       "regs[3]", "regs[4]", "regs[5]"};
 // todo: support more archs
 #if defined(__powerpc__)
 const char **calling_conv_regs = calling_conv_regs_ppc;
+#elif defined(__aarch64__)
+const char **calling_conv_regs = calling_conv_regs_arm64;
 #else
 const char **calling_conv_regs = calling_conv_regs_x86;
 #endif

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -166,6 +166,8 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
   // set up the command line argument wrapper
 #if defined(__powerpc64__)
   driver::Driver drv("", "ppc64le-unknown-linux-gnu", diags);
+#elif defined(__aarch64__)
+  driver::Driver drv("", "aarch64-unknown-linux-gnu", diags);
 #else
   driver::Driver drv("", "x86_64-unknown-linux-gnu", diags);
 #endif

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -44,6 +44,8 @@
 #ifndef __NR_bpf
 #if defined(__powerpc64__)
 #define __NR_bpf 361
+#elif defined(__aarch64__)
+#define __NR_bpf 280
 #else
 #define __NR_bpf 321
 #endif


### PR DESCRIPTION
ABI for aarch64: register x0-x7 are used for parameter and result. In bcc, there are 6 parameter registers are defined. So use x0-x5 as parameter. frame pointer, link register, stack pointer and pc are added in PT_REGS_xx according to arm64 architecture.

syscall number of bpf for aarch64 are defined in Kernel header uapi/asm-generic/unistd.h.

Signed-off-by: Zhiyi Sun <zhiyisun@gmail.com>