### PR TITLE
Fix _GNU_SOURCE redefined warning

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <arpa/inet.h>
 #include <errno.h>


### PR DESCRIPTION
Fix following warning:  

```
[  1%] Building C object src/cc/CMakeFiles/bpf-shared.dir/libbpf.c.o
/home/xiaonan/Project/bcc/src/cc/libbpf.c:16:0: warning: "_GNU_SOURCE" redefined
 #define _GNU_SOURCE

<command-line>:0:0: note: this is the location of the previous definition

```