### PR TITLE
Add xrange Python 2 -> 3 compatibility

### DIFF
--- a/tools/cpuunclaimed.py
+++ b/tools/cpuunclaimed.py
@@ -169,10 +169,10 @@ if args.csv:
     if args.timestamp:
         print("TIME", end=",")
     print("TIMESTAMP_ns", end=",")
-    print(",".join("CPU" + str(c) for c in xrange(ncpu)), end="")
+    print(",".join("CPU" + str(c) for c in range(ncpu)), end="")
     if args.fullcsv:
         print(",", end="")
-        print(",".join("OFFSET_ns_CPU" + str(c) for c in xrange(ncpu)), end="")
+        print(",".join("OFFSET_ns_CPU" + str(c) for c in range(ncpu)), end="")
     print()
 else:
     print(("Sampling run queues... Output every %s seconds. " +
@@ -255,10 +255,10 @@ while 1:
                     if args.timestamp:
                         print("%-8s" % strftime("%H:%M:%S"), end=",")
                     print("%d" % g_time, end=",")
-                    print(",".join(str(lens[c]) for c in xrange(ncpu)), end="")
+                    print(",".join(str(lens[c]) for c in range(ncpu)), end="")
                     if args.fullcsv:
                         print(",", end="")
-                        print(",".join(str(offs[c]) for c in xrange(ncpu)))
+                        print(",".join(str(offs[c]) for c in range(ncpu)))
                     else:
                         print()
             else:

--- a/tools/tplist.py
+++ b/tools/tplist.py
@@ -64,7 +64,7 @@ def print_tracepoints():
                                 print_tpoint(category, event)
 
 def print_usdt_argument_details(location):
-        for idx in xrange(0, location.num_arguments):
+        for idx in range(0, location.num_arguments):
                 arg = location.get_argument(idx)
                 print("    argument #%d %s" % (idx+1, arg))
 
@@ -72,7 +72,7 @@ def print_usdt_details(probe):
         if args.verbosity > 0:
                 print(probe)
                 if args.verbosity > 1:
-                        for idx in xrange(0, probe.num_locations):
+                        for idx in range(0, probe.num_locations):
                                 loc = probe.get_location(idx)
                                 print("  location #%d %s" % (idx+1, loc))
                                 print_usdt_argument_details(loc)


### PR DESCRIPTION
In case returning a list in Py2 is acceptable, I can update the patch to replace xrange by range instead.