### PR TITLE
Require a more recent, auto-updating version of snapd

### DIFF
--- a/snapcraft/snapcraft.yaml
+++ b/snapcraft/snapcraft.yaml
@@ -25,6 +25,7 @@ plugs:
     mount-observe: null
     system-observe: null
     system-trace: null
+assumes: [snapd2.23]
 apps:
     argdist:
         command: wrapper argdist


### PR DESCRIPTION
The 2.0.2 version of snapd that ships in Ubuntu 16.04.1 does not automatically update. However, aliases [weren't supported until snapd 2.21](https://insights.ubuntu.com/2017/01/28/ubuntu-core-how-to-enable-aliases-for-your-snaps-commands/) (which landed in Ubuntu 16.04.2). Thus users who try to install the bcc snap from 16.04.1 as Brenden tried to do in https://github.com/iovisor/bcc/pull/1134#issuecomment-298435716 will get confusing error messages unless they `apt update; apt install snapd`.

With this change landed they'll instead see:
```
sudo snap install --dangerous bcc_0.3.0-20170401-1747-c5f48c9_amd64.snap
error: cannot perform the following tasks:
- Mount snap "bcc" (unset) (snap "bcc" assumes unsupported features: snapd2.23 (try to update snapd and refresh the core snap))
```

It's the best we can do for 16.04.1 users without resorting to asking they first `apt update; apt install snapd`. For future cases I hope the message can further [guide them to the right action](https://forum.snapcraft.io/t/better-guidance-for-missing-features/504).