### PR TITLE
Move FileDesc to separated header file and install

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -67,7 +67,9 @@ target_link_libraries(bcc-static b_frontend clang_frontend bcc-loader-static ${c
 
 install(TARGETS bcc-shared LIBRARY COMPONENT libbcc
   DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES bpf_common.h bpf_module.h bcc_syms.h bcc_exception.h libbpf.h perf_reader.h BPF.h BPFTable.h shared_table.h table_desc.h table_storage.h COMPONENT libbcc
+install(FILES bpf_common.h bpf_module.h bcc_syms.h bcc_exception.h file_desc.h
+              libbpf.h perf_reader.h BPF.h BPFTable.h shared_table.h
+              table_desc.h table_storage.h COMPONENT libbcc
   DESTINATION include/bcc)
 install(DIRECTORY compat/linux/ COMPONENT libbcc
   DESTINATION include/bcc/compat/linux

--- a/src/cc/common.cc
+++ b/src/cc/common.cc
@@ -15,7 +15,6 @@
  */
 #include <fstream>
 #include <sstream>
-#include <unistd.h>
 
 #include "common.h"
 
@@ -48,38 +47,5 @@ std::vector<int> get_online_cpus() {
 std::vector<int> get_possible_cpus() {
   return read_cpu_range("/sys/devices/system/cpu/possible");
 }
-
-FileDesc::FileDesc(int fd) : fd_(fd) {}
-
-FileDesc::FileDesc(FileDesc &&that) : fd_(-1) { *this = std::move(that); }
-
-FileDesc::~FileDesc() {
-  if (fd_ >= 0)
-    ::close(fd_);
-}
-
-FileDesc &FileDesc::operator=(int fd) {
-  if (fd_ >= 0)
-    ::close(fd_);
-  fd_ = fd;
-  return *this;
-}
-
-FileDesc &FileDesc::operator=(FileDesc &&that) {
-  if (fd_ >= 0)
-    ::close(fd_);
-  fd_ = that.fd_;
-  that.fd_ = -1;
-  return *this;
-}
-
-FileDesc FileDesc::dup() const {
-  int dup_fd = ::dup(fd_);
-  return FileDesc(dup_fd);
-}
-
-FileDesc::operator int() { return fd_; }
-
-FileDesc::operator int() const { return fd_; }
 
 } // namespace ebpf

--- a/src/cc/common.h
+++ b/src/cc/common.h
@@ -17,8 +17,6 @@
 #pragma once
 
 #include <memory>
-#include <string>
-#include <tuple>
 #include <vector>
 
 namespace ebpf {
@@ -32,28 +30,5 @@ make_unique(Args &&... args) {
 std::vector<int> get_online_cpus();
 
 std::vector<int> get_possible_cpus();
-
-/// FileDesc is a helper class for managing open file descriptors. Copy is
-/// disallowed (call dup instead), and cleanup happens automatically.
-class FileDesc {
- public:
-  explicit FileDesc(int fd = -1);
-  FileDesc(FileDesc &&that);
-  FileDesc(const FileDesc &that) = delete;
-
-  ~FileDesc();
-
-  FileDesc &operator=(int fd);
-  FileDesc &operator=(FileDesc &&that);
-  FileDesc &operator=(const FileDesc &that) = delete;
-
-  operator int();
-  operator int() const;
-
-  FileDesc dup() const;
-
- private:
-  int fd_;
-};
 
 }  // namespace ebpf

--- a/src/cc/file_desc.h
+++ b/src/cc/file_desc.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <unistd.h>
+
+namespace ebpf {
+
+/// FileDesc is a helper class for managing open file descriptors. Copy is
+/// disallowed (call dup instead), and cleanup happens automatically.
+class FileDesc {
+ public:
+  explicit FileDesc(int fd = -1) : fd_(fd) {}
+  FileDesc(FileDesc &&that) : fd_(-1) { *this = std::move(that); }
+  FileDesc(const FileDesc &that) = delete;
+
+  ~FileDesc() {
+    if (fd_ >= 0)
+      ::close(fd_);
+  }
+
+  FileDesc &operator=(int fd) {
+    if (fd_ >= 0)
+      ::close(fd_);
+    fd_ = fd;
+    return *this;
+  }
+  FileDesc &operator=(FileDesc &&that) {
+    if (fd_ >= 0)
+      ::close(fd_);
+    fd_ = that.fd_;
+    that.fd_ = -1;
+    return *this;
+  }
+  FileDesc &operator=(const FileDesc &that) = delete;
+
+  FileDesc dup() const {
+    int dup_fd = ::dup(fd_);
+    return FileDesc(dup_fd);
+  }
+
+  operator int() { return fd_; }
+  operator int() const { return fd_; }
+
+ private:
+  int fd_;
+};
+
+}  // namespace ebpf

--- a/src/cc/frontends/b/codegen_llvm.cc
+++ b/src/cc/frontends/b/codegen_llvm.cc
@@ -33,8 +33,8 @@
 #include <llvm/IR/Module.h>
 
 #include "bcc_exception.h"
-#include "common.h"
 #include "codegen_llvm.h"
+#include "file_desc.h"
 #include "lexer.h"
 #include "libbpf.h"
 #include "linux/bpf.h"

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -23,7 +23,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "common.h"
+#include "file_desc.h"
 
 class ProcStat {
   std::string procfs_;

--- a/src/cc/table_desc.h
+++ b/src/cc/table_desc.h
@@ -23,7 +23,7 @@
 #include <string>
 
 #include "bcc_exception.h"
-#include "common.h"
+#include "file_desc.h"
 
 namespace clang {
 class ASTContext;


### PR DESCRIPTION
As discussed in https://github.com/iovisor/bcc/commit/b6b9c6db4a052d6d7e36548ecb20bfa4896e0f59, move `FileDesc` from `common.h` to a separated `file_desc.h` and install it.