### PR TITLE
Fix bpf_perf_event_read helper signature

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -192,7 +192,7 @@ static int (*bpf_skb_get_tunnel_key)(void *ctx, void *to, u32 size, u64 flags) =
   (void *) BPF_FUNC_skb_get_tunnel_key;
 static int (*bpf_skb_set_tunnel_key)(void *ctx, void *from, u32 size, u64 flags) =
   (void *) BPF_FUNC_skb_set_tunnel_key;
-static int (*bpf_perf_event_read)(void *map, u32 index) =
+static u64 (*bpf_perf_event_read)(void *map, u64 flags) =
   (void *) BPF_FUNC_perf_event_read;
 static int (*bpf_redirect)(int ifindex, u32 flags) =
   (void *) BPF_FUNC_redirect;


### PR DESCRIPTION
From Kernel the helper method `bpf_perf_event_read` returns an `u64`. Also, the `index` argument (now called `flags`) is also an `u64`, which could make a difference due to this change: https://github.com/torvalds/linux/commit/6816a7ffce32e999601825ddfd887f36d3052932