### PR TITLE
softirqs: Migrate to kernel tracepoints instead of kprobes

### DIFF
--- a/man/man8/softirqs.8
+++ b/man/man8/softirqs.8
@@ -9,10 +9,10 @@ show this time as either totals or histogram distributions. A system-wide
 summary of this time is shown by the %soft column of mpstat(1), and soft IRQ
 event counts (but not times) are available in /proc/softirqs.
 
-WARNING: This currently uses dynamic tracing of various soft interrupt
-functions, and can easily not work with different kernel versions. Check and
-adjust the code as necessary. Also try in a test environment and ensure this
-tool is safe before use. Future versions should switch to tracepoints.
+This tool uses the irq:softirq_enter and irq:softirq_exit kernel tracepoints,
+which is a stable tracing mechanism. BPF programs can attach to tracepoints
+from Linux 4.7 only. An older version of this tool is available in tools/old,
+and uses kprobes instead of tracepoints.
 
 Since this uses BPF, only the root user can use this tool.
 .SH REQUIREMENTS
@@ -87,7 +87,7 @@ example usage, output, and commentary for this tool.
 Linux
 .SH STABILITY
 Unstable - in development.
-.SH AUTHOR
-Brendan Gregg
+.SH AUTHORS
+Brendan Gregg, Sasha Goldshtein
 .SH SEE ALSO
 hardirqs(8)

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -242,11 +242,9 @@ class SmokeTests(TestCase):
     def test_slabratetop(self):
         self.run_with_duration("slabratetop.py 1 1")
 
+    @skipUnless(kernel_version_ge(4,7), "requires kernel >= 4.7")
     def test_softirqs(self):
-        # TODO Temporary disabled as softirqs.py doesn't work on recent
-        # kernels (can't find some of its attach targets). Need to revisit
-        # it to use the softirq tracepoints. Tracked in bcc#1031.
-        # self.run_with_duration("softirqs.py 1 1")
+        self.run_with_duration("softirqs.py 1 1")
         pass
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")


### PR DESCRIPTION
This commit migrates softirqs to use kernel tracepoints instead of
kprobes. Because tracepoints only provide the vector number and not
the function name, we use a conversion table, which is borrowed from
kernel/softirq.c, to translate the vector number to a display name.
This table is expected to be fairly stable. Notably, new names have
not been added since approximately 2009, and the last rename (without
adding or removing a name) was in 2014.

Resolves #1031.