### PR TITLE
Update the changes of flag HAVE_BPF_JIT in kernel 4.7 to the INSTALL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,8 @@ CONFIG_HAVE_BPF_JIT=y
 CONFIG_BPF_EVENTS=y
 ```
 
+For Linux kernel version 4.7 or newer, the flag `CONFIG_HAVE_BPF_JIT` has been replaced by `CONFIG_HAVE_EBPF_JIT` (for x86, arm64 and s390) or by `CONFIG_HAVE_CBPF_JIT` (for arm, mips, powerpc and sparc.)
+
 There are a few optional kernel flags needed for running bcc networking examples on vanilla kernel:
 
 ```


### PR DESCRIPTION
Since Linux kernel 4.7, the flag HAVE_BPF_JIT has been replaced by HAVE_CBPF_JIT and HAVE_EBPF_JIT:

https://github.com/torvalds/linux/commit/6077776b5908e0493a3946f7d3bc63871b201e87

I've updated the INSTALL.md to follow the changes. 