### PR TITLE
db* tools: miscellaneous fixes

### DIFF
--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -54,7 +54,7 @@ if not args.pids or len(args.pids) == 0:
 threshold_ns = args.threshold * 1000000
 
 program = """
-#include <linux/ptrace.h>
+#include <uapi/linux/ptrace.h>
 
 struct temp_t {
     u64 timestamp;

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -106,10 +106,11 @@ for usdt in usdts:
     usdt.enable_probe("query__start", "probe_start")
     usdt.enable_probe("query__done", "probe_end")
 
-bpf = BPF(text=program, usdt_contexts=usdts)
 if args.verbose:
     print('\n'.join(map(lambda u: u.get_text(), usdts)))
     print(program)
+
+bpf = BPF(text=program, usdt_contexts=usdts)
 
 class Data(ct.Structure):
     _fields_ = [

--- a/tools/dbstat.py
+++ b/tools/dbstat.py
@@ -52,7 +52,7 @@ if not args.pids or len(args.pids) == 0:
                                         "pidof postgres".split()).split())
 
 program = """
-#include <linux/ptrace.h>
+#include <uapi/linux/ptrace.h>
 
 BPF_HASH(temp, u64, u64);
 BPF_HISTOGRAM(latency);

--- a/tools/dbstat.py
+++ b/tools/dbstat.py
@@ -88,10 +88,11 @@ for usdt in usdts:
     usdt.enable_probe("query__start", "probe_start")
     usdt.enable_probe("query__done", "probe_end")
 
-bpf = BPF(text=program, usdt_contexts=usdts)
 if args.verbose:
     print('\n'.join(map(lambda u: u.get_text(), usdts)))
     print(program)
+
+bpf = BPF(text=program, usdt_contexts=usdts)
 
 print("Tracing database queries for pids %s slower than %d ms..." %
       (', '.join(map(str, args.pids)), args.threshold))


### PR DESCRIPTION
Use uapi/linux/ptrace.h instead of linux/ptrace.h in includes. Print the BPF program before loading it, when using the -v (verbose) mode. Reported as part of #1106.