### PR TITLE
Fix file descriptor leak

### DIFF
--- a/src/cc/bcc_perf_map.c
+++ b/src/cc/bcc_perf_map.c
@@ -44,6 +44,7 @@ int bcc_perf_map_nstgid(int pid) {
       nstgid = (int)strtol(strrchr(line, '\t'), NULL, 10);
   }
   free(line);
+  fclose(status);
 
   return nstgid;
 }


### PR DESCRIPTION
If you keep `tools/ustat.py` running for more than 17min (with 1sec refresh) it errors out with `too many open files`. Other tools may be affected.