### PR TITLE
Add build option for installing C++ examples

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -3,30 +3,35 @@
 
 include_directories(${CMAKE_SOURCE_DIR}/src/cc)
 
+option(INSTALL_CPP_EXAMPLES "Install C++ examples. Those binaries are statically linked and can take plenty of disk space" OFF)
+
 add_executable(HelloWorld HelloWorld.cc)
 target_link_libraries(HelloWorld bcc-static)
-install (TARGETS HelloWorld DESTINATION share/bcc/examples/cpp)
 
 add_executable(CPUDistribution CPUDistribution.cc)
 target_link_libraries(CPUDistribution bcc-static)
-install (TARGETS CPUDistribution DESTINATION share/bcc/examples/cpp)
 
 add_executable(RecordMySQLQuery RecordMySQLQuery.cc)
 target_link_libraries(RecordMySQLQuery bcc-static)
-install (TARGETS RecordMySQLQuery DESTINATION share/bcc/examples/cpp)
 
 add_executable(TCPSendStack TCPSendStack.cc)
 target_link_libraries(TCPSendStack bcc-static)
-install (TARGETS TCPSendStack DESTINATION share/bcc/examples/cpp)
 
 add_executable(RandomRead RandomRead.cc)
 target_link_libraries(RandomRead bcc-static)
-install (TARGETS RandomRead DESTINATION share/bcc/examples/cpp)
 
 add_executable(LLCStat LLCStat.cc)
 target_link_libraries(LLCStat bcc-static)
-install (TARGETS LLCStat DESTINATION share/bcc/examples/cpp)
 
 add_executable(FollyRequestContextSwitch FollyRequestContextSwitch.cc)
 target_link_libraries(FollyRequestContextSwitch bcc-static)
-install (TARGETS FollyRequestContextSwitch DESTINATION share/bcc/examples/cpp)
+
+if(INSTALL_CPP_EXAMPLES)
+  install (TARGETS HelloWorld DESTINATION share/bcc/examples/cpp)
+  install (TARGETS CPUDistribution DESTINATION share/bcc/examples/cpp)
+  install (TARGETS RecordMySQLQuery DESTINATION share/bcc/examples/cpp)
+  install (TARGETS TCPSendStack DESTINATION share/bcc/examples/cpp)
+  install (TARGETS RandomRead DESTINATION share/bcc/examples/cpp)
+  install (TARGETS LLCStat DESTINATION share/bcc/examples/cpp)
+  install (TARGETS FollyRequestContextSwitch DESTINATION share/bcc/examples/cpp)
+endif(INSTALL_CPP_EXAMPLES)


### PR DESCRIPTION
As discussed in #1048, the statically-linked binaries can take plenty of space.
Sorry for the inconvenience!