### PR TITLE
powerpc: update the build triplet

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -167,7 +167,11 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
 
   // set up the command line argument wrapper
 #if defined(__powerpc64__)
-  driver::Driver drv("", "ppc64le-unknown-linux-gnu", diags);
+#if defined(_CALL_ELF) && _CALL_ELF == 2
+  driver::Driver drv("", "powerpc64le-unknown-linux-gnu", diags);
+#else
+  driver::Driver drv("", "powerpc64-unknown-linux-gnu", diags);
+#endif
 #elif defined(__aarch64__)
   driver::Driver drv("", "aarch64-unknown-linux-gnu", diags);
 #else


### PR DESCRIPTION
The more commonly used triplet on ppc64le happens to be
powerpc64le-unknown-linux-gnu. The existing one causes problems in
certain build environments. Change this.

While at it, also include support for building on big endian.

Reported-by: Anton Blanchard <anton@samba.org>
Signed-off-by: Naveen N. Rao <naveen.n.rao@linux.vnet.ibm.com>