### PR TITLE
remove symbol name storage optimization

### DIFF
--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -66,9 +66,9 @@ public:
 
 class ProcSyms : SymbolCache {
   struct Symbol {
-    Symbol(const std::string *name, uint64_t start, uint64_t size, int flags = 0)
+    Symbol(const char *name, uint64_t start, uint64_t size, int flags = 0)
         : name(name), start(start), size(size), flags(flags) {}
-    const std::string *name;
+    std::string name;
     uint64_t start;
     uint64_t size;
     int flags;
@@ -84,7 +84,6 @@ class ProcSyms : SymbolCache {
     std::string name_;
     uint64_t start_;
     uint64_t end_;
-    std::unordered_set<std::string> symnames_;
     std::vector<Symbol> syms_;
 
     void load_sym_table();


### PR DESCRIPTION
Summary: not only is this implementation buggy (modifying the map invalidates pointers into it) but the cost of maintaining the map outstrips any performance benefits, according to perf. remove symnames_ and simplify implementation.

Test Plan: unit tests, used in my project