### PR TITLE
Add libbcc-example package for Ubuntu Xenial

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,7 +53,7 @@ Only the nightly packages are built for Ubuntu 16.04, but the steps are very str
 ```bash
 echo "deb [trusted=yes] https://repo.iovisor.org/apt/xenial xenial-nightly main" | sudo tee /etc/apt/sources.list.d/iovisor.list
 sudo apt-get update
-sudo apt-get install bcc-tools
+sudo apt-get install bcc-tools libbcc-examples
 ```
 
 ## Ubuntu Trusty - Binary


### PR DESCRIPTION
In reference to a `INSTALL.md` doc, I installed BCC on ubuntu 16.04 and tried to test it using `hello_world.py` or `task_switch.py`.

But it doesn't works well. Actually `/usr/share/bcc/examples` directory and files are not existed.
To test bcc action using example files, we need to install additional package `libbcc-examples`. 

So I added `libbcc-examples` package for ubuntu 16.04 in the INSTALL.md file.