### PR TITLE
Fixes bio{snoop,top} on 4.10

### DIFF
--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -106,14 +106,12 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
  * test, and maintenance burden.
  */
 #ifdef REQ_WRITE
-if (req->cmd_flags & REQ_WRITE) {
+    data.rwflag = !!(req->cmd_flags & REQ_WRITE);
+#elif defined(REQ_OP_SHIFT)
+    data.rwflag = !!((req->cmd_flags >> REQ_OP_SHIFT) == REQ_OP_WRITE);
 #else
-if ((req->cmd_flags >> REQ_OP_SHIFT) == REQ_OP_WRITE) {
+    data.rwflag = !!((req->cmd_flags & REQ_OP_MASK) == REQ_OP_WRITE);
 #endif
-        data.rwflag = 1;
-    } else {
-        data.rwflag = 0;
-    }
 
     events.perf_submit(ctx, &data, sizeof(data));
     start.delete(&req);

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -137,8 +137,10 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
  */
 #ifdef REQ_WRITE
     info.rwflag = !!(req->cmd_flags & REQ_WRITE);
-#else
+#elif defined(REQ_OP_SHIFT)
     info.rwflag = !!((req->cmd_flags >> REQ_OP_SHIFT) == REQ_OP_WRITE);
+#else
+    info.rwflag = !!((req->cmd_flags & REQ_OP_MASK) == REQ_OP_WRITE);
 #endif
 
     whop = whobyreq.lookup(&req);


### PR DESCRIPTION
This commit fixes #888 by making sure `REQ_OP_SHIFT` (removed in 4.10) is defined before evaluating, and adding code to handle 4.10's use of `REQ_OP_WRITE`.

`biosnoop.py` and `biotop.py` both check whether the op is a read or write, and now use more or less the same copy pasta code to do it.

Tested on 4.10-rc2.