### PR TITLE
Support symbol option in C++ API stack table

### DIFF
--- a/src/cc/BPF.cc
+++ b/src/cc/BPF.cc
@@ -504,11 +504,13 @@ BPFProgTable BPF::get_prog_table(const std::string& name) {
   return BPFProgTable({});
 }
 
-BPFStackTable BPF::get_stack_table(const std::string& name) {
+BPFStackTable BPF::get_stack_table(const std::string& name,
+                                   bool use_debug_file,
+                                   bool check_debug_file_crc) {
   TableStorage::iterator it;
   if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
-    return BPFStackTable(it->second);
-  return BPFStackTable({});
+    return BPFStackTable(it->second, use_debug_file, check_debug_file_crc);
+  return BPFStackTable({}, use_debug_file, check_debug_file_crc);
 }
 
 std::string BPF::get_uprobe_event(const std::string& binary_path,

--- a/src/cc/BPF.h
+++ b/src/cc/BPF.h
@@ -115,7 +115,9 @@ public:
 
   BPFProgTable get_prog_table(const std::string& name);
 
-  BPFStackTable get_stack_table(const std::string& name);
+  BPFStackTable get_stack_table(const std::string& name,
+                                bool use_debug_file = true,
+                                bool check_debug_file_crc = true);
 
   StatusTuple open_perf_buffer(const std::string& name,
                                perf_reader_raw_cb cb,

--- a/src/cc/BPFTable.h
+++ b/src/cc/BPFTable.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "bcc_exception.h"
+#include "bcc_syms.h"
 #include "bpf_module.h"
 #include "libbpf.h"
 #include "perf_reader.h"
@@ -205,14 +206,16 @@ struct stacktrace_t {
 
 class BPFStackTable : public BPFTableBase<int, stacktrace_t> {
  public:
-  BPFStackTable(const TableDesc& desc)
-      : BPFTableBase<int, stacktrace_t>(desc) {}
+  BPFStackTable(const TableDesc& desc,
+                bool use_debug_file,
+                bool check_debug_file_crc);
   ~BPFStackTable();
 
   std::vector<uintptr_t> get_stack_addr(int stack_id);
   std::vector<std::string> get_stack_symbol(int stack_id, int pid);
 
  private:
+  bcc_symbol_option symbol_option_;
   std::map<int, void*> pid_sym_;
 };
 

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -32,10 +32,6 @@
 #include "syms.h"
 #include "vendor/tinyformat.hpp"
 
-#ifndef STT_GNU_IFUNC
-#define STT_GNU_IFUNC 10
-#endif
-
 ino_t ProcStat::getinode_() {
   struct stat s;
   return (!stat(procfs_.c_str(), &s)) ? s.st_ino : -1;

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -31,6 +31,9 @@ struct bcc_symbol {
 
 typedef int (*SYM_CB)(const char *symname, uint64_t addr);
 
+#ifndef STT_GNU_IFUNC
+#define STT_GNU_IFUNC 10
+#endif
 static const uint32_t BCC_SYM_ALL_TYPES = 65535;
 struct bcc_symbol_option {
   int use_debug_file;


### PR DESCRIPTION
Add parameter to control the usage of debug files on symboling in C++ `BPFStackTable` API, using the newly added `bcc_symbol_option` support.

Default behavior the the same as current behavior.