### PR TITLE
Remove obsolete LUA_GLOBALSINDEX

### DIFF
--- a/src/lua/src/main.c
+++ b/src/lua/src/main.c
@@ -68,7 +68,7 @@ static int report(lua_State *L, int status) {
 static int traceback(lua_State *L) {
   if (!lua_isstring(L, 1)) /* 'message' not a string? */
     return 1;              /* keep it intact */
-  lua_getfield(L, LUA_GLOBALSINDEX, "debug");
+  lua_getglobal(L, "debug");
   if (!lua_istable(L, -1)) {
     lua_pop(L, 1);
     return 1;


### PR DESCRIPTION
Since `LUA_GLOBALSINDEX` is obsolete from `Lua 5.2`, use `lua_getglobal` function instead.