### PR TITLE
Fix segfault on incomplete types

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -618,6 +618,11 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
 
     unsigned i = 0;
     for (auto F : RD->fields()) {
+      if (F->getType().getTypePtr()->isIncompleteType()) {
+        error(F->getLocStart(), "unknown type");
+        return false;
+      }
+
       size_t sz = C.getTypeSize(F->getType()) >> 3;
       if (F->getName() == "key") {
         if (sz == 0) {

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -567,6 +567,16 @@ int foo(struct pt_regs *ctx) {
         with self.assertRaises(Exception):
             b = BPF(text=text)
 
+    def test_incomplete_type(self):
+        text = """
+BPF_HASH(drops, struct key_t);
+struct key_t {
+    u64 location;
+};
+"""
+        with self.assertRaises(Exception):
+            b = BPF(text=text)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The bcc rewriter segfaults when it encounters an incomplete type
(missing declaration or declaration after use) in a map declaration.
This pull request fixes it by first checking for incomplete types and
returning an error if one is found.

/cc @drzaeus77 