### PR TITLE
bpflist: Add to tests and use Python directory listing

### DIFF
--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -76,6 +76,9 @@ class SmokeTests(TestCase):
     def test_bitesize(self):
         self.run_with_int("biotop.py")
 
+    def test_bpflist(self):
+        self.run_with_duration("bpflist.py")
+
     def test_btrfsdist(self):
         # Will attempt to do anything meaningful only when btrfs is installed.
         self.run_with_duration("btrfsdist.py 1 1")


### PR DESCRIPTION
This commit adds bpflist to the smoke tests suite (omitted by mistake),
and switches to listing file descriptors using Python's `os` module
instead of relying on `ls` glob expansion, which is fragile when there
are many processes with many fds.

(Suggested by @brendangregg.)