### PR TITLE
fix a bug introduced by previous lua-bcc build fix commit

### DIFF
--- a/cmake/FindCompilerFlag.cmake
+++ b/cmake/FindCompilerFlag.cmake
@@ -4,6 +4,7 @@
 if (CMAKE_C_COMPILER_ID MATCHES "Clang")
 	set(COMPILER_NOPIE_FLAG "-nopie")
 else()
+	set(_backup_c_flags "${CMAKE_REQUIRED_FLAGS}")
 	set(CMAKE_REQUIRED_FLAGS "-no-pie")
 	CHECK_CXX_SOURCE_COMPILES("int main() {return 0;}"
 				  HAVE_NO_PIE_FLAG)
@@ -12,4 +13,5 @@ else()
 	else()
 		set(COMPILER_NOPIE_FLAG "")
 	endif()
+	set(CMAKE_REQUIRED_FLAGS "${_backup_c_flags}")
 endif()


### PR DESCRIPTION
The bug does not show up in my previous test probably because
I did not clean up the build directory and did not have a clean cmake.

In gcc 4.8.5 environment where -no-pie is not supported,
a clean cmake will trigger the issue as subsequent other
cxx compile test will fail due to additional -no-pie flag.

The fix is to reset the CMAKE_REQUIRED_FLAGS to its previous value
after the specific test.

Signed-off-by: Yonghong Song <yhs@fb.com>