### PR TITLE
Fix bug of missing to install simple_tc.py

### DIFF
--- a/examples/networking/CMakeLists.txt
+++ b/examples/networking/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(EXAMPLE_FILES simulation.py)
 set(EXAMPLE_PROGRAMS simple_tc.py)
-set(EXAMPLE_PROGRAMS tc_perf_event.py)
+set(EXAMPLE_PROGRAMS ${EXAMPLE_PROGRAMS} tc_perf_event.py)
 install(FILES ${EXAMPLE_FILES} DESTINATION share/bcc/examples/networking)
 install(PROGRAMS ${EXAMPLE_PROGRAMS} DESTINATION share/bcc/examples/networking)
 

--- a/examples/networking/CMakeLists.txt
+++ b/examples/networking/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(EXAMPLE_FILES simulation.py)
-set(EXAMPLE_PROGRAMS simple_tc.py)
-set(EXAMPLE_PROGRAMS ${EXAMPLE_PROGRAMS} tc_perf_event.py)
+set(EXAMPLE_PROGRAMS simple_tc.py tc_perf_event.py)
 install(FILES ${EXAMPLE_FILES} DESTINATION share/bcc/examples/networking)
 install(PROGRAMS ${EXAMPLE_PROGRAMS} DESTINATION share/bcc/examples/networking)
 


### PR DESCRIPTION
examples/networking/CMakeLists.txt set $EXAMPLE_PROGRAMS twice. The
second one(tc_perf_event.py) overwirte the first one(simple_tc.py).

Signed-off-by: Zhiyi Sun <zhiyisun@gmail.com>