### PR TITLE
flow_orifice: introduce new tool

### DIFF
--- a/man/man8/flow_orifice.8
+++ b/man/man8/flow_orifice.8
@@ -1,0 +1,59 @@
+.TH flow_orifice 8  "2017-04-30" "USER COMMANDS"
+.SH NAME
+flow_orifice \- Trace flows for their orifices during traversing the network stack. Uses Linux eBPF/bcc.
+.SH SYNOPSIS
+.B flow_orifice [\-h] [\-i]
+.SH DESCRIPTION
+This traces all flows regardless of their protocol, showing address, port,
+protocol, the qdisc index and the driving CPU behind the network stack
+traversal.  Overhead was of no concern of this tool, this means every packet is
+introspected. Therefore, use this with care on systems where network
+performance is of convern. This does trace every packet (like tcpdump(8) or a
+packet sniffer).
+
+This uses dynamic tracing of the kernel dev_hard_start_xmit() function, and
+will need to be updated to match kernel changes to these functions.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+.SH OPTIONS
+.TP
+\-h
+Print usage message.
+.TP
+\-i
+Interval of run in seconds.
+.SH EXAMPLES
+.TP
+Trace all flows for 5 seconds:
+#
+.B flow_orifice -i 5
+.TP
+.SH FIELDS
+.TP
+QDISC
+Qdisc(therefore queue of multiqueuing) used by flow.
+.TP
+CPU
+Network actions driving CPU.
+.TP
+FLOW
+Used to five tuple based flow specification.
+.SH OVERHEAD
+Can be tremendous depending on ongoing network traffic load on the system the introspection is to be performed. That is, be considerately careful in using this tool on production critical systems or alike.
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Matthias Tafelmeier
+.SH SEE ALSO
+tcpretrans(8) tcpdump(8) 

