### PR TITLE
Extend cpp table API

### DIFF
--- a/src/cc/BPF.cc
+++ b/src/cc/BPF.cc
@@ -482,6 +482,13 @@ std::string BPF::get_kprobe_event(const std::string& kernel_func,
   return res;
 }
 
+BPFProgTable BPF::get_prog_table(const std::string& name) {
+  TableStorage::iterator it;
+  if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+    return BPFProgTable(it->second);
+  return BPFProgTable({});
+}
+
 std::string BPF::get_uprobe_event(const std::string& binary_path,
                                   uint64_t offset, bpf_probe_attach_type type) {
   std::string res = attach_type_prefix(type) + "_";

--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -90,6 +90,14 @@ public:
                                 int group_fd = -1);
   StatusTuple detach_perf_event(uint32_t ev_type, uint32_t ev_config);
 
+  template <class ValueType>
+  BPFArrayTable<ValueType> get_array_table(const std::string& name) {
+    TableStorage::iterator it;
+    if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+      return BPFArrayTable<ValueType>(it->second);
+    return BPFArrayTable<ValueType>({});
+  }
+
   template <class KeyType, class ValueType>
   BPFHashTable<KeyType, ValueType> get_hash_table(const std::string& name) {
     TableStorage::iterator it;

--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -106,6 +106,8 @@ public:
     return BPFHashTable<KeyType, ValueType>({});
   }
 
+  BPFProgTable get_prog_table(const std::string& name);
+
   BPFStackTable get_stack_table(const std::string& name) {
     TableStorage::iterator it;
     if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))

--- a/src/cc/BPFTable.h
+++ b/src/cc/BPFTable.h
@@ -202,4 +202,20 @@ class BPFPerfBuffer : protected BPFTableBase<int, int> {
   std::unique_ptr<epoll_event[]> ep_events_;
 };
 
