### PR TITLE
Workaround for possible race in pyroute2.ipdb

### DIFF
--- a/examples/networking/simulation.py
+++ b/examples/networking/simulation.py
@@ -66,6 +66,7 @@ class Simulation(object):
 
         if out_ifc: out_ifc.up().commit()
         ns_ipdb.interfaces.lo.up().commit()
+        ns_ipdb.initdb()
         in_ifc = ns_ipdb.interfaces[in_ifname]
         with in_ifc as v:
             v.ifname = ns_ifc


### PR DESCRIPTION
In simulation.py, add a call to initdb() to force-refresh the netlink
socket and the interface list.

Signed-off-by: Brenden Blanco <bblanco@gmail.com>