### PR TITLE
usdt: fix argument passing on python3

### DIFF
--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -120,7 +120,7 @@ class USDT(object):
                 raise USDTException("USDT failed to instrument PID %d" % pid)
         elif path:
             self.path = path
-            self.context = lib.bcc_usdt_new_frompath(path)
+            self.context = lib.bcc_usdt_new_frompath(path.encode('ascii'))
             if self.context == None:
                 raise USDTException("USDT failed to instrument path %s" % path)
         else:


### PR DESCRIPTION
This fixes the following error:

$: ./tplist -v -v -l /usr/lib64/dri/i965_dri.so
argument 1: <class 'TypeError'>: wrong type