### PR TITLE
Use BPF_F_CURRENT_CPU in perf_submit when possible

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -65,6 +65,17 @@ BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries); \
 __attribute__((section("maps/export"))) \
 struct _name##_table_t __##_name
 
+// Identifier for current CPU used in perf_submit and perf_read
+// Prefer BPF_F_CURRENT_CPU flag, falls back to call helper for older kernel
+// Can be overridden from BCC
+#ifndef CUR_CPU_IDENTIFIER
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
+#define CUR_CPU_IDENTIFIER BPF_F_CURRENT_CPU
+#else
+#define CUR_CPU_IDENTIFIER bpf_get_smp_processor_id()
+#endif
+#endif
+
 // Table for pushing custom events to userspace via ring buffer
 #define BPF_PERF_OUTPUT(_name) \
 struct _name##_table_t { \

--- a/src/cc/frontends/clang/CMakeLists.txt
+++ b/src/cc/frontends/clang/CMakeLists.txt
@@ -2,4 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_DIR='\"${BCC_KERNEL_MODULES_DIR}\"'")
+if(DEFINED BCC_CUR_CPU_IDENTIFIER)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCUR_CPU_IDENTIFIER='\"${BCC_CUR_CPU_IDENTIFIER}\"'")
+endif()
+
 add_library(clang_frontend STATIC loader.cc b_frontend_action.cc tp_frontend_action.cc kbuild_helper.cc ../../common.cc)

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -341,7 +341,7 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           string args_other = rewriter_.getRewrittenText(expansionRange(SourceRange(Call->getArg(1)->getLocStart(),
                                                            Call->getArg(2)->getLocEnd())));
           txt = "bpf_perf_event_output(" + arg0 + ", bpf_pseudo_fd(1, " + fd + ")";
-          txt += ", bpf_get_smp_processor_id(), " + args_other + ")";
+          txt += ", CUR_CPU_IDENTIFIER, " + args_other + ")";
         } else if (memb_name == "perf_submit_skb") {
           string skb = rewriter_.getRewrittenText(expansionRange(Call->getArg(0)->getSourceRange()));
           string skb_len = rewriter_.getRewrittenText(expansionRange(Call->getArg(1)->getSourceRange()));

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -160,6 +160,10 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts, const st
     for (auto i = 0; i < ncflags; ++i)
       flags_cstr.push_back(cflags[i]);
   }
+#ifdef CUR_CPU_IDENTIFIER
+  string cur_cpu_flag = string("-DCUR_CPU_IDENTIFIER=") + CUR_CPU_IDENTIFIER;
+  flags_cstr.push_back(cur_cpu_flag.c_str());
+#endif
 
   // set up the error reporting class
   IntrusiveRefCntPtr<DiagnosticOptions> diag_opts(new DiagnosticOptions());

--- a/tests/python/test_perf_event.py
+++ b/tests/python/test_perf_event.py
@@ -17,7 +17,7 @@ BPF_ARRAY(prev, u64, NUM_CPUS);
 BPF_HISTOGRAM(dist);
 int kprobe__sys_getuid(void *ctx) {
     u32 cpu = bpf_get_smp_processor_id();
-    u64 val = cnt1.perf_read(cpu);
+    u64 val = cnt1.perf_read(CUR_CPU_IDENTIFIER);
 
     if (((s64)val < 0) && ((s64)val > -256))
         return 0;
@@ -27,7 +27,7 @@ int kprobe__sys_getuid(void *ctx) {
 }
 int kretprobe__sys_getuid(void *ctx) {
     u32 cpu = bpf_get_smp_processor_id();
-    u64 val = cnt1.perf_read(cpu);
+    u64 val = cnt1.perf_read(CUR_CPU_IDENTIFIER);
 
     if (((s64)val < 0) && ((s64)val > -256))
         return 0;


### PR DESCRIPTION
https://github.com/torvalds/linux/commit/1e33759c788c78f31d4d6f65bac647b23624734c introduced the `BPF_F_CURRENT_CPU` to be used in `bpf_perf_event_output`. Using it would improve efficiency by saving one helper call.

This commit adds a `CUR_CPU_IDENTIFIER` from `CMake` file that automatically decides whether to use the new flag based on the running Kernel version.

Updated rewriter. Tested with both configs.