### PR TITLE
Unify Perf Event related Enums and checks

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -468,41 +468,6 @@ class ProgArray(ArrayBase):
             raise Exception("Could not delete item")
 
 class PerfEventArray(ArrayBase):
-    class Event(object):
-        def __init__(self, typ, config):
-            self.typ = typ
-            self.config = config
-
-    HW_CPU_CYCLES                = Event(Perf.PERF_TYPE_HARDWARE, 0)
-    HW_INSTRUCTIONS              = Event(Perf.PERF_TYPE_HARDWARE, 1)
-    HW_CACHE_REFERENCES          = Event(Perf.PERF_TYPE_HARDWARE, 2)
-    HW_CACHE_MISSES              = Event(Perf.PERF_TYPE_HARDWARE, 3)
-    HW_BRANCH_INSTRUCTIONS       = Event(Perf.PERF_TYPE_HARDWARE, 4)
-    HW_BRANCH_MISSES             = Event(Perf.PERF_TYPE_HARDWARE, 5)
-    HW_BUS_CYCLES                = Event(Perf.PERF_TYPE_HARDWARE, 6)
-    HW_STALLED_CYCLES_FRONTEND   = Event(Perf.PERF_TYPE_HARDWARE, 7)
-    HW_STALLED_CYCLES_BACKEND    = Event(Perf.PERF_TYPE_HARDWARE, 8)
-    HW_REF_CPU_CYCLES            = Event(Perf.PERF_TYPE_HARDWARE, 9)
-
-    # not yet supported, wip
-    #HW_CACHE_L1D_READ        = Event(Perf.PERF_TYPE_HW_CACHE, 0<<0|0<<8|0<<16)
-    #HW_CACHE_L1D_READ_MISS   = Event(Perf.PERF_TYPE_HW_CACHE, 0<<0|0<<8|1<<16)
-    #HW_CACHE_L1D_WRITE       = Event(Perf.PERF_TYPE_HW_CACHE, 0<<0|1<<8|0<<16)
-    #HW_CACHE_L1D_WRITE_MISS  = Event(Perf.PERF_TYPE_HW_CACHE, 0<<0|1<<8|1<<16)
-    #HW_CACHE_L1D_PREF        = Event(Perf.PERF_TYPE_HW_CACHE, 0<<0|2<<8|0<<16)
-    #HW_CACHE_L1D_PREF_MISS   = Event(Perf.PERF_TYPE_HW_CACHE, 0<<0|2<<8|1<<16)
-    #HW_CACHE_L1I_READ        = Event(Perf.PERF_TYPE_HW_CACHE, 1<<0|0<<8|0<<16)
-    #HW_CACHE_L1I_READ_MISS   = Event(Perf.PERF_TYPE_HW_CACHE, 1<<0|0<<8|1<<16)
-    #HW_CACHE_L1I_WRITE       = Event(Perf.PERF_TYPE_HW_CACHE, 1<<0|1<<8|0<<16)
-    #HW_CACHE_L1I_WRITE_MISS  = Event(Perf.PERF_TYPE_HW_CACHE, 1<<0|1<<8|1<<16)
-    #HW_CACHE_L1I_PREF        = Event(Perf.PERF_TYPE_HW_CACHE, 1<<0|2<<8|0<<16)
-    #HW_CACHE_L1I_PREF_MISS   = Event(Perf.PERF_TYPE_HW_CACHE, 1<<0|2<<8|1<<16)
-    #HW_CACHE_LL_READ         = Event(Perf.PERF_TYPE_HW_CACHE, 2<<0|0<<8|0<<16)
-    #HW_CACHE_LL_READ_MISS    = Event(Perf.PERF_TYPE_HW_CACHE, 2<<0|0<<8|1<<16)
-    #HW_CACHE_LL_WRITE        = Event(Perf.PERF_TYPE_HW_CACHE, 2<<0|1<<8|0<<16)
-    #HW_CACHE_LL_WRITE_MISS   = Event(Perf.PERF_TYPE_HW_CACHE, 2<<0|1<<8|1<<16)
-    #HW_CACHE_LL_PREF         = Event(Perf.PERF_TYPE_HW_CACHE, 2<<0|2<<8|0<<16)
-    #HW_CACHE_LL_PREF_MISS    = Event(Perf.PERF_TYPE_HW_CACHE, 2<<0|2<<8|1<<16)
 
     def __init__(self, *args, **kwargs):
         super(PerfEventArray, self).__init__(*args, **kwargs)
@@ -556,18 +521,15 @@ class PerfEventArray(ArrayBase):
             # the fd is kept open in the map itself by the kernel
             os.close(fd)
 
-    def open_perf_event(self, ev):
-        """open_perf_event(ev)
+    def open_perf_event(self, typ, config):
+        """open_perf_event(typ, config)
 
         Configures the table such that calls from the bpf program to
         table.perf_read(bpf_get_smp_processor_id()) will return the hardware
         counter denoted by event ev on the local cpu.
         """
-        if not isinstance(ev, self.Event):
-            raise Exception("argument must be an Event, got %s", type(ev))
-
         for i in get_online_cpus():
-            self._open_perf_event(i, ev.typ, ev.config)
+            self._open_perf_event(i, typ, config)
 
 
 class PerCpuHash(HashTable):

--- a/tests/python/test_perf_event.py
+++ b/tests/python/test_perf_event.py
@@ -18,12 +18,20 @@ BPF_HISTOGRAM(dist);
 int kprobe__sys_getuid(void *ctx) {
     u32 cpu = bpf_get_smp_processor_id();
     u64 val = cnt1.perf_read(cpu);
+
+    if (((s64)val < 0) && ((s64)val > -256))
+        return 0;
+
     prev.update(&cpu, &val);
     return 0;
 }
 int kretprobe__sys_getuid(void *ctx) {
     u32 cpu = bpf_get_smp_processor_id();
     u64 val = cnt1.perf_read(cpu);
+
+    if (((s64)val < 0) && ((s64)val > -256))
+        return 0;
+
     u64 *prevp = prev.lookup(&cpu);
     if (prevp)
         dist.increment(bpf_log2l(val - *prevp));
@@ -34,7 +42,7 @@ int kretprobe__sys_getuid(void *ctx) {
                 cflags=["-DNUM_CPUS=%d" % multiprocessing.cpu_count()])
         cnt1 = b["cnt1"]
         try:
-            cnt1.open_perf_event(cnt1.HW_CPU_CYCLES)
+            cnt1.open_perf_event(bcc.PerfType.HARDWARE, bcc.PerfHWConfig.CPU_CYCLES)
         except:
             if ctypes.get_errno() == 2:
                 raise self.skipTest("hardware events unsupported")


### PR DESCRIPTION
Currently we have both helpers for reading Perf Event counters, and attaching to Perf Event counter overflow events. We have separated and duplicated value checking and Enums for them in Python API and C library. This change tries to unify them.

We are working on adding `HW_CACHE` event / read support on Kernel side, so this will make future addition of that into BCC easier.

In addition, make the BPF program of `test_perf_event.py` check for potential errno returned by `bpf_perf_event_read`, so that it would catch the cases when the Perf Event Array is not opened correctly. There is a small chance that a valid (`u64`) return value could coincide with an errno. But since this is a test case I think we should still add the check.