### PR TITLE
Trace external pointers from helpers

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -77,6 +77,9 @@ class ProbeChecker : public RecursiveASTVisitor<ProbeChecker> {
   }
   bool VisitCallExpr(CallExpr *E) {
     needs_probe_ = false;
+    if (VarDecl *V = dyn_cast<VarDecl>(E->getCalleeDecl())) {
+      needs_probe_ = V->getName() == "bpf_get_current_task";
+    }
     return false;
   }
   bool VisitParenExpr(ParenExpr *E) {

--- a/tools/cpuunclaimed.py
+++ b/tools/cpuunclaimed.py
@@ -144,8 +144,8 @@ int do_perf_event(struct bpf_perf_event_data *ctx)
     struct task_struct *task = NULL;
     struct cfs_rq_partial *my_q = NULL;
     task = (struct task_struct *)bpf_get_current_task();
-    bpf_probe_read(&my_q, sizeof(my_q), &task->se.cfs_rq);
-    bpf_probe_read(&len, sizeof(len), &my_q->nr_running);
+    my_q = (struct cfs_rq_partial *)task->se.cfs_rq;
+    len = my_q->nr_running;
 
     struct data_t data = {.ts = now, .cpu = cpu, .len = len};
     events.perf_submit(ctx, &data, sizeof(data));

--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -104,10 +104,9 @@ int kprobe__sys_mount(struct pt_regs *ctx, char __user *source,
     bpf_get_current_comm(event.enter.comm, sizeof(event.enter.comm));
     event.enter.flags = flags;
     task = (struct task_struct *)bpf_get_current_task();
-    bpf_probe_read(&nsproxy, sizeof(nsproxy), &task->nsproxy);
-    bpf_probe_read(&mnt_ns, sizeof(mnt_ns), &nsproxy->mnt_ns);
-    bpf_probe_read(&event.enter.mnt_ns, sizeof(event.enter.mnt_ns),
-               &mnt_ns->ns.inum);
+    nsproxy = task->nsproxy;
+    mnt_ns = nsproxy->mnt_ns;
+    event.enter.mnt_ns = mnt_ns->ns.inum;
     events.perf_submit(ctx, &event, sizeof(event));
 
     event.type = EVENT_MOUNT_SOURCE;
@@ -160,10 +159,9 @@ int kprobe__sys_umount(struct pt_regs *ctx, char __user *target, int flags)
     bpf_get_current_comm(event.enter.comm, sizeof(event.enter.comm));
     event.enter.flags = flags;
     task = (struct task_struct *)bpf_get_current_task();
-    bpf_probe_read(&nsproxy, sizeof(nsproxy), &task->nsproxy);
-    bpf_probe_read(&mnt_ns, sizeof(mnt_ns), &nsproxy->mnt_ns);
-    bpf_probe_read(&event.enter.mnt_ns, sizeof(event.enter.mnt_ns),
-               &mnt_ns->ns.inum);
+    nsproxy = task->nsproxy;
+    mnt_ns = nsproxy->mnt_ns;
+    event.enter.mnt_ns = mnt_ns->ns.inum;
     events.perf_submit(ctx, &event, sizeof(event));
 
     event.type = EVENT_UMOUNT_TARGET;

--- a/tools/runqlen.py
+++ b/tools/runqlen.py
@@ -81,8 +81,8 @@ int do_perf_event()
     // of BPF will support task_rq(p) or something similar as a more reliable
     // interface.
     task = (struct task_struct *)bpf_get_current_task();
-    bpf_probe_read(&my_q, sizeof(my_q), &task->se.cfs_rq);
-    bpf_probe_read(&len, sizeof(len), &my_q->nr_running);
+    my_q = (struct cfs_rq_partial *)task->se.cfs_rq;
+    len = my_q->nr_running;
 
     // Calculate run queue length by subtracting the currently running task,
     // if present. len 0 == idle, len 1 == one running task.


### PR DESCRIPTION
This pull request extends `ProbeChecker` to trace external pointers
from helpers. At this time, a single helper can return a kernel
pointer, `bpf_get_current_task`.

This change should probably be considered a breaking API change. In
bcc, it breaks a few tools that were relying on the rewriter not
being able to replace dereferences. For instance, the
`bpf_probe_read(&nsproxy, sizeof(nsproxy), &task->nsproxy)`
expression in `tools/mountsnoop.py` now returns an error.

/cc @drzaeus77 