+class BPFProgTable : protected BPFTableBase<int, int> {
+public:
+  BPFProgTable(const TableDesc& desc)
+      : BPFTableBase<int, int>(desc) {
+    if (desc.type != BPF_MAP_TYPE_PROG_ARRAY)
+      throw std::invalid_argument("Table '" + desc.name + "' is not a prog table");
+  }
+
+  // updates an element
+  StatusTuple update_value(const int& index, const int& value) {
+    if (!this->update(const_cast<int*>(&index), const_cast<int*>(&value)))
+      return StatusTuple(-1, "Error updating value: %s", std::strerror(errno));
+    return StatusTuple(0);
+  }
+};
+
 }  // namespace ebpf

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -11,6 +11,7 @@ add_test(NAME c_test_static COMMAND ${TEST_WRAPPER} c_test_static sudo ${CMAKE_C
 add_executable(test_libbcc
 	test_libbcc.cc
 	test_c_api.cc
+	test_array_table.cc
 	test_hash_table.cc
 	test_usdt_args.cc
 	test_usdt_probes.cc)

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -11,6 +11,7 @@ add_test(NAME c_test_static COMMAND ${TEST_WRAPPER} c_test_static sudo ${CMAKE_C
 add_executable(test_libbcc
 	test_libbcc.cc
 	test_c_api.cc
+	test_hash_table.cc
 	test_usdt_args.cc
 	test_usdt_probes.cc)
 

--- a/tests/cc/test_array_table.cc
+++ b/tests/cc/test_array_table.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017 Politecnico di Torino
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BPF.h"
+
+#include "catch.hpp"
+
+#include <random>
+#include <iostream>
+
+TEST_CASE("test array table", "[array_table]") {
+  const std::string BPF_PROGRAM = R"(
+    BPF_TABLE("hash", int, int, myhash, 128);
+    BPF_TABLE("array", int, int, myarray, 128);
+  )";
+
+  ebpf::BPF bpf;
+  ebpf::StatusTuple res(0);
+  res = bpf.init(BPF_PROGRAM);
+  REQUIRE(res.code() == 0);
+
+  ebpf::BPFArrayTable<int> t = bpf.get_array_table<int>("myarray");
+
+  SECTION("bad table type") {
+    // try to get table of wrong type
+    auto f1 = [&](){
+      bpf.get_array_table<int>("myhash");
+    };
+
+    REQUIRE_THROWS(f1());
+  }
+
+  SECTION("standard methods") {
+    int i, v1, v2;
+    i = 1;
+    v1 = 42;
+    // update element
+    res = t.update_value(i, v1);
+    REQUIRE(res.code() == 0);
+    res = t.get_value(i, v2);
+    REQUIRE(res.code() == 0);
+    REQUIRE(v2 == 42);
+
+    // update another element
+    i = 2;
+    v1 = 69;
+    res = t.update_value(i, v1);
+    REQUIRE(res.code() == 0);
+    res = t.get_value(i, v2);
+    REQUIRE(res.code() == 0);
+    REQUIRE(v2 == 69);
+
+    // get non existing element
+    i = 1024;
+    res = t.get_value(i, v2);
+    REQUIRE(res.code() != 0);
+  }
+
+  SECTION("full table") {
+    // random number generator
+    std::mt19937 rng;
+    rng.seed(std::random_device()());
+    std::uniform_int_distribution<int> dist;
+
+    std::vector<int> localtable(128);
+
+    for(int i = 0; i < 128; i++) {
+      int v = dist(rng);
+
+      res = t.update_value(i, v);
+      REQUIRE(res.code() == 0);
+
+      // save it in the local table to compare later on
+      localtable[i] = v;
+    }
+
+    std::vector<int> offlinetable = t.get_table_offline();
+    REQUIRE(localtable == offlinetable);
+  }
+}

--- a/tests/cc/test_hash_table.cc
+++ b/tests/cc/test_hash_table.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017 Politecnico di Torino
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BPF.h"
+
+#include "catch.hpp"
+
+TEST_CASE("test hash table", "[hash_table]") {
+  const std::string BPF_PROGRAM = R"(
+    BPF_TABLE("hash", int, int, myhash, 1024);
+    BPF_TABLE("array", int, int, myarray, 1024);
+  )";
+
+  ebpf::BPF bpf;
+  ebpf::StatusTuple res(0);
+  res = bpf.init(BPF_PROGRAM);
+  REQUIRE(res.code() == 0);
+
+  ebpf::BPFHashTable<int, int> t = bpf.get_hash_table<int, int>("myhash");
+
+  SECTION("bad table type") {
+    // try to get table of wrong type
+    auto f1 = [&](){
+      bpf.get_hash_table<int, int>("myarray");
+    };
+
+    REQUIRE_THROWS(f1());
+  }
+
+  SECTION("standard methods") {
+    int k, v1, v2;
+    k = 1;
+    v1 = 42;
+    // create new element
+    res = t.update_value(k, v1);
+    REQUIRE(res.code() == 0);
+    res = t.get_value(k, v2);
+    REQUIRE(res.code() == 0);
+    REQUIRE(v2 == 42);
+
+    // update existing element
+    v1 = 69;
+    res = t.update_value(k, v1);
+    REQUIRE(res.code() == 0);
+    res = t.get_value(k, v2);
+    REQUIRE(res.code() == 0);
+    REQUIRE(v2 == 69);
+
+    // remove existing element
+    res = t.remove_value(k);
+    REQUIRE(res.code() == 0);
+
+    // remove non existing element
+    res = t.remove_value(k);
+    REQUIRE(res.code() != 0);
+
+    // get non existing element
+    res = t.get_value(k, v2);
+    REQUIRE(res.code() != 0);
+  }
+}


### PR DESCRIPTION
The table API used with the BPF class was incomplete, it only allowed to get the value of an element of a table. 

This PR extends the API for the maps of type hash, array and prog (LPM is still missing).

hash:
- provide methods to update, delete and get an element.
- the [] operator allows to update and get the value of an element using the "table[key] = value" and "value = table[key]" syntax. 

array:
- provide methods to update and get an element
- operator [] offers the same functionality as in the hash table

prog:
- provide a method to update an element
- operator [] allows to update an element using the "table[index] = fd" syntax. 