### PR TITLE
avoid large map memory allocation in userspace

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -50,11 +50,11 @@ struct _name##_table_t { \
   void (*call) (void *, int index); \
   void (*increment) (_key_type); \
   int (*get_stackid) (void *, u64); \
-  _leaf_type data[_max_entries]; \
+  u32 max_entries; \
   int flags; \
 }; \
 __attribute__((section("maps/" _table_type))) \
-struct _name##_table_t _name = { .flags = (_flags) }
+struct _name##_table_t _name = { .flags = (_flags), .max_entries = (_max_entries) }
 
 #define BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries) \
 BPF_F_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries, 0)
@@ -84,10 +84,10 @@ struct _name##_table_t { \
   /* map.perf_submit(ctx, data, data_size) */ \
   int (*perf_submit) (void *, void *, u32); \
   int (*perf_submit_skb) (void *, u32, void *, u32); \
-  u32 data[0]; \
+  u32 max_entries; \
 }; \
 __attribute__((section("maps/perf_output"))) \
-struct _name##_table_t _name
+struct _name##_table_t _name = { .max_entries = 0 }
 
 // Table for reading hw perf cpu counters
 #define BPF_PERF_ARRAY(_name, _max_entries) \
@@ -96,10 +96,10 @@ struct _name##_table_t { \
   u32 leaf; \
   /* counter = map.perf_read(index) */ \
   u64 (*perf_read) (int); \
-  u32 data[_max_entries]; \
+  u32 max_entries; \
 }; \
 __attribute__((section("maps/perf_array"))) \
-struct _name##_table_t _name
+struct _name##_table_t _name = { .max_entries = (_max_entries) }
 
 #define BPF_HASH1(_name) \
   BPF_TABLE("hash", u64, u64, _name, 10240)

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -633,8 +633,14 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
         }
         table.leaf_size = sz;
         leaf_type = F->getType();
-      } else if (F->getName() == "data") {
-        table.max_entries = sz / table.leaf_size;
+      } else if (F->getName() == "max_entries") {
+        unsigned idx = F->getFieldIndex();
+        if (auto I = dyn_cast_or_null<InitListExpr>(Decl->getInit())) {
+          llvm::APSInt res;
+          if (I->getInit(idx)->EvaluateAsInt(res, C)) {
+            table.max_entries = res.getExtValue();
+          }
+        }
       } else if (F->getName() == "flags") {
         unsigned idx = F->getFieldIndex();
         if (auto I = dyn_cast_or_null<InitListExpr>(Decl->getInit())) {


### PR DESCRIPTION
In bcc, internal BPF_F_TABLE defines a structure to
contain all the table information for later easy
extraction. A global structure will be defined
with this type. Note that this structure will be
allocated by LLVM during compilation.

In the table structure, one of field is:
   _leaf_type data[_max_entries]

If the _leaf_type and _max_entries are big,
significant memory will be consumed. A big
_leaf_type size example is for BPF_STACK_TRACE map
with 127*8=1016 bytes. If max_entries is bigger
as well, significant amount of memory will be
consumed by LLVM.

This patch replaces
  _leaf_type data[_max_entries]
to
  u32 max_entries

The detail of a test example can be found in issue #1291.
For the example in #1291, without this patch, for a
BPF_STACK_TRACE map with 1M entries, the RSS is roughly
3GB (roughly 3KB per entry, looks like significant LLVM overhead).
With this patch, it is 5.8MB.

Signed-off-by: Yonghong Song <yhs@fb.com>