### PR TITLE
Put libfl-dev into Build-Depends on Debian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 9), cmake, libllvm3.7 | libllvm3.8,
     llvm-3.7-dev | llvm-3.8-dev, libclang-3.7-dev | libclang-3.8-dev,
-    libelf-dev, bison, flex, libedit-dev,
+    libelf-dev, bison, flex, libfl-dev, libedit-dev,
     clang-format | clang-format-3.7 | clang-format-3.8, python (>= 2.7),
     python-netaddr, python-pyroute2, luajit, libluajit-5.1-dev, arping,
     inetutils-ping | iputils-ping, iperf, netperf, ethtool, devscripts


### PR DESCRIPTION
On Debian Stretch `libfl-dev` is not installed automatically if you install `flex`, this takjes care of the issue.