### PR TITLE
python: handle null module in BPF.sym

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -989,12 +989,12 @@ class BPF(object):
         returned. When show_module is True, the module name is also included.
         When show_offset is True, the instruction offset as a hexadecimal
         number is also included in the string.
-        
+
         A pid of less than zero will access the kernel symbol cache.
 
         Example output when both show_module and show_offset are True:
             "start_thread+0x202 [libpthread-2.24.so]"
-        
+
         Example output when both show_module and show_offset are False:
             "start_thread"
         """
@@ -1002,7 +1002,8 @@ class BPF(object):
         offset = "+0x%x" % offset if show_offset and name is not None else ""
         name = name or "[unknown]"
         name = name + offset
-        module = " [%s]" % os.path.basename(module) if show_module else ""
+        module = " [%s]" % os.path.basename(module) \
+            if show_module and module is not None else ""
         return name + module
 
     @staticmethod


### PR DESCRIPTION
Check to see if `module` is None before attempting to call `os.path.basename`
on it. Before:

```
>>> BPF.sym(0x400001, 12345, show_module=True)
Traceback (most recent call last):
..
AttributeError: 'NoneType' object has no attribute 'rfind'
```

After:

```
>>> BPF.sym(0x400001, 12345, show_module=True)
'[unknown]'
```