### PR TITLE
Fix the Markdown list in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ pair of .c and .py files, and some are directories of files.
 
 #### Tools:
 <center><a href="images/bcc_tracing_tools_2017.png"><img src="images/bcc_tracing_tools_2017.png" border=0 width=700></a></center>
+
 - tools/[argdist](tools/argdist.py): Display function parameter values as a histogram or frequency count. [Examples](tools/argdist_example.txt).
 - tools/[bashreadline](tools/bashreadline.py): Print entered bash commands system wide. [Examples](tools/bashreadline_example.txt).
 - tools/[biolatency](tools/biolatency.py): Summarize block device I/O latency as a histogram. [Examples](tools/biolatency_example.txt).


### PR DESCRIPTION
The Markdown list in the README for tools is not rendered as HTML anymore.
Adding a newline before the list fixes it.

This display bug might have been caused by the [recent change of Markdown rendered on github.com](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown).