### PR TITLE
[RFC] add support for shared tables

### DIFF
--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -44,8 +44,9 @@ class BPF {
 public:
   static const int BPF_MAX_STACK_DEPTH = 127;
 
-  explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr)
-      : bpf_module_(new BPFModule(flag, ts)) {}
+  explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr,
+               const std::string &maps_ns = "")
+      : bpf_module_(new BPFModule(flag, ts, maps_ns)) {}
   StatusTuple init(const std::string& bpf_program,
                    const std::vector<std::string>& cflags = {},
                    const std::vector<USDT>& usdt = {});

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -59,12 +59,13 @@ class BPFModule {
                        const void *val);
 
  public:
-  BPFModule(unsigned flags, TableStorage *ts = nullptr);
+  BPFModule(unsigned flags, TableStorage *ts = nullptr, const std::string &maps_ns = "");
   ~BPFModule();
   int load_b(const std::string &filename, const std::string &proto_filename);
   int load_c(const std::string &filename, const char *cflags[], int ncflags);
   int load_string(const std::string &text, const char *cflags[], int ncflags);
   std::string id() const { return id_; }
+  std::string maps_ns() const { return maps_ns_; }
   size_t num_functions() const;
   uint8_t * function_start(size_t id) const;
   uint8_t * function_start(const std::string &name) const;
@@ -115,6 +116,7 @@ class BPFModule {
   std::map<llvm::Type *, std::string> readers_;
   std::map<llvm::Type *, std::string> writers_;
   std::string id_;
+  std::string maps_ns_;
   TableStorage *ts_;
   std::unique_ptr<TableStorage> local_ts_;
 };

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -65,6 +65,12 @@ BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries); \
 __attribute__((section("maps/export"))) \
 struct _name##_table_t __##_name
 
+// define a table that is shared accross the programs in the same namespace
+#define BPF_TABLE_SHARED(_table_type, _key_type, _leaf_type, _name, _max_entries) \
+BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries); \
+__attribute__((section("maps/shared"))) \
+struct _name##_table_t __##_name
+
 // Table for pushing custom events to userspace via ring buffer
 #define BPF_PERF_OUTPUT(_name) \
 struct _name##_table_t { \

--- a/src/cc/frontends/b/codegen_llvm.cc
+++ b/src/cc/frontends/b/codegen_llvm.cc
@@ -1224,7 +1224,7 @@ StatusTuple CodegenLLVM::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
   return StatusTuple(0);
 }
 
