### PR TITLE
add MEMBER_(ADDR|READ) helper macros

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -588,5 +588,22 @@ int tracepoint__##category##__##event(struct tracepoint__##category##__##event *
             bpf_probe_read((void *)dst, __length, (char *)args + __offset); \
         } while (0);
 
+#define MEMBER_ADDR(src, field)                                             \
+        ({                                                                  \
+            void* __ret;                                                    \
+            __ret = (void*) (((char*)src) + offsetof(typeof(*src), field)); \
+            __ret;                                                          \
+        })
+
+#define MEMBER_READ(dst, src, field)    \
+        do{                             \
+            bpf_probe_read(             \
+                dst,                    \
+                sizeof(src->field),     \
+                MEMBER_ADDR(src, field) \
+            );                          \
+        } while(0)
+
+
 #endif
 )********"


### PR DESCRIPTION
These helper macros are handy when bcc is not yet able to expand ``dst = src->member;`` constructs automatically. With these macro, such constructs can be written as ``MEMBER_READ(&dst, src, member)`` which preserve readability and functionality. It is also generic enough to fit a large number of use cases.

This is an adaptation of the macro introduced in https://blog.yadutaf.fr/2017/07/28/tracing-a-packet-journey-using-linux-tracepoints-perf-ebpf/. They may be of use to other users of bcc, hence this PR.

If this sounds good to you, I'll add some documentation to the reference guide before merging.