### PR TITLE
Fix an error message when detach a generic XDP program

### DIFF
--- a/examples/networking/xdp/xdp_drop_count.py
+++ b/examples/networking/xdp/xdp_drop_count.py
@@ -160,7 +160,7 @@ while 1:
         break;
 
 if mode == BPF.XDP:
-    b.remove_xdp(device)
+    b.remove_xdp(device, flags)
 else:
     ip.tc("del", "clsact", idx)
     ipdb.release()

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -781,7 +781,7 @@ int bpf_attach_xdp(const char *dev_name, int progfd, uint32_t flags) {
     // parse flags as passed by the user
     if (flags) {
         nla_xdp = (struct nlattr *)((char *)nla + nla->nla_len);
-        nla_xdp->nla_type = 3/*IFLA_XDP_SKB*/;
+        nla_xdp->nla_type = 3/*IFLA_XDP_FLAGS*/;
         nla_xdp->nla_len = NLA_HDRLEN + sizeof(flags);
         memcpy((char *)nla_xdp + NLA_HDRLEN, &flags, sizeof(flags));
         nla->nla_len += nla_xdp->nla_len;

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -591,12 +591,12 @@ class BPF(object):
                             % (dev, errstr))
 
     @staticmethod
-    def remove_xdp(dev):
+    def remove_xdp(dev, flags=0):
         '''
             This function removes any BPF function from a device on the
             device driver level (XDP)
         '''
-        res = lib.bpf_attach_xdp(dev.encode("ascii"), -1, 0)
+        res = lib.bpf_attach_xdp(dev.encode("ascii"), -1, flags)
         if res < 0:
             errstr = os.strerror(ct.get_errno())
             raise Exception("Failed to detach BPF from device %s: %s"


### PR DESCRIPTION
When detaching a generic XDP program to an interface without native XDP
support, remove_xdp() showed the following message:
    
   bpf: nlmsg error Operation not supported
    
Add the flags parameter to notify the kernel that it's a generic XDP
program.