### PR TITLE
Trace external pointers in parenthesized expressions

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -83,9 +83,6 @@ class ProbeChecker : public RecursiveASTVisitor<ProbeChecker> {
     }
     return false;
   }
-  bool VisitParenExpr(ParenExpr *E) {
-    return false;
-  }
   bool VisitDeclRefExpr(DeclRefExpr *E) {
     if (ptregs_.find(E->getDecl()) != ptregs_.end())
       needs_probe_ = true;

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -353,6 +353,17 @@ int trace_entry(struct pt_regs *ctx, struct request *req) {
         b = BPF(text=text)
         fn = b.load_func("trace_entry", BPF.KPROBE)
 
+    def test_paren_probe_read(self):
+        text = """
+#include <net/inet_sock.h>
+int trace_entry(struct pt_regs *ctx, struct sock *sk) {
+    u16 sport = ((struct inet_sock *)sk)->inet_sport;
+    return sport;
+}
+"""
+        b = BPF(text=text)
+        fn = b.load_func("trace_entry", BPF.KPROBE)
+
     def test_complex_leaf_types(self):
         text = """
 struct list;


### PR DESCRIPTION
Partially reverts #290, keeping the test case. With #1005, only
dereference operations are rewritten, removing the need for the
previous fix.

Reverting #290 allows bcc to rewrite more dereferences, as
highlighted in the new test case.

/cc @drzaeus77 