### PR TITLE
Add installation instructions for snap builds.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,6 +46,15 @@ Kernel compile flags can usually be checked by looking at `/proc/config.gz` or
 
 # Packages
 
+Nightly builds are provided for Ubuntu, Debian, Fedora, and any other
+distribution with [snapd](https://snapcraft.io/docs/core/install).
+
+```bash
+sudo snap install bcc --edge
+sudo snap connect bcc:system-observe
+sudo snap connect bcc:mount-observe
+```
+
 ## Ubuntu Xenial - Binary
 
 Only the nightly packages are built for Ubuntu 16.04, but the steps are very straightforward. No need to upgrade the kernel or compile from source!

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,7 +46,7 @@ Kernel compile flags can usually be checked by looking at `/proc/config.gz` or
 
 # Packages
 
-Nightly builds are provided for Ubuntu, Debian, Fedora, and any other
+Regular builds are provided for Ubuntu, Debian, Fedora, and any other
 distribution with [snapd](https://snapcraft.io/docs/core/install).
 
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,7 @@ distribution with [snapd](https://snapcraft.io/docs/core/install).
 ```bash
 sudo snap install bcc --edge
 sudo snap connect bcc:system-observe
+sudo snap connect bcc:system-trace
 sudo snap connect bcc:mount-observe
 ```
 


### PR DESCRIPTION
Hi,

We've been providing ~weekly builds of bcc for users of Ubuntu and other distros for a while now, but it would great if we could also get the docs to point at them.