### PR TITLE
tplist: don't fail if no verbosity is supplied

### DIFF
--- a/tools/tplist.py
+++ b/tools/tplist.py
@@ -26,7 +26,7 @@ parser.add_argument("-p", "--pid", type=int, default=None,
         help="List USDT probes in the specified process")
 parser.add_argument("-l", "--lib", default="",
         help="List USDT probes in the specified library or executable")
-parser.add_argument("-v", dest="verbosity", action="count",
+parser.add_argument("-v", dest="verbosity", action="count", default=0,
         help="Increase verbosity level (print variables, arguments, etc.)")
 parser.add_argument(dest="filter", nargs="?",
         help="A filter that specifies which probes/tracepoints to print")


### PR DESCRIPTION
Initialise the verbosity argument to 0, so that when no verbosity is
provided we don't fail with

$ tplist
kvmmmu:kvm_mmu_pagetable_walk
unorderable types: NoneType() > int()