### PR TITLE
argdist, trace: Support non-C identifier names

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -76,8 +76,7 @@ class Probe(object):
                 self.probe_num = Probe.probe_count
                 self.probe_name = "probe_%s_%d" % \
                                 (self._display_function(), self.probe_num)
-                if self.probe_name.find(".") > 0:   # for golang
-                    self.probe_name = self.probe_name.replace(".", "_DOT_")
+                self.probe_name = re.sub(r'[^A-Za-z0-9_]', '_', self.probe_name)
 
         def __str__(self):
                 return "%s:%s:%s FLT=%s ACT=%s/%s" % (self.probe_type,


### PR DESCRIPTION
When argdist or trace face a function that has characters
in its name that are not valid in C identifiers, they now
replace these characters with an underscore (`_`) when
generating function names and structure names to include
in the BPF program. As a result, it is now possible to
trace functions that have these identifiers in their names,
such as Golang functions like `fmt.Println`.

Resolves #903 reported by @brendangregg.