### PR TITLE
cc: Use debuginfo symbols in preference to executable symbols

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -360,9 +360,9 @@ static char *find_debug_via_debuglink(Elf *e, const char *binpath) {
   bindir = strdup(binpath);
   bindir = dirname(bindir);
 
-  // Search for the file in 'binpath'
-  sprintf(fullpath, "%s/%s", bindir, name);
-  if (access(fullpath, F_OK) != -1) {
+  // Search for the file in 'binpath', but ignore it if it matches the
+  // binary itself.
+  if (strcmp(fullpath, binpath) && access(fullpath, F_OK) != -1) {
     res = strdup(fullpath);
     goto DONE;
   }


### PR DESCRIPTION
We currently look for some forms of debuginfo file before falling
back to the executable. Rearrange our search to look for all debuginfo
files before finally trying the executable.

This fixes an issue found on ppc64le Ubuntu where glibc is stripped
and I could only create uprobes for dynamic linker symbols.

Signed-off-by: Anton Blanchard <anton@samba.org>