-StatusTuple CodegenLLVM::visit(Node *root, TableStorage &ts, const string &id) {
+StatusTuple CodegenLLVM::visit(Node *root, TableStorage &ts, const string &id, const string &maps_ns) {
   scopes_->set_current(scopes_->top_state());
   scopes_->set_current(scopes_->top_var());
 

--- a/src/cc/frontends/b/codegen_llvm.h
+++ b/src/cc/frontends/b/codegen_llvm.h
@@ -65,7 +65,7 @@ class CodegenLLVM : public Visitor {
   EXPAND_NODES(VISIT)
 #undef VISIT
 
-  STATUS_RETURN visit(Node *n, TableStorage &ts, const std::string &id);
+  STATUS_RETURN visit(Node *n, TableStorage &ts, const std::string &id, const std::string &maps_ns);
 
   int get_table_fd(const std::string &name) const;
 

--- a/src/cc/frontends/b/loader.cc
+++ b/src/cc/frontends/b/loader.cc
@@ -33,7 +33,7 @@ BLoader::~BLoader() {
 }
 
 int BLoader::parse(llvm::Module *mod, const string &filename, const string &proto_filename,
-                   TableStorage &ts, const string &id) {
+                   TableStorage &ts, const string &id, const std::string &maps_ns) {
   int rc;
 
   proto_parser_ = make_unique<ebpf::cc::Parser>(proto_filename);
@@ -61,7 +61,7 @@ int BLoader::parse(llvm::Module *mod, const string &filename, const string &prot
   }
 
   codegen_ = ebpf::make_unique<ebpf::cc::CodegenLLVM>(mod, parser_->scopes_.get(), proto_parser_->scopes_.get());
-  ret = codegen_->visit(parser_->root_node_, ts, id);
+  ret = codegen_->visit(parser_->root_node_, ts, id, maps_ns);
   if (ret.code() != 0 || ret.msg().size()) {
     fprintf(stderr, "Codegen error @line=%d: %s\n", ret.code(), ret.msg().c_str());
     return ret.code();

--- a/src/cc/frontends/b/loader.h
+++ b/src/cc/frontends/b/loader.h
@@ -38,7 +38,7 @@ class BLoader {
   explicit BLoader(unsigned flags);
   ~BLoader();
   int parse(llvm::Module *mod, const std::string &filename, const std::string &proto_filename,
-            TableStorage &ts, const std::string &id);
+            TableStorage &ts, const std::string &id, const std::string &maps_ns);
 
  private:
   unsigned flags_;

--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -122,7 +122,8 @@ class BFrontendAction : public clang::ASTFrontendAction {
  public:
   // Initialize with the output stream where the new source file contents
   // should be written.
-  BFrontendAction(llvm::raw_ostream &os, unsigned flags, TableStorage &ts, const std::string &id);
+  BFrontendAction(llvm::raw_ostream &os, unsigned flags, TableStorage &ts,
+                  const std::string &id, const std::string &maps_ns);
 
   // Called by clang when the AST has been completed, here the output stream
   // will be flushed.
@@ -134,12 +135,13 @@ class BFrontendAction : public clang::ASTFrontendAction {
   clang::Rewriter &rewriter() const { return *rewriter_; }
   TableStorage &table_storage() const { return ts_; }
   std::string id() const { return id_; }
-
+  std::string maps_ns() const { return maps_ns_; }
  private:
   llvm::raw_ostream &os_;
   unsigned flags_;
   TableStorage &ts_;
   std::string id_;
+  std::string maps_ns_;
   std::unique_ptr<clang::Rewriter> rewriter_;
 };
 

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -105,7 +105,8 @@ std::pair<bool, string> get_kernel_path_info(const string kdir)
 }
 
 int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts, const string &file,
-                       bool in_memory, const char *cflags[], int ncflags, const std::string &id) {
+                       bool in_memory, const char *cflags[], int ncflags, const std::string &id,
+                       const std::string &maps_ns) {
   using namespace clang;
 
   string main_path = "/virtual/main.c";
@@ -269,7 +270,7 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts, const st
   // capture the rewritten c file
   string out_str1;
   llvm::raw_string_ostream os1(out_str1);
-  BFrontendAction bact(os1, flags_, ts, id);
+  BFrontendAction bact(os1, flags_, ts, id, maps_ns);
   if (!compiler1.ExecuteAction(bact))
     return -1;
   unique_ptr<llvm::MemoryBuffer> out_buf1 = llvm::MemoryBuffer::getMemBuffer(out_str1);

--- a/src/cc/frontends/clang/loader.h
+++ b/src/cc/frontends/clang/loader.h
@@ -35,7 +35,8 @@ class ClangLoader {
   explicit ClangLoader(llvm::LLVMContext *ctx, unsigned flags);
   ~ClangLoader();
   int parse(std::unique_ptr<llvm::Module> *mod, TableStorage &ts, const std::string &file,
-            bool in_memory, const char *cflags[], int ncflags, const std::string &id);
+            bool in_memory, const char *cflags[], int ncflags, const std::string &id,
+            const std::string &maps_ns);
 
  private:
   static std::map<std::string, std::unique_ptr<llvm::MemoryBuffer>> remapped_files_;

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(test_libbcc
 	test_array_table.cc
 	test_bpf_table.cc
 	test_hash_table.cc
+	test_shared_table.cc
 	test_usdt_args.cc
 	test_usdt_probes.cc)
 

--- a/tests/cc/test_shared_table.cc
+++ b/tests/cc/test_shared_table.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017 Politecnico di Torino
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BPF.h"
+#include "catch.hpp"
+
+const std::string BPF_PROGRAM1 = R"(
+BPF_TABLE_SHARED("array", int, int, mysharedtable, 1024);
+)";
+
+const std::string BPF_PROGRAM2 = R"(
+BPF_TABLE("extern", int, int, mysharedtable, 1024);
+)";
+
+TEST_CASE("test shared table", "[shared_table]") {
+  // deploy 4 ebpf programs: 1a and 1b are in ns1, 2a and 2b in ns2
+  ebpf::BPF bpf1a(0, nullptr, "ns1");
+  ebpf::BPF bpf1b(0, nullptr, "ns1");
+  ebpf::BPF bpf2a(0, nullptr, "ns2");
+  ebpf::BPF bpf2b(0, nullptr, "ns2");
+
+  ebpf::StatusTuple res(0);
+
+  res = bpf1a.init(BPF_PROGRAM1);
+  REQUIRE(res.code() == 0);
+
+  res = bpf1b.init(BPF_PROGRAM2);
+  REQUIRE(res.code() == 0);
+
+  res = bpf2a.init(BPF_PROGRAM1);
+  REQUIRE(res.code() == 0);
+
+  res = bpf2b.init(BPF_PROGRAM2);
+  REQUIRE(res.code() == 0);
+
+  // get references to all tables
+  ebpf::BPFArrayTable<int> t1a = bpf1a.get_array_table<int>("mysharedtable");
+  ebpf::BPFArrayTable<int> t1b = bpf1b.get_array_table<int>("mysharedtable");
+  ebpf::BPFArrayTable<int> t2a = bpf2a.get_array_table<int>("mysharedtable");
+  ebpf::BPFArrayTable<int> t2b = bpf2b.get_array_table<int>("mysharedtable");
+
+  // test that tables within the same ns are shared
+  int v1, v2, v3;
+  res = t1a.update_value(13, 42);
+  REQUIRE(res.code() == 0);
+
+  res = t1b.get_value(13, v1);
+  REQUIRE(res.code() == 0);
+  REQUIRE(v1 == 42);
+
+  // test that tables are isolated within different ns
+  res = t2a.update_value(13, 69);
+  REQUIRE(res.code() == 0);
+
+  res = t2b.get_value(13, v2);
+  REQUIRE(res.code() == 0);
+  REQUIRE(v2 == 69);
+
+  res = t1b.get_value(13, v3);
+  REQUIRE(res.code() == 0);
+  REQUIRE(v3 == 42);  // value should still be 42
+}


### PR DESCRIPTION
Currently tables can be created in two modes:
1. private to the ebpf program
2. shared among all the ebpf programs created by the same user-space
process

This commit extends bcc allowing to create a table that is shared among
a set of specific ebpf programs.
This is useful when creating network functions that are composed
by more than 1 ebpf program, a map is shared among all the programs of
the network function but isolated from different instances of that
function.

This code is just a RFC for now, shared tables are not destroyed as the same behavior applies on public tables [1].

The code itself is quire simple, most of it is just to pass around the `maps_ns` parameter, any suggestion about how to implement it without adding an extra argument is welcome.

[1] https://github.com/iovisor/bcc/issues/1171