### PR TITLE
Fix bcc.lua build issue in Ubuntu 17.04

### DIFF
--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -24,7 +24,7 @@ if (LUAJIT_LIBRARIES AND LUAJIT)
 	set_target_properties(bcc-lua PROPERTIES LINKER_LANGUAGE C)
 	target_link_libraries(bcc-lua ${LUAJIT_LIBRARIES})
 	target_link_libraries(bcc-lua -Wl,--whole-archive bcc-static -Wl,--no-whole-archive)
-	target_link_libraries(bcc-lua -fno-pie)
+	target_link_libraries(bcc-lua -no-pie)
 
 	install(TARGETS bcc-lua RUNTIME DESTINATION bin)
 endif()


### PR DESCRIPTION
In fc25 box, gcc6.3.1 is configured with pie default off.
Here, pie stands for position independent execution.

In ubuntu 17.04, gcc6.3.0, however, is configured with
pie default on. The gcc driver automatically adds -pie
to the linker options.

Since bcc.lua build needs pie off, previously, -fno-pie
is passed to the compiler. -fno-pie is a gcc option
impacting the code generation and it didn't
negate the -pie option in the linker. The correct way
seems to use gcc linker option -no-pie which can
successfully cancel the default -pie in the linker.

Signed-off-by: Yonghong Song <yhs@fb.com>