### PR TITLE
Fix bug when finding symbols for shared libraries

### DIFF
--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -136,9 +136,9 @@ class ProcSyms : SymbolCache {
     std::vector<Symbol> syms_;
 
     void load_sym_table();
-    bool contains(uint64_t addr) const;
+    bool contains(uint64_t addr, uint64_t &offset) const;
     uint64_t start() const { return ranges_.begin()->start; }
-    bool find_addr(uint64_t addr, struct bcc_symbol *sym);
+    bool find_addr(uint64_t offset, struct bcc_symbol *sym);
     bool find_name(const char *symname, uint64_t *addr);
 
     static int _add_symbol(const char *symname, uint64_t start, uint64_t end,


### PR DESCRIPTION
A shared library can be loaded into multiple non-consecutive memory sections. Currently `Module::find_addr` always look up the address against the first section by subtracting the address with `start()`.

This commit fixes the issue by calculating the binary offset when calling `contains()` and respect to the memory section actually containing the address.