### PR TITLE
funclatency/sslsniff: fix the TypeError when enabling pid filter on u…

### DIFF
--- a/tools/funclatency.py
+++ b/tools/funclatency.py
@@ -45,7 +45,7 @@ parser = argparse.ArgumentParser(
     description="Time functions and print latency as a histogram",
     formatter_class=argparse.RawDescriptionHelpFormatter,
     epilog=examples)
-parser.add_argument("-p", "--pid",
+parser.add_argument("-p", "--pid", type=int,
     help="trace this PID only")
 parser.add_argument("-i", "--interval", default=99999999,
     help="summary interval, seconds")
@@ -147,7 +147,7 @@ need_key = args.function or (library and not args.pid)
 # code substitutions
 if args.pid:
     bpf_text = bpf_text.replace('FILTER',
-        'if (tgid != %s) { return 0; }' % args.pid)
+        'if (tgid != %d) { return 0; }' % args.pid)
 else:
     bpf_text = bpf_text.replace('FILTER', '')
 if args.milliseconds:

--- a/tools/sslsniff.py
+++ b/tools/sslsniff.py
@@ -30,7 +30,7 @@ parser = argparse.ArgumentParser(
     description="Sniff SSL data",
     formatter_class=argparse.RawDescriptionHelpFormatter,
     epilog=examples)
-parser.add_argument("-p", "--pid", help="sniff this PID only.")
+parser.add_argument("-p", "--pid", type=int, help="sniff this PID only.")
 parser.add_argument("-c", "--comm",
                     help="sniff only commands matching string.")
 parser.add_argument("-o", "--no-openssl", action="store_false", dest="openssl",
@@ -115,7 +115,7 @@ int probe_SSL_read_exit(struct pt_regs *ctx, void *ssl, void *buf, int num) {
 """
 
 if args.pid:
-    prog = prog.replace('FILTER', 'if (pid != %s) { return 0; }' % args.pid)
+    prog = prog.replace('FILTER', 'if (pid != %d) { return 0; }' % args.pid)
 else:
     prog = prog.replace('FILTER', '')
 


### PR DESCRIPTION
…probe

attach_uprobe() and attach_uretprobe() expect the type of pid argument
is "int" instead of "str". Fix it by specifying the type of the "-p"/"--pid"
option as "int", and updating the format string of args.pid accordingly.

Fixes: d73c58f0c8c754bd591264205ac2ddc83c1d2c7f