### PR TITLE
Add MapTypesVisitor for arbitrary inspection of types used as keys/va…

### DIFF
--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -100,6 +100,10 @@ public:
   StatusTuple close_perf_buffer(const std::string& name);
   void poll_perf_buffer(const std::string& name, int timeout = -1);
 
+  BPFModule* get_module() const {
+    return bpf_module_.get();
+  }
+
 private:
   StatusTuple load_func(const std::string& func_name, enum bpf_prog_type type,
                         int& fd);

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -67,7 +67,8 @@ target_link_libraries(bcc-static b_frontend clang_frontend bcc-loader-static ${c
 
 install(TARGETS bcc-shared LIBRARY COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES bpf_common.h bpf_module.h bcc_syms.h bcc_exception.h libbpf.h perf_reader.h BPF.h BPFTable.h shared_table.h COMPONENT libbcc
+install(FILES bpf_common.h bpf_module.h bcc_syms.h bcc_exception.h libbpf.h
+perf_reader.h BPF.h BPFTable.h shared_table.h table_desc.h COMPONENT libbcc
   DESTINATION include/bcc)
 install(DIRECTORY compat/linux/ COMPONENT libbcc
   DESTINATION include/bcc/compat/linux

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -326,6 +326,7 @@ unique_ptr<ExecutionEngine> BPFModule::finalize_rw(unique_ptr<Module> m) {
 // load an entire c file as a module
 int BPFModule::load_cfile(const string &file, bool in_memory, const char *cflags[], int ncflags) {
   clang_loader_ = make_unique<ClangLoader>(&*ctx_, flags_);
+  clang_loader_->set_map_types_visitor(map_types_visitor_);
   if (clang_loader_->parse(&mod_, &tables_, file, in_memory, cflags, ncflags))
     return -1;
   return 0;
@@ -414,6 +415,14 @@ int BPFModule::run_pass_manager(Module &mod) {
     PM.add(createPrintModulePass(outs()));
   PM.run(mod);
   return 0;
+}
+
+const std::vector<TableDesc>* BPFModule::get_tables() const {
+  return tables_.get();
+}
+
+void BPFModule::set_map_types_visitor(const std::shared_ptr<MapTypesVisitor>& visitor) {
+  map_types_visitor_ = visitor;
 }
 
 int BPFModule::finalize() {

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -34,6 +34,7 @@ namespace ebpf {
 struct TableDesc;
 class BLoader;
 class ClangLoader;
+class MapTypesVisitor;
 
 class BPFModule {
  private:
@@ -88,6 +89,8 @@ class BPFModule {
   int table_leaf_scanf(size_t id, const char *buf, void *leaf);
   char * license() const;
   unsigned kern_version() const;
+  const std::vector<TableDesc>* get_tables() const;
+  void set_map_types_visitor(const std::shared_ptr<MapTypesVisitor>& visitor);
  private:
   unsigned flags_;  // 0x1 for printing
   std::string filename_;
@@ -104,6 +107,7 @@ class BPFModule {
   std::vector<std::string> function_names_;
   std::map<llvm::Type *, llvm::Function *> readers_;
   std::map<llvm::Type *, llvm::Function *> writers_;
+  std::shared_ptr<MapTypesVisitor> map_types_visitor_;
 };
 
 }  // namespace ebpf

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -265,6 +265,7 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
   string out_str1;
   llvm::raw_string_ostream os1(out_str1);
   BFrontendAction bact(os1, flags_);
+  bact.set_map_types_visitor(map_types_visitor_);
   if (!compiler1.ExecuteAction(bact))
     return -1;
   unique_ptr<llvm::MemoryBuffer> out_buf1 = llvm::MemoryBuffer::getMemBuffer(out_str1);
@@ -298,5 +299,8 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
   return 0;
 }
 
+void ClangLoader::set_map_types_visitor(const std::shared_ptr<MapTypesVisitor>& visitor) {
+  map_types_visitor_ = visitor;
+}
 
 }  // namespace ebpf

--- a/src/cc/frontends/clang/loader.h
+++ b/src/cc/frontends/clang/loader.h
@@ -29,6 +29,7 @@ class MemoryBuffer;
 namespace ebpf {
 
 struct TableDesc;
+class MapTypesVisitor;
 
 class ClangLoader {
  public:
@@ -36,10 +37,14 @@ class ClangLoader {
   ~ClangLoader();
   int parse(std::unique_ptr<llvm::Module> *mod, std::unique_ptr<std::vector<TableDesc>> *tables,
             const std::string &file, bool in_memory, const char *cflags[], int ncflags);
+
+  void set_map_types_visitor(const std::shared_ptr<MapTypesVisitor>& visitor);
+
  private:
   static std::map<std::string, std::unique_ptr<llvm::MemoryBuffer>> remapped_files_;
   llvm::LLVMContext *ctx_;
   unsigned flags_;
+  std::shared_ptr<MapTypesVisitor> map_types_visitor_;
 };
 
 }  // namespace ebpf

--- a/src/cc/table_desc.h
+++ b/src/cc/table_desc.h
@@ -23,6 +23,11 @@ namespace llvm {
 class Function;
 }
 
+namespace clang {
+class ASTContext;
+class QualType;
+}
+
 namespace ebpf {
 
 struct TableDesc {
@@ -41,6 +46,17 @@ struct TableDesc {
   llvm::Function *leaf_snprintf;
   bool is_shared;
   bool is_extern;
+};
+
+class MapTypesVisitor {
+ public:
+  virtual ~MapTypesVisitor() {}
+
+  virtual void visit(
+      clang::ASTContext& C,
+      const std::string& table,
+      clang::QualType keyType,
+      clang::QualType leafType) = 0;
 };
 
 }  // namespace ebpf


### PR DESCRIPTION
…lues in BPF tables

I have a C++ project that among other things attempts to read BPF tables without having the type information for table keys and values at compile time.
More specifically, arbitrary BPF programs can be passed to my program and loaded, and my program needs to be able to read data that the BPF programs put in their tables.
In order to have an idea of how to convert the void pointer returned by bpf_lookup_elem() into usable data, my program needs access to the layout of the types constituting the tables' keys/values.
My approach is to have a visitor interface that can be called with the key/value AST types for each table during one of the compiler passes over the BPF program.
As an aside, the visitor I use traverses the AST and creates a lambda of the type folly::dynamic(const void*) that is callable with the pointer returned by bpf_lookup_elem() on the table. See https://github.com/facebook/folly/blob/master/folly/docs/Dynamic.md - effectively, I'm creating converters to JSON-codable dynamic objects similar to python dicts etc.
I don't particularly like the intrusiveness of threading the visitor through to the appropriate AST pass - as you can see, it's quite a few levels of indirection down from the API
However, I found this preferable to the two other approaches I could think of -
  Adding folly::dynamic as a dependency to libbcc and building in the converters directly
    This seems too heavyweight for a feature that is unlikely to have additional customers
  Instead of injecting the visitor, exposing necessary AST data out through the API for external processing
    This has the same issues as my ultimate approach but worse, as multiple clang components (ASTContext, QualTypes) would have to be saved and exposed at an API level

If anyone has a cleaner approach, I'm all ears

Also exposes table_desc.h in include/ (for MapTypesVisitor interface), BPFModule from BPF, and the vector of TableDescs from the BPFModule

I tested this with my project and by compiling/running bcc tests.