### PR TITLE
Add ability for users to control symboling behavior

### DIFF
--- a/src/cc/BPF.cc
+++ b/src/cc/BPF.cc
@@ -469,8 +469,9 @@ StatusTuple BPF::unload_func(const std::string& func_name) {
 StatusTuple BPF::check_binary_symbol(const std::string& binary_path,
                                      const std::string& symbol,
                                      uint64_t symbol_addr, bcc_symbol* output) {
+  // TODO: Fix output.module memory leak here
   int res = bcc_resolve_symname(binary_path.c_str(), symbol.c_str(),
-                                symbol_addr, 0, output);
+                                symbol_addr, 0, nullptr, output);
   if (res < 0)
     return StatusTuple(
         -1, "Unable to find offset for binary %s symbol %s address %lx",

--- a/src/cc/BPFTable.cc
+++ b/src/cc/BPFTable.cc
@@ -110,7 +110,7 @@ std::vector<std::string> BPFStackTable::get_stack_symbol(int stack_id,
   if (pid < 0)
     pid = -1;
   if (pid_sym_.find(pid) == pid_sym_.end())
-    pid_sym_[pid] = bcc_symcache_new(pid);
+    pid_sym_[pid] = bcc_symcache_new(pid, nullptr);
   void* cache = pid_sym_[pid];
 
   bcc_symbol symbol;

--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -182,7 +182,7 @@ static int list_in_scn(Elf *e, Elf_Scn *section, size_t stridx, size_t symsize,
       if (!(option->use_symbol_type & flag))
         continue;
 
-      if (callback(name, sym.st_value, sym.st_size, sym.st_info, payload) < 0)
+      if (callback(name, sym.st_value, sym.st_size, payload) < 0)
         return 1;      // signal termination to caller
     }
   }

--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -40,7 +40,7 @@ int bcc_elf_foreach_usdt(const char *path, bcc_elf_probecb callback,
                          void *payload);
 int bcc_elf_loadaddr(const char *path, uint64_t *address);
 int bcc_elf_foreach_sym(const char *path, bcc_elf_symcb callback,
-                        void *payload);
+                        void *option, void *payload);
 
 int bcc_elf_get_type(const char *path);
 int bcc_elf_is_shared_obj(const char *path);

--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -34,7 +34,9 @@ struct bcc_elf_usdt {
 
 typedef void (*bcc_elf_probecb)(const char *, const struct bcc_elf_usdt *,
                                 void *);
-typedef int (*bcc_elf_symcb)(const char *, uint64_t, uint64_t, int, void *);
+
+// Symbol name, start address, length, payload
+typedef int (*bcc_elf_symcb)(const char *, uint64_t, uint64_t, void *);
 
 int bcc_elf_foreach_usdt(const char *path, bcc_elf_probecb callback,
                          void *payload);

--- a/src/cc/bcc_perf_map.c
+++ b/src/cc/bcc_perf_map.c
@@ -109,7 +109,7 @@ int bcc_perf_map_foreach_sym(const char *path, bcc_perf_map_symcb callback,
     if (newline)
         newline[0] = '\0';
 
-    callback(cursor, begin, len, 0, payload);
+    callback(cursor, begin, len, payload);
   }
 
   free(line);

--- a/src/cc/bcc_perf_map.h
+++ b/src/cc/bcc_perf_map.h
@@ -24,8 +24,8 @@ extern "C" {
 #include <stdbool.h>
 #include <unistd.h>
 
-typedef int (*bcc_perf_map_symcb)(const char *, uint64_t, uint64_t, int,
-                                  void *);
+// Symbol name, start address, length, payload
+typedef int (*bcc_perf_map_symcb)(const char *, uint64_t, uint64_t, void *);
 
 bool bcc_is_perf_map(const char *path);
 

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -290,10 +290,10 @@ bool ProcSyms::Module::init() {
 }
 
 int ProcSyms::Module::_add_symbol(const char *symname, uint64_t start,
-                                  uint64_t end, int flags, void *p) {
+                                  uint64_t size, void *p) {
   Module *m = static_cast<Module *>(p);
   auto res = m->symnames_.emplace(symname);
-  m->syms_.emplace_back(&*(res.first), start, end, flags);
+  m->syms_.emplace_back(&*(res.first), start, size);
   return 0;
 }
 
@@ -450,8 +450,8 @@ int bcc_resolve_global_addr(int pid, const char *module, const uint64_t address,
   return 0;
 }
 
-static int _sym_cb_wrapper(const char *symname, uint64_t addr, uint64_t end,
-                           int flags, void *payload) {
+static int _sym_cb_wrapper(const char *symname, uint64_t addr, uint64_t,
+                           void *payload) {
   SYM_CB cb = (SYM_CB) payload;
   return cb(symname, addr);
 }
@@ -470,8 +470,8 @@ int bcc_foreach_function_symbol(const char *module, SYM_CB cb) {
       module, _sym_cb_wrapper, &default_option, (void *)cb);
 }
 
-static int _find_sym(const char *symname, uint64_t addr, uint64_t end,
-                     int flags, void *payload) {
+static int _find_sym(const char *symname, uint64_t addr, uint64_t,
+                     void *payload) {
   struct bcc_symbol *sym = (struct bcc_symbol *)payload;
   if (!strcmp(sym->name, symname)) {
     sym->offset = addr;

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -56,7 +56,12 @@ void bcc_symcache_refresh(void *resolver);
 
 int bcc_resolve_global_addr(int pid, const char *module, const uint64_t address,
                             uint64_t *global);
-int bcc_foreach_symbol(const char *module, SYM_CB cb);
+
+// Call cb on every function symbol in the specified module. Uses simpler
+// SYM_CB callback mainly for easier to use in Python API.
+// Will prefer use debug file and check debug file CRC when reading the module.
+int bcc_foreach_function_symbol(const char *module, SYM_CB cb);
+
 int bcc_find_symbol_addr(struct bcc_symbol *sym);
 int bcc_resolve_symname(const char *module, const char *symname,
                         const uint64_t addr, int pid, struct bcc_symbol *sym);

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -31,6 +31,14 @@ struct bcc_symbol {
 
 typedef int (*SYM_CB)(const char *symname, uint64_t addr);
 
+static const uint32_t BCC_SYM_ALL_TYPES = 65535;
+struct bcc_symbol_option {
+  int use_debug_file;
+  int check_debug_file_crc;
+  // Bitmask flags indicating what types of ELF symbols to use
+  uint32_t use_symbol_type;
+};
+
 void *bcc_symcache_new(int pid);
 void bcc_free_symcache(void *symcache, int pid);
 

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -39,7 +39,7 @@ struct bcc_symbol_option {
   uint32_t use_symbol_type;
 };
 
-void *bcc_symcache_new(int pid);
+void *bcc_symcache_new(int pid, struct bcc_symbol_option *option);
 void bcc_free_symcache(void *symcache, int pid);
 
 // The demangle_name pointer in bcc_symbol struct is returned from the

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -62,9 +62,22 @@ int bcc_resolve_global_addr(int pid, const char *module, const uint64_t address,
 // Will prefer use debug file and check debug file CRC when reading the module.
 int bcc_foreach_function_symbol(const char *module, SYM_CB cb);
 
-int bcc_find_symbol_addr(struct bcc_symbol *sym);
+// Find the offset of a symbol in a module binary. If addr is not zero, will
+// calculate the offset using the provided addr and the module's load address.
+//
+// If pid is provided, will use it to help lookup the module in the Process and
+// enter the Process's mount Namespace.
+//
+// If option is not NULL, will respect the specified options for lookup.
+// Otherwise default option will apply, which is to use debug file, verify
+// checksum, and try all types of symbols.
+//
+// Return 0 on success and -1 on failure. Output will be write to sym. After
+// use, sym->module need to be freed if it's not empty.
 int bcc_resolve_symname(const char *module, const char *symname,
-                        const uint64_t addr, int pid, struct bcc_symbol *sym);
+                        const uint64_t addr, int pid,
+                        struct bcc_symbol_option* option,
+                        struct bcc_symbol *sym);
 
 void *bcc_enter_mount_ns(int pid);
 void bcc_exit_mount_ns(void **guard);

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "file_desc.h"
+#include "bcc_syms.h"
 
 class ProcStat {
   std::string procfs_;
@@ -123,13 +124,15 @@ class ProcSyms : SymbolCache {
       Range(uint64_t s, uint64_t e) : start(s), end(e) {}
     };
 
-    Module(const char *name, ProcMountNS* mount_ns);
+    Module(const char *name, ProcMountNS* mount_ns,
+           struct bcc_symbol_option *option);
     bool init();
 
     std::string name_;
     std::vector<Range> ranges_;
     bool loaded_;
     ProcMountNS *mount_ns_;
+    bcc_symbol_option *symbol_option_;
     ModuleType type_;
 
     std::unordered_set<std::string> symnames_;
@@ -149,12 +152,13 @@ class ProcSyms : SymbolCache {
   std::vector<Module> modules_;
   ProcStat procstat_;
   std::unique_ptr<ProcMountNS> mount_ns_instance_;
+  bcc_symbol_option symbol_option_;
 
   static int _add_module(const char *, uint64_t, uint64_t, bool, void *);
   bool load_modules();
 
 public:
-  ProcSyms(int pid);
+  ProcSyms(int pid, struct bcc_symbol_option *option = nullptr);
   virtual void refresh();
   virtual bool resolve_addr(uint64_t addr, struct bcc_symbol *sym, bool demangle = true);
   virtual bool resolve_name(const char *module, const char *name,

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -98,12 +98,11 @@ private:
 
 class ProcSyms : SymbolCache {
   struct Symbol {
-    Symbol(const std::string *name, uint64_t start, uint64_t size, int flags = 0)
-        : name(name), start(start), size(size), flags(flags) {}
+    Symbol(const std::string *name, uint64_t start, uint64_t size)
+        : name(name), start(start), size(size) {}
     const std::string *name;
     uint64_t start;
     uint64_t size;
-    int flags;
 
     bool operator<(const struct Symbol& rhs) const {
       return start < rhs.start;
@@ -144,8 +143,8 @@ class ProcSyms : SymbolCache {
     bool find_addr(uint64_t offset, struct bcc_symbol *sym);
     bool find_name(const char *symname, uint64_t *addr);
 
-    static int _add_symbol(const char *symname, uint64_t start, uint64_t end,
-                           int flags, void *p);
+    static int _add_symbol(const char *symname, uint64_t start, uint64_t size,
+                           void *p);
   };
 
   int pid_;

--- a/src/cc/usdt_args.cc
+++ b/src/cc/usdt_args.cc
@@ -40,9 +40,11 @@ bool Argument::get_global_address(uint64_t *address, const std::string &binpath,
   }
 
   if (!bcc_elf_is_shared_obj(binpath.c_str())) {
-    struct bcc_symbol sym = {deref_ident_->c_str(), binpath.c_str(), 0x0};
-    if (!bcc_find_symbol_addr(&sym) && sym.offset) {
+    struct bcc_symbol sym;
+    if (bcc_resolve_symname(binpath.c_str(), deref_ident_->c_str(), 0x0, -1, nullptr, &sym) == 0) {
       *address = sym.offset;
+      if (sym.module)
+        ::free(const_cast<char*>(sym.module));
       return true;
     }
   }

--- a/src/cc/usdt_args.cc
+++ b/src/cc/usdt_args.cc
@@ -35,7 +35,12 @@ std::string Argument::ctype() const {
 bool Argument::get_global_address(uint64_t *address, const std::string &binpath,
                                   const optional<int> &pid) const {
   if (pid) {
-    return ProcSyms(*pid)
+    static struct bcc_symbol_option default_option = {
+      .use_debug_file = 1,
+      .check_debug_file_crc = 1,
+      .use_symbol_type = BCC_SYM_ALL_TYPES
+    };
+    return ProcSyms(*pid, &default_option)
         .resolve_name(binpath.c_str(), deref_ident_->c_str(), address);
   }
 

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -124,7 +124,7 @@ int bcc_resolve_symname(const char *module, const char *symname, const uint64_t 
                         int pid, struct bcc_symbol_option *option,
                         struct bcc_symbol *sym);
 void bcc_procutils_free(const char *ptr);
-void *bcc_symcache_new(int pid);
+void *bcc_symcache_new(int pid, struct bcc_symbol_option *option);
 void bcc_symbol_free_demangle_name(struct bcc_symbol *sym);
 int bcc_symcache_resolve(void *symcache, uint64_t addr, struct bcc_symbol *sym);
 void bcc_symcache_refresh(void *resolver);

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -114,6 +114,12 @@ struct bcc_symbol {
 	uint64_t offset;
 };
 
+struct bcc_symbol_option {
+  int use_debug_file;
+  int check_debug_file_crc;
+  uint32_t use_symbol_type;
+};
+
 int bcc_resolve_symname(const char *module, const char *symname, const uint64_t addr,
 		int pid, struct bcc_symbol *sym);
 void bcc_procutils_free(const char *ptr);

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -121,7 +121,8 @@ struct bcc_symbol_option {
 };
 
 int bcc_resolve_symname(const char *module, const char *symname, const uint64_t addr,
-		int pid, struct bcc_symbol *sym);
+                        int pid, struct bcc_symbol_option *option,
+                        struct bcc_symbol *sym);
 void bcc_procutils_free(const char *ptr);
 void *bcc_symcache_new(int pid);
 void bcc_symbol_free_demangle_name(struct bcc_symbol *sym);

--- a/src/lua/bcc/sym.lua
+++ b/src/lua/bcc/sym.lua
@@ -35,7 +35,7 @@ end
 local function check_path_symbol(module, symname, addr, pid)
   local sym = SYM()
   local module_path
-  if libbcc.bcc_resolve_symname(module, symname, addr or 0x0, pid or 0, sym) < 0 then
+  if libbcc.bcc_resolve_symname(module, symname, addr or 0x0, pid or 0, nil, sym) < 0 then
     if sym[0].module == nil then
       error("could not find library '%s' in the library path" % module)
     else

--- a/src/lua/bcc/sym.lua
+++ b/src/lua/bcc/sym.lua
@@ -19,7 +19,7 @@ local SYM = ffi.typeof("struct bcc_symbol[1]")
 
 local function create_cache(pid)
   return {
-    _CACHE = libbcc.bcc_symcache_new(pid or -1),
+    _CACHE = libbcc.bcc_symcache_new(pid or -1, nil),
     resolve = function(self, addr)
       local sym = SYM()
       if libbcc.bcc_symcache_resolve(self._CACHE, addr, sym) < 0 then

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -24,7 +24,7 @@ import errno
 import sys
 basestring = (unicode if sys.version_info[0] < 3 else str)
 
-from .libbcc import lib, _CB_TYPE, bcc_symbol, _SYM_CB_TYPE
+from .libbcc import lib, _CB_TYPE, bcc_symbol, bcc_symbol_option, _SYM_CB_TYPE
 from .table import Table
 from .perf import Perf
 from .utils import get_online_cpus
@@ -607,11 +607,12 @@ class BPF(object):
         sym = bcc_symbol()
         psym = ct.pointer(sym)
         c_pid = 0 if pid == -1 else pid
-        if lib.bcc_resolve_symname(module.encode("ascii"),
-                symname.encode("ascii"), addr or 0x0, c_pid, psym) < 0:
-            if not sym.module:
-                raise Exception("could not find library %s" % module)
-            lib.bcc_procutils_free(sym.module)
+        if lib.bcc_resolve_symname(
+            module.encode("ascii"), symname.encode("ascii"),
+            addr or 0x0, c_pid,
+            ct.cast(None, ct.POINTER(bcc_symbol_option)),
+            psym,
+        ) < 0:
             raise Exception("could not determine address of symbol %s" % symname)
         module_path = ct.cast(sym.module, ct.c_char_p).value.decode()
         lib.bcc_procutils_free(sym.module)

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -46,7 +46,8 @@ LOG_BUFFER_SIZE = 65536
 
 class SymbolCache(object):
     def __init__(self, pid):
-        self.cache = lib.bcc_symcache_new(pid)
+        self.cache = lib.bcc_symcache_new(
+                pid, ct.cast(None, ct.POINTER(bcc_symbol_option)))
 
     def resolve(self, addr, demangle):
         """

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -773,7 +773,8 @@ class BPF(object):
                 addresses.append((dname, addr))
             return 0
 
-        res = lib.bcc_foreach_symbol(name.encode('ascii'), _SYM_CB_TYPE(sym_cb))
+        res = lib.bcc_foreach_function_symbol(
+                name.encode('ascii'), _SYM_CB_TYPE(sym_cb))
         if res < 0:
             raise Exception("Error %d enumerating symbols in %s" % (res, name))
         return addresses

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -156,7 +156,7 @@ lib.bcc_foreach_function_symbol.restype = ct.c_int
 lib.bcc_foreach_function_symbol.argtypes = [ct.c_char_p, _SYM_CB_TYPE]
 
 lib.bcc_symcache_new.restype = ct.c_void_p
-lib.bcc_symcache_new.argtypes = [ct.c_int]
+lib.bcc_symcache_new.argtypes = [ct.c_int, ct.POINTER(bcc_symbol_option)]
 
 lib.bcc_free_symcache.restype = ct.c_void_p
 lib.bcc_free_symcache.argtypes = [ct.c_void_p, ct.c_int]

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -149,7 +149,7 @@ lib.bcc_procutils_language.argtypes = [ct.c_int]
 
 lib.bcc_resolve_symname.restype = ct.c_int
 lib.bcc_resolve_symname.argtypes = [
-    ct.c_char_p, ct.c_char_p, ct.c_ulonglong, ct.c_int, ct.POINTER(bcc_symbol)]
+    ct.c_char_p, ct.c_char_p, ct.c_ulonglong, ct.c_int, ct.POINTER(bcc_symbol_option), ct.POINTER(bcc_symbol)]
 
 _SYM_CB_TYPE = ct.CFUNCTYPE(ct.c_int, ct.c_char_p, ct.c_ulonglong)
 lib.bcc_foreach_function_symbol.restype = ct.c_int

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -152,8 +152,8 @@ lib.bcc_resolve_symname.argtypes = [
     ct.c_char_p, ct.c_char_p, ct.c_ulonglong, ct.c_int, ct.POINTER(bcc_symbol)]
 
 _SYM_CB_TYPE = ct.CFUNCTYPE(ct.c_int, ct.c_char_p, ct.c_ulonglong)
-lib.bcc_foreach_symbol.restype = ct.c_int
-lib.bcc_foreach_symbol.argtypes = [ct.c_char_p, _SYM_CB_TYPE]
+lib.bcc_foreach_function_symbol.restype = ct.c_int
+lib.bcc_foreach_function_symbol.argtypes = [ct.c_char_p, _SYM_CB_TYPE]
 
 lib.bcc_symcache_new.restype = ct.c_void_p
 lib.bcc_symcache_new.argtypes = [ct.c_int]

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -133,6 +133,13 @@ class bcc_symbol(ct.Structure):
             ('offset', ct.c_ulonglong),
         ]
 
+class bcc_symbol_option(ct.Structure):
+    _fields_ = [
+            ('use_debug_file', ct.c_int),
+            ('check_debug_file_crc', ct.c_int),
+            ('use_symbol_type', ct.c_uint),
+        ]
+
 lib.bcc_procutils_which_so.restype = ct.POINTER(ct.c_char)
 lib.bcc_procutils_which_so.argtypes = [ct.c_char_p, ct.c_int]
 lib.bcc_procutils_free.restype = None

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -195,7 +195,7 @@ static int mntns_func(void *arg) {
 
 TEST_CASE("resolve symbol addresses for a given PID", "[c_api]") {
   struct bcc_symbol sym;
-  void *resolver = bcc_symcache_new(getpid());
+  void *resolver = bcc_symcache_new(getpid(), nullptr);
 
   REQUIRE(resolver);
 
@@ -240,7 +240,7 @@ TEST_CASE("resolve symbol addresses for a given PID", "[c_api]") {
     child = spawn_child(0, true, true, mntns_func);
     REQUIRE(child > 0);
 
-    void *resolver = bcc_symcache_new(child);
+    void *resolver = bcc_symcache_new(child, nullptr);
     REQUIRE(resolver);
 
     REQUIRE(bcc_symcache_resolve_name(resolver, "/tmp/libz.so.1", "zlibVersion",
@@ -335,7 +335,7 @@ TEST_CASE("resolve symbols using /tmp/perf-pid.map", "[c_api]") {
     child = spawn_child(map_addr, /* own_pidns */ false, false, perf_map_func);
     REQUIRE(child > 0);
 
-    void *resolver = bcc_symcache_new(child);
+    void *resolver = bcc_symcache_new(child, nullptr);
     REQUIRE(resolver);
 
     REQUIRE(bcc_symcache_resolve(resolver, (unsigned long long)map_addr,
@@ -355,7 +355,7 @@ TEST_CASE("resolve symbols using /tmp/perf-pid.map", "[c_api]") {
     child = spawn_child(map_addr, /* own_pidns */ true, false, perf_map_func);
     REQUIRE(child > 0);
 
-    void *resolver = bcc_symcache_new(child);
+    void *resolver = bcc_symcache_new(child, nullptr);
     REQUIRE(resolver);
 
     REQUIRE(bcc_symcache_resolve(resolver, (unsigned long long)map_addr,
@@ -372,7 +372,7 @@ TEST_CASE("resolve symbols using /tmp/perf-pid.map", "[c_api]") {
         perf_map_func_mntns);
     REQUIRE(child > 0);
 
-    void *resolver = bcc_symcache_new(child);
+    void *resolver = bcc_symcache_new(child, nullptr);
     REQUIRE(resolver);
 
     REQUIRE(bcc_symcache_resolve(resolver, (unsigned long long)map_addr,
@@ -391,7 +391,7 @@ TEST_CASE("resolve symbols using /tmp/perf-pid.map", "[c_api]") {
     string path = perf_map_path(child);
     REQUIRE(make_perf_map_file(path, (unsigned long long)map_addr) == 0);
 
-    void *resolver = bcc_symcache_new(child);
+    void *resolver = bcc_symcache_new(child, nullptr);
     REQUIRE(resolver);
 
     REQUIRE(bcc_symcache_resolve(resolver, (unsigned long long)map_addr,

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -92,7 +92,7 @@ TEST_CASE("file-backed mapping identification") {
 TEST_CASE("resolve symbol name in external library", "[c_api]") {
   struct bcc_symbol sym;
 
-  REQUIRE(bcc_resolve_symname("c", "malloc", 0x0, 0, &sym) == 0);
+  REQUIRE(bcc_resolve_symname("c", "malloc", 0x0, 0, nullptr, &sym) == 0);
   REQUIRE(string(sym.module).find("libc.so") != string::npos);
   REQUIRE(sym.module[0] == '/');
   REQUIRE(sym.offset != 0);
@@ -102,7 +102,7 @@ TEST_CASE("resolve symbol name in external library", "[c_api]") {
 TEST_CASE("resolve symbol name in external library using loaded libraries", "[c_api]") {
   struct bcc_symbol sym;
 
-  REQUIRE(bcc_resolve_symname("bcc", "bcc_procutils_which", 0x0, getpid(), &sym) == 0);
+  REQUIRE(bcc_resolve_symname("bcc", "bcc_procutils_which", 0x0, getpid(), nullptr, &sym) == 0);
   REQUIRE(string(sym.module).find("libbcc.so") != string::npos);
   REQUIRE(sym.module[0] == '/');
   REQUIRE(sym.offset != 0);


### PR DESCRIPTION
This set of changes mainly adds `bcc_symbol_option`, and use it across stack to control how we want to do symboling.

The main motivation for this is that we often want different symboling behavior depending on the environment. For example, reading debug file and verifying its CRC checksum could be very expensive for a large binary, and we may not want to do that in some production systems. However we prefer doing so for some other use cases, such as in the script tools. So hard-code any behavior would not fit the need of all users.

`bcc_symbol_option` holds various configurations of what to do for symboling. It is passed from user API all the way down to ELF helpers. This also makes future addition to more different options easy and possible.

This set of changes touches many parts components of BCC. To make it easier to review, I have break it down to multiple small commits, and added explanation in both code comments and commit message. However, not all commits will compile.

This set of changes keeps all current behaviors unchanged, and allows pass `NULL` / `nullptr` option parameter to indicate use default, which is current behaviors. I will put up follow up PRs to make the options configurable in C++ and Python API so that users could configure the behavior they want.

cc @markdrayton @goldshtn 