### PR TITLE
u* tools: automatically detect the language

### DIFF
--- a/src/cc/bcc_proc.h
+++ b/src/cc/bcc_proc.h
@@ -41,6 +41,7 @@ int bcc_procutils_each_ksym(bcc_procutils_ksymcb callback, void *payload);
 void bcc_procutils_free(const char *ptr);
 bool bcc_procutils_enter_mountns(int pid, struct ns_cookie *nc);
 bool bcc_procutils_exit_mountns(struct ns_cookie *nc);
+const char *bcc_procutils_language(int pid);
 
 #ifdef __cplusplus
 }

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -134,6 +134,8 @@ lib.bcc_procutils_which_so.restype = ct.POINTER(ct.c_char)
 lib.bcc_procutils_which_so.argtypes = [ct.c_char_p, ct.c_int]
 lib.bcc_procutils_free.restype = None
 lib.bcc_procutils_free.argtypes = [ct.c_void_p]
+lib.bcc_procutils_language.restype = ct.POINTER(ct.c_char)
+lib.bcc_procutils_language.argtypes = [ct.c_int]
 
 lib.bcc_resolve_symname.restype = ct.c_int
 lib.bcc_resolve_symname.argtypes = [

--- a/src/python/bcc/utils.py
+++ b/src/python/bcc/utils.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ctypes as ct
+
+from .libbcc import lib
 
 def _read_cpu_range(path):
     cpus = []
@@ -31,3 +34,8 @@ def get_online_cpus():
 
 def get_possible_cpus():
     return _read_cpu_range('/sys/devices/system/cpu/possible')
+
+def detect_language(candidates, pid):
+    res = lib.bcc_procutils_language(pid)
+    language = ct.cast(res, ct.c_char_p).value.decode()
+    return language if language in candidates else None

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -36,6 +36,12 @@ using namespace std;
 
 static pid_t spawn_child(void *, bool, bool, int (*)(void *));
 
+TEST_CASE("language detection", "[c_api]") {
+  const char *c = bcc_procutils_language(getpid());
+  REQUIRE(c);
+  REQUIRE(string(c).compare("c") == 0);
+}
+
 TEST_CASE("shared object resolution", "[c_api]") {
   char *libm = bcc_procutils_which_so("m", 0);
   REQUIRE(libm);

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -311,14 +311,14 @@ class SmokeTests(TestCase):
     def test_ucalls(self):
         # This attaches a large number (300+) kprobes, which can be slow,
         # so use an increased timeout value.
-        self.run_with_int("ucalls.py -S %d" % os.getpid(),
+        self.run_with_int("ucalls.py -l none -S %d" % os.getpid(),
                           timeout=30, kill_timeout=30)
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
     def test_uflow(self):
         # The Python installed on the Ubuntu buildbot doesn't have USDT
         # probes, so we can't run uflow.
-        # self.run_with_int("uflow.py python %d" % os.getpid())
+        # self.run_with_int("uflow.py -l python %d" % os.getpid())
         pass
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
@@ -329,7 +329,7 @@ class SmokeTests(TestCase):
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
     def test_uobjnew(self):
-        self.run_with_int("uobjnew.py c %d" % os.getpid())
+        self.run_with_int("uobjnew.py -l c %d" % os.getpid())
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
     def test_ustat(self):

--- a/tests/python/test_utils.py
+++ b/tests/python/test_utils.py
@@ -2,9 +2,10 @@
 # Copyright (c) Catalysts GmbH
 # Licensed under the Apache License, Version 2.0 (the "License")
 
-from bcc.utils import get_online_cpus
+from bcc.utils import get_online_cpus, detect_language
 import multiprocessing
 import unittest
+import os
 
 class TestUtils(unittest.TestCase):
     def test_get_online_cpus(self):
@@ -13,6 +14,10 @@ class TestUtils(unittest.TestCase):
 
         self.assertEqual(len(online_cpus), num_cores)
 
+    def test_detect_language(self):
+        candidates = ["java", "ruby", "php", "node", "c", "python"]
+        language = detect_language(candidates, os.getpid())
+        self.assertEqual(language, "python")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/ucalls_example.txt
+++ b/tools/ucalls_example.txt
@@ -12,7 +12,7 @@ argdist, biotop, fileslower, and others.
 
 For example, to trace method call latency in a Java application:
 
-# ucalls -L -l java $(pidof java)
+# ucalls -L $(pidof java)
 Tracing calls in process 26877 (language: java)... Ctrl-C to quit.
 
 METHOD                                              # CALLS TIME (us)
@@ -48,7 +48,7 @@ Detaching kernel probes, please wait...
 To print only the top 5 methods and report times in milliseconds (the default
 is microseconds):
 
-# ucalls -l python -mT 5 $(pidof python)
+# ucalls -mT 5 $(pidof python)
 Tracing calls in process 26914 (language: python)... Ctrl-C to quit.
 
 METHOD                                              # CALLS
@@ -60,7 +60,8 @@ METHOD                                              # CALLS
 USAGE message:
 
 # ./ucalls.py -h
-usage: ucalls.py [-h] [-l {java,python,ruby,php}] [-T TOP] [-L] [-S] [-v] [-m]
+usage: ucalls.py [-h] [-l {java,python,ruby,php,none}] [-T TOP] [-L] [-S] [-v]
+                 [-m]
                  pid [interval]
 
 Summarize method calls in high-level languages.
@@ -71,7 +72,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -l {java,python,ruby,php}, --language {java,python,ruby,php}
+  -l {java,python,ruby,php,none}, --language {java,python,ruby,php,none}
                         language to trace (if none, trace syscalls only)
   -T TOP, --top TOP     number of most frequent/slow calls to print
   -L, --latency         record method latency from enter to exit (except

--- a/tools/uflow_example.txt
+++ b/tools/uflow_example.txt
@@ -10,7 +10,7 @@ method invocations.
 
 For example, trace all Ruby method calls in a specific process:
 
-# ./uflow ruby 27245
+# ./uflow -l ruby 27245
 Tracing method calls in ruby process 27245... Ctrl-C to quit.
 CPU PID    TID    TIME(us) METHOD
 3   27245  27245  4.536    <- IO.gets                              
@@ -34,7 +34,7 @@ and the <- and -> arrows indicate the direction of the event (exit or entry).
 Often, the amount of output can be overwhelming. You can filter specific 
 classes or methods. For example, trace only methods from the Thread class:
 
-# ./uflow -C java/lang/Thread java $(pidof java)
+# ./uflow -C java/lang/Thread $(pidof java)
 Tracing method calls in java process 27722... Ctrl-C to quit.
 CPU PID    TID    TIME(us) METHOD
 3   27722  27731  3.144    -> java/lang/Thread.<init>              
@@ -88,17 +88,18 @@ thread running on the same CPU.
 USAGE message:
 
 # ./uflow -h
-usage: uflow.py [-h] [-M METHOD] [-C CLAZZ] [-v] {java,python,ruby,php} pid
+usage: uflow.py [-h] [-l {java,python,ruby,php}] [-M METHOD] [-C CLAZZ] [-v]
+                pid
 
 Trace method execution flow in high-level languages.
 
 positional arguments:
-  {java,python,ruby,php}
-			language to trace
   pid                   process id to attach to
 
 optional arguments:
   -h, --help            show this help message and exit
+  -l {java,python,ruby,php}, --language {java,python,ruby,php}
+                        language to trace
   -M METHOD, --method METHOD
                         trace only calls to methods starting with this prefix
   -C CLAZZ, --class CLAZZ
@@ -107,7 +108,7 @@ optional arguments:
                         purposes)
 
 examples:
-    ./uflow java 185                # trace Java method calls in process 185
-    ./uflow ruby 1344               # trace Ruby method calls in process 1344
-    ./uflow -M indexOf java 185     # trace only 'indexOf'-prefixed methods
-    ./uflow -C '<stdin>' python 180 # trace only REPL-defined methods
+    ./uflow -l java 185                # trace Java method calls in process 185
+    ./uflow -l ruby 134                # trace Ruby method calls in process 134
+    ./uflow -M indexOf -l java 185     # trace only 'indexOf'-prefixed methods
+    ./uflow -C '<stdin>' -l python 180 # trace only REPL-defined methods

--- a/tools/ugc_example.txt
+++ b/tools/ugc_example.txt
@@ -8,7 +8,7 @@ the GC event is also provided.
 
 For example, to trace all garbage collection events in a specific Node process:
 
-# ugc node $(pidof node)
+# ugc $(pidof node)
 Tracing garbage collections in node process 30012... Ctrl-C to quit.
 START    TIME (us) DESCRIPTION                             
 1.500    1181.00  GC scavenge
@@ -44,7 +44,7 @@ Occasionally, it might be useful to filter out collections that are very short,
 or display only collections that have a specific description. The -M and -F
 switches can be useful for this:
 
-# ugc -F Tenured java $(pidof java)
+# ugc -F Tenured $(pidof java)
 Tracing garbage collections in java process 29907... Ctrl-C to quit.
 START    TIME (us) DESCRIPTION                             
 0.360    4309.00  MarkSweepCompact Tenured Gen used=287528->287528 max=173408256->173408256
@@ -52,7 +52,7 @@ START    TIME (us) DESCRIPTION
 4.648    4139.00  MarkSweepCompact Tenured Gen used=287528->287528 max=173408256->173408256
 ^C
 
-# ugc -M 1 java $(pidof java)
+# ugc -M 1 $(pidof java)
 Tracing garbage collections in java process 29907... Ctrl-C to quit.
 START    TIME (us) DESCRIPTION                             
 0.160    3715.00  MarkSweepCompact Code Cache used=287528->3209472 max=173408256->251658240
@@ -68,18 +68,19 @@ START    TIME (us) DESCRIPTION
 USAGE message:
 
 # ugc -h
-usage: ugc.py [-h] [-v] [-m] [-M MINIMUM] [-F FILTER]
-              {java,python,ruby,node} pid
+usage: ugc.py [-h] [-l {java,python,ruby,node}] [-v] [-m] [-M MINIMUM]
+              [-F FILTER]
+              pid
 
 Summarize garbage collection events in high-level languages.
 
 positional arguments:
-  {java,python,ruby,node}
-                        language to trace
   pid                   process id to attach to
 
 optional arguments:
   -h, --help            show this help message and exit
+  -l {java,python,ruby,node}, --language {java,python,ruby,node}
+                        language to trace
   -v, --verbose         verbose mode: print the BPF program (for debugging
                         purposes)
   -m, --milliseconds    report times in milliseconds (default is microseconds)
@@ -89,6 +90,6 @@ optional arguments:
                         display only GCs whose description contains this text
 
 examples:
-    ./ugc java 185           # trace Java GCs in process 185
-    ./ugc ruby 1344 -m       # trace Ruby GCs reporting in ms
-    ./ugc -M 10 java 185     # trace only Java GCs longer than 10ms
+    ./ugc -l java 185        # trace Java GCs in process 185
+    ./ugc -l ruby 1344 -m    # trace Ruby GCs reporting in ms
+    ./ugc -M 10 -l java 185  # trace only Java GCs longer than 10ms

--- a/tools/uobjnew_example.txt
+++ b/tools/uobjnew_example.txt
@@ -9,7 +9,7 @@ can in turn cause heavy garbage collection.
 For example, trace Ruby object allocations when running some simple commands
 in irb (the Ruby REPL):
 
-# ./uobjnew ruby 27245
+# ./uobjnew -l ruby 27245
 Tracing allocations in process 27245 (language: ruby)... Ctrl-C to quit.
 
 TYPE                           # ALLOCS      # BYTES
@@ -28,7 +28,7 @@ Plain C/C++ allocations (through "malloc") are also supported. We can't report
 the type being allocated, but we can report the object sizes at least. Also,
 print only the top 10 rows by number of bytes allocated:
 
-# ./uobjnew -S 10 c 27245
+# ./uobjnew -S 10 -l c 27245
 Tracing allocations in process 27245 (language: c)... Ctrl-C to quit.
 
 TYPE                           # ALLOCS      # BYTES
@@ -48,18 +48,19 @@ block size 80                       569        45520
 USAGE message:
 
 # ./uobjnew -h
-usage: uobjnew.py [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v]
-                  {java,ruby,c} pid [interval]
+usage: uobjnew.py [-h] [-l {java,ruby,c}] [-C TOP_COUNT] [-S TOP_SIZE] [-v]
+                  pid [interval]
 
 Summarize object allocations in high-level languages.
 
 positional arguments:
-  {java,ruby,c}         language to trace
   pid                   process id to attach to
   interval              print every specified number of seconds
 
 optional arguments:
   -h, --help            show this help message and exit
+  -l {java,ruby,c}, --language {java,ruby,c}
+                        language to trace
   -C TOP_COUNT, --top-count TOP_COUNT
                         number of most frequently allocated types to print
   -S TOP_SIZE, --top-size TOP_SIZE
@@ -68,7 +69,7 @@ optional arguments:
                         purposes)
 
 examples:
-    ./uobjnew java 145         # summarize Java allocations in process 145
-    ./uobjnew c 2020 1         # grab malloc() sizes and print every second
-    ./uobjnew ruby 6712 -C 10  # top 10 Ruby types by number of allocations
-    ./uobjnew ruby 6712 -S 10  # top 10 Ruby types by total size
+    ./uobjnew -l java 145         # summarize Java allocations in process 145
+    ./uobjnew -l c 2020 1         # grab malloc() sizes and print every second
+    ./uobjnew -l ruby 6712 -C 10  # top 10 Ruby types by number of allocations
+    ./uobjnew -l ruby 6712 -S 10  # top 10 Ruby types by total size

--- a/tools/uthreads_example.txt
+++ b/tools/uthreads_example.txt
@@ -39,7 +39,7 @@ instead.
 USAGE message:
 
 # ./uthreads -h
-usage: uthreads.py [-h] [-l {java}] [-v] pid
+usage: uthreads.py [-h] [-l {java,none}] [-v] pid
 
 Trace thread creation/destruction events in high-level languages.
 
@@ -48,7 +48,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -l {java}, --language {java}
+  -l {java,none}, --language {java,none}
                         language to trace (none for pthreads only)
   -v, --verbose         verbose mode: print the BPF program (for debugging
                         purposes)


### PR DESCRIPTION
Looks into `/proc/$pid/cmdline`, `/proc/$pid/exe`, and
`/proc/$pid/maps` to determine the language. `-l` switch can override
the detected language. In `uthreads` and `ucalls`, the language can
be overwritten to 'none' to trace pthreads and syscalls respectively.

All tools now use the -l switch to set the language.

Should I put the `detect_language` function elsewhere? It's the same
in all tools except for `uobjnew.py` (to handle the C case).

Fixes #864.

/cc @goldshtn @brendangregg 