### PR TITLE
cc: Prefer external debuginfo files to the binary itself

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -360,9 +360,12 @@ static char *find_debug_via_debuglink(Elf *e, const char *binpath) {
   bindir = strdup(binpath);
   bindir = dirname(bindir);
 
-  // Search for the file in 'binpath'
+  // Search for the file in 'binpath', but ignore the file we find if it
+  // matches the binary itself: the binary will always be probed later on,
+  // and it might contain poorer symbols (e.g. stripped or partial symbols)
+  // than the external debuginfo that might be available elsewhere.
   sprintf(fullpath, "%s/%s", bindir, name);
-  if (access(fullpath, F_OK) != -1) {
+  if (strcmp(fullpath, binpath) != 0 && access(fullpath, F_OK) != -1) {
     res = strdup(fullpath);
     goto DONE;
   }


### PR DESCRIPTION
On some distributions, the debuglink section in the binary will
not have a .debug file extension. As a result, we will try to look
for the debuginfo file in the binary itself, immediately find it,
and abort looking for any other alternatives. This is not good,
because the binary might contain stripped or partial symbols,
which precludes certain tools from realizing their full potential.

Fix by checking that the debuginfo file we're trying to use is
not the same as the binary file. In any case, if external debuginfo
can't be found, we will fall back to the symbols in the original
binary file, if present, so this should not regress any existing
scenario.

This was originally reported by @antonblanchard in #1011.