### PR TITLE
bcc-lua: --no-pie, not -no-pie

### DIFF
--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -27,7 +27,7 @@ if (LUAJIT_LIBRARIES AND LUAJIT)
   if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     target_link_libraries(bcc-lua -nopie)
   else()
-    target_link_libraries(bcc-lua -no-pie)
+    target_link_libraries(bcc-lua --no-pie)
   endif()
 
 	install(TARGETS bcc-lua RUNTIME DESTINATION bin)


### PR DESCRIPTION
Some versions of GCC don't accept `-no-pie`. For instance, on a GCC 5 build I
have here:

```
$ gcc -no-pie
gcc: error: unrecognized command line option ‘-no-pie’
gcc: fatal error: no input files
```

5.4 from Xenial will take `-no-pie`, as will versions of 4, 6 and 7 that I
tried. The issue may be related to
https://www.mail-archive.com/gcc-patches@gcc.gnu.org/msg170818.html but I'm not
certain.

A workaround for this is to use `--no-pie`, which is accepted by all versions
of GCC 4, 5, 6 and 7 that I tried.