### PR TITLE
Added the option(USINGISYSTEM) of Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 # As reported in issue #735, GCC 6 has some behavioral problems when
 # dealing with -isystem. Hence, skip the warning optimization
 # altogether on that compiler.
+option(USINGISYSTEM "using -isystem" ON)
 execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-if (GCC_VERSION VERSION_LESS 6.0)
+if (USINGISYSTEM AND GCC_VERSION VERSION_LESS 6.0)
   # iterate over all available directories in LLVM_INCLUDE_DIRS to
   # generate a correctly tokenized list of parameters
   foreach(ONE_LLVM_INCLUDE_DIR ${LLVM_INCLUDE_DIRS})


### PR DESCRIPTION
When using Clang 3.9(compiled by GCC 6.x), bcc will used -isystem,
because the GCC_VERSION(get the version of the Clang) is less 6.0.
And then the compiler will compile failed. So we need this option to skip using -isystem.