### PR TITLE
Fix variable names in exceptions

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -779,7 +779,7 @@ class BPF(object):
         (path, addr) = BPF._check_path_symbol(name, sym, addr)
         ev_name = "p_%s_0x%x" % (self._probe_repl.sub("_", path), addr)
         if ev_name not in self.open_uprobes:
-            raise Exception("Uprobe %s is not attached" % event)
+            raise Exception("Uprobe %s is not attached" % ev_name)
         lib.perf_reader_free(self.open_uprobes[ev_name])
         desc = "-:uprobes/%s" % ev_name
         res = lib.bpf_detach_uprobe(desc.encode("ascii"))
@@ -831,7 +831,7 @@ class BPF(object):
         (path, addr) = BPF._check_path_symbol(name, sym, addr)
         ev_name = "r_%s_0x%x" % (self._probe_repl.sub("_", path), addr)
         if ev_name not in self.open_uprobes:
-            raise Exception("Kretprobe %s is not attached" % event)
+            raise Exception("Uretprobe %s is not attached" % ev_name)
         lib.perf_reader_free(self.open_uprobes[ev_name])
         desc = "-:uprobes/%s" % ev_name
         res = lib.bpf_detach_uprobe(desc.encode("ascii"))


### PR DESCRIPTION
Trying to detach an unattached uprobe results in the following incorrect error message:
```Python traceback
Traceback (most recent call last):
  File "tools/gethostlatency.py", line 88, in <module>
    b.detach_uprobe(name="c", sym="gethostbyname")
  File "/usr/lib/python2.7/dist-packages/bcc/__init__.py", line 783, in detach_uprobe
    raise Exception("Uprobe %s is not attached" % event)
NameError: global name 'event' is not defined
```
This pull request fixes it.