### PR TITLE
Fixes for debian and ubuntu docker build

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,14 +1,17 @@
-FROM debian:jessie
+FROM debian:stretch
 
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv 15CF4D18AF4F7421 && \
-    echo "deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main" > /etc/apt/sources.list.d/llvm.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends sudo build-essential fakeroot bison cmake debhelper devscripts flex git libedit-dev python zlib1g-dev libllvm3.8 llvm-3.8-dev libclang-3.8-dev libelf-dev luajit libluajit-5.1-dev && \
-    mkdir -p /usr/share/llvm-3.8 && \
-    ln -s /usr/lib/llvm-3.8/share/llvm/cmake /usr/share/llvm-3.8/cmake
+MAINTAINER Brenden Blanco <bblanco@gmail.com>
+
+RUN DEBIAN_RELEASE=stretch && \
+    # Adding non-free repo for netperf
+    echo "deb http://deb.debian.org/debian ${DEBIAN_RELEASE} non-free" > \
+        /etc/apt/sources.list.d/debian-non-free.list && \
+    apt-get -qq update && \
+    apt-get -y install pbuilder aptitude
 
 COPY ./ /root/bcc
 
 WORKDIR /root/bcc
 
-RUN ./scripts/build-deb.sh
+RUN /usr/lib/pbuilder/pbuilder-satisfydepends && \
+    ./scripts/build-deb.sh

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,20 +1,13 @@
-# File to be used for building an Ubuntu .deb
+FROM ubuntu:xenial
 
-FROM ubuntu:trusty
+MAINTAINER Brenden Blanco <bblanco@gmail.com>
 
-MAINTAINER Brenden Blanco <bblanco@plumgrid.com>
+RUN apt-get -qq update && \
+    apt-get -y install pbuilder aptitude
 
-RUN apt-get -y install wget
-RUN printf "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty main\ndeb-src http://llvm.org/apt/trusty/ llvm-toolchain-trusty main\n" > /etc/apt/sources.list.d/llvm.list
-RUN wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-get -y update
+COPY ./ /root/bcc
 
-RUN apt-get -y install bison build-essential cmake debhelper devscripts flex git libedit-dev python zlib1g-dev
-RUN apt-get -y install libllvm3.8 llvm-3.8-dev libclang-3.8-dev
-
-RUN mkdir -p /root/bcc/build
-COPY ./ /root/bcc/
-WORKDIR /root
-RUN tar zcf bcc_0.1.1.orig.tar.gz bcc/
 WORKDIR /root/bcc
-RUN DEB_BUILD_OPTIONS="nocheck parallel=4" debuild -us -uc
+
+RUN /usr/lib/pbuilder/pbuilder-satisfydepends && \
+    ./scripts/build-deb.sh

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 9), cmake, libllvm3.7 | libllvm3.8,
     llvm-3.7-dev | llvm-3.8-dev, libclang-3.7-dev | libclang-3.8-dev,
-    libelf-dev, bison, flex, libfl-dev, libedit-dev,
+    libelf-dev, bison, flex, libfl-dev, libedit-dev, zlib1g-dev, git,
     clang-format | clang-format-3.7 | clang-format-3.8, python (>= 2.7),
     python-netaddr, python-pyroute2, luajit, libluajit-5.1-dev, arping,
     inetutils-ping | iputils-ping, iperf, netperf, ethtool, devscripts


### PR DESCRIPTION
* Fixed build for debian and ubuntu
* Bumped debian and ubuntu versions (fix some build-dependency issues)
* Made debian and ubuntu Dockerfiles use the same build script
* Build-dependencies are now installing automatically via pbuilder
* Fixed build-dependencies in control files

So this is my proposal for changing Dockerfiles.
I tried to build debian and ubuntu packages but completely failed at it. First of all in ubuntu ```apt-get -y install wget``` didn't work without ```apt-get update```. Second issue that even with added ```apt-get update``` there were a lot of build issues (missing packages, orig tar.gz files etc).

In debian situation is a little better but still I had no success with building package because of some dependency issues.

I've decided that there is simplier way to build packages for both systems. I bumped ubuntu and debian versions, made them use control file to install dependencies (via pbuilder) and then made them use the same ```./scripts/build-deb.sh``` script for building. And now everything works fine.

Now debian and ubuntu use the same build mechanism without using external repositories (new lts versions of both systems contains all necessary stuff  for building packages).

Please tell me if I've missed something or made it wrong. I'm ready to fix it.