### PR TITLE
Use uintptr_t for addresses in C++ API

### DIFF
--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -215,7 +215,7 @@ private:
   std::string name_;
   std::string probe_func_;
 
-  std::vector<intptr_t> addresses_;
+  std::vector<uintptr_t> addresses_;
 
   std::string program_text_;
 

--- a/src/cc/BPFTable.cc
+++ b/src/cc/BPFTable.cc
@@ -91,8 +91,8 @@ BPFStackTable::~BPFStackTable() {
     bcc_free_symcache(it.second, it.first);
 }
 
-std::vector<intptr_t> BPFStackTable::get_stack_addr(int stack_id) {
-  std::vector<intptr_t> res;
+std::vector<uintptr_t> BPFStackTable::get_stack_addr(int stack_id) {
+  std::vector<uintptr_t> res;
   stacktrace_t stack;
   if (!lookup(&stack_id, &stack))
     return res;

--- a/src/cc/BPFTable.h
+++ b/src/cc/BPFTable.h
@@ -208,7 +208,7 @@ class BPFHashTable : public BPFTableBase<KeyType, ValueType> {
 // From src/cc/export/helpers.h
 static const int BPF_MAX_STACK_DEPTH = 127;
 struct stacktrace_t {
-  intptr_t ip[BPF_MAX_STACK_DEPTH];
+  uintptr_t ip[BPF_MAX_STACK_DEPTH];
 };
 
 class BPFStackTable : public BPFTableBase<int, stacktrace_t> {
@@ -217,7 +217,7 @@ class BPFStackTable : public BPFTableBase<int, stacktrace_t> {
       : BPFTableBase<int, stacktrace_t>(desc) {}
   ~BPFStackTable();
 
-  std::vector<intptr_t> get_stack_addr(int stack_id);
+  std::vector<uintptr_t> get_stack_addr(int stack_id);
   std::vector<std::string> get_stack_symbol(int stack_id, int pid);
 
  private:


### PR DESCRIPTION
Underlying helpers all use unsigned numbers for Instruction addresses. It makes sense for the C++ API to be consistent.