### PR TITLE
cmake: Explicitly mark static libraries as such

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(bcc-shared SHARED bpf_common.cc bpf_module.cc libbpf.c perf_reader.c
 set_target_properties(bcc-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
 set_target_properties(bcc-shared PROPERTIES OUTPUT_NAME bcc)
 
-add_library(bcc-loader-static libbpf.c perf_reader.c bcc_elf.c bcc_perf_map.c bcc_proc.c)
+add_library(bcc-loader-static STATIC libbpf.c perf_reader.c bcc_elf.c bcc_perf_map.c bcc_proc.c)
 add_library(bcc-static STATIC bpf_common.cc bpf_module.cc shared_table.cc exported_files.cc bcc_syms.cc usdt_args.cc usdt.cc common.cc BPF.cc BPFTable.cc)
 set_target_properties(bcc-static PROPERTIES OUTPUT_NAME bcc)
 

--- a/src/cc/frontends/b/CMakeLists.txt
+++ b/src/cc/frontends/b/CMakeLists.txt
@@ -11,5 +11,5 @@ if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
   set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/lexer.ll.cc PROPERTIES COMPILE_FLAGS "-Wno-deprecated-register")
 endif()
 
-add_library(b_frontend loader.cc codegen_llvm.cc node.cc parser.cc printer.cc
+add_library(b_frontend STATIC loader.cc codegen_llvm.cc node.cc parser.cc printer.cc
   type_check.cc ${BISON_Parser_OUTPUTS} ${FLEX_Lexer_OUTPUTS})

--- a/src/cc/frontends/clang/CMakeLists.txt
+++ b/src/cc/frontends/clang/CMakeLists.txt
@@ -2,4 +2,4 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_DIR='\"${BCC_KERNEL_MODULES_DIR}\"'")
-add_library(clang_frontend loader.cc b_frontend_action.cc tp_frontend_action.cc kbuild_helper.cc ../../common.cc)
+add_library(clang_frontend STATIC loader.cc b_frontend_action.cc tp_frontend_action.cc kbuild_helper.cc ../../common.cc)


### PR DESCRIPTION
Some distros (e.g Fedora) override the default behaviour of building
static libraries to building dynamic ones instead. By explicitly
building the correct libraries as static, we make sure BCC properly
compiles everywhere.