### PR TITLE
Verify format specifiers in bpf_trace_printk in rewriter

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -74,8 +74,11 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
 
  private:
   clang::SourceRange expansionRange(clang::SourceRange range);
+  bool checkFormatSpecifiers(const std::string& fmt, clang::SourceLocation loc);
   template <unsigned N>
   clang::DiagnosticBuilder error(clang::SourceLocation loc, const char (&fmt)[N]);
+  template <unsigned N>
+  clang::DiagnosticBuilder warning(clang::SourceLocation loc, const char (&fmt)[N]);
 
   clang::ASTContext &C;
   clang::DiagnosticsEngine &diag_;


### PR DESCRIPTION
Verifies format specifiers while rewriting calls to bpf_trace_printk
and prints a warning the printk will be rejected by the kernel at
runtime.

For tests, redirects stderr at the file descriptor level in order to
catch warnings from the C library.

Fixes #124.

/cc @drzaeus77 

I noticed the kernel doesn't check that the number of format
specifiers equals the number of arguments. Is that normal?
(`CAP_SYS_ADMIN` is required to call `bpf_trace_printk`, but it still
feels weird.)