### PR TITLE
Use late-binding to finalize snprintf/sscanf

### DIFF
--- a/src/cc/BPFTable.h
+++ b/src/cc/BPFTable.h
@@ -39,41 +39,27 @@ class BPFTableBase {
   size_t capacity() { return desc.max_entries; }
 
   StatusTuple string_to_key(const std::string& key_str, KeyType* key) {
-    if (!desc.key_sscanf)
-      return StatusTuple(-1, "Key sscanf not available");
-    if (desc.key_sscanf(key_str.c_str(), key) != 0)
-      return StatusTuple(-1, "Error on key_sscanff: %s", std::strerror(errno));
-    return StatusTuple(0);
+    return desc.key_sscanf(key_str.c_str(), key);
   }
 
   StatusTuple string_to_leaf(const std::string& value_str, ValueType* value) {
-    if (!desc.leaf_sscanf)
-      return StatusTuple(-1, "Leaf sscanf not available");
-    if (desc.leaf_sscanf(value_str.c_str(), value) != 0)
-      return StatusTuple(-1, "Error on leaf_sscanff: %s", std::strerror(errno));
-    return StatusTuple(0);
+    return desc.leaf_sscanf(value_str.c_str(), value);
   }
 
   StatusTuple key_to_string(const KeyType* key, std::string& key_str) {
     char buf[8 * desc.key_size];
-    if (!desc.key_snprintf)
-      return StatusTuple(-1, "Key snprintf not available");
-    if (desc.key_snprintf(buf, sizeof(buf), key) < 0)
-      return StatusTuple(-1, "Error on key_sprintf: %s", std::strerror(errno));
-
-    key_str.assign(buf);
-    return StatusTuple(0);
+    StatusTuple rc = desc.key_snprintf(buf, sizeof(buf), key);
+    if (!rc.code())
+      key_str.assign(buf);
+    return rc;
   }
 
   StatusTuple leaf_to_string(const ValueType* value, std::string& value_str) {
     char buf[8 * desc.leaf_size];
-    if (!desc.leaf_snprintf)
-      return StatusTuple(-1, "Leaf snprintf not available");
-    if (desc.leaf_snprintf(buf, sizeof(buf), value) < 0)
-      return StatusTuple(-1, "Error on leaf_sprintf: %s", std::strerror(errno));
-
-    value_str.assign(buf);
-    return StatusTuple(0);
+    StatusTuple rc = desc.leaf_snprintf(buf, sizeof(buf), value);
+    if (!rc.code())
+      value_str.assign(buf);
+    return rc;
   }
 
  protected:

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -124,16 +124,16 @@ static StatusTuple unimplemented_snprintf(char *, size_t, const void *) {
 }
 
 BPFModule::~BPFModule() {
-  engine_.reset();
-  rw_engine_.reset();
-  ctx_.reset();
-
   for (auto &v : tables_) {
     v->key_sscanf = unimplemented_sscanf;
     v->leaf_sscanf = unimplemented_sscanf;
     v->key_snprintf = unimplemented_snprintf;
     v->leaf_snprintf = unimplemented_snprintf;
   }
+
+  engine_.reset();
+  rw_engine_.reset();
+  ctx_.reset();
 
   ts_->DeletePrefix(Path({id_}));
 }

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 
+#include "bcc_exception.h"
+
 namespace llvm {
 class ExecutionEngine;
 class Function;
@@ -44,14 +46,18 @@ class BPFModule {
   int finalize();
   int annotate();
   std::unique_ptr<llvm::ExecutionEngine> finalize_rw(std::unique_ptr<llvm::Module> mod);
-  llvm::Function * make_reader(llvm::Module *mod, llvm::Type *type);
-  llvm::Function * make_writer(llvm::Module *mod, llvm::Type *type);
+  std::string make_reader(llvm::Module *mod, llvm::Type *type);
+  std::string make_writer(llvm::Module *mod, llvm::Type *type);
   void dump_ir(llvm::Module &mod);
   int load_file_module(std::unique_ptr<llvm::Module> *mod, const std::string &file, bool in_memory);
   int load_includes(const std::string &text);
   int load_cfile(const std::string &file, bool in_memory, const char *cflags[], int ncflags);
   int kbuild_flags(const char *uname_release, std::vector<std::string> *cflags);
   int run_pass_manager(llvm::Module &mod);
+  StatusTuple sscanf(std::string fn_name, const char *str, void *val);
+  StatusTuple snprintf(std::string fn_name, char *str, size_t sz,
+                       const void *val);
+
  public:
   BPFModule(unsigned flags, TableStorage *ts = nullptr);
   ~BPFModule();
@@ -106,8 +112,8 @@ class BPFModule {
   std::vector<TableDesc *> tables_;
   std::map<std::string, size_t> table_names_;
   std::vector<std::string> function_names_;
-  std::map<llvm::Type *, llvm::Function *> readers_;
-  std::map<llvm::Type *, llvm::Function *> writers_;
+  std::map<llvm::Type *, std::string> readers_;
+  std::map<llvm::Type *, std::string> writers_;
   std::string id_;
   TableStorage *ts_;
   std::unique_ptr<TableStorage> local_ts_;

--- a/src/cc/table_desc.h
+++ b/src/cc/table_desc.h
@@ -18,14 +18,12 @@
 
 #include <unistd.h>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 
+#include "bcc_exception.h"
 #include "common.h"
-
-namespace llvm {
-class Function;
-}
 
 namespace clang {
 class ASTContext;
@@ -34,8 +32,8 @@ class QualType;
 
 namespace ebpf {
 
-typedef int (*sscanf_fn)(const char *, void *);
-typedef int (*snprintf_fn)(char *, size_t, const void *);
+typedef std::function<StatusTuple(const char *, void *)> sscanf_fn;
+typedef std::function<StatusTuple(char *, size_t, const void *)> snprintf_fn;
 
 /// TableDesc uniquely stores all of the runtime state for an active bpf table.
 /// The copy constructor/assign operator are disabled since the file handles
@@ -68,10 +66,6 @@ class TableDesc {
         leaf_size(0),
         max_entries(0),
         flags(0),
-        key_sscanf(nullptr),
-        leaf_sscanf(nullptr),
-        key_snprintf(nullptr),
-        leaf_snprintf(nullptr),
         is_shared(false),
         is_extern(false) {}
   TableDesc(const std::string &name, FileDesc &&fd, int type, size_t key_size,
@@ -83,10 +77,6 @@ class TableDesc {
         leaf_size(leaf_size),
         max_entries(max_entries),
         flags(flags),
-        key_sscanf(nullptr),
-        leaf_sscanf(nullptr),
-        key_snprintf(nullptr),
-        leaf_snprintf(nullptr),
         is_shared(false),
         is_extern(false) {}
   TableDesc(TableDesc &&that) = default;


### PR DESCRIPTION
Not all users require the snprintf/sscanf helpers, and in some types the
finalization can take a long time. Defer the finalization until the
first use. Wrap the invocation with a bound function such that the
BPFTable and other users don't need to keep an explicit BPFModule
reference. Use-after-free will be avoided by resetting the function to
an error-returning stub when/if the BPFModule is freed.

Signed-off-by: Brenden Blanco <bblanco@gmail.com>