### PR TITLE
filetop: support specifying sort column via cmdline argument

### DIFF
--- a/man/man8/filetop.8
+++ b/man/man8/filetop.8
@@ -2,14 +2,15 @@
 .SH NAME
 filetop \- File reads and writes by filename and process. Top for files.
 .SH SYNOPSIS
-.B filetop [\-h] [\-C] [\-r MAXROWS] [\-p PID] [interval] [count]
+.B filetop [\-h] [\-C] [\-r MAXROWS] [\-s {reads,writes,rbytes,wbytes}] [\-p PID] [interval] [count]
 .SH DESCRIPTION
 This is top for files.
 
-This traces file reads and writes, and prints a per-file summary every
-interval (by default, 1 second). The summary is sorted on the highest read
-throughput (Kbytes). By default only IO on regular files is shown. The -a
-option will list all file types (sokets, FIFOs, etc).
+This traces file reads and writes, and prints a per-file summary every interval
+(by default, 1 second). By default the summary is sorted on the highest read
+throughput (Kbytes). Sorting order can be changed via -s option. By default only
+IO on regular files is shown. The -a option will list all file types (sokets,
+FIFOs, etc).
 
 This uses in-kernel eBPF maps to store per process summaries for efficiency.
 
@@ -38,6 +39,9 @@ Don't clear the screen.
 .TP
 \-r MAXROWS
 Maximum number of rows to print. Default is 20.
+.TP
+\-s {reads,writes,rbytes,wbytes}
+Sort column. Default is rbytes (read throughput).
 .TP
 \-p PID
 Trace this PID only.

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -38,6 +38,9 @@ parser.add_argument("-C", "--noclear", action="store_true",
     help="don't clear the screen")
 parser.add_argument("-r", "--maxrows", default=20,
     help="maximum rows to print, default 20")
+parser.add_argument("-s", "--sort", default="rbytes",
+    choices=["reads", "writes", "rbytes", "wbytes"],
+    help="sort column, default rbytes")
 parser.add_argument("-p", "--pid", type=int, metavar="PID", dest="tgid",
     help="trace this PID only")
 parser.add_argument("interval", nargs="?", default=1,
@@ -184,7 +187,8 @@ while 1:
     counts = b.get_table("counts")
     line = 0
     for k, v in reversed(sorted(counts.items(),
-                                key=lambda counts: counts[1].rbytes)):
+                                key=lambda counts:
+                                  getattr(counts[1], args.sort))):
         name = k.name.decode()
         if k.name_len > DNAME_INLINE_LEN:
             name = name[:-3] + "..."

--- a/tools/filetop_example.txt
+++ b/tools/filetop_example.txt
@@ -29,10 +29,11 @@ PID    COMM             READS  WRITES R_Kb    W_Kb    T FILE
 26628  ld               12     0      52      0       R swap.o
 [...]
 
-This shows various files read and written during a Linux kernel build. The
-output is sorted by the total read size in Kbytes (R_Kb). This is instrumenting
-at the VFS interface, so this is reads and writes that may return entirely
-from the file system cache (page cache).
+This shows various files read and written during a Linux kernel build. By
+default the output is sorted by the total read size in Kbytes (R_Kb). Sorting
+order can be changed via -s option. This is instrumenting at the VFS interface,
+so this is reads and writes that may return entirely from the file system cache
+(page cache).
 
 While not printed, the average read and write size can be calculated by
 dividing R_Kb by READS, and the same for writes.
@@ -146,6 +147,8 @@ optional arguments:
   -C, --noclear         don't clear the screen
   -r MAXROWS, --maxrows MAXROWS
                         maximum rows to print, default 20
+  -s {reads,writes,rbytes,wbytes}, --sort {reads,writes,rbytes,wbytes}
+                        sort column, default rbytes
   -p PID, --pid PID     trace this PID only
 
 examples:


### PR DESCRIPTION
I've found useful to be able to sort filetop results by write throughput instead of read throughput.

Let's add command line argument for this.

Testing:

I've tested the following filetop commands and they work as expected.
```
tools/filetop.py –help
tools/filetop.py
tools/filetop.py -s wbytes
```