### PR TITLE
Fix long running test_debuginfo and python3 fix

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -71,7 +71,8 @@ class SymbolCache(object):
     def resolve_name(self, module, name):
         addr = ct.c_ulonglong()
         if lib.bcc_symcache_resolve_name(
-                    self.cache, module, name, ct.pointer(addr)) < 0:
+                    self.cache, module.encode("ascii"),
+                    name.encode("ascii"), ct.pointer(addr)) < 0:
             return -1
         return addr.value
 

--- a/tests/python/test_debuginfo.py
+++ b/tests/python/test_debuginfo.py
@@ -22,6 +22,7 @@ class Harness(TestCase):
 
     def tearDown(self):
         self.process.kill()
+        self.process.wait()
 
     def resolve_addr(self):
         sym, offset, module = self.syms.resolve(self.addr)
@@ -45,6 +46,7 @@ class TestDebuglink(Harness):
                                 .split())
 
     def tearDown(self):
+        super(TestDebuglink, self).tearDown()
         subprocess.check_output('rm dummy dummy.debug'.split())
 
     def test_resolve_addr(self):
@@ -65,6 +67,7 @@ class TestBuildid(Harness):
             '/12/3456789abcdef0123456789abcdef012345678.debug').split())
 
     def tearDown(self):
+        super(TestBuildid, self).tearDown()
         subprocess.check_output('rm dummy'.split())
         subprocess.check_output(('rm /usr/lib/debug/.build-id/12' +
             '/3456789abcdef0123456789abcdef012345678.debug').split())


### PR DESCRIPTION
Make sure subclass calls super().tearDown to clean up dummy process.
Also, fixup a python3 str.encode().

Fixes: #1013
Signed-off-by: Brenden Blanco <bblanco@gmail.com>