### PR TITLE
python - set attach_xdp's default flag value to 0

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -572,7 +572,7 @@ class BPF(object):
         self._del_kprobe(ev_name)
 
     @staticmethod
-    def attach_xdp(dev, fn, flags):
+    def attach_xdp(dev, fn, flags=0):
         '''
             This function attaches a BPF function to a device on the device
             driver level (XDP)


### PR DESCRIPTION
Hi,

Following commit 9f3cab70d290d62f663d36369a441b0ee359e8d1 attach_xdp() requires a 3rd flag argument.
It caused me an error when I tried to launch some old code I had.
This just sets default flag value to 0 so that it is not explicitly required.

BR,