### PR TITLE
Use normal inlining in clang loader

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -287,6 +287,9 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts, const st
   invocation2.getFrontendOpts().Inputs.push_back(
       FrontendInputFile(main_path, IK_C));
   invocation2.getFrontendOpts().DisableFree = false;
+  // Resort to normal inlining. In -O0 the default is OnlyAlwaysInlining and
+  // clang might add noinline attribute even for functions with inline hint.
+  invocation2.getCodeGenOpts().setInlining(CodeGenOptions::NormalInlining);
   // suppress warnings in the 2nd pass, but bail out on errors (our fault)
   invocation2.getDiagnosticOpts().IgnoreWarnings = true;
   compiler2.createDiagnostics();


### PR DESCRIPTION
This is a follow up to https://github.com/iovisor/bcc/pull/1114.

In clang -O0 the default inlining mode is `OnlyAlwaysInlining`. With a recent version of clang/llvm, this might break `static inline` functions from kernel headers, e.g. `ip_is_fragment` from `net/ip.h`.
```
error: <unknown>:0:0: in function process i32 (%struct.xdp_md*): A call to global function 'ip_is_fragment' is not supported. Please use __attribute__((always_inline) to make sure this function is inlined.
```

This pull request set the inlining mode to `NormalInlining` in second pass of clang loader, so that the hinted inline functions could be properly inlined.