### PR TITLE
Improve C++ API perf buffer polling

### DIFF
--- a/src/cc/BPF.cc
+++ b/src/cc/BPF.cc
@@ -98,7 +98,7 @@ StatusTuple BPF::detach_all() {
   }
 
   for (auto it : perf_buffers_) {
-    auto res = it.second->close();
+    auto res = it.second->close_all_cpu();
     if (res.code() != 0) {
       error_msg += "Failed to close perf buffer " + it.first + ": ";
       error_msg += res.msg() + "\n";
@@ -279,7 +279,7 @@ StatusTuple BPF::open_perf_buffer(const std::string& name,
   if (perf_buffers_.find(name) == perf_buffers_.end())
     perf_buffers_[name] = new BPFPerfBuffer(bpf_module_.get(), name);
   auto table = perf_buffers_[name];
-  TRY2(table->open(cb, cb_cookie));
+  TRY2(table->open_all_cpu(cb, cb_cookie));
   return StatusTuple(0);
 }
 
@@ -287,7 +287,7 @@ StatusTuple BPF::close_perf_buffer(const std::string& name) {
   auto it = perf_buffers_.find(name);
   if (it == perf_buffers_.end())
     return StatusTuple(-1, "Perf buffer for %s not open", name.c_str());
-  TRY2(it->second->close());
+  TRY2(it->second->close_all_cpu());
   return StatusTuple(0);
 }
 

--- a/src/cc/BPFTable.h
+++ b/src/cc/BPFTable.h
@@ -126,8 +126,8 @@ public:
       : BPFTableBase<int, int>(bpf_module, name) {}
   ~BPFPerfBuffer();
 
-  StatusTuple open(perf_reader_raw_cb cb, void* cb_cookie);
-  StatusTuple close();
+  StatusTuple open_all_cpu(perf_reader_raw_cb cb, void* cb_cookie);
+  StatusTuple close_all_cpu();
   void poll(int timeout);
 
 private:
@@ -135,6 +135,7 @@ private:
   StatusTuple close_on_cpu(int cpu);
 
   std::map<int, perf_reader*> cpu_readers_;
+  std::vector<perf_reader*> readers_;
 };
 
 }  // namespace ebpf


### PR DESCRIPTION
- Pre-create a list of `perf_reader` pointers so we don't need to construct it on every poll cycle.
- When opening reader for all CPUs, make sure already-opened resources get cleaned if it fails in the middle.
- Due to user-reported confusion, rename `open` and `close` so it's more obvious it's operating on all CPUs.
- Add CPU ID in the example.