### PR TITLE
Fix uninitialized ProcMountNS in USDT Context

### DIFF
--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -285,7 +285,8 @@ void Context::each_uprobe(each_uprobe_cb callback) {
   }
 }
 
-Context::Context(const std::string &bin_path) : loaded_(false) {
+Context::Context(const std::string &bin_path)
+    : mount_ns_instance_(new ProcMountNS(-1)), loaded_(false) {
   std::string full_path = resolve_bin_path(bin_path);
   if (!full_path.empty()) {
     if (bcc_elf_foreach_usdt(full_path.c_str(), _each_probe, this) == 0) {


### PR DESCRIPTION
In #1263 we added to use the Mount Namespace's inode as part of the de-duplication key when generating USDT text([here](https://github.com/iovisor/bcc/blob/master/src/cc/usdt.cc#L374)). However the `ProcMoundNS` instance where the inode comes from would not be initialized when the `Context` is constructed with a binary instead of a PID. This causes tools to fail and crash. The commit fixes by initializing an empty `ProcMountNS` for the binary code path.