### PR TITLE
funclatency: remove unnecessary include

### DIFF
--- a/tools/funclatency.py
+++ b/tools/funclatency.py
@@ -90,7 +90,6 @@ if not args.regexp:
 # define BPF program
 bpf_text = """
 #include <uapi/linux/ptrace.h>
-#include <linux/blkdev.h>
 
 typedef struct ip_pid {
     u64 ip;


### PR DESCRIPTION
```
# ./funclatency.py 'go:fmt.Println'
In file included from /virtual/main.c:3:
In file included from /lib/modules/4.9.0-rc5-virtual/build/include/linux/blkdev.h:9:
In file included from /lib/modules/4.9.0-rc5-virtual/build/include/linux/genhd.h:64:
In file included from /lib/modules/4.9.0-rc5-virtual/build/include/linux/device.h:24:
In file included from /lib/modules/4.9.0-rc5-virtual/build/include/linux/pinctrl/devinfo.h:21:
In file included from /lib/modules/4.9.0-rc5-virtual/build/include/linux/pinctrl/consumer.h:17:
In file included from /lib/modules/4.9.0-rc5-virtual/build/include/linux/seq_file.h:10:
/lib/modules/4.9.0-rc5-virtual/build/include/linux/fs.h:2693:9: warning: comparison of unsigned enum expression < 0 is always false [-Wtautological-compare]
        if (id < 0 || id >= READING_MAX_ID)
            ~~ ^ ~
1 warning generated.
```

That unnecessary include was also throwing this unnecessary warning.

PS. That warning should be fixed in Linux 4.11/4.12 (it made it into mm recently).