### PR TITLE
cc: Don't parse the same module multiple times for USDT probes

### DIFF
--- a/src/cc/usdt.cc
+++ b/src/cc/usdt.cc
@@ -200,7 +200,13 @@ void Context::_each_probe(const char *binpath, const struct bcc_elf_usdt *probe,
 }
 
 int Context::_each_module(const char *modpath, uint64_t, uint64_t, void *p) {
-  bcc_elf_foreach_usdt(modpath, _each_probe, p);
+  Context *ctx = static_cast<Context *>(p);
+  // Modules may be reported multiple times if they contain more than one
+  // executable region. We are going to parse the ELF on disk anyway, so we
+  // don't need these duplicates.
+  if (ctx->modules_.insert(modpath).second /*inserted new?*/) {
+    bcc_elf_foreach_usdt(modpath, _each_probe, p);
+  }
   return 0;
 }
 

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -191,6 +191,7 @@ public:
 
 class Context {
   std::vector<std::unique_ptr<Probe>> probes_;
+  std::unordered_set<std::string> modules_;
 
   optional<int> pid_;
   optional<ProcStat> pid_stat_;


### PR DESCRIPTION
If a module has more than one executable region, it is reported
multiple times by `bcc_procutils_each_module`. This is fine for
symbol resolution, but we don't need the duplicates for parsing
the ELF header looking for USDT probes: the first appearance of
that module is enough. This also prevents issues with the same
probe appearing multiple times with the same location, which
results in an invalid program when reading USDT arguments.

Fix by storing each visited module in the USDT::Context class,
and ignoring modules that were already visited.