### PR TITLE
Incremental reference improvment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ See [INSTALL.md](INSTALL.md) for installation steps on your platform.
 
 See [FAQ.txt](FAQ.txt) for the most common troubleshoot questions.
 
+## Reference guide
+
+See [docs/reference_guide.md](docs/reference_guide.md) for the reference guide to the bcc and bcc/BPF APIs.
+
 ## Contents
 
 Some of these are single files that contain both C and Python, others have a
@@ -203,7 +207,6 @@ to add support for the language of your choice and send a pull request!
 
 - [docs/tutorial.md](docs/tutorial.md): Using bcc tools to solve performance, troubleshooting, and networking issues.
 - [docs/tutorial_bcc_python_developer.md](docs/tutorial_bcc_python_developer.md): Developing new bcc programs using the Python interface.
-- [docs/reference_guide.md](docs/reference_guide.md): Reference guide to the bcc and bcc/BPF APIs.
 
 ### Networking
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -141,6 +141,8 @@ This is a macro that instruments the tracepoint defined by *category*:*event*.
 
 Arguments are available in an ```args``` struct, which are the tracepoint arguments. One way to list these is to cat the relevant format file under /sys/kernel/debug/tracing/events/*category*/*event*/format.
 
+The ```args``` struct can be used in place of ``ctx`` in each functions requiring a context as an argument. This includes notably [perf_submit()](#3-perf_submit).
+
 For example:
 
 ```C


### PR DESCRIPTION
There are 2 parts in the PR. The first one attempts to make the reference documentation easier to find. The second one make it clear that the "magic" argument of the probes attached to tracepoints can be used as the 'ctx' arguments in functions requiring it as explained in https://github.com/iovisor/bcc/issues/1251 and used in https://blog.yadutaf.fr/2017/07/28/tracing-a-packet-journey-using-linux-tracepoints-perf-ebpf/.