### PR TITLE
Use targeted process to resolve library names

### DIFF
--- a/src/cc/BPF.cc
+++ b/src/cc/BPF.cc
@@ -462,7 +462,7 @@ StatusTuple BPF::check_binary_symbol(const std::string& binary_path,
                                      const std::string& symbol,
                                      uint64_t symbol_addr, bcc_symbol* output) {
   int res = bcc_resolve_symname(binary_path.c_str(), symbol.c_str(),
-                                symbol_addr, output);
+                                symbol_addr, 0, output);
   if (res < 0)
     return StatusTuple(
         -1, "Unable to find offset for binary %s symbol %s address %lx",

--- a/src/cc/bcc_proc.h
+++ b/src/cc/bcc_proc.h
@@ -27,7 +27,7 @@ extern "C" {
 typedef int (*bcc_procutils_modulecb)(const char *, uint64_t, uint64_t, void *);
 typedef void (*bcc_procutils_ksymcb)(const char *, uint64_t, void *);
 
-const char *bcc_procutils_which_so(const char *libname);
+const char *bcc_procutils_which_so(const char *libname, int pid);
 char *bcc_procutils_which(const char *binpath);
 int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
                               void *payload);

--- a/src/cc/bcc_proc.h
+++ b/src/cc/bcc_proc.h
@@ -27,11 +27,12 @@ extern "C" {
 typedef int (*bcc_procutils_modulecb)(const char *, uint64_t, uint64_t, void *);
 typedef void (*bcc_procutils_ksymcb)(const char *, uint64_t, void *);
 
-const char *bcc_procutils_which_so(const char *libname, int pid);
+char *bcc_procutils_which_so(const char *libname, int pid);
 char *bcc_procutils_which(const char *binpath);
 int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
                               void *payload);
 int bcc_procutils_each_ksym(bcc_procutils_ksymcb callback, void *payload);
+void bcc_procutils_free(const char *ptr);
 
 #ifdef __cplusplus
 }

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -304,7 +304,7 @@ int bcc_foreach_symbol(const char *module, SYM_CB cb) {
 }
 
 int bcc_resolve_symname(const char *module, const char *symname,
-                        const uint64_t addr, struct bcc_symbol *sym) {
+                        const uint64_t addr, int pid, struct bcc_symbol *sym) {
   uint64_t load_addr;
 
   sym->module = NULL;
@@ -317,7 +317,7 @@ int bcc_resolve_symname(const char *module, const char *symname,
   if (strchr(module, '/')) {
     sym->module = module;
   } else {
-    sym->module = bcc_procutils_which_so(module);
+    sym->module = bcc_procutils_which_so(module, pid);
   }
 
   if (sym->module == NULL)

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -315,7 +315,7 @@ int bcc_resolve_symname(const char *module, const char *symname,
     return -1;
 
   if (strchr(module, '/')) {
-    sym->module = module;
+    sym->module = strdup(module);
   } else {
     sym->module = bcc_procutils_which_so(module, pid);
   }

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -43,7 +43,7 @@ int bcc_resolve_global_addr(int pid, const char *module, const uint64_t address,
 int bcc_foreach_symbol(const char *module, SYM_CB cb);
 int bcc_find_symbol_addr(struct bcc_symbol *sym);
 int bcc_resolve_symname(const char *module, const char *symname,
-                        const uint64_t addr, struct bcc_symbol *sym);
+                        const uint64_t addr, int pid, struct bcc_symbol *sym);
 #ifdef __cplusplus
 }
 #endif

--- a/src/cc/usdt.cc
+++ b/src/cc/usdt.cc
@@ -223,8 +223,9 @@ std::string Context::resolve_bin_path(const std::string &bin_path) {
   if (char *which = bcc_procutils_which(bin_path.c_str())) {
     result = which;
     ::free(which);
-  } else if (const char *which_so = bcc_procutils_which_so(bin_path.c_str(), 0)) {
+  } else if (char *which_so = bcc_procutils_which_so(bin_path.c_str(), 0)) {
     result = which_so;
+    ::free(which_so);
   }
 
   return result;

--- a/src/cc/usdt.cc
+++ b/src/cc/usdt.cc
@@ -223,7 +223,7 @@ std::string Context::resolve_bin_path(const std::string &bin_path) {
   if (char *which = bcc_procutils_which(bin_path.c_str())) {
     result = which;
     ::free(which);
-  } else if (const char *which_so = bcc_procutils_which_so(bin_path.c_str())) {
+  } else if (const char *which_so = bcc_procutils_which_so(bin_path.c_str(), 0)) {
     result = which_so;
   }
 

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -110,6 +110,7 @@ struct bcc_symbol {
 
 int bcc_resolve_symname(const char *module, const char *symname, const uint64_t addr,
 		int pid, struct bcc_symbol *sym);
+void bcc_procutils_free(const char *ptr);
 void *bcc_symcache_new(int pid);
 int bcc_symcache_resolve(void *symcache, uint64_t addr, struct bcc_symbol *sym);
 void bcc_symcache_refresh(void *resolver);

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -109,7 +109,7 @@ struct bcc_symbol {
 };
 
 int bcc_resolve_symname(const char *module, const char *symname, const uint64_t addr,
-		struct bcc_symbol *sym);
+		int pid, struct bcc_symbol *sym);
 void *bcc_symcache_new(int pid);
 int bcc_symcache_resolve(void *symcache, uint64_t addr, struct bcc_symbol *sym);
 void bcc_symcache_refresh(void *resolver);

--- a/src/lua/bcc/sym.lua
+++ b/src/lua/bcc/sym.lua
@@ -32,7 +32,7 @@ end
 
 local function check_path_symbol(module, symname, addr)
   local sym = SYM()
-  if libbcc.bcc_resolve_symname(module, symname, addr or 0x0, sym) < 0 then
+  if libbcc.bcc_resolve_symname(module, symname, addr or 0x0, 0, sym) < 0 then
     if sym[0].module == nil then
       error("could not find library '%s' in the library path" % module)
     else

--- a/src/lua/bcc/sym.lua
+++ b/src/lua/bcc/sym.lua
@@ -32,15 +32,20 @@ end
 
 local function check_path_symbol(module, symname, addr)
   local sym = SYM()
+  local module_path
   if libbcc.bcc_resolve_symname(module, symname, addr or 0x0, 0, sym) < 0 then
     if sym[0].module == nil then
       error("could not find library '%s' in the library path" % module)
     else
+      module_path = ffi.string(sym[0].module)
+      libbcc.bcc_procutils_free(sym[0].module)
       error("failed to resolve symbol '%s' in '%s'" % {
-        symname, ffi.string(sym[0].module)})
+        symname, module_path})
     end
   end
-  return ffi.string(sym[0].module), sym[0].offset
+  module_path = ffi.string(sym[0].module)
+  libbcc.bcc_procutils_free(sym[0].module)
+  return module_path, sym[0].offset
 end
 
 return { create_cache=create_cache, check_path_symbol=check_path_symbol }

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -770,15 +770,15 @@ class BPF(object):
         self._add_uprobe(ev_name, res)
         return self
 
-    def detach_uprobe(self, name="", sym="", addr=None):
-        """detach_uprobe(name="", sym="", addr=None)
+    def detach_uprobe(self, name="", sym="", addr=None, pid=-1):
+        """detach_uprobe(name="", sym="", addr=None, pid=-1)
 
         Stop running a bpf function that is attached to symbol 'sym' in library
         or binary 'name'.
         """
 
         name = str(name)
-        (path, addr) = BPF._check_path_symbol(name, sym, addr, -1)
+        (path, addr) = BPF._check_path_symbol(name, sym, addr, pid)
         ev_name = "p_%s_0x%x" % (self._probe_repl.sub("_", path), addr)
         if ev_name not in self.open_uprobes:
             raise Exception("Uprobe %s is not attached" % ev_name)
@@ -822,15 +822,15 @@ class BPF(object):
         self._add_uprobe(ev_name, res)
         return self
 
-    def detach_uretprobe(self, name="", sym="", addr=None):
-        """detach_uretprobe(name="", sym="", addr=None)
+    def detach_uretprobe(self, name="", sym="", addr=None, pid=-1):
+        """detach_uretprobe(name="", sym="", addr=None, pid=-1)
 
         Stop running a bpf function that is attached to symbol 'sym' in library
         or binary 'name'.
         """
 
         name = str(name)
-        (path, addr) = BPF._check_path_symbol(name, sym, addr, -1)
+        (path, addr) = BPF._check_path_symbol(name, sym, addr, pid)
         ev_name = "r_%s_0x%x" % (self._probe_repl.sub("_", path), addr)
         if ev_name not in self.open_uprobes:
             raise Exception("Uretprobe %s is not attached" % ev_name)

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -131,11 +131,11 @@ class bcc_symbol(ct.Structure):
         ]
 
 lib.bcc_procutils_which_so.restype = ct.c_char_p
-lib.bcc_procutils_which_so.argtypes = [ct.c_char_p]
+lib.bcc_procutils_which_so.argtypes = [ct.c_char_p, ct.c_int]
 
 lib.bcc_resolve_symname.restype = ct.c_int
 lib.bcc_resolve_symname.argtypes = [
-    ct.c_char_p, ct.c_char_p, ct.c_ulonglong, ct.POINTER(bcc_symbol)]
+    ct.c_char_p, ct.c_char_p, ct.c_ulonglong, ct.c_int, ct.POINTER(bcc_symbol)]
 
 _SYM_CB_TYPE = ct.CFUNCTYPE(ct.c_int, ct.c_char_p, ct.c_ulonglong)
 lib.bcc_foreach_symbol.restype = ct.c_int

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -126,12 +126,14 @@ class bcc_symbol(ct.Structure):
     _fields_ = [
             ('name', ct.c_char_p),
             ('demangle_name', ct.c_char_p),
-            ('module', ct.c_char_p),
+            ('module', ct.POINTER(ct.c_char)),
             ('offset', ct.c_ulonglong),
         ]
 
