### PR TITLE
Fix bcc_resolve_symname memory leak in C++ API

### DIFF
--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -171,7 +171,9 @@ private:
 
   StatusTuple check_binary_symbol(const std::string& binary_path,
                                   const std::string& symbol,
-                                  uint64_t symbol_addr, bcc_symbol* output);
+                                  uint64_t symbol_addr,
+                                  std::string &module_res,
+                                  uint64_t &offset_res);
 
   std::unique_ptr<BPFModule> bpf_module_;
 


### PR DESCRIPTION
The returned `module` pointer need to be freed properly. This commit fixes the issue by updated result handling in `check_binary_symbol` helper.