### PR TITLE
python: Allow module=None when resolving kernel symbols

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -71,7 +71,7 @@ class SymbolCache(object):
     def resolve_name(self, module, name):
         addr = ct.c_ulonglong()
         if lib.bcc_symcache_resolve_name(
-                    self.cache, module.encode("ascii"),
+                    self.cache, module.encode("ascii") if module else None,
                     name.encode("ascii"), ct.pointer(addr)) < 0:
             return -1
         return addr.value
@@ -1018,7 +1018,7 @@ class BPF(object):
 
         Translate a kernel memory address into a kernel function name, which is
         returned. When show_module is True, the module name ("kernel") is also
-        included. When show_offset is true, the instruction offset as a 
+        included. When show_offset is true, the instruction offset as a
         hexadecimal number is also included in the string.
 
         Example output when both show_module and show_offset are True:

--- a/tests/python/test_debuginfo.py
+++ b/tests/python/test_debuginfo.py
@@ -4,8 +4,27 @@
 
 import os
 import subprocess
-from bcc import SymbolCache
+from bcc import SymbolCache, BPF
 from unittest import main, TestCase
+
+class TestKSyms(TestCase):
+    def grab_sym(self):
+        # Grab the first symbol in kallsyms that has type 't'.
+        with open("/proc/kallsyms") as f:
+            for line in f:
+                (addr, t, name) = line.strip().split()
+                if t == "t":
+                    return (addr, name)
+
+    def test_ksymname(self):
+        sym = BPF.ksymname("__kmalloc")
+        self.assertIsNotNone(sym)
+        self.assertNotEqual(sym, 0)
+
+    def test_ksym(self):
+        (addr, name) = self.grab_sym()
+        sym = BPF.ksym(int(addr, 16))
+        self.assertEqual(sym, name)
 
 class Harness(TestCase):
     def setUp(self):


### PR DESCRIPTION
An earlier commit 7b35436 introduced an encode call designed to
support Python 3.x when passing the module name to `bcc_symcache_resolve_name`.
This breaks current code because the module may be None when
resolving kernel symbols, e.g. using the `BPF.ksymname` API.

This commit fixes the regression and introduces a test for `ksym`
and `ksymname` that would have caught it in the first place.

Resolves #1054.