### PR TITLE
Small improvements to symboling availiability

### DIFF
--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -33,6 +33,11 @@ ino_t ProcStat::getinode_() {
   return (!stat(procfs_.c_str(), &s)) ? s.st_ino : -1;
 }
 
+bool ProcStat::is_stale() {
+  ino_t cur_inode = getinode_();
+  return (cur_inode > 0) &&  (cur_inode != inode_);
+}
+
 ProcStat::ProcStat(int pid)
     : procfs_(tfm::format("/proc/%d/exe", pid)), inode_(getinode_()) {}
 

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -190,7 +190,7 @@ bool ProcSyms::resolve_name(const char *module, const char *name,
 }
 
 ProcSyms::Module::Module(const char *name, int pid, bool in_ns)
-  : name_(name), pid_(pid), in_ns_(in_ns) {
+  : name_(name), pid_(pid), in_ns_(in_ns), loaded_(false) {
   struct ns_cookie nsc;
 
   bcc_procutils_enter_mountns(pid_, &nsc);
@@ -213,8 +213,9 @@ bool ProcSyms::Module::is_perf_map() const {
 void ProcSyms::Module::load_sym_table() {
   struct ns_cookie nsc = {-1, -1};
 
-  if (syms_.size())
+  if (loaded_)
     return;
+  loaded_ = true;
 
   if (is_perf_map()) {
     if (in_ns_)

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -91,6 +91,7 @@ class ProcSyms : SymbolCache {
     bool is_so_;
     int pid_;
     bool in_ns_;
+    bool loaded_;
     std::unordered_set<std::string> symnames_;
     std::vector<Symbol> syms_;
 

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -30,7 +30,7 @@ class ProcStat {
 
 public:
   ProcStat(int pid);
-  bool is_stale() { return inode_ != getinode_(); }
+  bool is_stale();
   void reset() { inode_ = getinode_(); }
 };
 


### PR DESCRIPTION
Two commits to avoid trying to read unable-to-read `Module` every time, and refresh-and-clear the loaded symbols when Process is terminated. Commit messages contain more description.