### PR TITLE
libbpf: fix build warning on setns

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#define _GNU_SOURCE
 
 #include <arpa/inet.h>
 #include <errno.h>


### PR DESCRIPTION
The macro _GNU_SOURCE should be defined to pick up the function
declaration for setns.  Fixes build warning:

"src/cc/libbpf.c:482:7: warning: implicit declaration of
 function 'setns' [-Wimplicit-function-declaration]
   if (setns(target_fd, CLONE_NEWNS)) {"

Signed-off-by: Colin Ian King <colin.king@canonical.com>