### PR TITLE
Use more safe snprintf instead of sprintf;

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -379,21 +379,21 @@ static char *find_debug_via_debuglink(Elf *e, const char *binpath,
   // matches the binary itself: the binary will always be probed later on,
   // and it might contain poorer symbols (e.g. stripped or partial symbols)
   // than the external debuginfo that might be available elsewhere.
-  sprintf(fullpath, "%s/%s", bindir, name);
+  snprintf(fullpath, sizeof(fullpath),"%s/%s", bindir, name);
   if (strcmp(fullpath, binpath) != 0 && access(fullpath, F_OK) != -1) {
     res = strdup(fullpath);
     goto DONE;
   }
 
   // Search for the file in 'binpath'/.debug
-  sprintf(fullpath, "%s/.debug/%s", bindir, name);
+  snprintf(fullpath, sizeof(fullpath), "%s/.debug/%s", bindir, name);
   if (access(fullpath, F_OK) != -1) {
     res = strdup(fullpath);
     goto DONE;
   }
 
   // Search for the file in the global debug directory /usr/lib/debug/'binpath'
-  sprintf(fullpath, "/usr/lib/debug%s/%s", bindir, name);
+  snprintf(fullpath, sizeof(fullpath), "/usr/lib/debug%s/%s", bindir, name);
   if (access(fullpath, F_OK) != -1) {
     res = strdup(fullpath);
     goto DONE;
@@ -417,7 +417,7 @@ static char *find_debug_via_buildid(Elf *e) {
   //    mm/nnnnnn...nnnn.debug
   // Where mm are the first two characters of the buildid, and nnnn are the
   // rest of the build id, followed by .debug.
-  sprintf(fullpath, "/usr/lib/debug/.build-id/%c%c/%s.debug",
+  snprintf(fullpath, sizeof(fullpath), "/usr/lib/debug/.build-id/%c%c/%s.debug",
           buildid[0], buildid[1], buildid + 2);
   if (access(fullpath, F_OK) != -1) {
     return strdup(fullpath);

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -81,7 +81,7 @@ int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
   FILE *procmap;
   int ret;
 
-  sprintf(procmap_filename, "/proc/%ld/maps", (long)pid);
+  snprintf(procmap_filename, sizeof(procmap_filename), "/proc/%ld/maps", (long)pid);
   procmap = fopen(procmap_filename, "r");
 
   if (!procmap)
@@ -327,7 +327,7 @@ static bool which_so_in_process(const char* libname, int pid, char* libpath) {
   char search1[search_len + 1];
   char search2[search_len + 1];
 
-  sprintf(mappings_file, "/proc/%ld/maps", (long)pid);
+  snprintf(mappings_file, sizeof(mappings_file), "/proc/%ld/maps", (long)pid);
   FILE *fp = fopen(mappings_file, "r");
   if (!fp)
     return NULL;
@@ -400,12 +400,12 @@ const char *language_c = "c";
 const int nb_languages = 5;
 
 const char *bcc_procutils_language(int pid) {
-  char procfilename[22], line[4096], pathname[32], *str;
+  char procfilename[24], line[4096], pathname[32], *str;
   FILE *procfile;
   int i, ret;
 
   /* Look for clues in the absolute path to the executable. */
-  sprintf(procfilename, "/proc/%ld/exe", (long)pid);
+  snprintf(procfilename, sizeof(procfilename), "/proc/%ld/exe", (long)pid);
   if (realpath(procfilename, line)) {
     for (i = 0; i < nb_languages; i++)
       if (strstr(line, languages[i]))
@@ -413,7 +413,7 @@ const char *bcc_procutils_language(int pid) {
   }
 
 
-  sprintf(procfilename, "/proc/%ld/maps", (long)pid);
+  snprintf(procfilename, sizeof(procfilename), "/proc/%ld/maps", (long)pid);
   procfile = fopen(procfilename, "r");
   if (!procfile)
     return NULL;
@@ -434,7 +434,7 @@ const char *bcc_procutils_language(int pid) {
         newline[0] = '\0';
       while (isspace(mapname[0])) mapname++;
       for (i = 0; i < nb_languages; i++) {
-        sprintf(pathname, "/lib%s", languages[i]);
+        snprintf(pathname, sizeof(pathname), "/lib%s", languages[i]);
         if (strstr(mapname, pathname))
           return languages[i];
         if ((str = strstr(mapname, "libc")) &&


### PR DESCRIPTION
1. Use more safe snprintf instead of sprintf;
2. Modify procfilename buffer length in bcc_procutils_language function. This will fix following compile warning:  

```
[ 77%] Building C object src/cc/CMakeFiles/bcc-shared.dir/bcc_proc.c.o
/root/Project/bcc/src/cc/bcc_proc.c: In function 'bcc_procutils_language':
/root/Project/bcc/src/cc/bcc_proc.c:416:25: warning: 'sprintf' may write a terminating nul past the end of the destination [-Wformat-overflow=]
   sprintf(procfilename, "/proc/%ld/maps", (long)pid);
                         ^~~~~~~~~~~~~~~~
/root/Project/bcc/src/cc/bcc_proc.c:416:3: note: 'sprintf' output between 13 and 23 bytes into a destination of size 22
   sprintf(procfilename, "/proc/%ld/maps", (long)pid);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```