### PR TITLE
Update after lookup in map.increment for HASH types

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -332,12 +332,14 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           string lookup = "bpf_map_lookup_elem_(bpf_pseudo_fd(1, " + fd + ")";
           string update = "bpf_map_update_elem_(bpf_pseudo_fd(1, " + fd + ")";
           txt  = "({ typeof(" + name + ".key) _key = " + arg0 + "; ";
-          if (desc->second.type == BPF_MAP_TYPE_HASH) {
-            txt += "typeof(" + name + ".leaf) _zleaf; memset(&_zleaf, 0, sizeof(_zleaf)); ";
-            txt += update + ", &_key, &_zleaf, BPF_NOEXIST); ";
-          }
           txt += "typeof(" + name + ".leaf) *_leaf = " + lookup + ", &_key); ";
-          txt += "if (_leaf) (*_leaf)++; })";
+          txt += "if (_leaf) (*_leaf)++; ";
+          if (desc->second.type == BPF_MAP_TYPE_HASH) {
+            txt += "else { typeof(" + name + ".leaf) _zleaf; memset(&_zleaf, 0, sizeof(_zleaf)); ";
+            txt += "_zleaf++; ";
+            txt += update + ", &_key, &_zleaf, BPF_NOEXIST); } ";
+          }
+          txt += "})";
         } else if (memb_name == "perf_submit") {
           string name = Ref->getDecl()->getName();
           string arg0 = rewriter_.getRewrittenText(expansionRange(Call->getArg(0)->getSourceRange()));


### PR DESCRIPTION
Performing the update before lookup incurs an extra spinlock in the
kernel, which hurts performance. Reorder the code and increment to 1.
The memset is there I believe due to some type mismatch warnings, so I'm
leaving as is rather than doing a direct assign to 1. The resulting code
is optimized away anyway.

Fixes: #1314
Signed-off-by: Brenden Blanco <bblanco@gmail.com>