### PR TITLE
Change clang frontend optimization level from 0 to 2

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -133,7 +133,10 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts, const st
 
   // -fno-color-diagnostics: this is a workaround for a bug in llvm terminalHasColors() as of
   // 22 Jul 2016. Also see bcc #615.
-  vector<const char *> flags_cstr({"-O0", "-emit-llvm", "-I", dstack.cwd(),
+  // Enable -O2 for clang. In clang 5.0, -O0 may result in funciton marking as
+  // noinline and optnone (if not always inlining).
+  // Note that first argument is ignored in clang compilation invocation.
+  vector<const char *> flags_cstr({"-O0", "-O2", "-emit-llvm", "-I", dstack.cwd(),
                                    "-Wno-deprecated-declarations",
                                    "-Wno-gnu-variable-sized-type-not-at-end",
                                    "-Wno-pragma-once-outside-header",


### PR DESCRIPTION
The issue is caused by the following clang change on 5.0:
https://reviews.llvm.org/D28404

Basically, at -O0, unless always inlining is specified, a
function will be marked as optnone and noinline.

This causes two kinds of issues: (1). optnone will generate
suboptimal code with heavy stack use and this high likely can
cause verifier failure; and (2). even if user mark all his/her
defined functions in bpf program as always inlining, some
functions in linux header files are not marked as always inline
and hence will be marked as noinline instead, ultimately
causing llvm complaining about global function reference.

This patch bumps the clang optimization level to -O2.
This should work with older versions of llvm as well.

Signed-off-by: Yonghong Song <yhs@fb.com>