### PR TITLE
Enable recursive scanf support for char[] as string

### DIFF
--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -121,6 +121,38 @@ BPF_HASH(stats, int, struct { u32 a[3]; u32 b; }, 10);
         self.assertEqual(l.a[2], 3)
         self.assertEqual(l.b, 4)
 
+    def test_sscanf_string(self):
+        text = """
+struct Symbol {
+    char name[128];
+    char path[128];
+};
+struct Event {
+    uint32_t pid;
+    uint32_t tid;
+    struct Symbol stack[64];
+};
+BPF_TABLE("array", int, struct Event, comms, 1);
+"""
+        b = BPF(text=text)
+        t = b.get_table("comms")
+        s1 = t.leaf_sprintf(t[0])
+        fill = b' { "" "" }' * 63
+        self.assertEqual(s1, b'{ 0x0 0x0 [ { "" "" }%s ] }' % fill)
+        l = t.Leaf(1, 2)
+        name = b"libxyz"
+        path = b"/usr/lib/libxyz.so"
+        l.stack[0].name = name
+        l.stack[0].path = path
+        s2 = t.leaf_sprintf(l)
+        self.assertEqual(s2,
+                b'{ 0x1 0x2 [ { "%s" "%s" }%s ] }' % (name, path, fill))
+        l = t.leaf_scanf(s2)
+        self.assertEqual(l.pid, 1)
+        self.assertEqual(l.tid, 2)
+        self.assertEqual(l.stack[0].name, name)
+        self.assertEqual(l.stack[0].path, path)
+
     def test_iosnoop(self):
         text = """
 #include <linux/blkdev.h>


### PR DESCRIPTION
When a bpf table contains i8[] in one of its keys/leaves, use "" to
enclose the value, rather than [ %i %i %i ... ] format. This simplifies
the code that is generated for cases such as #1154, and brings it back
under ~200ms code generation, instead of >30s. This change of format is
not particularly robust (it doesn't handle escaping the doublequote
character itself), but it should make more sense for the common case,
such as tracing files and pathnames.

The test case included tests both the functionality of the format string
handling as well as the compile time, since test_clang already has an
implicit 10second timeout limit.

Fixes: #1154
Signed-off-by: Brenden Blanco <bblanco@gmail.com>