### PR TITLE
add missing inclusion guards in bcc/proto.h

### DIFF
--- a/src/cc/export/proto.h
+++ b/src/cc/export/proto.h
@@ -15,6 +15,9 @@ R"********(
  * limitations under the License.
  */
 
+#ifndef __BCC_PROTO_H
+#define __BCC_PROTO_H
+
 #include <uapi/linux/if_ether.h>
 
 #define BPF_PACKET_HEADER __attribute__((packed)) __attribute__((deprecated("packet")))
@@ -142,4 +145,6 @@ struct vxlan_gbp_t {
   unsigned int key:24;
   unsigned int rsv6:8;
 } BPF_PACKET_HEADER;
+
+#endif
 )********"


### PR DESCRIPTION
The lack of the these guards causes different issues.  For example, if a program loaded through hover includes bcc/proto.h, it fails to compile because proto.h is included twice.