### PR TITLE
Restrict rewrite of unary operators to dereference operator

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -200,7 +200,7 @@ bool ProbeVisitor::VisitBinaryOperator(BinaryOperator *E) {
   return true;
 }
 bool ProbeVisitor::VisitUnaryOperator(UnaryOperator *E) {
-  if (E->getOpcode() == UO_AddrOf)
+  if (E->getOpcode() != UO_Deref)
     return true;
   if (memb_visited_.find(E) != memb_visited_.end())
     return true;

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -408,6 +408,17 @@ int dns_test(struct __sk_buff *skb) {
         """
         b = BPF(text=text)
 
+    def test_unary_operator(self):
+        text = """
+#include <linux/fs.h>
+#include <uapi/linux/ptrace.h>
+int trace_read_entry(struct pt_regs *ctx, struct file *file) {
+    return !file->f_op->read_iter;
+}
+        """
+        b = BPF(text=text)
+        b.attach_kprobe(event="__vfs_read", fn_name="trace_read_entry")
+
 if __name__ == "__main__":
     main()
 


### PR DESCRIPTION
This pull request limits the rewriting of unary operators to the
dereference operator and fixes #344.

Since the whole expression, unary operator included, is replaced by a
call to bpf_probe_read, the dereference operator is currently the
only unary operator properly rewritten anyway. When rewriting an
increment expression (++val) for instance, the increment operator is
lost in translation:
```c
// struct file *val = ++file;
struct file *val = ({ typeof(struct file *) _val;
                      memset(&_val, 0, sizeof(_val));
                      bpf_probe_read(&_val, sizeof(_val), (u64)file);
                      _val; });
```

Restricting the rewriting to dereference operators fixes #344 because
bcc won't try anymore to translate the logical negation in:
`!file->f_op->read_iter`.

/cc @drzaeus77 @brendangregg 