### PR TITLE
Use new Kernel functionality to get first key of map

### DIFF
--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -34,6 +34,7 @@ int bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size,
 int bpf_update_elem(int fd, void *key, void *value, unsigned long long flags);
 int bpf_lookup_elem(int fd, void *key, void *value);
 int bpf_delete_elem(int fd, void *key);
+int bpf_get_first_key(int fd, void *key, size_t key_size);
 int bpf_get_next_key(int fd, void *key, void *next_key);
 
 int bpf_prog_load(enum bpf_prog_type prog_type,

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -69,6 +69,8 @@ lib.bpf_table_leaf_sscanf.argtypes = [ct.c_void_p, ct.c_ulonglong,
 # keep in sync with libbpf.h
 lib.bpf_get_next_key.restype = ct.c_int
 lib.bpf_get_next_key.argtypes = [ct.c_int, ct.c_void_p, ct.c_void_p]
+lib.bpf_get_first_key.restype = ct.c_int
+lib.bpf_get_first_key.argtypes = [ct.c_int, ct.c_void_p, ct.c_uint]
 lib.bpf_lookup_elem.restype = ct.c_int
 lib.bpf_lookup_elem.argtypes = [ct.c_int, ct.c_void_p, ct.c_void_p]
 lib.bpf_update_elem.restype = ct.c_int

--- a/tests/cc/test_hash_table.cc
+++ b/tests/cc/test_hash_table.cc
@@ -71,4 +71,17 @@ TEST_CASE("test hash table", "[hash_table]") {
     res = t.get_value(k, v2);
     REQUIRE(res.code() != 0);
   }
+
+  SECTION("walk table") {
+    for (int i = 1; i <= 10; i++) {
+      res = t.update_value(i * 3, i);
+      REQUIRE(res.code() == 0);
+    }
+    auto offline = t.get_table_offline();
+    REQUIRE(offline.size() == 10);
+    for (const auto &pair : offline) {
+      REQUIRE(pair.first % 3 == 0);
+      REQUIRE(pair.first / 3 == pair.second);
+    }
+  }
 }


### PR DESCRIPTION
In https://github.com/torvalds/linux/commit/8fe45924387be6b5c1be59a7eb330790c61d5d10 we changed `BPF_MAP_GET_NEXT_KEY` so that it will return the first key of the map is given `NULL`. This helps us to walk the map without having to guess a non-existing key.

This change adds a helper `bpf_get_first_key` that automatically tries to use this new way to get first key of a map, and falls back to current behavior of trying a few different values if running on older Kernels. Also changes to use this new helper in C++ and  Python API.