### PR TITLE
Remove unnecessary bpf_probe_reads

### DIFF
--- a/tools/tcpconnlat.py
+++ b/tools/tcpconnlat.py
@@ -93,14 +93,14 @@ int trace_connect(struct pt_regs *ctx, struct sock *sk)
 // are fast path and processed elsewhere, and leftovers are processed by
 // tcp_rcv_state_process(). We can trace this for handshake completion.
 // This should all be switched to static tracepoints when available.
-int trace_tcp_rcv_state_process(struct pt_regs *ctx, struct sock *sk)
+int trace_tcp_rcv_state_process(struct pt_regs *ctx, struct sock *skp)
 {
     // will be in TCP_SYN_SENT for handshake
-    if (sk->__sk_common.skc_state != TCP_SYN_SENT)
+    if (skp->__sk_common.skc_state != TCP_SYN_SENT)
         return 0;
 
     // check start and calculate delta
-    struct info_t *infop = start.lookup(&sk);
+    struct info_t *infop = start.lookup(&skp);
     if (infop == 0) {
         return 0;   // missed entry or filtered
     }
@@ -109,19 +109,15 @@ int trace_tcp_rcv_state_process(struct pt_regs *ctx, struct sock *sk)
 
     // pull in details
     u16 family = 0, dport = 0;
-    struct sock *skp = NULL;
-    bpf_probe_read(&skp, sizeof(skp), &sk);
-    bpf_probe_read(&family, sizeof(family), &skp->__sk_common.skc_family);
-    bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+    family = skp->__sk_common.skc_family;
+    dport = skp->__sk_common.skc_dport;
 
     // emit to appropriate data path
     if (family == AF_INET) {
         struct ipv4_data_t data4 = {.pid = infop->pid, .ip = 4};
         data4.ts_us = now / 1000;
-        bpf_probe_read(&data4.saddr, sizeof(u32),
-            &skp->__sk_common.skc_rcv_saddr);
-        bpf_probe_read(&data4.daddr, sizeof(u32),
-            &skp->__sk_common.skc_daddr);
+        data4.saddr = skp->__sk_common.skc_rcv_saddr;
+        data4.daddr = skp->__sk_common.skc_daddr;
         data4.dport = ntohs(dport);
         data4.delta_us = (now - ts) / 1000;
         __builtin_memcpy(&data4.task, infop->task, sizeof(data4.task));
@@ -131,16 +127,16 @@ int trace_tcp_rcv_state_process(struct pt_regs *ctx, struct sock *sk)
         struct ipv6_data_t data6 = {.pid = infop->pid, .ip = 6};
         data6.ts_us = now / 1000;
         bpf_probe_read(&data6.saddr, sizeof(data6.saddr),
-            &skp->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+            skp->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
         bpf_probe_read(&data6.daddr, sizeof(data6.daddr),
-            &skp->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+            skp->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
         data6.dport = ntohs(dport);
         data6.delta_us = (now - ts) / 1000;
         __builtin_memcpy(&data6.task, infop->task, sizeof(data6.task));
         ipv6_events.perf_submit(ctx, &data6, sizeof(data6));
     }
 
-    start.delete(&sk);
+    start.delete(&skp);
 
     return 0;
 }


### PR DESCRIPTION
While working on improving bcc's rewriting of dereferences, I found a few tools that use `bpf_probe_read`s where bcc already support deferences.

I tested that the three tools still work as expected on both IPv4 and IPv6 connections.

Note: The same applies to several tools in `tools/old/`, but I wasn't sure we're supposed to change those.