### PR TITLE
bcc_proc.c: fix stack overflow in bcc_procutils_which()

### DIFF
--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -46,8 +46,10 @@ char *bcc_procutils_which(const char *binpath) {
     const size_t path_len = next - PATH;
 
     if (path_len) {
-      snprintf(buffer, sizeof(buffer), "%.*s/%s",
-	       (int)path_len, PATH, binpath);
+      int ret = snprintf(buffer, sizeof(buffer), "%.*s/%s",
+	                  (int)path_len, PATH, binpath);
+      if (ret < 0 || ret >= sizeof(buffer))
+        return 0;
 
       if (bcc_elf_is_exe(buffer))
         return strdup(buffer);

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -46,9 +46,8 @@ char *bcc_procutils_which(const char *binpath) {
     const size_t path_len = next - PATH;
 
     if (path_len) {
-      memcpy(buffer, PATH, path_len);
-      buffer[path_len] = '/';
-      strcpy(buffer + path_len + 1, binpath);
+      snprintf(buffer, sizeof(buffer), "%.*s/%s",
+	       (int)path_len, PATH, binpath);
 
       if (bcc_elf_is_exe(buffer))
         return strdup(buffer);


### PR DESCRIPTION
This commit fixes a stack overflow in `bcc_procutils_which()`.

If `PATH` contains a very long component (> 4096), `memcpy()` will trigger a buffer overflow warning and abort.

To reproduce the bug run this:

```
$ PATH="$PATH:$(python2 -c 'print "A"*4097')" python2 -c 'import bcc;bcc.lib.bcc_procutils_which("foobar")'
```

Tested on Ubuntu 16.04 with bcc from git/repo.