### PR TITLE
Debian jessie .deb build config and automated test fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 *.swp
 *.swo
 *.pyc
+.idea
 
-# Build artefacts
+# Build artifacts
 /build/
+cmake-build-debug
+debian/**/*.log
+obj-x86_64-linux-gnu

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
   - [Arch](#arch---aur)
   - [Gentoo](#gentoo---portage)
 * [Source](#source)
-  - [Debian](#Debian)
+  - [Debian](#debian)
   - [Ubuntu](#ubuntu---source)
   - [Fedora](#fedora---source)
 * [Older Instructions](#older-instructions)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
   - [Arch](#arch---aur)
   - [Gentoo](#gentoo---portage)
 * [Source](#source)
-  - [Debian](#debian)
+  - [Debian](#debian---source)
   - [Ubuntu](#ubuntu---source)
   - [Fedora](#fedora---source)
 * [Older Instructions](#older-instructions)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -153,6 +153,86 @@ The appropriate dependencies (e.g., ```clang```, ```llvm``` with BPF backend) wi
 
 # Source
 
+## Debian - Source
+
+```
+ROUGH NOTES:
+
+Add jessie-backports repo
+Add non-free repo to sources.list
+Install latest 4.x kernel and headers from jessie-backports
+See updated control file for all package-build dependencies
+Other required tooling: devscripts
+
+debuild -b -uc -us
+
+Re-running tests:
+cd obj-x86_64-linux-gnu/
+sudo /usr/bin/ctest --force-new-ctest-process -j1 -V
+
+20: Test command: /home/mikep/bcc/obj-x86_64-linux-gnu/tests/wrapper.sh "py_uprobes" "sudo" "/home/mikep/bcc/tests/python/test_uprobes.py"  
+20: Test timeout computed to be: 9.99988e+06
+20: Python 2.7.9   
+20: .Arena 0:
+20: system bytes     =   13803520
+20: in use bytes     =    2970096
+20: Total (incl. mmap):
+20: system bytes     =   14594048
+20: in use bytes     =    3760624
+20: max mmap regions =          4
+20: max mmap bytes   =    1589248
+20: F
+20: ======================================================================
+20: FAIL: test_simple_library (__main__.TestUprobes)
+20: ----------------------------------------------------------------------
+20: Traceback (most recent call last):
+20:   File "/home/mikep/bcc/tests/python/test_uprobes.py", line 34, in test_simple_library
+20:     self.assertEqual(b["stats"][ctypes.c_int(0)].value, 2)
+20: AssertionError: 0L != 2
+
+26: Test command: /home/mikep/bcc/obj-x86_64-linux-gnu/tests/wrapper.sh "lua_test_uprobes" "sudo" "/usr/bin/luajit" "test_uprobes.lua"
+26: Test timeout computed to be: 9.99988e+06
+26: Python 2.7.9   
+26: Arena 0:
+26: system bytes     =   12394496
+26: in use bytes     =    1561664
+26: Total (incl. mmap):
+26: system bytes     =   12394496
+26: in use bytes     =    1561664
+26: max mmap regions =          4
+26: max mmap bytes   =     999424
+26: .F
+26: Failed tests:  
+26: -------------  
+26: 1) TestUprobes.test_simple_library
+26: test_uprobes.lua:38: expected: 2, actual: 0
+26: stack traceback:
+26:     test_uprobes.lua:38: in function 'TestUprobes.test_simple_library'
+26:
+26: Ran 2 tests in 0.141 seconds, 1 successes, 1 failures
+26: Failed
+26/28 Test #26: lua_test_uprobes .................***Failed    0.27 sec
+
+test 28
+      Start 28: lua_test_standalone
+
+28: Test command: /home/mikep/bcc/tests/lua/test_standalone.sh
+28: Test timeout computed to be: 9.99988e+06  
+28: + cd src/lua
+28: + [[ ! -x bcc-lua ]]
+28: + ldd bcc-lua
+28: + grep -q luajit
+28: + rm -f libbcc.so probe.lua
+28: + echo 'return function(BPF) print("Hello world") end'
+28: + ./bcc-lua probe.lua
+28: Hello world
+28: + fail 'bcc-lua runs without libbcc.so'   
+28: + echo 'test failed: bcc-lua runs without libbcc.so'
+28: test failed: bcc-lua runs without libbcc.so
+28: + exit 1
+28/28 Test #28: lua_test_standalone ..............***Failed    0.01 sec
+```
+
 ## Ubuntu - Source
 
 To build the toolchain from source, one needs:

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,12 @@ Maintainer: Brenden Blanco <bblanco@plumgrid.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.5
-Build-Depends: debhelper (>= 9), cmake, libllvm3.7 | libllvm3.8, llvm-3.7-dev | llvm-3.8-dev, libclang-3.7-dev | libclang-3.8-dev, libelf-dev, bison, flex, libedit-dev, clang-format | clang-format-3.7, python-netaddr, python-pyroute2, luajit, libluajit-5.1-dev
+Build-Depends: debhelper (>= 9), cmake, libllvm3.7 | libllvm3.8,
+    llvm-3.7-dev | llvm-3.8-dev, libclang-3.7-dev | libclang-3.8-dev,
+    libelf-dev, bison, flex, libedit-dev,
+    clang-format | clang-format-3.7 | clang-format-3.8, python (>= 2.7),
+    python-netaddr, python-pyroute2, luajit, libluajit-5.1-dev, arping,
+    inetutils-ping | iputils-ping, iperf, netperf, ethtool
 Homepage: https://github.com/iovisor/bcc
 
 Package: libbcc

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9), cmake, libllvm3.7 | libllvm3.8,
     libelf-dev, bison, flex, libedit-dev,
     clang-format | clang-format-3.7 | clang-format-3.8, python (>= 2.7),
     python-netaddr, python-pyroute2, luajit, libluajit-5.1-dev, arping,
-    inetutils-ping | iputils-ping, iperf, netperf, ethtool
+    inetutils-ping | iputils-ping, iperf, netperf, ethtool, devscripts
 Homepage: https://github.com/iovisor/bcc
 
 Package: libbcc

--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -180,7 +180,7 @@ end
 function Bpf:attach_uprobe(args)
   Bpf.check_probe_quota(1)
 
-  local path, addr = Sym.check_path_symbol(args.name, args.sym, args.addr)
+  local path, addr = Sym.check_path_symbol(args.name, args.sym, args.addr, args.pid)
   local fn = self:load_func(args.fn_name, 'BPF_PROG_TYPE_KPROBE')
   local ptype = args.retprobe and "r" or "p"
   local ev_name = string.format("%s_%s_0x%p", ptype, path:gsub("[^%a%d]", "_"), addr)

--- a/src/lua/bcc/sym.lua
+++ b/src/lua/bcc/sym.lua
@@ -30,10 +30,10 @@ local function create_cache(pid)
   }
 end
 
-local function check_path_symbol(module, symname, addr)
+local function check_path_symbol(module, symname, addr, pid)
   local sym = SYM()
   local module_path
-  if libbcc.bcc_resolve_symname(module, symname, addr or 0x0, 0, sym) < 0 then
+  if libbcc.bcc_resolve_symname(module, symname, addr or 0x0, pid or 0, sym) < 0 then
     if sym[0].module == nil then
       error("could not find library '%s' in the library path" % module)
     else

--- a/tests/lua/test_standalone.sh
+++ b/tests/lua/test_standalone.sh
@@ -19,22 +19,8 @@ if ldd bcc-lua | grep -q luajit; then
     fail "bcc-lua depends on libluajit"
 fi
 
-rm -f libbcc.so probe.lua
+rm -f probe.lua
 echo "return function(BPF) print(\"Hello world\") end" > probe.lua
-
-if ./bcc-lua "probe.lua"; then
-    fail "bcc-lua runs without libbcc.so"
-fi
-
-if ! env LIBBCC_SO_PATH=../cc/libbcc.so ./bcc-lua "probe.lua"; then
-    fail "bcc-lua cannot load libbcc.so through the environment"
-fi
-
-ln -s ../cc/libbcc.so
-
-if ! ./bcc-lua "probe.lua"; then
-    fail "bcc-lua cannot find local libbcc.so"
-fi
 
 PROBE="../../../examples/lua/offcputime.lua"
 

--- a/tests/lua/test_uprobes.lua
+++ b/tests/lua/test_uprobes.lua
@@ -27,8 +27,8 @@ int count(struct pt_regs *ctx) {
   local text = text:gsub("PID", tostring(pid))
 
   local b = BPF:new{text=text}
-  b:attach_uprobe{name="c", sym="malloc_stats", fn_name="count"}
-  b:attach_uprobe{name="c", sym="malloc_stats", fn_name="count", retprobe=true}
+  b:attach_uprobe{name="c", sym="malloc_stats", fn_name="count", pid=pid}
+  b:attach_uprobe{name="c", sym="malloc_stats", fn_name="count", pid=pid, retprobe=true}
 
   assert_equals(BPF.num_open_uprobes(), 2)
 

--- a/tests/python/test_brb2.py
+++ b/tests/python/test_brb2.py
@@ -68,6 +68,16 @@ ipr = IPRoute()
 ipdb = IPDB(nl=ipr)
 sim = Simulation(ipdb)
 
+allocated_interfaces = set(ipdb.interfaces.keys())
+
+def get_next_iface(prefix):
+    i = 0
+    while True:
+        iface = "{0}{1}".format(prefix, i)
+        if iface not in allocated_interfaces:
+            allocated_interfaces.add(iface)
+            return iface
+        i += 1
 
 class TestBPFSocket(TestCase):
     def setup_br(self, br, veth_rt_2_br, veth_pem_2_br, veth_br_2_pem):
@@ -84,15 +94,15 @@ class TestBPFSocket(TestCase):
             br1.add_port(ipdb.interfaces[veth_rt_2_br])
             br1.up()
         subprocess.call(["sysctl", "-q", "-w", "net.ipv6.conf." + br + ".disable_ipv6=1"])
-            
+
     def set_default_const(self):
         self.ns1            = "ns1"
         self.ns2            = "ns2"
         self.ns_router      = "ns_router"
-        self.br1            = "br1"
+        self.br1            = get_next_iface("br")
         self.veth_pem_2_br1 = "v20"
         self.veth_br1_2_pem = "v21"
-        self.br2            = "br2"
+        self.br2            = get_next_iface("br")
         self.veth_pem_2_br2 = "v22"
         self.veth_br2_2_pem = "v23"
 

--- a/tests/python/test_uprobes.py
+++ b/tests/python/test_uprobes.py
@@ -24,18 +24,18 @@ int count(struct pt_regs *ctx) {
         incr(0);
     return 0;
 }"""
-        text = text.replace("PID", "%d" % os.getpid())
-        print text
+        test_pid = os.getpid()
+        text = text.replace("PID", "%d" % test_pid)
         b = bcc.BPF(text=text)
-        b.attach_uprobe(name="c", sym="malloc_stats", fn_name="count")
-        b.attach_uretprobe(name="c", sym="malloc_stats", fn_name="count")
+        b.attach_uprobe(name="c", sym="malloc_stats", fn_name="count", pid=test_pid)
+        b.attach_uretprobe(name="c", sym="malloc_stats", fn_name="count", pid=test_pid)
         libc = ctypes.CDLL("libc.so.6")
         libc.malloc_stats.restype = None
         libc.malloc_stats.argtypes = []
         libc.malloc_stats()
         self.assertEqual(b["stats"][ctypes.c_int(0)].value, 2)
-        b.detach_uretprobe(name="c", sym="malloc_stats")
-        b.detach_uprobe(name="c", sym="malloc_stats")
+        b.detach_uretprobe(name="c", sym="malloc_stats", pid=test_pid)
+        b.detach_uprobe(name="c", sym="malloc_stats", pid=test_pid)
 
     def test_simple_binary(self):
         text = """

--- a/tests/python/test_uprobes.py
+++ b/tests/python/test_uprobes.py
@@ -18,12 +18,14 @@ static void incr(int idx) {
         ++(*ptr);
 }
 int count(struct pt_regs *ctx) {
+    bpf_trace_printk("count() uprobe fired");
     u32 pid = bpf_get_current_pid_tgid();
     if (pid == PID)
         incr(0);
     return 0;
 }"""
         text = text.replace("PID", "%d" % os.getpid())
+        print text
         b = bcc.BPF(text=text)
         b.attach_uprobe(name="c", sym="malloc_stats", fn_name="count")
         b.attach_uretprobe(name="c", sym="malloc_stats", fn_name="count")


### PR DESCRIPTION
Updated deb packaging config to support building packages jessie / jessie-backports

Updated INSTALL.md with Debian build / install instructions

Updated Python and Lua uprobes tests and related code to take advantage of https://github.com/iovisor/bcc/pull/875

Removed `libbcc.so`-related tests from `tests/lua/test_standalone.sh` since one was failing and all were obsoleted by a change to statically link libbcc into `bcc-lua`