### PR TITLE
Fix usage of CMAKE_BUILD_TYPE setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@
 cmake_minimum_required(VERSION 2.8.7)
 
 project(bcc)
-set(CMAKE_BUILD_TYPE Release)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
 
 enable_testing()
 


### PR DESCRIPTION
The build type was set to Release in the top level cmake file.
This was a rather confusing behaviour, as one would expect to
be able to easily debug the code after using `cmake -DCMAKE_BUILD_TYPE=Debug`.