### PR TITLE
Improve perf event clean up

### DIFF
--- a/src/cc/BPF.cc
+++ b/src/cc/BPF.cc
@@ -561,8 +561,8 @@ StatusTuple BPF::detach_perf_event_all_cpu(open_probe_t& attr) {
   bool has_error = false;
   std::string err_msg;
   for (const auto& it : *attr.per_cpu_fd) {
-    int res = close(it.second);
-    if (res < 0) {
+    int res = bpf_close_perf_event_fd(it.second);
+    if (res != 0) {
       has_error = true;
       err_msg += "Failed to close perf event FD " + std::to_string(it.second) +
                  " For CPU " + std::to_string(it.first) + ": ";

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -808,10 +808,21 @@ int bpf_attach_perf_event(int progfd, uint32_t ev_type, uint32_t ev_config,
   return fd;
 }
 
-int bpf_detach_perf_event(uint32_t ev_type, uint32_t ev_config) {
-  // Right now, there is nothing to do, but it's a good idea to encourage
-  // callers to detach anything they attach.
-  return 0;
+int bpf_close_perf_event_fd(int fd) {
+  int res, error = 0;
+  if (fd >= 0) {
+    res = ioctl(fd, PERF_EVENT_IOC_DISABLE, 0);
+    if (res != 0) {
+      perror("ioctl(PERF_EVENT_IOC_DISABLE) failed");
+      error = res;
+    }
+    res = close(fd);
+    if (res != 0) {
+      perror("close perf event FD failed");
+      error = (res && !error) ? res : error;
+    }
+  }
+  return error;
 }
 
 int bpf_obj_pin(int fd, const char *pathname)

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -82,7 +82,8 @@ int bpf_attach_xdp(const char *dev_name, int progfd, uint32_t flags);
 int bpf_attach_perf_event(int progfd, uint32_t ev_type, uint32_t ev_config,
                           uint64_t sample_period, uint64_t sample_freq,
                           pid_t pid, int cpu, int group_fd);
-int bpf_detach_perf_event(uint32_t ev_type, uint32_t ev_config);
+
+int bpf_close_perf_event_fd(int fd);
 
 int bpf_obj_pin(int fd, const char *pathname);
 int bpf_obj_get(const char *pathname);

--- a/src/cc/perf_reader.c
+++ b/src/cc/perf_reader.c
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <unistd.h>
 #include <linux/perf_event.h>
@@ -63,8 +64,10 @@ void perf_reader_free(void *ptr) {
   if (ptr) {
     struct perf_reader *reader = ptr;
     munmap(reader->base, reader->page_size * (reader->page_cnt + 1));
-    if (reader->fd >= 0)
+    if (reader->fd >= 0) {
+      ioctl(reader->fd, PERF_EVENT_IOC_DISABLE, 0);
       close(reader->fd);
+    }
     free(reader->buf);
     free(ptr);
   }

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -730,13 +730,13 @@ class BPF(object):
         except KeyError:
             raise Exception("Perf event type {} config {} not attached".format(
                 ev_type, ev_config))
+
+        res = 0
         for fd in fds.values():
-            os.close(fd)
-        res = lib.bpf_detach_perf_event(ev_type, ev_config)
-        if res < 0:
+            res = lib.bpf_close_perf_event_fd(fd) or res
+        if res != 0:
             raise Exception("Failed to detach BPF from perf event")
         del self.open_perf_events[(ev_type, ev_config)]
-        return res
 
     def _add_uprobe(self, name, probe):
         global _num_open_probes

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -115,14 +115,15 @@ lib.perf_reader_free.argtypes = [ct.c_void_p]
 lib.perf_reader_fd.restype = int
 lib.perf_reader_fd.argtypes = [ct.c_void_p]
 
-lib.bpf_attach_xdp.restype = ct.c_int;
+lib.bpf_attach_xdp.restype = ct.c_int
 lib.bpf_attach_xdp.argtypes = [ct.c_char_p, ct.c_int, ct.c_uint]
 
-lib.bpf_attach_perf_event.restype = ct.c_int;
+lib.bpf_attach_perf_event.restype = ct.c_int
 lib.bpf_attach_perf_event.argtype = [ct.c_int, ct.c_uint, ct.c_uint, ct.c_ulonglong, ct.c_ulonglong,
         ct.c_int, ct.c_int, ct.c_int]
-lib.bpf_detach_perf_event.restype = ct.c_int;
-lib.bpf_detach_perf_event.argtype = [ct.c_uint, ct.c_uint]
+
+lib.bpf_close_perf_event_fd.restype = ct.c_int
+lib.bpf_close_perf_event_fd.argtype = [ct.c_int]
 
 # bcc symbol helpers
 class bcc_symbol(ct.Structure):


### PR DESCRIPTION
Recently we noticed that when all references of a perf event FD are closed, the free-ing of the perf event happens asynchronously and could delay for as much as over 100ms. If we are opening and closing perf events frequently, this delayed free could cause exhaustion of the physical PMU resource and failures. This is my rough understanding and @4ast could probably explain the situation much better than I do.

This set of changes:
- Adds `bpf_close_perf_event_fd` helper and use it when detaching BPF program from perf event in C++ and Python API.
- Disable the perf event fd in `perf_reader_free` before closing.

Will address `bpf_perf_event_read` and the perf ring buffer use cases in separated commits.