### PR TITLE
[RFC]: Extend table API with string support 

### DIFF
--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -90,6 +90,13 @@ public:
                                 int group_fd = -1);
   StatusTuple detach_perf_event(uint32_t ev_type, uint32_t ev_config);
 
+  BPFTable get_table(const std::string& name) {
+    TableStorage::iterator it;
+    if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+      return BPFTable(it->second);
+    return BPFTable({});
+  }
+
   template <class ValueType>
   BPFArrayTable<ValueType> get_array_table(const std::string& name) {
     TableStorage::iterator it;

--- a/src/cc/table_desc.h
+++ b/src/cc/table_desc.h
@@ -67,6 +67,9 @@ class FileDesc {
   int fd;
 };
 
+typedef int (*sscanf_fn)(const char *, void *);
+typedef int (*snprintf_fn)(char *, size_t, const void *);
+
 /// TableDesc uniquely stores all of the runtime state for an active bpf table.
 /// The copy constructor/assign operator are disabled since the file handles
 /// owned by this table are not implicitly copyable. One should call the dup()
@@ -118,10 +121,10 @@ class TableDesc {
   int flags;
   std::string key_desc;
   std::string leaf_desc;
-  llvm::Function *key_sscanf;
-  llvm::Function *leaf_sscanf;
-  llvm::Function *key_snprintf;
-  llvm::Function *leaf_snprintf;
+  sscanf_fn key_sscanf;
+  sscanf_fn leaf_sscanf;
+  snprintf_fn key_snprintf;
+  snprintf_fn leaf_snprintf;
   bool is_shared;
   bool is_extern;
 };

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(test_libbcc
 	test_libbcc.cc
 	test_c_api.cc
 	test_array_table.cc
+	test_bpf_table.cc
 	test_hash_table.cc
 	test_usdt_args.cc
 	test_usdt_probes.cc)

--- a/tests/cc/test_bpf_table.cc
+++ b/tests/cc/test_bpf_table.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017 Politecnico di Torino
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BPF.h"
+#include "catch.hpp"
+
+TEST_CASE("test bpf table", "[bpf_table]") {
+  const std::string BPF_PROGRAM = R"(
+    BPF_TABLE("hash", int, int, myhash, 128);
+  )";
+
+  ebpf::BPF *bpf(new ebpf::BPF);
+  ebpf::StatusTuple res(0);
+  res = bpf->init(BPF_PROGRAM);
+  REQUIRE(res.code() == 0);
+
+  ebpf::BPFTable t = bpf->get_table("myhash");
+
+  // update element
+  std::string value;
+  res = t.update_value("0x07", "0x42");
+  REQUIRE(res.code() == 0);
+  res = t.get_value("0x07", value);
+  REQUIRE(res.code() == 0);
+  REQUIRE(value == "0x42");
+
+  // update another element
+  res = t.update_value("0x11", "0x777");
+  REQUIRE(res.code() == 0);
+  res = t.get_value("0x11", value);
+  REQUIRE(res.code() == 0);
+  REQUIRE(value == "0x777");
+
+  // remove value
+  res = t.remove_value("0x11");
+  REQUIRE(res.code() == 0);
+  res = t.get_value("0x11", value);
+  REQUIRE(res.code() != 0);
+
+  // delete bpf_module, call to key/leaf printf/scanf must fail
+  delete bpf;
+
+  res = t.update_value("0x07", "0x42");
+  REQUIRE(res.code() != 0);
+
+  res = t.get_value("0x07", value);
+  REQUIRE(res.code() != 0);
+
+  res = t.remove_value("0x07");
+  REQUIRE(res.code() != 0);
+}


### PR DESCRIPTION
Currently it is only possible to access the key/leaf from/to string functions using the bpf_module class.
This PR extends the high level c++ api to also support it.

First commit exposes the conversion functions. The second one exposes a new kind of table that can be accessed using only strings without knowing structure of the data saved on the map.

Please note that this feature is useful when implementing remote map access, as hover for example.