### PR TITLE
Segmentation fault in LLVM when using float arguments

### DIFF
--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -438,7 +438,7 @@ int trace_read_entry(struct pt_regs *ctx, struct file *file) {
         text = """
 #include <uapi/linux/ptrace.h>
 int trace_entry(struct pt_regs *ctx) {
-  bpf_trace_printk("%0.2f\\n", 1);
+  bpf_trace_printk("%0.2f\\n", 1.0);
   return 0;
 }
 """
@@ -455,7 +455,7 @@ int trace_entry(struct pt_regs *ctx) {
         text = """
 #include <uapi/linux/ptrace.h>
 int trace_entry(struct pt_regs *ctx) {
-  bpf_trace_printk("%lf\\n", 1);
+  bpf_trace_printk("%lf\\n", 1.0);
   return 0;
 }
 """


### PR DESCRIPTION
Attached is a simple new test to illustrate the LLVM segmentation fault discovered in #1046. The segfault happens only under Fedora when trying the destroy the `LLVMContext` object after using floats as function arguments.

Here is the backtrace retrieved by @goldshtn:
```
Program received signal SIGSEGV, Segmentation fault.
0x00007fffeed87dfc in void llvm::DeleteContainerSeconds<llvm::DenseMap<llvm::APFloat, llvm::ConstantFP*, llvm::DenseMapAPFloatKeyInfo, llvm::detail::DenseMapPair<llvm::APFloat, llvm::ConstantFP*> > >(llvm::DenseMap<llvm::APFloat, llvm::ConstantFP*, llvm::DenseMapAPFloatKeyInfo, llvm::detail::DenseMapPair<llvm::APFloat, llvm::ConstantFP*> >&) () from /lib64/libbcc.so.0
Missing separate debuginfos, use: dnf debuginfo-install clang-libs-3.8.1-1.fc25.x86_64 elfutils-libelf-0.168-1.fc25.x86_64 llvm-libs-3.8.1-2.fc25.x86_64
(gdb) bt
#0  0x00007fffeed87dfc in void llvm::DeleteContainerSeconds<llvm::DenseMap<llvm::APFloat, llvm::ConstantFP*, llvm::DenseMapAPFloatKeyInfo, llvm::detail::DenseMapPair<llvm::APFloat, llvm::ConstantFP*> > >(llvm::DenseMap<llvm::APFloat, llvm::ConstantFP*, llvm::DenseMapAPFloatKeyInfo, llvm::detail::DenseMapPair<llvm::APFloat, llvm::ConstantFP*> >&) () from /lib64/libbcc.so.0
#1  0x00007fffeed886c5 in llvm::LLVMContextImpl::~LLVMContextImpl() () from /lib64/libbcc.so.0
#2  0x00007fffeed839c1 in llvm::LLVMContext::~LLVMContext() () from /lib64/libbcc.so.0
#3  0x00007fffee0ba97b in ebpf::BPFModule::~BPFModule() () from /lib64/libbcc.so.0
#4  0x00007fffee0b8a8e in bpf_module_destroy () from /lib64/libbcc.so.0
#5  0x00007fffefb44c58 in ffi_call_unix64 () at ../src/x86/unix64.S:76
#6  0x00007fffefb446ba in ffi_call (cif=cif@entry=0x7fffffffdca0, fn=fn@entry=0x7fffee0b8a80 <bpf_module_destroy>, rvalue=<optimized out>, rvalue@entry=0x7fffffffdbf0, avalue=avalue@entry=0x7fffffffdbd0)
    at ../src/x86/ffi64.c:525
#7  0x00007fffefd57957 in _call_function_pointer (argcount=1, resmem=0x7fffffffdbf0, restype=<optimized out>, atypes=<optimized out>, avalues=0x7fffffffdbd0, pProc=0x7fffee0b8a80 <bpf_module_destroy>, 
    flags=4361) at /usr/src/debug/Python-2.7.13/Modules/_ctypes/callproc.c:841
#8  _ctypes_callproc (pProc=pProc@entry=0x7fffee0b8a80 <bpf_module_destroy>, argtuple=argtuple@entry=(93824995766496,), flags=4361, 
    argtypes=argtypes@entry=(<built-in method from_param of _ctypes.PyCSimpleType object at remote 0x555555823e60>,), restype=None, checker=0x0)
    at /usr/src/debug/Python-2.7.13/Modules/_ctypes/callproc.c:1184
#9  0x00007fffefd51382 in PyCFuncPtr_call (self=<optimized out>, inargs=<optimized out>, kwds=<optimized out>) at /usr/src/debug/Python-2.7.13/Modules/_ctypes/_ctypes.c:3979
#10 0x00007ffff7a41003 in PyObject_Call (func=func@entry=<_FuncPtr(__name__='bpf_module_destroy') at remote 0x7ffff7eb6ae0>, arg=arg@entry=(93824995766496,), kw=kw@entry=0x0)
    at /usr/src/debug/Python-2.7.13/Objects/abstract.c:2547
#11 0x00007ffff7ad9828 in do_call (nk=0, na=1, pp_stack=0x7fffffffdea0, func=<optimized out>) at /usr/src/debug/Python-2.7.13/Python/ceval.c:4646
#12 call_function (oparg=<optimized out>, pp_stack=0x7fffffffdea0) at /usr/src/debug/Python-2.7.13/Python/ceval.c:4451
#13 PyEval_EvalFrameEx (
    f=f@entry=Frame 0x7fffe7400250, for file /usr/lib/python2.7/site-packages/bcc/__init__.py, line 1100, in cleanup (self=<BPF(funcs={'trace_entry': <Function(fd=4, name='trace_entry', bpf=<...>) at remote 0x7ffff7ea0710>}, tables={}, open_tracepoints={}, open_uprobes={}, open_kprobes={}, tracefile=None, _user_cb=None, _reader_cb_impl=<CFunctionType at remote 0x7fffe7e69940>, module=93824995766496, debug=0, open_perf_events={}) at remote 0x7ffff7ea0610>, k='p___kmalloc', v=<c_void_p at remote 0x7fffe7e3ae60>), throwflag=throwflag@entry=0) at /usr/src/debug/Python-2.7.13/Python/ceval.c:3063
#14 0x00007ffff7addadc in PyEval_EvalCodeEx (co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7ffff7e79aa8, argcount=1, kws=kws@entry=0x7ffff7faa068, kwcount=0, 
    defs=0x0, defcount=0, closure=0x0) at /usr/src/debug/Python-2.7.13/Python/ceval.c:3661
#15 0x00007ffff7a6604d in function_call (func=<function at remote 0x7fffe6fabcf8>, 
    arg=(<BPF(funcs={'trace_entry': <Function(fd=4, name='trace_entry', bpf=<...>) at remote 0x7ffff7ea0710>}, tables={}, open_tracepoints={}, open_uprobes={}, open_kprobes={}, tracefile=None, _user_cb=None, _reader_cb_impl=<CFunctionType at remote 0x7fffe7e69940>, module=93824995766496, debug=0, open_perf_events={}) at remote 0x7ffff7ea0610>,), kw={}) at /usr/src/debug/Python-2.7.13/Objects/funcobject.c:523
#16 0x00007ffff7a41003 in PyObject_Call (func=func@entry=<function at remote 0x7fffe6fabcf8>, 
    arg=arg@entry=(<BPF(funcs={'trace_entry': <Function(fd=4, name='trace_entry', bpf=<...>) at remote 0x7ffff7ea0710>}, tables={}, open_tracepoints={}, open_uprobes={}, open_kprobes={}, tracefile=None, _user_cb=None, _reader_cb_impl=<CFunctionType at remote 0x7fffe7e69940>, module=93824995766496, debug=0, open_perf_events={}) at remote 0x7ffff7ea0610>,), kw=kw@entry={})
    at /usr/src/debug/Python-2.7.13/Objects/abstract.c:2547
#17 0x00007ffff7ad8093 in ext_do_call (nk=<optimized out>, na=1, flags=<optimized out>, pp_stack=0x7fffffffe148, func=<function at remote 0x7fffe6fabcf8>) at /usr/src/debug/Python-2.7.13/Python/ceval.c:4743
#18 PyEval_EvalFrameEx (
    f=f@entry=Frame 0x7ffff7e64de0, for file /usr/lib64/python2.7/atexit.py, line 24, in _run_exitfuncs (exc_info=None, func=<instancemethod at remote 0x7ffff7f2db90>, targs=(), kargs={}), 
    throwflag=throwflag@entry=0) at /usr/src/debug/Python-2.7.13/Python/ceval.c:3102
#19 0x00007ffff7addadc in PyEval_EvalCodeEx (co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=args@entry=0x7ffff7faa068, argcount=0, kws=kws@entry=0x0, kwcount=0, defs=0x0, 
    defcount=0, closure=0x0) at /usr/src/debug/Python-2.7.13/Python/ceval.c:3661
#20 0x00007ffff7a65f6c in function_call (func=<function at remote 0x7ffff7ea1e60>, arg=(), kw=0x0) at /usr/src/debug/Python-2.7.13/Objects/funcobject.c:523
#21 0x00007ffff7a41003 in PyObject_Call (func=func@entry=<function at remote 0x7ffff7ea1e60>, arg=arg@entry=(), kw=<optimized out>) at /usr/src/debug/Python-2.7.13/Objects/abstract.c:2547
#22 0x00007ffff7ad3bc7 in PyEval_CallObjectWithKeywords (func=func@entry=<function at remote 0x7ffff7ea1e60>, arg=(), arg@entry=0x0, kw=kw@entry=0x0) at /usr/src/debug/Python-2.7.13/Python/ceval.c:4298
#23 0x00007ffff7af8c67 in call_sys_exitfunc () at /usr/src/debug/Python-2.7.13/Python/pythonrun.c:1764
#24 Py_Finalize () at /usr/src/debug/Python-2.7.13/Python/pythonrun.c:423
#25 0x00007ffff7b0adbb in Py_Main (argc=<optimized out>, argv=<optimized out>) at /usr/src/debug/Python-2.7.13/Modules/main.c:665
#26 0x00007ffff6d23401 in __libc_start_main (main=0x5555555547a0 <main>, argc=2, argv=0x7fffffffe578, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffffffe568)
    at ../csu/libc-start.c:289
#27 0x00005555555547da in _start ()
```