### PR TITLE
Snap aliases

### DIFF
--- a/snapcraft/snapcraft.yaml
+++ b/snapcraft/snapcraft.yaml
@@ -110,6 +110,9 @@ apps:
     funclatency:
         command: wrapper funclatency
         aliases: [funclatency]
+    funcslower:
+        command: wrapper funcslower
+        aliases: [funcslower]
     gethostlatency:
         command: wrapper gethostlatency
         aliases: [gethostlatency]

--- a/snapcraft/snapcraft.yaml
+++ b/snapcraft/snapcraft.yaml
@@ -28,196 +28,292 @@ plugs:
 apps:
     argdist:
         command: wrapper argdist
+        aliases: [argdist]
     bashreadline:
         command: wrapper bashreadline
+        aliases: [bashreadline]
     biolatency:
         command: wrapper biolatency
+        aliases: [biolatency]
     biosnoop:
         command: wrapper biosnoop
+        aliases: [biosnoop]
     biotop:
         command: wrapper biotop
+        aliases: [biotop]
     bitesize:
         command: wrapper bitesize
+        aliases: [bitesize]
     bpflist:
         command: wrapper bpflist
+        aliases: [bpflist]
     btrfsdist:
         command: wrapper btrfsdist
+        aliases: [btrfsdist]
     btrfsslower:
         command: wrapper btrfsslower
+        aliases: [btrfsslower]
     cachestat:
         command: wrapper cachestat
+        aliases: [cachestat]
     cachetop:
         command: wrapper cachetop
+        aliases: [cachetop]
     capable:
         command: wrapper capable
+        aliases: [capable]
     cobjnew:
         command: wrapper cobjnew
+        aliases: [cobjnew]
     cpudist:
         command: wrapper cpudist
+        aliases: [cpudist]
     cpuunclaimed:
         command: wrapper cpuunclaimed
+        aliases: [cpuunclaimed]
     dbslower:
         command: wrapper dbslower
+        aliases: [dbslower]
     dbstat:
         command: wrapper dbstat
+        aliases: [dbstat]
     dcsnoop:
         command: wrapper dcsnoop
+        aliases: [dcsnoop]
     dcstat:
         command: wrapper dcstat
+        aliases: [dcstat]
     deadlock-detector:
         command: wrapper deadlock_detector
+        aliases: [deadlock-detector]
     execsnoop:
         command: wrapper execsnoop
+        aliases: [execsnoop]
     ext4dist:
         command: wrapper ext4dist
+        aliases: [ext4dist]
     ext4slower:
         command: wrapper ext4slower
+        aliases: [ext4slower]
     filelife:
         command: wrapper filelife
+        aliases: [filelife]
     fileslower:
         command: wrapper fileslower
+        aliases: [fileslower]
     filetop:
         command: wrapper filetop
+        aliases: [filetop]
     funccount:
         command: wrapper funccount
+        aliases: [funccount]
     funclatency:
         command: wrapper funclatency
+        aliases: [funclatency]
     gethostlatency:
         command: wrapper gethostlatency
+        aliases: [gethostlatency]
     hardirqs:
         command: wrapper hardirqs
+        aliases: [hardirqs]
     javacalls:
         command: wrapper javacalls
+        aliases: [javacalls]
     javaflow:
         command: wrapper javaflow
+        aliases: [javaflow]
     javagc:
         command: wrapper javagc
+        aliases: [javagc]
     javaobjnew:
         command: wrapper javaobjnew
+        aliases: [javaobjnew]
     javastat:
         command: wrapper javastat
+        aliases: [javastat]
     javathreads:
         command: wrapper javathreads
+        aliases: [javathreads]
     killsnoop:
         command: wrapper killsnoop
+        aliases: [killsnoop]
     llcstat:
         command: wrapper llcstat
+        aliases: [llcstat]
     mdflush:
         command: wrapper mdflush
+        aliases: [mdflush]
     memleak:
         command: wrapper memleak
+        aliases: [memleak]
     mountsnoop:
         command: wrapper mountsnoop
+        aliases: [mountsnoop]
     mysqld-qslower:
         command: wrapper mysqld_qslower
+        aliases: [mysqld-qslower]
     nodegc:
         command: wrapper nodegc
+        aliases: [nodegc]
     nodestat:
         command: wrapper nodestat
+        aliases: [nodestat]
     offcputime:
         command: wrapper offcputime
+        aliases: [offcputime]
     offwaketime:
         command: wrapper offwaketime
+        aliases: [offwaketime]
     oomkill:
         command: wrapper oomkill
+        aliases: [oomkill]
     opensnoop:
         command: wrapper opensnoop
