### PR TITLE
Use fast compression in test deb builds

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -24,14 +24,20 @@ pushd $TMP
 tar xf bcc_$revision.orig.tar.gz
 cd bcc
 
+debuild=debuild
 if [[ "$buildtype" = "test" ]]; then
+  # when testing, use faster compression options
+  debuild+=" --preserve-envvar PATH"
+  echo -e '#!/bin/bash\nexec /usr/bin/dpkg-deb -z1 "$@"' \
+    | sudo tee /usr/local/bin/dpkg-deb
+  sudo chmod +x /usr/local/bin/dpkg-deb
   dch -b -v $revision-$release "$git_subject"
 fi
 if [[ "$buildtype" = "nightly" ]]; then
   dch -v $revision-$release "$git_subject"
 fi
 
-DEB_BUILD_OPTIONS="nocheck parallel=${PARALLEL}" debuild -us -uc
+DEB_BUILD_OPTIONS="nocheck parallel=${PARALLEL}" $debuild -us -uc
 popd
 
 cp $TMP/*.deb .


### PR DESCRIPTION
Builds on GCE/ubuntu image were taking a long time due to combination of
disk speed/single core, and the default dpkg-deb compression level
(-z9). The dpkg-deb alone step was taking up to 5 minutes. Reduce to ~1
minute by forcing -z1. Unfortunately, it was not obvious how to capture
the option in debuild command, so this is a bit hacky.

Signed-off-by: Brenden Blanco <bblanco@gmail.com>