### PR TITLE
Travis CI build to check compliance with PEP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: generic
+install:
+  - sudo apt-get install -y python-pip
+  - sudo pip install pep8
+script:
+  - find tools/ -type f -name "*.py" | xargs pep8 -r --show-source --ignore=E123,E125,E126,E127,E128,E302

--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -200,7 +200,7 @@ u64 __time = bpf_ktime_get_ns();
                 elif self.probe_type == "u":
                         self.library = parts[1]
                         self.probe_func_name = self._make_valid_identifier(
-                                "%s_probe%d" % \
+                                "%s_probe%d" %
                                 (self.function, Probe.next_probe_index))
                         self._enable_usdt_probe()
                 else:
@@ -238,10 +238,10 @@ u64 __time = bpf_ktime_get_ns();
                         (any(map(check, self.exprs)) or check(self.filter))
 
                 self.probe_func_name = self._make_valid_identifier(
-                        "%s_probe%d" % \
+                        "%s_probe%d" %
                         (self.function, Probe.next_probe_index))
                 self.probe_hash_name = self._make_valid_identifier(
-                        "%s_hash%d" % \
+                        "%s_hash%d" %
                         (self.function, Probe.next_probe_index))
                 Probe.next_probe_index += 1
 

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -13,7 +13,7 @@
 #
 # Strongly inspired by Brendan Gregg's work on the mysqld_qslower script.
 #
-# Copyright 2017, Sasha Goldshtein 
+# Copyright 2017, Sasha Goldshtein
 # Licensed under the Apache License, Version 2.0
 #
 # 15-Feb-2017   Sasha Goldshtein   Created this.
