### PR TITLE
Install sudo inside the debian build container

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -3,7 +3,7 @@ FROM debian:jessie
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv 15CF4D18AF4F7421 && \
     echo "deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main" > /etc/apt/sources.list.d/llvm.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends build-essential fakeroot bison cmake debhelper devscripts flex git libedit-dev python zlib1g-dev libllvm3.8 llvm-3.8-dev libclang-3.8-dev libelf-dev luajit libluajit-5.1-dev && \
+    apt-get install -y --no-install-recommends sudo build-essential fakeroot bison cmake debhelper devscripts flex git libedit-dev python zlib1g-dev libllvm3.8 llvm-3.8-dev libclang-3.8-dev libelf-dev luajit libluajit-5.1-dev && \
     mkdir -p /usr/share/llvm-3.8 && \
     ln -s /usr/lib/llvm-3.8/share/llvm/cmake /usr/share/llvm-3.8/cmake
 


### PR DESCRIPTION
The jessie image used for the build container does not include sudo, but `scripts/build-deb.sh` [requires it](https://github.com/iovisor/bcc/blob/master/scripts/build-deb.sh#L32:L33). This installs the sudo package so that containerized package builds work as expected on jessie.