### PR TITLE
Fix ld error due to debian/ubuntu -pie default

### DIFF
--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -24,6 +24,7 @@ if (LUAJIT_LIBRARIES AND LUAJIT)
 	set_target_properties(bcc-lua PROPERTIES LINKER_LANGUAGE C)
 	target_link_libraries(bcc-lua ${LUAJIT_LIBRARIES})
 	target_link_libraries(bcc-lua -Wl,--whole-archive bcc-static -Wl,--no-whole-archive)
+	target_link_libraries(bcc-lua -no-pie)
 
 	install(TARGETS bcc-lua RUNTIME DESTINATION bin)
 endif()


### PR DESCRIPTION
Fixes #782. Solution taken verbatim from @jepio's comment in https://github.com/iovisor/bcc/issues/782#issuecomment-259075010:

> The problem is the --enable-default-pie flag that debian/ubuntu seem to configure gcc with.

I ran into the same issue attempting to compile from source (following INSTALLING.md) on a fresh Ubuntu 16.10/Yakkety host:

```
Linking C executable bcc-lua
/usr/bin/ld: libluajit-5.1.a(ljamalg.o): relocation R_X86_64_32S
    against `.rodata' can not be used when making a shared object;
    recompile with -fPIC
/usr/bin/ld: final link failed: Nonrepresentable section on output
```

Build succeeded after patch was applied.

Not sure if the `--enable-default-pie` flag has been adjusted in more recent version of Debian/Ubuntu. If so, feel free to close WONTFIX if this doesn't seem valuable. I just figured I'd package it up in a PR since I had it sitting there.

/cc @mkevac, @ColinIanKing