### PR TITLE
Use PID to resolve path of target libraries

### DIFF
--- a/tools/funclatency.py
+++ b/tools/funclatency.py
@@ -201,9 +201,10 @@ if not library:
     b.attach_kretprobe(event_re=pattern, fn_name="trace_func_return")
     matched = b.num_open_kprobes()
 else:
-    b.attach_uprobe(name=library, sym_re=pattern, fn_name="trace_func_entry")
+    b.attach_uprobe(name=library, sym_re=pattern, fn_name="trace_func_entry",
+                    pid=args.pid or -1)
     b.attach_uretprobe(name=library, sym_re=pattern,
-                       fn_name="trace_func_return")
+                       fn_name="trace_func_return", pid=args.pid or -1)
     matched = b.num_open_uprobes()
 
 if matched == 0:

--- a/tools/sslsniff.py
+++ b/tools/sslsniff.py
@@ -130,18 +130,20 @@ b = BPF(text=prog)
 # on its exit (Mark Drayton)
 #
 if args.openssl:
-    b.attach_uprobe(name="ssl", sym="SSL_write", fn_name="probe_SSL_write")
-    b.attach_uprobe(name="ssl", sym="SSL_read", fn_name="probe_SSL_read_enter")
+    b.attach_uprobe(name="ssl", sym="SSL_write", fn_name="probe_SSL_write",
+                    pid=args.pid or -1)
+    b.attach_uprobe(name="ssl", sym="SSL_read", fn_name="probe_SSL_read_enter",
+                    pid=args.pid or -1)
     b.attach_uretprobe(name="ssl", sym="SSL_read",
-                       fn_name="probe_SSL_read_exit")
+                       fn_name="probe_SSL_read_exit", pid=args.pid or -1)
 
 if args.gnutls:
     b.attach_uprobe(name="gnutls", sym="gnutls_record_send",
-                    fn_name="probe_SSL_write")
+                    fn_name="probe_SSL_write", pid=args.pid or -1)
     b.attach_uprobe(name="gnutls", sym="gnutls_record_recv",
-                    fn_name="probe_SSL_read_enter")
+                    fn_name="probe_SSL_read_enter", pid=args.pid or -1)
     b.attach_uretprobe(name="gnutls", sym="gnutls_record_recv",
-                       fn_name="probe_SSL_read_exit")
+                       fn_name="probe_SSL_read_exit", pid=args.pid or -1)
 
 # define output data structure in Python
 TASK_COMM_LEN = 16  # linux/sched.h


### PR DESCRIPTION
I went through the tools and found two where we don't already leverage #875 to use the PID (if given), when resolving the path of target libraries.

/cc @adrianlzt @brendangregg 