@@ -27,7 +27,7 @@ examples = """examples:
     dbslower postgres            # trace PostgreSQL queries slower than 1ms
     dbslower postgres -p 188 322 # trace specific PostgreSQL processes
     dbslower mysql -p 480 -m 30  # trace MySQL queries slower than 30ms
-    dbslower mysql -p 480 -v     # trace MySQL queries and print the BPF program
+    dbslower mysql -p 480 -v     # trace MySQL queries & print the BPF program
 """
 parser = argparse.ArgumentParser(
     description="",
@@ -134,4 +134,3 @@ print("%-14s %-6s %8s %s" % ("TIME(s)", "PID", "MS", "QUERY"))
 bpf["events"].open_perf_buffer(print_event, page_cnt=64)
 while True:
     bpf.kprobe_poll()
-

--- a/tools/dbstat.py
+++ b/tools/dbstat.py
@@ -8,7 +8,7 @@
 # This tool uses USDT probes, which means it needs MySQL and PostgreSQL built
 # with USDT (DTrace) support.
 #
-# Copyright 2017, Sasha Goldshtein 
+# Copyright 2017, Sasha Goldshtein
 # Licensed under the Apache License, Version 2.0
 #
 # 15-Feb-2017   Sasha Goldshtein   Created this.
@@ -80,7 +80,7 @@ int probe_end(struct pt_regs *ctx) {
 }
 """
 program = program.replace("SCALE", str(1000 if args.microseconds else 1000000))
-program = program.replace("FILTER", "" if args.threshold == 0 else \
+program = program.replace("FILTER", "" if args.threshold == 0 else
         "if (delta / 1000000 < %d) { return 0; }" % args.threshold)
 
 usdts = map(lambda pid: USDT(pid=pid), args.pids)

--- a/tools/old/memleak.py
+++ b/tools/old/memleak.py
@@ -186,8 +186,9 @@ int alloc_exit(struct pt_regs *ctx)
         allocs.update(&address, &info);
 
         if (SHOULD_PRINT) {
-                bpf_trace_printk("alloc exited, size = %lu, result = %lx, frames = %d\\n",
-                                 info.size, address, info.num_frames);
+                bpf_trace_printk("alloc exited, size = %lu, result = %lx,"
+                                 "frames = %d\\n", info.size, address,
+                                 info.num_frames);
         }
         return 0;
 }

--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -23,7 +23,8 @@ import sys
 #  cat syscallent.h | awk -F, '{ gsub(/[ \t"}]/, "", $4);
 #                                gsub(/[ \t/*]/, "", $5);
 #                                print "    "$5": \""$4"\","; }
-#                              BEGIN { print "syscalls = {" } END { print "}" }'
+#                              BEGIN { print "syscalls = {" }
+#                              END { print "}" }'
 #
 syscalls = {
     0: "read",
@@ -459,7 +460,7 @@ def comm_for_pid(pid):
 
 def agg_colval(key):
     if args.process:
-        return "%-6d %-15s" % (key.value, comm_for_pid(key.value)) 
+        return "%-6d %-15s" % (key.value, comm_for_pid(key.value))
     else:
         return syscalls.get(key.value, "[unknown: %d]" % key.value)
 
@@ -478,7 +479,8 @@ def print_latency_stats():
     data = bpf["data"]
     print("[%s]" % strftime("%H:%M:%S"))
     print("%-22s %8s %16s" % (agg_colname, "COUNT", time_colname))
-    for k, v in sorted(data.items(), key=lambda kv: -kv[1].total_ns)[:args.top]:
+    for k, v in sorted(data.items(),
+                       key=lambda kv: -kv[1].total_ns)[:args.top]:
         if k.value == 0xFFFFFFFF:
             continue    # happens occasionally, we don't need it
         print(("%-22s %8d " + ("%16.6f" if args.milliseconds else "%16.3f")) %
@@ -497,4 +499,3 @@ while True:
         if not args.interval:
             print_stats()
         break
-

--- a/tools/tplist.py
+++ b/tools/tplist.py
@@ -66,7 +66,7 @@ def print_tracepoints():
 def print_usdt_argument_details(location):
         for idx in range(0, location.num_arguments):
                 arg = location.get_argument(idx)
-                print("    argument #%d %s" % (idx+1, arg))
+                print("    argument #%d %s" % (idx + 1, arg))
 
 def print_usdt_details(probe):
         if args.verbosity > 0:
@@ -74,7 +74,7 @@ def print_usdt_details(probe):
                 if args.verbosity > 1:
                         for idx in range(0, probe.num_locations):
                                 loc = probe.get_location(idx)
-                                print("  location #%d %s" % (idx+1, loc))
+                                print("  location #%d %s" % (idx + 1, loc))
                                 print_usdt_argument_details(loc)
                 else:
                         print("  %d location(s)" % probe.num_locations)

--- a/tools/trace.py
+++ b/tools/trace.py
@@ -53,7 +53,8 @@ class Probe(object):
                 self.probe_num = Probe.probe_count
                 self.probe_name = "probe_%s_%d" % \
                                 (self._display_function(), self.probe_num)
-                self.probe_name = re.sub(r'[^A-Za-z0-9_]', '_', self.probe_name)
+                self.probe_name = re.sub(r'[^A-Za-z0-9_]', '_',
+                                         self.probe_name)
 
         def __str__(self):
                 return "%s:%s:%s FLT=%s ACT=%s/%s" % (self.probe_type,
@@ -81,7 +82,8 @@ class Probe(object):
                                              text).groups()
 
                 self._parse_spec(spec)
-                self.signature = sig[1:-1] if sig else None # remove the parens
+                # Remove the parens
+                self.signature = sig[1:-1] if sig else None
                 if self.signature and self.probe_type in ['u', 't']:
                         self._bail("USDT and tracepoint probes can't have " +
                                    "a function signature; use arg1, arg2, " +

--- a/tools/ucalls.py
+++ b/tools/ucalls.py
@@ -257,7 +257,8 @@ def get_data():
                            bpf["systimes"].items())
             data.extend(syscalls)
         else:
-            syscalls = map(lambda kv: (bpf.ksym(kv[0].value), (kv[1].value, 0)),
+            syscalls = map(lambda kv: (bpf.ksym(kv[0].value),
+                                       (kv[1].value, 0)),
                            bpf["syscounts"].items())
             data.extend(syscalls)
 
@@ -294,8 +295,8 @@ while True:
         data = data[-args.top:]
     for key, value in data:
         if args.latency:
-            time = value[1]/1000000.0 if args.milliseconds else \
-                   value[1]/1000.0
+            time = value[1] / 1000000.0 if args.milliseconds else \
+                   value[1] / 1000.0
             print("%-50s %8d %6.2f" % (key, value[0], time))
         else:
             print("%-50s %8d" % (key, value[0]))

--- a/tools/uflow.py
+++ b/tools/uflow.py
@@ -97,7 +97,7 @@ int NAME(struct pt_regs *ctx) {
 def enable_probe(probe_name, func_name, read_class, read_method, is_return):
     global program, trace_template, usdt
     depth = "*depth + 1" if not is_return else "*depth | (1ULL << 63)"
-    update = "++(*depth);" if not is_return else  "if (*depth) --(*depth);"
+    update = "++(*depth);" if not is_return else "if (*depth) --(*depth);"
     filter_class = "if (!prefix_class(data.clazz)) { return 0; }" \
                    if args.clazz else ""
     filter_method = "if (!prefix_method(data.method)) { return 0; }" \

--- a/tools/ugc.py
+++ b/tools/ugc.py
@@ -134,8 +134,10 @@ if args.language == "java":
     bpf_probe_read(&event.string1, sizeof(event.string1), (void *)manager);
     bpf_probe_read(&event.string2, sizeof(event.string2), (void *)pool);
     """
-    formatter = lambda e: "%s %s used=%d->%d max=%d->%d" % \
-                (e.string1, e.string2, e.field1, e.field3, e.field2, e.field4)
+
+    def formatter(e):
+        "%s %s used=%d->%d max=%d->%d" % \
+            (e.string1, e.string2, e.field1, e.field3, e.field2, e.field4)
     probes.append(Probe("mem__pool__gc__begin", "mem__pool__gc__end",
                         begin_save, end_save, formatter))
     probes.append(Probe("gc__begin", "gc__end",
@@ -155,8 +157,10 @@ elif args.language == "python":
     event.field1 = e->field1;
     event.field2 = objs;
     """
-    formatter = lambda event: "gen %d GC collected %d objects" % \
-                              (event.field1, event.field2)
+
+    def formatter(event):
+        "gen %d GC collected %d objects" % \
+            (event.field1, event.field2)
     probes.append(Probe("gc__start", "gc__done",
                         begin_save, end_save, formatter))
 #
@@ -214,10 +218,10 @@ start_ts = time.time()
 
 def print_event(cpu, data, size):
     event = ct.cast(data, ct.POINTER(GCEvent)).contents
-    elapsed = event.elapsed_ns/1000000 if args.milliseconds else \
-              event.elapsed_ns/1000
+    elapsed = event.elapsed_ns / 1000000 if args.milliseconds else \
+              event.elapsed_ns / 1000
     description = probes[event.probe_index].format(event)
-    if args.filter and not args.filter in description:
+    if args.filter and args.filter not in description:
         return
     print("%-8.3f %-8.2f %s" % (time.time() - start_ts, elapsed, description))
 

--- a/tools/uobjnew.py
+++ b/tools/uobjnew.py
@@ -110,7 +110,8 @@ int object_alloc_entry(struct pt_regs *ctx) {
     usdt.enable_probe_or_bail("object__create", "object_alloc_entry")
     for thing in ["string", "hash", "array"]:
         program += create_template.replace("THETHING", thing)
-        usdt.enable_probe_or_bail("%s__create" % thing, "%s_alloc_entry" % thing)
+        usdt.enable_probe_or_bail("%s__create" % thing,
+                                  "%s_alloc_entry" % thing)
 #
 # C
 #

--- a/tools/ustat.py
+++ b/tools/ustat.py
@@ -244,8 +244,9 @@ class Tool(object):
             counts.update(probe.get_counts(self.bpf))
             targets.update(probe.targets)
         if self.args.sort:
-            counts = sorted(counts.items(), key=lambda kv:
-                            -kv[1].get(self.args.sort.upper(), 0))
+            sort_field = self.args.sort.upper()
+            counts = sorted(counts.items(),
+                            key=lambda kv: -kv[1].get(sort_field, 0))
         else:
             counts = sorted(counts.items(), key=lambda kv: kv[0])
         for pid, stats in counts:


### PR DESCRIPTION
This Travis CI build only checks the compliance with PEP8 (ignoring E123, E125, E126, E127, E128, and E302).

It only runs `pep8` against Python files in `tools/`. Should I extend it to all Python files in the repository?

I installed `pep8` using pip to get the last version; the version in Ubuntu 12.04 packages misses a few errors.

/cc @brendangregg 