### PR TITLE
add bpf_obj_pin/bpf_obj_get to pin/get bpf objects

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -67,7 +67,7 @@ target_link_libraries(bcc-static b_frontend clang_frontend bcc-loader-static ${c
 
 install(TARGETS bcc-shared LIBRARY COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES bpf_common.h bpf_module.h bcc_syms.h bcc_exception.h libbpf.h perf_reader.h BPF.h BPFTable.h COMPONENT libbcc
+install(FILES bpf_common.h bpf_module.h bcc_syms.h bcc_exception.h libbpf.h perf_reader.h BPF.h BPFTable.h shared_table.h COMPONENT libbcc
   DESTINATION include/bcc)
 install(DIRECTORY compat/linux/ COMPONENT libbcc
   DESTINATION include/bcc/compat/linux

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -631,3 +631,22 @@ int bpf_detach_perf_event(uint32_t ev_type, uint32_t ev_config) {
   // callers to detach anything they attach.
   return 0;
 }
+
+int bpf_obj_pin(int fd, const char *pathname)
+{
+  union bpf_attr attr = {
+    .pathname = ptr_to_u64((void *)pathname),
+    .bpf_fd = fd,
+  };
+
+  return syscall(__NR_bpf, BPF_OBJ_PIN, &attr, sizeof(attr));
+}
+
+int bpf_obj_get(const char *pathname)
+{
+  union bpf_attr attr = {
+    .pathname = ptr_to_u64((void *)pathname),
+  };
+
+  return syscall(__NR_bpf, BPF_OBJ_GET, &attr, sizeof(attr));
+}

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -71,6 +71,9 @@ int bpf_attach_perf_event(int progfd, uint32_t ev_type, uint32_t ev_config,
                           pid_t pid, int cpu, int group_fd);
 int bpf_detach_perf_event(uint32_t ev_type, uint32_t ev_config);
 
+int bpf_obj_pin(int fd, const char *pathname);
+int bpf_obj_get(const char *pathname);
+
 #define LOG_BUF_SIZE 65536
 
 // Put non-static/inline functions in their own section with this prefix +


### PR DESCRIPTION
This is just a port from kernel's libbpf code (`samples/bpf/libbpf.[h|c]`). Also `shared_table.h` is added to exported headers. The use case is one agent process creates a map and pins it into bpffs. Another agent process can later retrieve the map via `bpf_obj_get()` and use it as an extern table.