### PR TITLE
Fix bpf_dins_pkt rewrite in BinaryOperator

### DIFF
--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -392,5 +392,24 @@ int process(struct xdp_md *ctx) {
         t = b["act"]
         self.assertEquals(len(t), 32);
 
+    def test_bpf_dins_pkt_rewrite(self):
+        text = """
+#include <bcc/proto.h>
+int dns_test(struct __sk_buff *skb) {
+    u8 *cursor = 0;
+    struct ethernet_t *ethernet = cursor_advance(cursor, sizeof(*ethernet));
+    if(ethernet->type == ETH_P_IP) {
+        struct ip_t *ip = cursor_advance(cursor, sizeof(*ip));
+        ip->src = ip->dst;
+        return 0;
+    }
+    return -1;
+}
+        """
+        b = BPF(text=text)
+
 if __name__ == "__main__":
     main()
+
+
+


### PR DESCRIPTION
This pull request fixes #537 by changing the way `BinaryOperator`
expressions are rewritten.

Binary operator expressions where the left hand-side expression is a
reference to the packet are replaced by a call to the `bpf_dins_pkt`
helper. When replacing text, the Clang Rewriter tries to maintain a
list of offsets between the original and the new position of tokens.

However, replacing the whole binary operator expression with the call
to `bpf_dins_pkt` confuses the Rewriter and it is unable to track the
new position of the right hand-side expression. Rewriting the binary
operator expression in two times without rewriting the right
hand-side expression itself solves the issue.

I believe the second issue reported in #537 by @mvbpolito is a
different bug. It's specific to the use of a constant in a rewritten
expression. The constant seems "invisible" to the Clang rewriter.
~~I haven't found a proper way to fix it yet.~~ See #1008.

/cc @drzaeus77 @valkum 