### PR TITLE
Implement free_compiler_resource interface method

### DIFF
--- a/src/cc/usdt.cc
+++ b/src/cc/usdt.cc
@@ -152,7 +152,7 @@ bool Probe::usdt_getarg(std::ostream &stream) {
 
   for (size_t arg_n = 0; arg_n < arg_count; ++arg_n) {
     std::string ctype = largest_arg_type(arg_n);
-    std::string cptr = tfm::format("*((volatile %s *)dest)", ctype);
+    std::string cptr = tfm::format("dest", ctype);
 
     tfm::format(stream,
                 "static __always_inline int _bpf_readarg_%s_%d("

--- a/src/cc/usdt_args.cc
+++ b/src/cc/usdt_args.cc
@@ -67,17 +67,17 @@ bool Argument::assign_to_local(std::ostream &stream,
   }
 
   if (!deref_offset_) {
-    tfm::format(stream, "%s = (%s)ctx->%s;", local_name, ctype(),
+    tfm::format(stream, "%s = *(volatile %s *)&ctx->%s;", local_name, ctype(),
                 *base_register_name_);
     return true;
   }
 
   if (deref_offset_ && !deref_ident_) {
-    tfm::format(stream, "{ u64 __addr = ctx->%s + (%d)",
+    tfm::format(stream, "{ u64 __addr = (*(volatile u64 *)&ctx->%s) + (%d)",
                 *base_register_name_, *deref_offset_);
     if (index_register_name_) {
       int scale = scale_.value_or(1);
-      tfm::format(stream, " + (ctx->%s * %d);", *index_register_name_, scale);
+      tfm::format(stream, " + ((*(volatile u64 *)&ctx->%s) * %d);", *index_register_name_, scale);
     } else {
       tfm::format(stream, ";");
     }


### PR DESCRIPTION
  o Many bcc use cases have a pattern like
    step_1: compile and load the program
    step_2: runtime monitoring by read/write to maps

    step_1 will allocate some memory for compilation, and
    right now they are not freed until process got killed
    or module unloaded.

    step_2 still uses the module for map-related functionality.
    step_2 will not use compilation context except for
    sscanf/snprintf functions.

  o This patch provides a new interface function
    free_compiler_resource.
    Application can call after step 1 to
    free compiler-incurred memory consumption.

    Optionally, free_compiler_resource can call
    malloc_trim to return top freed heap memory back
    to system. This is useful for glibc malloc.
    For some other malloc libraries like jemalloc,
    explicit malloc_trim is not needed.

  o A new python test case is added. For a real simple test, I have
    ('Before freeing and returning memory:', ['RssAnon:', '16788', 'kB'])
    ('After freeing and returning memory:', ['RssAnon:', '8196', 'kB'])

Signed-off-by: Yonghong Song <yhs@fb.com>