### PR TITLE
gethostlatency: Filter by process ID

### DIFF
--- a/man/man8/gethostlatency.8
+++ b/man/man8/gethostlatency.8
@@ -21,6 +21,10 @@ and may need modifications to match your software and processor architecture.
 Since this uses BPF, only the root user can use this tool.
 .SH REQUIREMENTS
 CONFIG_BPF and bcc.
+.SH OPTIONS
+.TP
+\-p PID
+Trace this process ID only.
 .SH EXAMPLES
 .TP
 Trace host lookups (getaddrinfo/gethostbyname[2]) system wide:

--- a/tools/gethostlatency_example.txt
+++ b/tools/gethostlatency_example.txt
@@ -19,3 +19,19 @@ TIME      PID    COMM          LATms HOST
 In this example, the first call to lookup "www.iovisor.org" took 90 ms, and
 the second took 0 ms (cached). The slowest call in this example was to "foo",
 which was an unsuccessful lookup.
+
+
+USAGE message:
+
+# ./gethostlatency -h
+usage: gethostlatency [-h] [-p PID]
+
+Show latency for getaddrinfo/gethostbyname[2] calls
+
+optional arguments:
+  -h, --help         show this help message and exit
+  -p PID, --pid PID  trace this PID only
+
+examples:
+    ./gethostlatency           # trace all TCP accept()s
+    ./gethostlatency -p 181    # only trace PID 181


### PR DESCRIPTION
This pull request adds an option to `gethostlatency.py` to only trace processes with a given PID.

/cc @brendangregg 