### PR TITLE
Fixes for LLVM 4.0 and python3

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -345,7 +345,8 @@ int BPFModule::load_includes(const string &text) {
 
 int BPFModule::annotate() {
   for (auto fn = mod_->getFunctionList().begin(); fn != mod_->getFunctionList().end(); ++fn)
-    fn->addFnAttr(Attribute::AlwaysInline);
+    if (!fn->hasFnAttribute(Attribute::NoInline))
+      fn->addFnAttr(Attribute::AlwaysInline);
 
   // separate module to hold the reader functions
   auto m = make_unique<Module>("sscanf", *ctx_);

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -284,7 +284,7 @@ static inline void bpf_store_dword(void *skb, u64 off, u64 val) {
 #define MASK(_n) ((_n) < 64 ? (1ull << (_n)) - 1 : ((u64)-1LL))
 #define MASK128(_n) ((_n) < 128 ? ((unsigned __int128)1 << (_n)) - 1 : ((unsigned __int128)-1))
 
-static unsigned int bpf_log2(unsigned int v)
+static inline unsigned int bpf_log2(unsigned int v)
 {
   unsigned int r;
   unsigned int shift;
@@ -297,7 +297,7 @@ static unsigned int bpf_log2(unsigned int v)
   return r;
 }
 
-static unsigned int bpf_log2l(unsigned long v)
+static inline unsigned int bpf_log2l(unsigned long v)
 {
   unsigned int hi = v >> 32;
   if (hi)

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -137,6 +137,8 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
                                    "-Wno-deprecated-declarations",
                                    "-Wno-gnu-variable-sized-type-not-at-end",
                                    "-fno-color-diagnostics",
+                                   "-fno-unwind-tables",
+                                   "-fno-asynchronous-unwind-tables",
                                    "-x", "c", "-c", abs_file.c_str()});
 
   KBuildHelper kbuild_helper(kdir, kernel_path_info.first);

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -197,9 +197,9 @@ def print_event(cpu, data, size):
             if args.timestamp:
                 print("%-8.3f" % (time.time() - start_ts), end="")
             ppid = get_ppid(event.pid)
-            print("%-16s %-6s %-6s %3s %s" % (event.comm, event.pid,
+            print("%-16s %-6s %-6s %3s %s" % (event.comm.decode(), event.pid,
                     ppid if ppid > 0 else "?", event.retval,
-                    ' '.join(argv[event.pid])))
+                    b' '.join(argv[event.pid]).decode()))
 
         del(argv[event.pid])
 


### PR DESCRIPTION
Avoid conflicting [no]inline attributes in function annotation. This was
probably always there but now 4.0 is treating this as an error.
Also, explicitly inline several functions in helpers.h.

Turn off unwind tables in the flags passed to clang. This was generating
calls to the elf relocator, which doesn't work for the BPF target. It is
unclear which change in LLVM 4.0 altered this behavior.

On python3, handle byte strings in the usual way for supporting
backwards compatibility.

Fixes: #876 
Signed-off-by: Brenden Blanco <bblanco@gmail.com>