### PR TITLE
Fix compiler warning on redefined Macro

### DIFF
--- a/src/cc/BPFTable.cc
+++ b/src/cc/BPFTable.cc
@@ -136,12 +136,14 @@ StatusTuple BPFPerfBuffer::close_all_cpu() {
   std::string errors;
   bool has_error = false;
 
-  int close_res = close(epfd_);
-  epfd_ = -1;
-  ep_events_.reset();
-  if (close_res != 0) {
-    has_error = true;
-    errors += std::string(std::strerror(errno)) + "\n";
+  if (epfd_ >= 0) {
+    int close_res = close(epfd_);
+    epfd_ = -1;
+    ep_events_.reset();
+    if (close_res != 0) {
+      has_error = true;
+      errors += std::string(std::strerror(errno)) + "\n";
+    }
   }
 
   std::vector<int> opened_cpus;

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>

--- a/src/cc/perf_reader.c
+++ b/src/cc/perf_reader.c
@@ -244,7 +244,7 @@ void perf_reader_event_read(struct perf_reader *reader) {
       if (reader->lost_cb) {
         reader->lost_cb(lost);
       } else {
-        fprintf(stderr, "Possibly lost " PRIu64 " samples\n", lost);
+        fprintf(stderr, "Possibly lost %" PRIu64 " samples\n", lost);
       }
     } else if (e->type == PERF_RECORD_SAMPLE) {
       if (reader->type == PERF_TYPE_TRACEPOINT)


### PR DESCRIPTION
The `_GNU_SOURCE` flag is being passed by command-line argument most of the time, causing a warning:
```
[ 52%] Building C object src/cc/CMakeFiles/bcc-shared.dir/bcc_proc.c.o
/tmp/rpmbuild.hW1e0H/BUILD/bcc/src/cc/bcc_proc.c:16:0: warning: "_GNU_SOURCE" redefined
 #define _GNU_SOURCE
```