--- a/tools/flow_orifice.py
+++ b/tools/flow_orifice.py
@@ -1,0 +1,189 @@
+#!/usr/bin/python
+# @lint-avoid-python-3-compatibility-imports
+#
+# Copyright (C) 2017  Matthias Tafelmeier
+#
+# flow_orifice.py is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# flow_orifice.py is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from bcc import BPF
+import argparse
+import time
+from socket import inet_ntop, AF_INET, AF_INET6
+import ctypes as ct
+from struct import pack
+
+#todo
+examples = """examples:
+    ./flow_orifice         # 
+"""
+
+parser = argparse.ArgumentParser(
+    description="Trace flows traversing down the network stack",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("-i", "--interval", default=3, type=int,
+    help="interval of run in seconds")
+args = parser.parse_args()
+
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+
+struct ipv4_data_t {
+    int cpu;
+    u16 qu_idx;
+    u64 saddr;
+    u64 daddr;
+    u64 lport;
+    u64 dport;
+    char prot[32];
+};
+
+struct ipv6_data_t {
+    int cpu;
+    u16 qu_idx;
+    unsigned __int128 saddr;
+    unsigned __int128 daddr;
+    u64 lport;
+    u64 dport;
+    char prot[32];
+};
+
+BPF_PERF_OUTPUT(ipv4_flows);
+BPF_PERF_OUTPUT(ipv6_flows);
+
+int trace_hard_start_xmit(struct pt_regs *ctx, struct sk_buff *skb)
+{
+    u64 zero = 0;
+    struct sk_buff *_skb = NULL;
+    bpf_probe_read(&_skb, sizeof(_skb), &skb);
+    struct sock *skp = NULL;
+    bpf_probe_read(&skp, sizeof(skp), &_skb->sk);
+    u16 _qu_idx = skb->queue_mapping;
+    int curr_cpu = bpf_get_smp_processor_id();
+
+    // get flow details
+    u16 family = 0, lport = 0, dport = 0;
+    struct proto *prot_ref = NULL;
+    bpf_probe_read(&family, sizeof(family), &skp->__sk_common.skc_family);
+    bpf_probe_read(&lport, sizeof(lport), &skp->__sk_common.skc_num);
+    bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+    bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+    bpf_probe_read(&prot_ref, sizeof(prot_ref), &skp->__sk_common.skc_prot);
+
+    if (family == AF_INET) {
+        struct ipv4_data_t data4 = { .cpu = curr_cpu, .qu_idx = _qu_idx };
+        data4.lport = lport;
+        data4.dport = ntohs(dport);
+        bpf_probe_read(&data4.prot, sizeof(data4.prot),
+            &prot_ref->name);
+        bpf_probe_read(&data4.saddr, sizeof(u32),
+            &skp->__sk_common.skc_rcv_saddr);
+        bpf_probe_read(&data4.daddr, sizeof(u32),
+            &skp->__sk_common.skc_daddr);
+        ipv4_flows.perf_submit(ctx, &data4, sizeof(data4));
+    } else if (family == AF_INET6) {
+        struct ipv6_data_t data6 = { .cpu = curr_cpu, .qu_idx = _qu_idx };
+        data6.lport = lport;
+        data6.dport = ntohs(dport);
+        bpf_probe_read(&data6.prot, sizeof(data6.prot),
+            &prot_ref->name);
+        bpf_probe_read(&data6.saddr, sizeof(data6.saddr),
+            &skp->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+        bpf_probe_read(&data6.daddr, sizeof(data6.daddr),
+            &skp->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+        ipv6_flows.perf_submit(ctx, &data6, sizeof(data6));
+    }
+    // drop other
+
+    return 0;
+}
+"""
+
+# entry data
+class Data_ipv4(ct.Structure):
+    _fields_ = [
+        ("cpu", ct.c_int),
+        ("qu_idx", ct.c_ushort),
+        ("saddr", ct.c_ulonglong),
+        ("daddr", ct.c_ulonglong),
+        ("lport", ct.c_ulonglong),
+        ("dport", ct.c_ulonglong),
+        ("prot", ct.c_char * 32)
+    ]
+
+class Data_ipv6(ct.Structure):
+    _fields_ = [
+        ("cpu", ct.c_int),
+        ("qu_idx", ct.c_ushort),
+        ("saddr", (ct.c_ulonglong * 2)),
+        ("daddr", (ct.c_ulonglong * 2)),
+        ("lport", ct.c_ulonglong),
+        ("dport", ct.c_ulonglong),
+        ("prot", ct.c_char * 32)
+    ]
+
+def set_surrogate_aux(f_event):
+    if f_event.qu_idx not in flows_hive.keys():
+        flows_hive[f_event.qu_idx] = {}
+
+    if f_event.cpu not in flows_hive[f_event.qu_idx].keys():
+        flows_hive[f_event.qu_idx][f_event.cpu] = {}
+
+
+def gather_ipv4_flow(cpu, data, size):
+    f_event = ct.cast(data, ct.POINTER(Data_ipv4)).contents
+    set_surrogate_aux(f_event)
+
+    proto = f_event.prot
+    s_tuple = "%s:%s" % (inet_ntop(AF_INET, pack('I', f_event.saddr)), f_event.lport)
+    d_tuple = "%s:%s" % (inet_ntop(AF_INET, pack('I', f_event.daddr)), f_event.dport)
+    flow_str = "%-20s %-20s %-20s " % (proto, s_tuple, d_tuple)
+    flows_hive[f_event.qu_idx][f_event.cpu][flow_str] = None
+
+def gather_ipv6_flow(cpu, data, size):
+    f_event = ct.cast(data, ct.POINTER(Data_ipv6)).contents
+    set_surrogate_aux(f_event)
+
+    proto = f_event.prot
+    s_tuple = "%s:%s" % (inet_ntop(AF_INET6, f_event.saddr), f_event.lport)
+    d_tuple = "%s:%s" % (inet_ntop(AF_INET6, f_event.daddr), f_event.dport)
+    flow_str = "%-20s %-20s %-20s " % (proto, s_tuple, d_tuple)
+    flows_hive[f_event.qu_idx][f_event.cpu][flow_str] = None
+
+#data gathering representation
+flows_hive = {}
+
+b = BPF(text=bpf_text)
+b.attach_kprobe(event="dev_hard_start_xmit", fn_name="trace_hard_start_xmit")
+
+b['ipv4_flows'].open_perf_buffer(gather_ipv4_flow)
+b['ipv6_flows'].open_perf_buffer(gather_ipv6_flow)
+
+t_end = time.time() + args.interval
+while time.time() < t_end:
+    b.kprobe_poll()
+
+#header
+print("QDISC%-5sCPU%-5sFLOW" % (" ", " "))
+for qu_idx, per_cpu_flows in flows_hive.items():
+    print ("".ljust(80, "*"))
+    print("%s" % (qu_idx))
+    for cpu, flows in per_cpu_flows.items():
+        print ("".ljust(80, "-"))
+        indent = 13
+        print("%s\n".rjust(indent) % (cpu))
+        for f in flows.keys():
+            indent = 23
+            print ("%-40s".rjust(indent) % f)

--- a/tools/flow_orifice_example.txt
+++ b/tools/flow_orifice_example.txt
@@ -1,0 +1,72 @@
+Demonstrations of flow_orifice, the Linux eBPF/bcc version.
+
+
+This traces what qdiscs flows are travesing on their travel down the network stack.
+For example:
+
+The -i option determines the interval in seconds one want to trace the network stack.
+
+# ./flow_orifice.py -i 5
+
+QDISC     CPU     FLOW
+********************************************************************************
+0
+--------------------------------------------------------------------------------
+          0
+
+                  TCP                  192.168.122.250:33785 192.168.122.1:41196  
+                  TCP                  192.168.122.250:36787 192.168.122.1:34906  
+                  TCP                  192.168.122.250:46533 192.168.122.1:34213  
+                  TCP                  192.168.122.250:34009 192.168.122.1:39924  
+                  TCP                  192.168.122.250:35761 192.168.122.1:39950  
+                  TCP                  192.168.122.250:40701 192.168.122.1:40906  
+                  TCP                  192.168.122.250:42601 192.168.122.1:43146  
+                  TCP                  192.168.122.250:45633 192.168.122.1:45892  
+                  TCP                  192.168.122.250:37915 192.168.122.1:32998  
+--------------------------------------------------------------------------------
+          1
+
+                  TCP                  192.168.122.250:36787 192.168.122.1:34906  
+                  TCP                  192.168.122.250:34009 192.168.122.1:39924  
+                  TCP                  192.168.122.250:35761 192.168.122.1:39950  
+                  TCP                  192.168.122.250:40701 192.168.122.1:40906  
+                  TCP                  192.168.122.250:42601 192.168.122.1:43146  
+                  TCP                  192.168.122.250:39477 192.168.122.1:43903  
+                  TCP                  192.168.122.250:46441 192.168.122.1:45566  
+                  TCP                  192.168.122.250:35739 192.168.122.1:46183  
+                  TCP                  192.168.122.250:38983 192.168.122.1:42120  
+                  TCP                  192.168.122.250:35545 192.168.122.1:33159  
+
+********************************************************************************
+1
+--------------------------------------------------------------------------------
+          0
+
+
+                  RAW                  0.0.0.0:1            0.0.0.0:0            
+
+--------------------------------------------------------------------------------
+          1
+
+                  UDP                  192.168.122.250:50305 212.18.3.18:123      
+
+
+In this ouptut the flows passing through qdisc 0 and 1 of a multiqueuing device
+are shown. The flows are driven down the stack by processes running on CPUs 0
+and 1. 
+
+USAGE message:
+
+# ./flow_orifice.py -h
+usage: flow_orifice.py [-h] [-i INTERVAL]
+
+Trace flows traversing down the network stack
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -i INTERVAL, --interval INTERVAL
+                        interval of run in seconds
+
+examples:
+    ./flow_orifice   -i 5      # trace flow for 5 seconds 
+


### PR DESCRIPTION
Add flow tracing tool to introspect qdisc/queues used by certain
CPUs. Helps at infering during net stack tuning.

-> Missing:
- Further breakdowns, depictions.
- better filtering (e.g. non-local)

Signed-off-by: Matthias Tafelmeier <matthias.tafelmeier@gmx.net>