### PR TITLE
support bcc on arm64(aarch64) platform

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -135,6 +135,11 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, unique_ptr<vector<TableDes
   // 22 Jul 2016. Also see bcc #615.
   vector<const char *> flags_cstr({"-O0", "-emit-llvm", "-I", dstack.cwd(),
                                    "-Wno-deprecated-declarations",
+                                   "-Wno-asm-operand-widths",
+                                   "-Wno-visibility",
+                                   "-Wno-int-to-pointer-cast",
+                                   "-Wno-implicit-function-declaration", 
+                                   "-Wno-tautological-compare",
                                    "-Wno-gnu-variable-sized-type-not-at-end",
                                    "-fno-color-diagnostics",
                                    "-fno-unwind-tables",


### PR DESCRIPTION
As for aarch64 platform, the corresponding linux kernel header files might contain assemble code and register names directly. However clang compiler does not recognize them and will fail to compile them. Therefore, in order to make clang compiler happy, some header files will be revised in order to avoid including them. But these header file changes will be rollbacked automatically when bcc command has finished. 