### PR TITLE
fix incorrect code generation in usdt

### DIFF
--- a/src/cc/usdt.cc
+++ b/src/cc/usdt.cc
@@ -152,7 +152,7 @@ bool Probe::usdt_getarg(std::ostream &stream) {
 
   for (size_t arg_n = 0; arg_n < arg_count; ++arg_n) {
     std::string ctype = largest_arg_type(arg_n);
-    std::string cptr("dest");
+    std::string cptr = tfm::format("*((%s *)dest)", ctype);
 
     tfm::format(stream,
                 "static __always_inline int _bpf_readarg_%s_%d("


### PR DESCRIPTION
o This is caused by my ignorant error in previous usdt change.
  Obviously, I need to store into pointer address in order to
  propagate value back to caller.
o Thanks Tetsuo Handa pointing this out.

Signed-off-by: Yonghong Song <yhs@fb.com>