### PR TITLE
zfs tools fix for zpl_read/zpl_write removal

### DIFF
--- a/tools/zfsdist.py
+++ b/tools/zfsdist.py
@@ -133,12 +133,26 @@ if debug:
 b = BPF(text=bpf_text)
 
 # common file functions
-b.attach_kprobe(event="zpl_read", fn_name="trace_entry")
-b.attach_kprobe(event="zpl_write", fn_name="trace_entry")
+if BPF.get_kprobe_functions('zpl_iter'):
+    b.attach_kprobe(event="zpl_iter_read", fn_name="trace_entry")
+    b.attach_kprobe(event="zpl_iter_write", fn_name="trace_entry")
+elif BPF.get_kprobe_functions('zpl_aio'):
+    b.attach_kprobe(event="zpl_aio_read", fn_name="trace_entry")
+    b.attach_kprobe(event="zpl_aio_write", fn_name="trace_entry")
+else:
+    b.attach_kprobe(event="zpl_read", fn_name="trace_entry")
+    b.attach_kprobe(event="zpl_write", fn_name="trace_entry")
 b.attach_kprobe(event="zpl_open", fn_name="trace_entry")
 b.attach_kprobe(event="zpl_fsync", fn_name="trace_entry")
-b.attach_kretprobe(event="zpl_read", fn_name="trace_read_return")
-b.attach_kretprobe(event="zpl_write", fn_name="trace_write_return")
+if BPF.get_kprobe_functions('zpl_iter'):
+    b.attach_kretprobe(event="zpl_iter_read", fn_name="trace_read_return")
+    b.attach_kretprobe(event="zpl_iter_write", fn_name="trace_write_return")
+elif BPF.get_kprobe_functions('zpl_aio'):
+    b.attach_kretprobe(event="zpl_aio_read", fn_name="trace_read_return")
+    b.attach_kretprobe(event="zpl_aio_write", fn_name="trace_write_return")
+else:
+    b.attach_kretprobe(event="zpl_read", fn_name="trace_read_return")
+    b.attach_kretprobe(event="zpl_write", fn_name="trace_write_return")
 b.attach_kretprobe(event="zpl_open", fn_name="trace_open_return")
 b.attach_kretprobe(event="zpl_fsync", fn_name="trace_fsync_return")
 

--- a/tools/zfsslower.py
+++ b/tools/zfsslower.py
@@ -276,12 +276,26 @@ def print_event(cpu, data, size):
 b = BPF(text=bpf_text)
 
 # common file functions
-b.attach_kprobe(event="zpl_read", fn_name="trace_rw_entry")
-b.attach_kprobe(event="zpl_write", fn_name="trace_rw_entry")
+if BPF.get_kprobe_functions('zpl_iter'):
+    b.attach_kprobe(event="zpl_iter_read", fn_name="trace_rw_entry")
+    b.attach_kprobe(event="zpl_iter_write", fn_name="trace_rw_entry")
+elif BPF.get_kprobe_functions('zpl_aio'):
+    b.attach_kprobe(event="zpl_aio_read", fn_name="trace_rw_entry")
+    b.attach_kprobe(event="zpl_aio_write", fn_name="trace_rw_entry")
+else:
+    b.attach_kprobe(event="zpl_read", fn_name="trace_rw_entry")
+    b.attach_kprobe(event="zpl_write", fn_name="trace_rw_entry")
 b.attach_kprobe(event="zpl_open", fn_name="trace_open_entry")
 b.attach_kprobe(event="zpl_fsync", fn_name="trace_fsync_entry")
-b.attach_kretprobe(event="zpl_read", fn_name="trace_read_return")
-b.attach_kretprobe(event="zpl_write", fn_name="trace_write_return")
+if BPF.get_kprobe_functions('zpl_iter'):
+    b.attach_kretprobe(event="zpl_iter_read", fn_name="trace_read_return")
+    b.attach_kretprobe(event="zpl_iter_write", fn_name="trace_write_return")
+elif BPF.get_kprobe_functions('zpl_aio'):
+    b.attach_kretprobe(event="zpl_aio_read", fn_name="trace_read_return")
+    b.attach_kretprobe(event="zpl_aio_write", fn_name="trace_write_return")
+else:
+    b.attach_kretprobe(event="zpl_read", fn_name="trace_read_return")
+    b.attach_kretprobe(event="zpl_write", fn_name="trace_write_return")
 b.attach_kretprobe(event="zpl_open", fn_name="trace_open_return")
 b.attach_kretprobe(event="zpl_fsync", fn_name="trace_fsync_return")
 


### PR DESCRIPTION
Simple check for available `zpl_.*read`/`zpl_.*write` functions.
Fix #1248 