+        aliases: [opensnoop]
     phpcalls:
         command: wrapper phpcalls
+        aliases: [phpcalls]
     phpflow:
         command: wrapper phpflow
+        aliases: [phpflow]
     phpstat:
         command: wrapper phpstat
+        aliases: [phpstat]
     pidpersec:
         command: wrapper pidpersec
+        aliases: [pidpersec]
     profile:
         command: wrapper profile
+        aliases: [profile]
     pythoncalls:
         command: wrapper pythoncalls
+        aliases: [pythoncalls]
     pythonflow:
         command: wrapper pythonflow
+        aliases: [pythonflow]
     pythongc:
         command: wrapper pythongc
+        aliases: [pythongc]
     pythonstat:
         command: wrapper pythonstat
+        aliases: [pythonstat]
     rubycalls:
         command: wrapper rubycalls
+        aliases: [rubycalls]
     rubyflow:
         command: wrapper rubyflow
+        aliases: [rubyflow]
     rubygc:
         command: wrapper rubygc
+        aliases: [rubygc]
     rubyobjnew:
         command: wrapper rubyobjnew
+        aliases: [rubyobjnew]
     rubystat:
         command: wrapper rubystat
+        aliases: [rubystat]
     runqlat:
         command: wrapper runqlat
+        aliases: [runqlat]
     runqlen:
         command: wrapper runqlen
+        aliases: [runqlen]
     slabratetop:
         command: wrapper slabratetop
+        aliases: [slabratetop]
     softirqs:
         command: wrapper softirqs
+        aliases: [softirqs]
     solisten:
         command: wrapper solisten
+        aliases: [solisten]
     sslsniff:
         command: wrapper sslsniff
+        aliases: [sslsniff]
     stackcount:
         command: wrapper stackcount
+        aliases: [stackcount]
     stacksnoop:
         command: wrapper stacksnoop
+        aliases: [stacksnoop]
     statsnoop:
         command: wrapper statsnoop
+        aliases: [statsnoop]
     syncsnoop:
         command: wrapper syncsnoop
+        aliases: [syncsnoop]
     syscount:
         command: wrapper syscount
+        aliases: [syscount]
     tcpaccept:
         command: wrapper tcpaccept
+        aliases: [tcpaccept]
     tcpconnect:
         command: wrapper tcpconnect
+        aliases: [tcpconnect]
     tcpconnlat:
         command: wrapper tcpconnlat
+        aliases: [tcpconnlat]
     tcplife:
         command: wrapper tcplife
+        aliases: [tcplife]
     tcpretrans:
         command: wrapper tcpretrans
+        aliases: [tcpretrans]
     tcptop:
         command: wrapper tcptop
+        aliases: [tcptop]
     tcptracer:
         command: wrapper tcptracer
+        aliases: [tcptracer]
     tplist:
         command: wrapper tplist
+        aliases: [tplist]
     trace:
         command: wrapper trace
+        aliases: [trace]
     ttysnoop:
         command: wrapper ttysnoop
+        aliases: [ttysnoop]
     ucalls:
         command: wrapper lib/ucalls
+        aliases: [ucalls]
     uflow:
         command: wrapper lib/uflow
+        aliases: [uflow]
     ugc:
         command: wrapper lib/ugc
+        aliases: [ugc]
     uobjnew:
         command: wrapper lib/uobjnew
+        aliases: [uobjnew]
     ustat:
         command: wrapper lib/ustat
+        aliases: [ustat]
     uthreads:
         command: wrapper lib/uthreads
+        aliases: [uthreads]
     vfscount:
         command: wrapper vfscount
+        aliases: [vfscount]
     vfsstat:
         command: wrapper vfsstat
+        aliases: [vfsstat]
     wakeuptime:
         command: wrapper wakeuptime
+        aliases: [wakeuptime]
     xfsdist:
         command: wrapper xfsdist
+        aliases: [xfsdist]
     xfsslower:
         command: wrapper xfsslower
+        aliases: [xfsslower]
     zfsdist:
         command: wrapper zfsdist
+        aliases: [zfsdist]
     zfsslower:
         command: wrapper zfsslower
+        aliases: [zfsslower]
 parts:
     bcc:
         plugin: cmake


### PR DESCRIPTION
This sets up some command aliases for the bcc snap. You can test these manually with, for example:
```
sudo snap alias bcc biotop
biotop
```
Once we have a snap uploaded with this in place I'll ask that the aliases get set to auto. End users won't have to know about aliases or the `bcc.biotop` namespacing. They'll just type `biotop` as they do for traditional package installs.