### PR TITLE
Only load non-zero and function symbols in ProcSyms

### DIFF
--- a/src/cc/bcc_perf_map.c
+++ b/src/cc/bcc_perf_map.c
@@ -98,7 +98,7 @@ int bcc_perf_map_foreach_sym(const char *path, bcc_perf_map_symcb callback,
     if (newline)
         newline[0] = '\0';
 
-    callback(cursor, begin, len, len > 0 ? STT_FUNC : STT_OBJECT, payload);
+    callback(cursor, begin, len, STT_FUNC, payload);
   }
 
   free(line);

--- a/src/cc/bcc_perf_map.c
+++ b/src/cc/bcc_perf_map.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <ctype.h>
+#include <linux/elf.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -97,7 +98,7 @@ int bcc_perf_map_foreach_sym(const char *path, bcc_perf_map_symcb callback,
     if (newline)
         newline[0] = '\0';
 
-    callback(cursor, begin, len, 0, payload);
+    callback(cursor, begin, len, len > 0 ? STT_FUNC : STT_OBJECT, payload);
   }
 
   free(line);


### PR DESCRIPTION
`ProcSyms` is currently loading everything, which is slow and inefficient.
Tested on some common libraries.

Originally:
```
(trunk)                          Loaded <PATH>/libpthread-2.23.so   Entries: 2163    Unique names: 1066
(trunk)                          Loaded <PATH>/libstdc++.so.6.0.21  Entries: 18394   Unique names: 6553
(trunk)                          Loaded <PATH>/libc-2.23.so         Entries: 15980   Unique names: 7431
(trunk)                          Loaded <PATH>/hhvm                 Entries: 394265  Unique names: 188241
```
Not loading zero symbols:
```
(trunk)(no_zero_addr)            Loaded <PATH>/libpthread-2.23.so   Entries: 1676    Unique names: 709
(trunk)(no_zero_addr)            Loaded <PATH>/libstdc++.so.6.0.21  Entries: 17724   Unique names: 6113
(trunk)(no_zero_addr)            Loaded <PATH>/libc-2.23.so         Entries: 14495   Unique names: 6119
(trunk)(no_zero_addr)            Loaded <PATH>/hhvm                 Entries: 383567  Unique names: 181845
```
Further only load functions:
```
(trunk)(no_zero_addr)(only_func) Loaded <PATH>/libpthread-2.23.so   Entries: 1310    Unique names: 555
(trunk)(no_zero_addr)(only_func) Loaded <PATH>/libstdc++.so.6.0.21  Entries: 12682   Unique names: 4362
(trunk)(no_zero_addr)(only_func) Loaded <PATH>/libc-2.23.so         Entries: 11652   Unique names: 4985
(trunk)(no_zero_addr)(only_func) Loaded <PATH>/hhvm                 Entries: 260369  Unique names: 129575
```