### PR TITLE
Improve helper Macros

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -28,16 +28,17 @@ This guide is incomplete. If something feels missing, check the bcc and kernel s
     - [Maps](#maps)
         - [1. BPF_TABLE](#1-bpf_table)
         - [2. BPF_HASH](#2-bpf_hash)
-        - [3. BPF_HISTOGRAM](#3-bpf_histogram)
-        - [4. BPF_STACK_TRACE](#4-bpf_stack_trace)
-        - [5. BPF_PERF_ARRAY](#5-bpf_perf_array)
-        - [6. map.lookup()](#6-maplookup)
-        - [7. map.lookup_or_init()](#7-maplookup_or_init)
-        - [8. map.delete()](#8-mapdelete)
-        - [9. map.update()](#9-mapupdate)
-        - [10. map.increment()](#10-mapincrement)
-        - [11. map.get_stackid()](#11-mapget_stackid)
-        - [12. map.perf_read()](#12-mapperf_read)
+        - [3. BPF_ARRAY](#2-bpf_array)
+        - [4. BPF_HISTOGRAM](#4-bpf_histogram)
+        - [5. BPF_STACK_TRACE](#5-bpf_stack_trace)
+        - [6. BPF_PERF_ARRAY](#6-bpf_perf_array)
+        - [7. map.lookup()](#7-maplookup)
+        - [8. map.lookup_or_init()](#8-maplookup_or_init)
+        - [9. map.delete()](#9-mapdelete)
+        - [10. map.update()](#10-mapupdate)
+        - [11. map.increment()](#11-mapincrement)
+        - [12. map.get_stackid()](#12-mapget_stackid)
+        - [13. map.perf_read()](#13-mapperf_read)
 
 - [bcc Python](#bcc-python)
     - [Initialization](#initialization)
@@ -402,7 +403,29 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=BPF_HASH+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=BPF_HASH+path%3Atools&type=Code)
 
-### 3. BPF_HISTOGRAM
+### 3. BPF_ARRAY
+
+Syntax: ```BPF_ARRAY(name [, leaf_type [, size]])```
+
+Creates an int-indexed array which is optimized for fastest lookup and update, named ```name```, with optional parameters.
+
+Defaults: ```BPF_ARRAY(name, leaf_type=u64, size=10240)```
+
+For example:
+
+```C
+BPF_ARRAY(counts, u64, 32);
+```
+
+This creates an array named ```counts``` where with 32 buckets and 64-bit integer values. This array is used by the funccount.py example for saving call count of each function.
+
+Methods (covered later): map.lookup(), map.update(), map.increment(). Note that all array elements are pre-allocated with zero values and can not be deleted.
+
+Examples in situ:
+[search /examples](https://github.com/iovisor/bcc/search?q=BPF_ARRAY+path%3Aexamples&type=Code),
+[search /tools](https://github.com/iovisor/bcc/search?q=BPF_ARRAY+path%3Atools&type=Code)
+
+### 4. BPF_HISTOGRAM
 
 Syntax: ```BPF_HISTOGRAM(name [, key_type [, size ]])```
 
@@ -424,7 +447,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=BPF_HISTOGRAM+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=BPF_HISTOGRAM+path%3Atools&type=Code)
 
-### 4. BPF_STACK_TRACE
+### 5. BPF_STACK_TRACE
 
 Syntax: ```BPF_STACK_TRACE(name, max_entries)```
 
@@ -444,7 +467,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=BPF_STACK_TRACE+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=BPF_STACK_TRACE+path%3Atools&type=Code)
 
-### 5. BPF_PERF_ARRAY
+### 6. BPF_PERF_ARRAY
 
 Syntax: ```BPF_PERF_ARRAY(name, max_entries)```
 
@@ -467,7 +490,7 @@ Methods (covered later): map.perf_read().
 Examples in situ:
 [search /tests](https://github.com/iovisor/bcc/search?q=BPF_PERF_ARRAY+path%3Atests&type=Code)
 
-### 6. map.lookup()
+### 7. map.lookup()
 
 Syntax: ```*val map.lookup(&key)```
 
@@ -477,7 +500,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=lookup+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=lookup+path%3Atools&type=Code)
 
-### 7. map.lookup_or_init()
+### 8. map.lookup_or_init()
 
 Syntax: ```*val map.lookup_or_init(&key, &zero)```
 
@@ -487,7 +510,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=lookup_or_init+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=lookup_or_init+path%3Atools&type=Code)
 
-### 8. map.delete()
+### 9. map.delete()
 
 Syntax: ```map.delete(&key)```
 
@@ -497,7 +520,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=delete+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=delete+path%3Atools&type=Code)
 
-### 9. map.update()
+### 10. map.update()
 
 Syntax: ```map.update(&key, &val)```
 
@@ -507,7 +530,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=update+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=update+path%3Atools&type=Code)
 
-### 10. map.increment()
+### 11. map.increment()
 
 Syntax: ```map.increment(key)```
 
@@ -517,7 +540,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=increment+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=increment+path%3Atools&type=Code)
 
-### 11. map.get_stackid()
+### 12. map.get_stackid()
 
 Syntax: ```int map.get_stackid(void *ctx, u64 flags)```
 
@@ -527,7 +550,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=get_stackid+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=get_stackid+path%3Atools&type=Code)
 
-### 12. map.perf_read()
+### 13. map.perf_read()
 
 Syntax: ```u64 map.perf_read(u32 cpu)```
 

--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -669,7 +669,7 @@ struct key_t {
   u32 curr_pid;
 };
 // map_type, key_type, leaf_type, table_name, num_entry
-BPF_TABLE("hash", struct key_t, u64, stats, 1024);
+BPF_HASH(struct key_t, u64, stats, 1024);
 // attach to finish_task_switch in kernel/sched/core.c, which has the following
 // prototype:
 //   struct rq *finish_task_switch(struct task_struct *prev)

--- a/examples/lua/task_switch.lua
+++ b/examples/lua/task_switch.lua
@@ -24,7 +24,7 @@ struct key_t {
   u32 curr_pid;
 };
 // map_type, key_type, leaf_type, table_name, num_entry
-BPF_TABLE("hash", struct key_t, u64, stats, 1024);
+BPF_HASH(stats, struct key_t, u64, 1024);
 int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
   struct key_t key = {};
   u64 zero = 0, *val;

--- a/examples/networking/distributed_bridge/tunnel.c
+++ b/examples/networking/distributed_bridge/tunnel.c
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License")
 #include <bcc/proto.h>
 
-BPF_TABLE("hash", u32, int, vni2if, 1024);
+BPF_HASH(vni2if, u32, int, 1024);
 
 struct vni_key {
   u64 mac;
@@ -15,12 +15,12 @@ struct host {
   u64 rx_pkts;
   u64 tx_pkts;
 };
-BPF_TABLE("hash", struct vni_key, struct host, mac2host, 10240);
+BPF_HASH(mac2host, struct vni_key, struct host);
 
 struct config {
   int tunnel_ifindex;
 };
-BPF_TABLE("hash", int, struct config, conf, 1);
+BPF_HASH(conf, int, struct config, 1);
 
 // Handle packets from the encap device, demux into the dest tenant
 int handle_ingress(struct __sk_buff *skb) {

--- a/examples/networking/distributed_bridge/tunnel_mesh.c
+++ b/examples/networking/distributed_bridge/tunnel_mesh.c
@@ -5,15 +5,15 @@
 struct config {
   int tunnel_ifindex;
 };
-BPF_TABLE("hash", int, struct config, conf, 1);
+BPF_HASH(conf, int, struct config, 1);
 
 struct tunnel_key {
   u32 tunnel_id;
   u32 remote_ipv4;
 };
-BPF_TABLE("hash", struct tunnel_key, int, tunkey2if, 1024);
+BPF_HASH(tunkey2if, struct tunnel_key, int, 1024);
 
-BPF_TABLE("hash", int, struct tunnel_key, if2tunkey, 1024);
+BPF_HASH(if2tunkey, int, struct tunnel_key, 1024);
 
 // Handle packets from the encap device, demux into the dest tenant
 int handle_ingress(struct __sk_buff *skb) {

--- a/examples/networking/dns_matching/dns_matching.c
+++ b/examples/networking/dns_matching/dns_matching.c
@@ -51,7 +51,7 @@ struct Leaf {
   unsigned char p[4];
 };
 
-BPF_TABLE("hash", struct Key, struct Leaf, cache, 128);
+BPF_HASH(cache, struct Key, struct Leaf, 128);
 
 int dns_matching(struct __sk_buff *skb)
 {

--- a/examples/networking/http_filter/http-parse-complete.c
+++ b/examples/networking/http_filter/http-parse-complete.c
@@ -19,7 +19,7 @@ struct Leaf {
 //BPF_TABLE(map_type, key_type, leaf_type, table_name, num_entry) 
 //map <Key, Leaf>
 //tracing sessions having same Key(dst_ip, src_ip, dst_port,src_port)
-BPF_TABLE("hash", struct Key, struct Leaf, sessions, 1024);
+BPF_HASH(sessions, struct Key, struct Leaf, 1024);
 
 /*eBPF program.
   Filter IP and TCP packets, having payload not empty

--- a/examples/networking/neighbor_sharing/tc_neighbor_sharing.c
+++ b/examples/networking/neighbor_sharing/tc_neighbor_sharing.c
@@ -7,7 +7,7 @@ struct ipkey {
   u32 client_ip;
 };
 
-BPF_TABLE("hash", struct ipkey, int, learned_ips, 1024);
+BPF_HASH(learned_ips, struct ipkey, int, 1024);
 
 // trivial action
 int pass(struct __sk_buff *skb) {

--- a/examples/networking/tunnel_monitor/monitor.c
+++ b/examples/networking/tunnel_monitor/monitor.c
@@ -16,7 +16,7 @@ struct counters {
   u64 rx_bytes;
 };
 
-BPF_TABLE("hash", struct ipkey, struct counters, stats, 1024);
+BPF_HASH(stats, struct ipkey, struct counters, 1024);
 BPF_TABLE("prog", int, int, parser, 10);
 
 enum cb_index {

--- a/examples/networking/vlan_learning/vlan_learning.c
+++ b/examples/networking/vlan_learning/vlan_learning.c
@@ -12,10 +12,10 @@ struct ifindex_leaf_t {
 };
 
 // redirect based on mac -> out_ifindex (auto-learning)
-BPF_TABLE("hash", int, struct ifindex_leaf_t, egress, 4096);
+BPF_HASH(egress, int, struct ifindex_leaf_t, 4096);
 
 // redirect based on mac -> out_ifindex (config-driven)
-BPF_TABLE("hash", u64, struct ifindex_leaf_t, ingress, 4096);
+BPF_HASH(ingress, struct ifindex_leaf_t, 4096);
 
 int handle_phys2virt(struct __sk_buff *skb) {
   // only handle vlan packets

--- a/examples/tracing/task_switch.py
+++ b/examples/tracing/task_switch.py
@@ -14,7 +14,7 @@ struct key_t {
   u32 curr_pid;
 };
 // map_type, key_type, leaf_type, table_name, num_entry
-BPF_TABLE("hash", struct key_t, u64, stats, 1024);
+BPF_HASH(stats, struct key_t, u64, 1024);
 int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
   struct key_t key = {};
   u64 zero = 0, *val;

--- a/examples/tracing/trace_perf_output.py
+++ b/examples/tracing/trace_perf_output.py
@@ -24,7 +24,7 @@ def cb(cpu, data, size):
 
 prog = """
 BPF_PERF_OUTPUT(events);
-BPF_TABLE("array", int, u64, counters, 10);
+BPF_ARRAY(counters, u64, 10);
 int kprobe__sys_clone(void *ctx) {
   struct {
     u64 ts;

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -95,13 +95,31 @@ struct _name##_table_t _name
   BPF_TABLE("hash", _key_type, u64, _name, 10240)
 #define BPF_HASH3(_name, _key_type, _leaf_type) \
   BPF_TABLE("hash", _key_type, _leaf_type, _name, 10240)
+#define BPF_HASH4(_name, _key_type, _leaf_type, _size) \
+  BPF_TABLE("hash", _key_type, _leaf_type, _name, _size)
+
 // helper for default-variable macro function
-#define BPF_HASHX(_1, _2, _3, NAME, ...) NAME
+#define BPF_HASHX(_1, _2, _3, _4, NAME, ...) NAME
 
 // Define a hash function, some arguments optional
 // BPF_HASH(name, key_type=u64, leaf_type=u64, size=10240)
 #define BPF_HASH(...) \
-  BPF_HASHX(__VA_ARGS__, BPF_HASH3, BPF_HASH2, BPF_HASH1)(__VA_ARGS__)
+  BPF_HASHX(__VA_ARGS__, BPF_HASH4, BPF_HASH3, BPF_HASH2, BPF_HASH1)(__VA_ARGS__)
+
+#define BPF_ARRAY1(_name) \
+  BPF_TABLE("array", int, u64, _name, 10240)
+#define BPF_ARRAY2(_name, _leaf_type) \
+  BPF_TABLE("array", int, _leaf_type, _name, 10240)
+#define BPF_ARRAY3(_name, _leaf_type, _size) \
+  BPF_TABLE("array", int, _leaf_type, _name, _size)
+
+// helper for default-variable macro function
+#define BPF_ARRAYX(_1, _2, _3, NAME, ...) NAME
+
+// Define an array function, some arguments optional
+// BPF_ARRAY(name, leaf_type=u64, size=10240)
+#define BPF_ARRAY(...) \
+  BPF_ARRAYX(__VA_ARGS__, BPF_ARRAY3, BPF_ARRAY2, BPF_ARRAY1)(__VA_ARGS__)
 
 #define BPF_HIST1(_name) \
   BPF_TABLE("histogram", int, u64, _name, 64)

--- a/tests/lua/test_clang.lua
+++ b/tests/lua/test_clang.lua
@@ -51,7 +51,7 @@ end
 
 function TestClang:test_sscanf()
   local text = [[
-BPF_TABLE("hash", int, struct { u64 a; u64 b; u32 c:18; u32 d:14; struct { u32 a; u32 b; } s; }, stats, 10);
+BPF_HASH(stats, int, struct { u64 a; u64 b; u32 c:18; u32 d:14; struct { u32 a; u32 b; } s; }, 10);
 
 int foo(void *ctx) {
     return 0;
@@ -76,7 +76,7 @@ int foo(void *ctx) {
 end
 
 function TestClang:test_sscanf_array()
-  local text = [[ BPF_TABLE("hash", int, struct { u32 a[3]; u32 b; }, stats, 10); ]]
+  local text = [[ BPF_HASH(stats, int, struct { u32 a[3]; u32 b; }, 10); ]]
 
   local b = BPF:new{text=text, debug=0}
   local t = b:get_table("stats")
@@ -103,7 +103,7 @@ struct key_t {
     struct request *req;
 };
 
-BPF_TABLE("hash", struct key_t, u64, start, 1024);
+BPF_HASH(start, struct key_t, u64, 1024);
 int do_request(struct pt_regs *ctx, struct request *req) {
     struct key_t key = {};
 
@@ -236,7 +236,7 @@ struct key_t {
   u32 prev_pid;
   u32 curr_pid;
 };
-BPF_TABLE("hash", struct key_t, u64, stats, 1024);
+BPF_HASH(stats, struct key_t, u64, 1024);
 int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
   struct key_t key = {};
   u64 zero = 0, *val;
@@ -296,9 +296,9 @@ union emptyu {
   struct empty em3;
   struct empty em4;
 };
-BPF_TABLE("array", int, struct list, t1, 1);
-BPF_TABLE("array", int, struct list *, t2, 1);
-BPF_TABLE("array", int, union emptyu, t3, 1);
+BPF_ARRAY(t1, struct list, 1);
+BPF_ARRAY(t2, struct list *, 1);
+BPF_ARRAY(t3, union emptyu, 1);
 ]]
   local b = BPF:new{text=text}
   local ffi = require("ffi")

--- a/tests/lua/test_uprobes.lua
+++ b/tests/lua/test_uprobes.lua
@@ -10,7 +10,7 @@ ffi.cdef[[
 function TestUprobes:test_simple_library()
   local text = [[
 #include <uapi/linux/ptrace.h>
-BPF_TABLE("array", int, u64, stats, 1);
+BPF_ARRAY(stats, u64, 1);
 static void incr(int idx) {
     u64 *ptr = stats.lookup(&idx);
     if (ptr)
@@ -41,7 +41,7 @@ end
 function TestUprobes:test_simple_binary()
   local text = [[
 #include <uapi/linux/ptrace.h>
-BPF_TABLE("array", int, u64, stats, 1);
+BPF_ARRAY(stats, u64, 1);
 static void incr(int idx) {
     u64 *ptr = stats.lookup(&idx);
     if (ptr)

--- a/tests/python/test_array.py
+++ b/tests/python/test_array.py
@@ -12,7 +12,7 @@ from unittest import main, TestCase
 
 class TestArray(TestCase):
     def test_simple(self):
-        b = BPF(text="""BPF_TABLE("array", int, u64, table1, 128);""")
+        b = BPF(text="""BPF_ARRAY(table1, u64, 128);""")
         t1 = b["table1"]
         t1[ct.c_int(0)] = ct.c_ulonglong(100)
         t1[ct.c_int(127)] = ct.c_ulonglong(1000)
@@ -24,7 +24,7 @@ class TestArray(TestCase):
         self.assertEqual(len(t1), 128)
 
     def test_native_type(self):
-        b = BPF(text="""BPF_TABLE("array", int, u64, table1, 128);""")
+        b = BPF(text="""BPF_ARRAY(table1, u64, 128);""")
         t1 = b["table1"]
         t1[0] = ct.c_ulonglong(100)
         t1[-2] = ct.c_ulonglong(37)

--- a/tests/python/test_bpf_log.py
+++ b/tests/python/test_bpf_log.py
@@ -15,7 +15,7 @@ error_msg = "R0 invalid mem access 'map_value_or_null'\n"
 text = """
        #include <uapi/linux/ptrace.h>
        #include <bcc/proto.h>
-       BPF_TABLE("hash", int, int, t1, 10);
+       BPF_HASH(t1, int, int, 10);
        int sim_port(struct __sk_buff *skb) {
            int x = 0, *y;
        """

--- a/tests/python/test_brb.c
+++ b/tests/python/test_brb.c
@@ -26,33 +26,33 @@ BPF_TABLE("prog", u32, u32, jump, 16);
 
 // physical endpoint manager (pem) tables which connects to boeht bridge 1 and bridge 2
 // <port_id, bpf_dest>
-BPF_TABLE("array", u32, bpf_dest_t, pem_dest, 256);
+BPF_ARRAY(pem_dest, bpf_dest_t, 256);
 // <port_id, ifindex>
-BPF_TABLE("array", u32, u32, pem_port, 256);
+BPF_ARRAY(pem_port, u32, 256);
 // <ifindex, port_id>
-BPF_TABLE("hash", u32, u32, pem_ifindex, 256);
+BPF_HASH(pem_ifindex, u32, u32, 256);
 // <0, tx2vm_pkts>
-BPF_TABLE("array", u32, u32, pem_stats, 1);
+BPF_ARRAY(pem_stats, u32, 1);
 
 // bridge 1 (br1) tables
 // <port_id, bpf_dest>
-BPF_TABLE("array", u32, bpf_dest_t, br1_dest, 256);
+BPF_ARRAY(br1_dest, bpf_dest_t, 256);
 // <eth_addr, port_id>
-BPF_TABLE("hash", eth_addr_t, u32, br1_mac, 256);
+BPF_HASH(br1_mac, eth_addr_t, u32, 256);
 // <0, rtr_ifindex>
-BPF_TABLE("array", u32, u32, br1_rtr, 1);
+BPF_ARRAY(br1_rtr, u32, 1);
 // <mac, ifindex>
-BPF_TABLE("hash", eth_addr_t, u32, br1_mac_ifindex, 1);
+BPF_HASH(br1_mac_ifindex, eth_addr_t, u32, 1);
 
 // bridge 2 (br2) tables
 // <port_id, bpf_dest>
-BPF_TABLE("array", u32, bpf_dest_t, br2_dest, 256);
+BPF_ARRAY(br2_dest, bpf_dest_t, 256);
 // <eth_addr, port_id>
-BPF_TABLE("hash", eth_addr_t, u32, br2_mac, 256);
+BPF_HASH(br2_mac, eth_addr_t, u32, 256);
 // <0, rtr_ifindex>
-BPF_TABLE("array", u32, u32, br2_rtr, 1);
+BPF_ARRAY(br2_rtr, u32, 1);
 // <mac, ifindex>
-BPF_TABLE("hash", eth_addr_t, u32, br2_mac_ifindex, 1);
+BPF_HASH(br2_mac_ifindex, eth_addr_t, u32, 1);
 
 int pem(struct __sk_buff *skb) {
     bpf_metadata_t meta = {};

--- a/tests/python/test_brb2.c
+++ b/tests/python/test_brb2.c
@@ -4,9 +4,9 @@
 
 // physical endpoint manager (pem) tables which connects VMs and bridges
 // <ifindex_in, ifindex_out>
-BPF_TABLE("hash", u32, u32, pem_dest, 256);
+BPF_HASH(pem_dest, u32, u32, 256);
 // <0, tx_pkts>
-BPF_TABLE("array", u32, u32, pem_stats, 1);
+BPF_ARRAY(pem_stats, u32, 1);
 
 int pem(struct __sk_buff *skb) {
     u32 ifindex_in, *ifindex_p;

--- a/tests/python/test_call1.c
+++ b/tests/python/test_call1.c
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License")
 
 BPF_TABLE("prog", int, int, jump, 64);
-BPF_TABLE("array", int, u64, stats, 64);
+BPF_ARRAY(stats, u64, 64);
 
 enum states {
   S_EOP = 1,

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -86,7 +86,7 @@ int do_completion(struct pt_regs *ctx, struct request *req) {
 
     def test_sscanf(self):
         text = """
-BPF_TABLE("hash", int, struct { u64 a; u64 b; u64 c:36; u64 d:28; struct { u32 a; u32 b; } s; }, stats, 10);
+BPF_HASH(stats, int, struct { u64 a; u64 b; u64 c:36; u64 d:28; struct { u32 a; u32 b; } s; }, 10);
 int foo(void *ctx) {
     return 0;
 }
@@ -107,7 +107,7 @@ int foo(void *ctx) {
 
     def test_sscanf_array(self):
         text = """
-BPF_TABLE("hash", int, struct { u32 a[3]; u32 b; }, stats, 10);
+BPF_HASH(stats, int, struct { u32 a[3]; u32 b; }, 10);
 """
         b = BPF(text=text, debug=0)
         t = b.get_table("stats")
@@ -130,7 +130,7 @@ struct key_t {
     struct request *req;
 };
 
-BPF_TABLE("hash", struct key_t, u64, start, 1024);
+BPF_HASH(start, struct key_t, u64, 1024);
 int do_request(struct pt_regs *ctx, struct request *req) {
     struct key_t key = {};
 
@@ -268,7 +268,7 @@ struct key_t {
   u32 prev_pid;
   u32 curr_pid;
 };
-BPF_TABLE("hash", struct key_t, u64, stats, 1024);
+BPF_HASH(stats, struct key_t, u64, 1024);
 int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
   struct key_t key = {};
   u64 zero = 0, *val;
@@ -325,9 +325,9 @@ union emptyu {
   struct empty em3;
   struct empty em4;
 };
-BPF_TABLE("array", int, struct list, t1, 1);
-BPF_TABLE("array", int, struct list *, t2, 1);
-BPF_TABLE("array", int, union emptyu, t3, 1);
+BPF_ARRAY(t1, struct list, 1);
+BPF_ARRAY(t2, struct list *, 1);
+BPF_ARRAY(t3, union emptyu, 1);
 """
         b = BPF(text=text)
         import ctypes
@@ -351,7 +351,7 @@ BPF_TABLE("array", int, union emptyu, t3, 1);
 
     def test_nested_union(self):
         text = """
-BPF_TABLE("hash", struct bpf_tunnel_key, int, t1, 1);
+BPF_HASH(t1, struct bpf_tunnel_key, int, 1);
 """
         b = BPF(text=text)
         t1 = b["t1"]
@@ -389,7 +389,7 @@ int process(struct xdp_md *ctx) {
 
     def test_update_macro_arg(self):
         text = """
-BPF_TABLE("array", u32, u32, act, 32);
+BPF_ARRAY(act, u32, 32);
 
 #define JMP_IDX_PIPE (1U << 1)
 

--- a/tests/python/test_clang_complex.c
+++ b/tests/python/test_clang_complex.c
@@ -10,7 +10,7 @@ struct FwdKey {
 struct FwdLeaf {
   u32 fwd_idx:32;
 };
-BPF_TABLE("hash", struct FwdKey, struct FwdLeaf, fwd_map, 1);
+BPF_HASH(fwd_map, struct FwdKey, struct FwdLeaf, 1);
 
 // array
 struct ConfigKey {
@@ -29,7 +29,7 @@ struct MacaddrKey {
 struct MacaddrLeaf {
   u64 mac;
 };
-BPF_TABLE("hash", struct MacaddrKey, struct MacaddrLeaf, macaddr_map, 11);
+BPF_HASH(macaddr_map, struct MacaddrKey, struct MacaddrLeaf, 11);
 
 // hash
 struct SlaveKey {
@@ -38,7 +38,7 @@ struct SlaveKey {
 struct SlaveLeaf {
   u32 slave_ifindex;
 };
-BPF_TABLE("hash", struct SlaveKey, struct SlaveLeaf, slave_map, 10);
+BPF_HASH(slave_map, struct SlaveKey, struct SlaveLeaf, 10);
 
 int handle_packet(struct __sk_buff *skb) {
   int ret = 0;

--- a/tests/python/test_perf_event.py
+++ b/tests/python/test_perf_event.py
@@ -13,7 +13,7 @@ class TestPerfCounter(unittest.TestCase):
     def test_cycles(self):
         text = """
 BPF_PERF_ARRAY(cnt1, NUM_CPUS);
-BPF_TABLE("array", u32, u64, prev, NUM_CPUS);
+BPF_ARRAY(prev, u64, NUM_CPUS);
 BPF_HISTOGRAM(dist);
 int kprobe__sys_getuid(void *ctx) {
     u32 cpu = bpf_get_smp_processor_id();

--- a/tests/python/test_stat1.c
+++ b/tests/python/test_stat1.c
@@ -12,7 +12,7 @@ struct IPLeaf {
   u64 tx_pkts;
 };
 
-BPF_TABLE("hash", struct IPKey, struct IPLeaf, stats, 256);
+BPF_HASH(stats, struct IPKey, struct IPLeaf, 256);
 
 int on_packet(struct __sk_buff *skb) {
   u8 *cursor = 0;

--- a/tests/python/test_trace2.c
+++ b/tests/python/test_trace2.c
@@ -3,7 +3,7 @@
 #include <linux/ptrace.h>
 struct Ptr { u64 ptr; };
 struct Counters { u64 stat1; };
-BPF_TABLE("hash", struct Ptr, struct Counters, stats, 1024);
+BPF_HASH(stats, struct Ptr, struct Counters, 1024);
 
 int count_sched(struct pt_regs *ctx) {
   struct Ptr key = {.ptr = PT_REGS_PARM1(ctx)};

--- a/tests/python/test_trace2.py
+++ b/tests/python/test_trace2.py
@@ -12,7 +12,7 @@ text = """
 #include <linux/ptrace.h>
 struct Ptr { u64 ptr; };
 struct Counters { u64 stat1; };
-BPF_TABLE("hash", struct Ptr, struct Counters, stats, 1024);
+BPF_HASH(stats, struct Ptr, struct Counters, 1024);
 
 int count_sched(struct pt_regs *ctx) {
   struct Ptr key = {.ptr=PT_REGS_PARM1(ctx)};

--- a/tests/python/test_trace3.c
+++ b/tests/python/test_trace3.c
@@ -4,9 +4,9 @@
 #include <linux/blkdev.h>
 struct Request { u64 rq; };
 struct Time { u64 start; };
-BPF_TABLE("hash", struct Request, struct Time, requests, 1024);
+BPF_HASH(requests, struct Request, struct Time, 1024);
 #define SLOTS 100
-BPF_TABLE("array", u32, u64, latency, SLOTS);
+BPF_ARRAY(latency, u64, SLOTS);
 
 static u32 log2(u32 v) {
   u32 r, shift;

--- a/tests/python/test_trace4.py
+++ b/tests/python/test_trace4.py
@@ -12,7 +12,7 @@ class TestKprobeRgx(TestCase):
         self.b = BPF(text="""
         typedef struct { int idx; } Key;
         typedef struct { u64 val; } Val;
-        BPF_TABLE("hash", Key, Val, stats, 3);
+        BPF_HASH(stats, Key, Val, 3);
         int hello(void *ctx) {
           stats.lookup_or_init(&(Key){1}, &(Val){0})->val++;
           return 0;

--- a/tests/python/test_uprobes.py
+++ b/tests/python/test_uprobes.py
@@ -11,7 +11,7 @@ class TestUprobes(unittest.TestCase):
     def test_simple_library(self):
         text = """
 #include <uapi/linux/ptrace.h>
-BPF_TABLE("array", int, u64, stats, 1);
+BPF_ARRAY(stats, u64, 1);
 static void incr(int idx) {
     u64 *ptr = stats.lookup(&idx);
     if (ptr)
@@ -40,7 +40,7 @@ int count(struct pt_regs *ctx) {
     def test_simple_binary(self):
         text = """
 #include <uapi/linux/ptrace.h>
-BPF_TABLE("array", int, u64, stats, 1);
+BPF_ARRAY(stats, u64, 1);
 static void incr(int idx) {
     u64 *ptr = stats.lookup(&idx);
     if (ptr)

--- a/tests/python/test_xlate1.c
+++ b/tests/python/test_xlate1.c
@@ -11,7 +11,7 @@ struct IPLeaf {
   u64 ip_xlated_pkts;
   u64 arp_xlated_pkts;
 };
-BPF_TABLE("hash", struct IPKey, struct IPLeaf, xlate, 1024);
+BPF_HASH(xlate, struct IPKey, struct IPLeaf, 1024);
 
 int on_packet(struct __sk_buff *skb) {
   u8 *cursor = 0;

--- a/tools/dcstat.py
+++ b/tools/dcstat.py
@@ -49,7 +49,7 @@ enum stats {
     S_MAXSTAT
 };
 
-BPF_TABLE("array", int, u64, stats, S_MAXSTAT + 1);
+BPF_ARRAY(stats, u64, S_MAXSTAT + 1);
 
 /*
  * How this is instrumented, and how to interpret the statistics, is very much

--- a/tools/deadlock_detector.c
+++ b/tools/deadlock_detector.c
@@ -30,8 +30,7 @@ struct thread_to_held_mutex_leaf_t {
 };
 
 // Map of thread ID -> array of (mutex addresses, stack id)
-BPF_TABLE("hash", u32, struct thread_to_held_mutex_leaf_t,
-          thread_to_held_mutexes, 2097152);
+BPF_HASH(thread_to_held_mutexes, u32, struct thread_to_held_mutex_leaf_t, 2097152);
 
 // Key type for edges. Represents an edge from mutex1 => mutex2.
 struct edges_key_t {
@@ -48,7 +47,7 @@ struct edges_leaf_t {
 };
 
 // Represents all edges currently in the mutex wait graph.
-BPF_TABLE("hash", struct edges_key_t, struct edges_leaf_t, edges, 2097152);
+BPF_HASH(edges, struct edges_key_t, struct edges_leaf_t, 2097152);
 
 // Info about parent thread when a child thread is created.
 struct thread_created_leaf_t {
@@ -58,7 +57,7 @@ struct thread_created_leaf_t {
 };
 
 // Map of child thread pid -> info about parent thread.
-BPF_TABLE("hash", u32, struct thread_created_leaf_t, thread_to_parent, 10240);
+BPF_HASH(thread_to_parent, u32, struct thread_created_leaf_t);
 
 // Stack traces when threads are created and when mutexes are locked/unlocked.
 BPF_STACK_TRACE(stack_traces, 655360);

--- a/tools/funccount.py
+++ b/tools/funccount.py
@@ -178,7 +178,7 @@ int PROBE_FUNCTION(void *ctx) {
         """
         bpf_text = """#include <uapi/linux/ptrace.h>
 
-BPF_TABLE("array", int, u64, counts, NUMLOCATIONS);
+BPF_ARRAY(counts, u64, NUMLOCATIONS);
         """
 
         # We really mean the tgid from the kernel's perspective, which is in

--- a/tools/pidpersec.py
+++ b/tools/pidpersec.py
@@ -26,7 +26,7 @@ enum stat_types {
     S_MAXSTAT
 };
 
-BPF_TABLE("array", int, u64, stats, S_MAXSTAT + 1);
+BPF_ARRAY(stats, u64, S_MAXSTAT + 1);
 
 void stats_increment(int key) {
     u64 *leaf = stats.lookup(&key);

--- a/tools/vfscount.py
+++ b/tools/vfscount.py
@@ -23,7 +23,7 @@ struct key_t {
     u64 ip;
 };
 
-BPF_TABLE("hash", struct key_t, u64, counts, 256);
+BPF_HASH(counts, struct key_t, u64, 256);
 
     int do_count(struct pt_regs *ctx) {
     struct key_t key = {};

--- a/tools/vfsstat.py
+++ b/tools/vfsstat.py
@@ -49,7 +49,7 @@ enum stat_types {
     S_MAXSTAT
 };
 
-BPF_TABLE("array", int, u64, stats, S_MAXSTAT + 1);
+BPF_ARRAY(stats, u64, S_MAXSTAT + 1);
 
 void stats_increment(int key) {
     u64 *leaf = stats.lookup(&key);


### PR DESCRIPTION
- Documentations indicates we can pass a size argument for `BPF_HASH`, but we actually can't. This PR fixes that.
- This PR also adds helper Macros for popular array map type.
- Make tools and examples use those new Macros.