### PR TITLE
Add default -Wno-address-of-packed-membe to Clang loader

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -137,6 +137,8 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts, const st
                                    "-Wno-deprecated-declarations",
                                    "-Wno-gnu-variable-sized-type-not-at-end",
                                    "-Wno-pragma-once-outside-header",
+                                   "-Wno-address-of-packed-member",
+                                   "-Wno-unknown-warning-option",
                                    "-fno-color-diagnostics",
                                    "-fno-unwind-tables",
                                    "-fno-asynchronous-unwind-tables",


### PR DESCRIPTION
New LLVM version (4.0.0) has added this warning. Unfortunately if the BPF program includes `<linux/sched.h>` (which is widely used in BCC tools), this warning will be triggered:
```
In file included from /virtual/main.c:46:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/include/linux/sched.h:19:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/include/linux/timex.h:56:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/include/uapi/linux/timex.h:56:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/include/linux/time.h:5:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/include/linux/seqlock.h:35:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/include/linux/spinlock.h:50:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/include/linux/preempt.h:59:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/arch/x86/include/asm/preempt.h:6:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/include/linux/thread_info.h:54:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/arch/x86/include/asm/thread_info.h:52:
In file included from /lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/arch/x86/include/asm/cpufeature.h:4:
/lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/arch/x86/include/asm/processor.h:465:30: warning: taking address of packed member 'sp0' of class or structure
      'x86_hw_tss' may result in an unaligned pointer value [-Waddress-of-packed-member]
        return this_cpu_read_stable(cpu_tss.x86_tss.sp0);
                                    ^~~~~~~~~~~~~~~~~~~
/lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/arch/x86/include/asm/percpu.h:391:59: note: expanded from macro 'this_cpu_read_stable'
#define this_cpu_read_stable(var)       percpu_stable_op("mov", var)
                                                                ^~~
/lib/modules/4.6.7-38_fbk8_2591_gf27713f/build/arch/x86/include/asm/percpu.h:223:16: note: expanded from macro 'percpu_stable_op'
                    : "p" (&(var)));                    \
                             ^~~
```
It is annoying since the warnings are printed to `stderr` directly.

This Diff removes this warning. Unfortunately if LLVM is on an older version user will see a
```
warning: unknown warning option '-Wno-address-of-packed-member' [-Wunknown-warning-option]
```
instead:( I very much want to gate it, but it seems hard to find out the linked LLVM version inside the code:(