### PR TITLE
Trace external pointers through maps

### DIFF
--- a/examples/tracing/tcpv4connect.py
+++ b/examples/tracing/tcpv4connect.py
@@ -55,11 +55,9 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
 
 	// pull in details
 	struct sock *skp = *skpp;
-	u32 saddr = 0, daddr = 0;
-	u16 dport = 0;
-	bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
-	bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
-	bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+	u32 saddr = skp->__sk_common.skc_rcv_saddr;
+	u32 daddr = skp->__sk_common.skc_daddr;
+	u16 dport = skp->__sk_common.skc_dport;
 
 	// output
 	bpf_trace_printk("trace_tcp4connect %x %x %d\\n", saddr, daddr, ntohs(dport));

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -461,6 +461,36 @@ int process(struct xdp_md *ctx) {
         t = b["act"]
         self.assertEquals(len(t), 32);
 
+    def test_ext_ptr_maps(self):
+        bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+#include <bcc/proto.h>
+
+BPF_HASH(currsock, u32, struct sock *);
+
+int trace_entry(struct pt_regs *ctx, struct sock *sk,
+    struct sockaddr *uaddr, int addr_len) {
+    u32 pid = bpf_get_current_pid_tgid();
+    currsock.update(&pid, &sk);
+    return 0;
+};
+
+int trace_exit(struct pt_regs *ctx) {
+    u32 pid = bpf_get_current_pid_tgid();
+    struct sock **skpp;
+    skpp = currsock.lookup(&pid);
+    if (skpp) {
+        struct sock *skp = *skpp;
+        return skp->__sk_common.skc_dport;
+    }
+    return 0;
+}
+        """
+        b = BPF(text=bpf_text)
+        b.load_func("trace_entry", BPF.KPROBE)
+        b.load_func("trace_exit", BPF.KPROBE)
+
     def test_bpf_dins_pkt_rewrite(self):
         text = """
 #include <bcc/proto.h>

--- a/tools/hardirqs.py
+++ b/tools/hardirqs.py
@@ -86,15 +86,9 @@ int trace_completion(struct pt_regs *ctx)
     if (tsp == 0 || descp == 0) {
         return 0;   // missed start
     }
-    // Note: descp is a value from map, so '&' can be done without
-    // probe_read, but the next level irqaction * needs a probe read.
-    // Do these steps first after reading the map, otherwise some of these
-    // pointers may get pushed onto the stack and verifier will fail.
-    struct irqaction *action = 0;
-    bpf_probe_read(&action, sizeof(action), &(*descp)->action);
-    const char **namep = &action->name;
-    char *name = 0;
-    bpf_probe_read(&name, sizeof(name), namep);
+    struct irq_desc *desc = *descp;
+    struct irqaction *action = desc->action;
+    char *name = (char *)action->name;
     delta = bpf_ktime_get_ns() - *tsp;
 
     // store as sum or histogram

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -108,18 +108,15 @@ static int trace_connect_return(struct pt_regs *ctx, short ipver)
 
     // pull in details
     struct sock *skp = *skpp;
-    u16 dport = 0;
-    bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+    u16 dport = skp->__sk_common.skc_dport;
 
     FILTER_PORT
 
     if (ipver == 4) {
         struct ipv4_data_t data4 = {.pid = pid, .ip = ipver};
         data4.ts_us = bpf_ktime_get_ns() / 1000;
-        bpf_probe_read(&data4.saddr, sizeof(u32),
-            &skp->__sk_common.skc_rcv_saddr);
-        bpf_probe_read(&data4.daddr, sizeof(u32),
-            &skp->__sk_common.skc_daddr);
+        data4.saddr = skp->__sk_common.skc_rcv_saddr;
+        data4.daddr = skp->__sk_common.skc_daddr;
         data4.dport = ntohs(dport);
         bpf_get_current_comm(&data4.task, sizeof(data4.task));
         ipv4_events.perf_submit(ctx, &data4, sizeof(data4));
@@ -128,9 +125,9 @@ static int trace_connect_return(struct pt_regs *ctx, short ipver)
         struct ipv6_data_t data6 = {.pid = pid, .ip = ipver};
         data6.ts_us = bpf_ktime_get_ns() / 1000;
         bpf_probe_read(&data6.saddr, sizeof(data6.saddr),
-            &skp->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+            skp->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
         bpf_probe_read(&data6.daddr, sizeof(data6.daddr),
-            &skp->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+            skp->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
         data6.dport = ntohs(dport);
         bpf_get_current_comm(&data6.task, sizeof(data6.task));
         ipv6_events.perf_submit(ctx, &data6, sizeof(data6));


### PR DESCRIPTION
The bcc rewriter currently traces external pointers using
`ProbeVisitor` in order to replace dereferences with calls to
`bpf_probe_read`. It is, however, unable to trace them through maps.

This pull request fixes this for simple (yet common) cases. Through a
first traversal of the Clang AST, `MapVisitor` looks for calls to
update (and insert) to find maps with an external pointer as value.
When `ProbeVisitor` runs, in a second time, it looks for calls to
lookup (and lookup_or_init). If the map was registered as having an
external pointer as value, the l-value of the lookup assignment is
marked as being an external pointer.

Two traversals of the Clang AST are needed because the update of a
map may happen after the lookup in the AST. Therefore, the first
traversal makes sure we inspect all updates before acting on lookups.
To implement this two-stage traversal without parsing the AST twice,
`ProbeConsumer` and `BTypeConsumer` now implement
`HandleTranslationUnit`, which is called after a whole translation
unit has been parsed.

This change should probably be considered a breaking API change. In
bcc, it breaks a few tools that were relying on the rewriter not
being able to replace dereferences. For instance, the
`bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr)`
expression in `examples/tracing/tcpv4connect.py` now returns an error.

Fixes #253.

/cc @drzaeus77 