### PR TITLE
Add -fno-stack-protector to CFLAGS

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -89,6 +89,7 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
   cflags->push_back("-D__HAVE_BUILTIN_BSWAP64__");
   cflags->push_back("-Wno-unused-value");
   cflags->push_back("-Wno-pointer-sign");
+  cflags->push_back("-fno-stack-protector");
 
   return 0;
 }


### PR DESCRIPTION
When compiling ebpf programs on Alpine Linux the compiler throws the following
error:

LLVM ERROR: Cannot select: 0x56049b79dcb0: ch,glue = BPFISD::CALL 0x56049a93ad60, TargetExternalSymbol:i64'__stack_chk_fail'
  0x56049b391500: i64 = TargetExternalSymbol'__stack_chk_fail'
    In function: waker

Disabling the stack protector explicitly with '-fno-stack-protector'
fixes this error.

# clang version 3.8.1 (tags/RELEASE_381/final)
Target: x86_64-alpine-linux-musl
Thread model: posix
InstalledDir: /usr/bin

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>