-lib.bcc_procutils_which_so.restype = ct.c_char_p
+lib.bcc_procutils_which_so.restype = ct.POINTER(ct.c_char)
 lib.bcc_procutils_which_so.argtypes = [ct.c_char_p, ct.c_int]
+lib.bcc_procutils_free.restype = None
+lib.bcc_procutils_free.argtypes = [ct.c_void_p]
 
 lib.bcc_resolve_symname.restype = ct.c_int
 lib.bcc_resolve_symname.argtypes = [

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -30,17 +30,19 @@
 using namespace std;
 
 TEST_CASE("shared object resolution", "[c_api]") {
-  const char *libm = bcc_procutils_which_so("m", 0);
+  char *libm = bcc_procutils_which_so("m", 0);
   REQUIRE(libm);
   REQUIRE(libm[0] == '/');
   REQUIRE(string(libm).find("libm.so") != string::npos);
+  free(libm);
 }
 
 TEST_CASE("shared object resolution using loaded libraries", "[c_api]") {
-  const char *libelf = bcc_procutils_which_so("elf", getpid());
+  char *libelf = bcc_procutils_which_so("elf", getpid());
   REQUIRE(libelf);
   REQUIRE(libelf[0] == '/');
   REQUIRE(string(libelf).find("libelf") != string::npos);
+  free(libelf);
 }
 
 TEST_CASE("binary resolution with `which`", "[c_api]") {
@@ -68,6 +70,7 @@ TEST_CASE("resolve symbol name in external library", "[c_api]") {
   REQUIRE(string(sym.module).find("libc.so") != string::npos);
   REQUIRE(sym.module[0] == '/');
   REQUIRE(sym.offset != 0);
+  bcc_procutils_free(sym.module);
 }
 
 TEST_CASE("resolve symbol name in external library using loaded libraries", "[c_api]") {
@@ -77,6 +80,7 @@ TEST_CASE("resolve symbol name in external library using loaded libraries", "[c_
   REQUIRE(string(sym.module).find("libbcc.so") != string::npos);
   REQUIRE(sym.module[0] == '/');
   REQUIRE(sym.offset != 0);
+  bcc_procutils_free(sym.module);
 }
 
 extern "C" int _a_test_function(const char *a_string) {

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -30,10 +30,17 @@
 using namespace std;
 
 TEST_CASE("shared object resolution", "[c_api]") {
-  const char *libm = bcc_procutils_which_so("m");
+  const char *libm = bcc_procutils_which_so("m", 0);
   REQUIRE(libm);
   REQUIRE(libm[0] == '/');
   REQUIRE(string(libm).find("libm.so") != string::npos);
+}
+
+TEST_CASE("shared object resolution using loaded libraries", "[c_api]") {
+  const char *libelf = bcc_procutils_which_so("elf", getpid());
+  REQUIRE(libelf);
+  REQUIRE(libelf[0] == '/');
+  REQUIRE(string(libelf).find("libelf") != string::npos);
 }
 
 TEST_CASE("binary resolution with `which`", "[c_api]") {
@@ -57,8 +64,17 @@ TEST_CASE("list all kernel symbols", "[c_api]") {
 TEST_CASE("resolve symbol name in external library", "[c_api]") {
   struct bcc_symbol sym;
 
-  REQUIRE(bcc_resolve_symname("c", "malloc", 0x0, &sym) == 0);
+  REQUIRE(bcc_resolve_symname("c", "malloc", 0x0, 0, &sym) == 0);
   REQUIRE(string(sym.module).find("libc.so") != string::npos);
+  REQUIRE(sym.module[0] == '/');
+  REQUIRE(sym.offset != 0);
+}
+
+TEST_CASE("resolve symbol name in external library using loaded libraries", "[c_api]") {
+  struct bcc_symbol sym;
+
+  REQUIRE(bcc_resolve_symname("bcc", "bcc_procutils_which", 0x0, getpid(), &sym) == 0);
+  REQUIRE(string(sym.module).find("libbcc.so") != string::npos);
   REQUIRE(sym.module[0] == '/');
   REQUIRE(sym.offset != 0);
 }


### PR DESCRIPTION
This pull request implements the first strategy discussed at #853 to improve the selection of libraries for `attach_uprobe`.

To resolve library names, `bcc_procutils_which_so` now leverages mapped libraries of the targeted process, if a PID is given. It uses the kernel's `/proc/$pid/maps` to extract mapped libraries.

Any other tests I should add?

/cc @vmg @goldshtn 