### PR TITLE
usdt: Make namespace aware

### DIFF
--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -61,14 +61,18 @@ char *bcc_procutils_which(const char *binpath) {
   return 0;
 }
 
+#define STARTS_WITH(mapname, prefix) (!strncmp(mapname, prefix, sizeof(prefix)-1))
+
 int bcc_mapping_is_file_backed(const char *mapname) {
-  return mapname[0] &&
-    strncmp(mapname, "//anon", sizeof("//anon") - 1) &&
-    strncmp(mapname, "/dev/zero", sizeof("/dev/zero") - 1) &&
-    strncmp(mapname, "/anon_hugepage", sizeof("/anon_hugepage") - 1) &&
-    strncmp(mapname, "[stack", sizeof("[stack") - 1) &&
-    strncmp(mapname, "/SYSV", sizeof("/SYSV") - 1) &&
-    strncmp(mapname, "[heap]", sizeof("[heap]") - 1);
+  return mapname[0] && !(
+    STARTS_WITH(mapname, "//anon") ||
+    STARTS_WITH(mapname, "/dev/zero") ||
+    STARTS_WITH(mapname, "/anon_hugepage") ||
+    STARTS_WITH(mapname, "[stack") ||
+    STARTS_WITH(mapname, "/SYSV") ||
+    STARTS_WITH(mapname, "[heap]") ||
+    STARTS_WITH(mapname, "[vsyscall]") ||
+    STARTS_WITH(mapname, "[vdso]"));
 }
 
 int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -20,6 +20,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "ns_guard.h"
 #include "syms.h"
 #include "vendor/optional.hpp"
 
@@ -149,6 +150,7 @@ class Probe {
   std::vector<Location> locations_;
 
   optional<int> pid_;
+  ProcMountNS *mount_ns_;
   optional<bool> in_shared_object_;
 
   optional<std::string> attached_to_;
@@ -163,7 +165,7 @@ class Probe {
 
 public:
   Probe(const char *bin_path, const char *provider, const char *name,
-        uint64_t semaphore, const optional<int> &pid);
+        uint64_t semaphore, const optional<int> &pid, ProcMountNS *ns);
 
   size_t num_locations() const { return locations_.size(); }
   size_t num_arguments() const { return locations_.front().arguments_.size(); }
@@ -195,6 +197,7 @@ class Context {
 
   optional<int> pid_;
   optional<ProcStat> pid_stat_;
+  std::unique_ptr<ProcMountNS> mount_ns_instance_;
   bool loaded_;
 
   static void _each_probe(const char *binpath, const struct bcc_elf_usdt *probe,


### PR DESCRIPTION
When trying to attach probes to a namespaced process (i.e. one inside a container), we access directly the `/proc/$pid/maps` file in our local procfs. The paths to the mapped files inside the procfs, however, are relative to the chroot of the process instead of the global FS root.

To work around this, this PR makes the USDT code in BCC aware of namespaces, by using the `ProcMountNS` helpers that were previously introduced to the library.

We should now be able to attach and trace probes to processes namespaced inside a container.

Note that tracing using **`uprobes`** is only supported in Docker deployments when using the `devicemapper` (and most likely `brtfs`) storage drivers. The overlay FSs (`aufs`, `overlayfs`, `overlayfs2`) do not seem to be properly writing the userspace breakpoints on the binaries, so the uprobes cannot trigger.