### PR TITLE
Fix "for loop initial declarations only in C99" compile error

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -246,7 +246,8 @@ static int find_buildid(Elf *e, char *buildid) {
 
   char *buf = (char *)data->d_buf + 16;
   size_t length = data->d_size - 16;
-  for (size_t i = 0; i < length; ++i) {
+  size_t i = 0;
+  for (i = 0; i < length; ++i) {
     sprintf(buildid + (i * 2), "%02hhx", buf[i]);
   }
 


### PR DESCRIPTION
#967 seems to have introduced a build failure under GCC 4.8.4 (Ubuntu 14.04):

```
/home/mark/bcc/src/cc/bcc_elf.c: In function ‘find_buildid’:
/home/mark/bcc/src/cc/bcc_elf.c:249:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (size_t i = 0; i < length; ++i) {
   ^
/home/mark/bcc/src/cc/bcc_elf.c:249:3: note: use option -std=c99 or -std=gnu99 to compile your code
```

This fixes it. cc @goldshtn 