### PR TITLE
Improve matching of file-backed memory mappings

### DIFF
--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -70,6 +70,16 @@ char *bcc_procutils_which(const char *binpath) {
   return 0;
 }
 
+int bcc_mapping_is_file_backed(const char *mapname) {
+  return mapname[0] &&
+    strncmp(mapname, "//anon", sizeof("//anon") - 1) &&
+    strncmp(mapname, "/dev/zero", sizeof("/dev/zero") - 1) &&
+    strncmp(mapname, "/anon_hugepage", sizeof("/anon_hugepage") - 1) &&
+    strncmp(mapname, "[stack", sizeof("[stack") - 1) &&
+    strncmp(mapname, "/SYSV", sizeof("/SYSV") - 1) &&
+    strncmp(mapname, "[heap]", sizeof("[heap]") - 1);
+}
+
 int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
                               void *payload) {
   char procmap_filename[128];
@@ -102,7 +112,7 @@ int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
 
       while (isspace(mapname[0])) mapname++;
 
-      if (strchr(perm, 'x') && mapname[0] && mapname[0] != '[') {
+      if (strchr(perm, 'x') && bcc_mapping_is_file_backed(mapname)) {
         if (callback(mapname, (uint64_t)begin, (uint64_t)end, payload) < 0)
           break;
       }

--- a/src/cc/bcc_proc.h
+++ b/src/cc/bcc_proc.h
@@ -29,6 +29,7 @@ typedef void (*bcc_procutils_ksymcb)(const char *, uint64_t, void *);
 
 char *bcc_procutils_which_so(const char *libname, int pid);
 char *bcc_procutils_which(const char *binpath);
+int bcc_mapping_is_file_backed(const char *mapname);
 int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
                               void *payload);
 int bcc_procutils_each_ksym(bcc_procutils_ksymcb callback, void *payload);

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -64,6 +64,18 @@ TEST_CASE("list all kernel symbols", "[c_api]") {
   bcc_procutils_each_ksym(_test_ksym, NULL);
 }
 
+TEST_CASE("file-backed mapping identification") {
+  CHECK(bcc_mapping_is_file_backed("/bin/ls") == 1);
+  CHECK(bcc_mapping_is_file_backed("") == 0);
+  CHECK(bcc_mapping_is_file_backed("//anon") == 0);
+  CHECK(bcc_mapping_is_file_backed("/dev/zero") == 0);
+  CHECK(bcc_mapping_is_file_backed("/anon_hugepage") == 0);
+  CHECK(bcc_mapping_is_file_backed("/anon_hugepage (deleted)") == 0);
+  CHECK(bcc_mapping_is_file_backed("[stack") == 0);
+  CHECK(bcc_mapping_is_file_backed("/SYSV") == 0);
+  CHECK(bcc_mapping_is_file_backed("[heap]") == 0);
+}
+
 TEST_CASE("resolve symbol name in external library", "[c_api]") {
   struct bcc_symbol sym;
 


### PR DESCRIPTION
Use the same rules as perf to determine if a mapping in /proc/pid/maps is
file-backed. This allows mappings in anonymous huge pages and so on to fall
back to resolving from /tmp/perf-pid.map, if appropriate.

ref: http://lxr.free-electrons.com/source/tools/perf/util/map.c#L28