### PR TITLE
[tools][memleak.py] add parameter for specifying object to load malloc/free from

### DIFF
--- a/man/man8/memleak.8
+++ b/man/man8/memleak.8
@@ -3,7 +3,7 @@
 memleak \- Print a summary of outstanding allocations and their call stacks to detect memory leaks. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B memleak [-h] [-p PID] [-t] [-a] [-o OLDER] [-c COMMAND] [-s SAMPLE_RATE]
-[-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE] [INTERVAL] [COUNT]
+[-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE] [-O OBJ] [INTERVAL] [COUNT]
 .SH DESCRIPTION
 memleak traces and matches memory allocation and deallocation requests, and
 collects call stacks for each allocation. memleak can then print a summary
@@ -52,6 +52,9 @@ Capture only allocations that are larger than or equal to MIN_SIZE bytes.
 .TP
 \-Z MAX_SIZE
 Capture only allocations that are smaller than or equal to MAX_SIZE bytes.
+.TP
+\-O OBJ
+Attach to malloc and free in specified object instead of resolving libc. Ignored when kernel allocations are profiled.
 .TP
 INTERVAL
 Print a summary of oustanding allocations and their call stacks every INTERVAL seconds.

--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -135,6 +135,8 @@ parser.add_argument("-z", "--min-size", type=int,
         help="capture only allocations larger than this size")
 parser.add_argument("-Z", "--max-size", type=int,
         help="capture only allocations smaller than this size")
+parser.add_argument("-O", "--obj", type=str, default="c",
+        help="attach to malloc & free in the specified object")
 
 args = parser.parse_args()
 
@@ -149,6 +151,7 @@ num_prints = args.count
 top_stacks = args.top
 min_size = args.min_size
 max_size = args.max_size
+obj = args.obj
 
 if min_size is not None and max_size is not None and min_size > max_size:
         print("min_size (-z) can't be greater than max_size (-Z)")
@@ -251,11 +254,11 @@ bpf_program = BPF(text=bpf_source)
 
 if not kernel_trace:
         print("Attaching to malloc and free in pid %d, Ctrl+C to quit." % pid)
-        bpf_program.attach_uprobe(name="c", sym="malloc",
+        bpf_program.attach_uprobe(name=obj, sym="malloc",
                                   fn_name="alloc_enter", pid=pid)
-        bpf_program.attach_uretprobe(name="c", sym="malloc",
+        bpf_program.attach_uretprobe(name=obj, sym="malloc",
                                      fn_name="alloc_exit", pid=pid)
-        bpf_program.attach_uprobe(name="c", sym="free",
+        bpf_program.attach_uprobe(name=obj, sym="free",
                                   fn_name="free_enter", pid=pid)
 else:
         print("Attaching to kmalloc and kfree, Ctrl+C to quit.")

--- a/tools/memleak_example.txt
+++ b/tools/memleak_example.txt
@@ -150,14 +150,16 @@ of the sampling rate applied.
 USAGE message:
 
 # ./memleak -h
-usage: memleak [-h] [-p PID] [-t] [-a] [-o OLDER] [-c COMMAND]
-                  [-s SAMPLE_RATE] [-d STACK_DEPTH] [-T TOP]
+usage: memleak.py [-h] [-p PID] [-t] [-a] [-o OLDER] [-c COMMAND]
+                  [-s SAMPLE_RATE] [-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE]
+                  [-O OBJ]
                   [interval] [count]
 
 Trace outstanding memory allocations that weren't freed.
 Supports both user-mode allocations made with malloc/free and kernel-mode
 allocations made with kmalloc/kfree.
 
+positional arguments:
   interval              interval in seconds to print outstanding allocations
   count                 number of times to print the report before exiting
 
@@ -175,13 +177,12 @@ optional arguments:
                         execute and trace the specified command
   -s SAMPLE_RATE, --sample-rate SAMPLE_RATE
                         sample every N-th allocation to decrease the overhead
-  -d STACK_DEPTH, --stack_depth STACK_DEPTH
-                        maximum stack depth to capture
   -T TOP, --top TOP     display only this many top allocating stacks (by size)
   -z MIN_SIZE, --min-size MIN_SIZE
                         capture only allocations larger than this size
   -Z MAX_SIZE, --max-size MAX_SIZE
                         capture only allocations smaller than this size
+  -O OBJ, --obj OBJ     attach to malloc & free in the specified object
 
 EXAMPLES:
 


### PR DESCRIPTION
This commit adds a way to specify object to load malloc/free from, leaving previous value as a default. In cases when binary statically links different implementation of malloc, or preloads libc from different location, memleak in current form won't capture any samples. For statically linked malloc implementation use full path to binary as OBJ.