### PR TITLE
Improve kprobe instance handling

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -88,9 +88,7 @@ static int bcc_get_instance(char *buf, size_t buf_size) {
   int res;
   // An instance has already been created.
   if (bcc_instance_probe_cnt >= 0) {
-    res = snprintf(buf, buf_size, "/sys/kernel/debug/tracing/instances/bcc_%d/", getpid());
-    if (res <= 0 || res >= buf_size)
-      return BCC_INSTANCE_FAIL;
+    snprintf(buf, buf_size, "/sys/kernel/debug/tracing/instances/bcc_%d/", getpid());
     return 0;
   }
   // Already failed creating an instance. Don't try again and use default.


### PR DESCRIPTION
This change improves instance logic and clean-up for failure of kprobe attaching. Specifically:
- Move instance creation to a separated helper with clear logic of error handling and fallback.
- Improves check on all `snprintf` return results for possible buffer overflow.
- Make sure the event is deleted if the attaching (i.e.`bpf_attach_tracing_event`) failed.
- Currently, if we attach `kprobe1` and `kprobe2` in a BCC Process, both of them would be under the instance `bcc_PID`. However when we detach say `kprobe1`, we would just delete the instance. `kprobe2` would still be running since the event is still references by the attached probe, but user would not be able to see the instance under `/sys/kernel/debug/tracing/instances` for debug. Moreover, if now we attach a `kprobe3`, we will re-create an instance `bcc_PID` but that would actually be a different instance from the first one we created, which is confusing and consumes more Kernel memory. Fixed in this change by keeping a probe count and only delete when it's 0.
