### PR TITLE
Fix netlink pid check

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -803,7 +803,7 @@ int bpf_attach_xdp(const char *dev_name, int progfd, uint32_t flags) {
     for (nh = (struct nlmsghdr *)buf; NLMSG_OK(nh, len);
          nh = NLMSG_NEXT(nh, len)) {
         if (nh->nlmsg_pid != sa.nl_pid) {
-            fprintf(stderr, "bpf: Wrong pid %d, expected %d\n",
+            fprintf(stderr, "bpf: Wrong pid %u, expected %u\n",
                    nh->nlmsg_pid, sa.nl_pid);
             errno = EBADMSG;
             goto cleanup;


### PR DESCRIPTION
The first patch fixes bogus check for netlink pid in bpf_attach_xdp, by which bpf_attach_xdp incorrectly ended up with failure.
The second patch improves printf format of pid.