### PR TITLE
llcstat: fix TypeError on python3

### DIFF
--- a/tools/llcstat.py
+++ b/tools/llcstat.py
@@ -104,7 +104,7 @@ for (k, v) in b.get_table('ref_count').items():
     # This happens on some PIDs due to missed counts caused by sampling
     hit = (v.value - miss) if (v.value >= miss) else 0
     print('{:<8d} {:<16s} {:<4d} {:>12d} {:>12d} {:>6.2f}%'.format(
-        k.pid, k.name, k.cpu, v.value, miss,
+        k.pid, k.name.decode(), k.cpu, v.value, miss,
         (float(hit) / float(v.value)) * 100.0))
 print('Total References: {} Total Misses: {} Hit Rate: {:.2f}%'.format(
     tot_ref, tot_miss, (float(tot_ref - tot_miss) / float(tot_ref)) * 100.0))


### PR DESCRIPTION
The bytes object has no __format__ method of its own, inheriting it from
object, so an exception is thrown in python3 when it's passed to a
formatted string since formatting instructions are type specific.

$: ./llcstat
Running for 10 seconds or hit Ctrl-C to end.
PID      NAME             CPU     REFERENCE         MISS    HIT%
Traceback (most recent call last):
  File "./llcstat", line 108, in <module>
    (float(hit) / float(v.value)) * 100.0))
TypeError: non-empty format string passed to object.__format__