### PR TITLE
Free demangle_name after use

### DIFF
--- a/src/cc/BPFTable.cc
+++ b/src/cc/BPFTable.cc
@@ -61,9 +61,11 @@ std::vector<std::string> BPFStackTable::get_stack_symbol(int stack_id,
   bcc_symbol symbol;
   for (auto addr : addresses)
     if (bcc_symcache_resolve(cache, addr, &symbol) != 0)
-      res.push_back("[UNKNOWN]");
-    else
+      res.emplace_back("[UNKNOWN]");
+    else {
       res.push_back(symbol.demangle_name);
+      bcc_symbol_free_demangle_name(&symbol);
+    }
 
   return res;
 }

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -307,6 +307,11 @@ void bcc_free_symcache(void *symcache, int pid) {
     delete static_cast<ProcSyms*>(symcache);
 }
 
+void bcc_symbol_free_demangle_name(struct bcc_symbol *sym) {
+  if (sym->demangle_name && (sym->demangle_name != sym->name))
+    free(const_cast<char*>(sym->demangle_name));
+}
+
 int bcc_symcache_resolve(void *resolver, uint64_t addr,
                          struct bcc_symbol *sym) {
   SymbolCache *cache = static_cast<SymbolCache *>(resolver);

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -34,6 +34,10 @@ typedef int (*SYM_CB)(const char *symname, uint64_t addr);
 void *bcc_symcache_new(int pid);
 void bcc_free_symcache(void *symcache, int pid);
 
+// The demangle_name pointer in bcc_symbol struct is returned from the
+// __cxa_demangle function call, which is supposed to be freed by caller. Call
+// this function after done using returned result of bcc_symcache_resolve.
+void bcc_symbol_free_demangle_name(struct bcc_symbol *sym);
 int bcc_symcache_resolve(void *symcache, uint64_t addr, struct bcc_symbol *sym);
 int bcc_symcache_resolve_no_demangle(void *symcache, uint64_t addr,
                                      struct bcc_symbol *sym);

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -118,6 +118,7 @@ int bcc_resolve_symname(const char *module, const char *symname, const uint64_t 
 		int pid, struct bcc_symbol *sym);
 void bcc_procutils_free(const char *ptr);
 void *bcc_symcache_new(int pid);
+void bcc_symbol_free_demangle_name(struct bcc_symbol *sym);
 int bcc_symcache_resolve(void *symcache, uint64_t addr, struct bcc_symbol *sym);
 void bcc_symcache_refresh(void *resolver);
 ]]

--- a/src/lua/bcc/sym.lua
+++ b/src/lua/bcc/sym.lua
@@ -25,7 +25,9 @@ local function create_cache(pid)
       if libbcc.bcc_symcache_resolve(self._CACHE, addr, sym) < 0 then
         return "[unknown]", 0x0
       end
-      return ffi.string(sym[0].demangle_name), sym[0].offset
+      local name_res = ffi.string(sym[0].demangle_name)
+      libbcc.bcc_symbol_free_demangle_name(sym);
+      return name_res, sym[0].offset
     end
   }
 end

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -69,9 +69,13 @@ class SymbolCache(object):
                 return (None, sym.offset,
                         ct.cast(sym.module, ct.c_char_p).value.decode())
             return (None, addr, None)
-        return (
-            sym.demangle_name.decode() if demangle else sym.name.decode(),
-            sym.offset, ct.cast(sym.module, ct.c_char_p).value.decode())
+        if demangle:
+            name_res = sym.demangle_name.decode()
+            lib.bcc_symbol_free_demangle_name(psym)
+        else:
+            name_res = sym.name.decode()
+        return (name_res, sym.offset,
+                ct.cast(sym.module, ct.c_char_p).value.decode())
 
     def resolve_name(self, module, name):
         addr = ct.c_ulonglong()

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -152,6 +152,9 @@ lib.bcc_symcache_new.argtypes = [ct.c_int]
 lib.bcc_free_symcache.restype = ct.c_void_p
 lib.bcc_free_symcache.argtypes = [ct.c_void_p, ct.c_int]
 
+lib.bcc_symbol_free_demangle_name.restype = ct.c_void_p
+lib.bcc_symbol_free_demangle_name.argtypes = [ct.POINTER(bcc_symbol)]
+
 lib.bcc_symcache_resolve.restype = ct.c_int
 lib.bcc_symcache_resolve.argtypes = [ct.c_void_p, ct.c_ulonglong, ct.POINTER(bcc_symbol)]
 


### PR DESCRIPTION
According to the [documentation of `__cxa_demangle`](https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html), caller is supposed to free the returned result pointer after use. We (aka I) missed this in #638 and are probably leaking memory because of this.

This PR fixes the issue by calling a newly added `bcc_symbol_free_demangle_name` after use of the demangled name, across C++, Python and Lua APIs. 