### PR TITLE
Minor fixes for example and compiler warning

### DIFF
--- a/examples/cpp/TCPSendStack.cc
+++ b/examples/cpp/TCPSendStack.cc
@@ -32,7 +32,7 @@ BPF_HASH(counts, struct stack_key_t, uint64_t);
 
 int on_tcp_send(struct pt_regs *ctx) {
   struct stack_key_t key = {};
-  key.pid = bpf_get_current_pid_tgid();
+  key.pid = bpf_get_current_pid_tgid() >> 32;
   bpf_get_current_comm(&key.name, sizeof(key.name));
   key.kernel_stack = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
   key.user_stack = stack_traces.get_stackid(

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -159,7 +159,7 @@ int bpf_get_first_key(int fd, void *key, size_t key_size)
       // trigger a page fault in kernel and affect performence. Hence we use
       // ~0 which will fail and return fast.
       // This should fail since we pass an invalid pointer for value.
-      if (bpf_lookup_elem(fd, key, ~0) >= 0)
+      if (bpf_lookup_elem(fd, key, (void *)~0) >= 0)
         return -1;
       // This means the key doesn't exist.
       if (errno == ENOENT)


### PR DESCRIPTION
Two small fixes for example logic and compiler warning for not casting integer to pointer