### PR TITLE
Fix delitem operation for PROG_ARRAYs

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -463,6 +463,13 @@ class ProgArray(ArrayBase):
             leaf = self.Leaf(leaf.fd)
         super(ProgArray, self).__setitem__(key, leaf)
 
+    def __delitem__(self, key):
+        key = self._normalize_key(key)
+        key_p = ct.pointer(key)
+        res = lib.bpf_delete_elem(self.map_fd, ct.cast(key_p, ct.c_void_p))
+        if res < 0:
+            raise Exception("Could not delete item")
+
 class PerfEventArray(ArrayBase):
     class Event(object):
         def __init__(self, typ, config):

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -504,5 +504,26 @@ void do_trace(struct pt_regs *ctx) {
         self.assertEqual(1, b["dummy"][ct.c_ulong(0)].value)
         self.assertEqual(2, b["dummy"][ct.c_ulong(1)].value)
 
+    def test_prog_array_delete(self):
+        text = """
+BPF_TABLE("prog", int, int, dummy, 256);
+"""
+        b1 = BPF(text=text)
+        text = """
+int do_next(struct pt_regs *ctx) {
+    return 0;
+}
+"""
+        b2 = BPF(text=text)
+        fn = b2.load_func("do_next", BPF.KPROBE)
+        c_key = ct.c_int(0)
+        b1["dummy"][c_key] = ct.c_int(fn.fd)
+        b1["dummy"].__delitem__(c_key);
+        with self.assertRaises(KeyError):
+            b1["dummy"][c_key]
+
+
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
In bcc, `ProgArray.__delitem__` defaults to `ArrayBase.__delitem__`
which uses the `bpf_update_elem` helper to clear the item (override
with a null value). However, eBPF doesn't offer a `bpf_update_elem`
helper for prog arrays.

This pull request overrides `__delitem__` in `ProgArray` to use the
`bpf_delete_item` helper.