### PR TITLE
annotate program tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ if(NOT DEFINED BCC_KERNEL_MODULES_DIR)
   set(BCC_KERNEL_MODULES_DIR "/lib/modules")
 endif()
 
+if(NOT DEFINED BCC_PROG_TAG_DIR)
+  set(BCC_PROG_TAG_DIR "/var/tmp/bcc")
+endif()
+
 # As reported in issue #735, GCC 6 has some behavioral problems when
 # dealing with -isystem. Hence, skip the warning optimization
 # altogether on that compiler.

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/compat)
 add_definitions(${LLVM_DEFINITIONS})
 configure_file(libbcc.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libbcc.pc @ONLY)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -DBCC_PROG_TAG_DIR='\"${BCC_PROG_TAG_DIR}\"'")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 
 include(static_libstdc++)

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -488,6 +488,10 @@ StatusTuple BPF::load_func(const std::string& func_name,
 
   if (fd < 0)
     return StatusTuple(-1, "Failed to load %s: %d", func_name.c_str(), fd);
+
+  bpf_module_->annotate_prog_tag(func_name, fd,
+                                 reinterpret_cast<struct bpf_insn*>(func_start),
+                                 func_size);
   funcs_[func_name] = fd;
   return StatusTuple(0);
 }

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -37,6 +37,7 @@ class TableDesc;
 class TableStorage;
 class BLoader;
 class ClangLoader;
+class FuncSource;
 
 class BPFModule {
  private:
@@ -68,6 +69,10 @@ class BPFModule {
   size_t num_functions() const;
   uint8_t * function_start(size_t id) const;
   uint8_t * function_start(const std::string &name) const;
+  const char * function_source(const std::string &name) const;
+  const char * function_source_rewritten(const std::string &name) const;
+  int annotate_prog_tag(const std::string &name, int fd,
+			struct bpf_insn *insn, int prog_len);
   const char * function_name(size_t id) const;
   size_t function_size(size_t id) const;
   size_t function_size(const std::string &name) const;
@@ -108,6 +113,7 @@ class BPFModule {
   std::unique_ptr<llvm::Module> mod_;
   std::unique_ptr<BLoader> b_loader_;
   std::unique_ptr<ClangLoader> clang_loader_;
+  std::unique_ptr<FuncSource> func_src_;
   std::map<std::string, std::tuple<uint8_t *, uintptr_t>> sections_;
   std::vector<TableDesc *> tables_;
   std::map<std::string, size_t> table_names_;

--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -42,6 +42,7 @@ class StringRef;
 namespace ebpf {
 
 class BFrontendAction;
+class FuncSource;
 
 // Type visitor and rewriter for B programs.
 // It will look for B-specific features and rewrite them into a valid
@@ -122,7 +123,8 @@ class BFrontendAction : public clang::ASTFrontendAction {
  public:
   // Initialize with the output stream where the new source file contents
   // should be written.
-  BFrontendAction(llvm::raw_ostream &os, unsigned flags, TableStorage &ts, const std::string &id);
+  BFrontendAction(llvm::raw_ostream &os, unsigned flags, TableStorage &ts, const std::string &id,
+                  FuncSource& func_src);
 
   // Called by clang when the AST has been completed, here the output stream
   // will be flushed.
@@ -141,6 +143,9 @@ class BFrontendAction : public clang::ASTFrontendAction {
   TableStorage &ts_;
   std::string id_;
   std::unique_ptr<clang::Rewriter> rewriter_;
+  friend class BTypeVisitor;
+  std::map<std::string, clang::SourceRange> func_range_;
+  FuncSource& func_src_;
 };
 
 }  // namespace visitor

--- a/src/cc/frontends/clang/loader.h
+++ b/src/cc/frontends/clang/loader.h
@@ -30,12 +30,29 @@ class MemoryBuffer;
 
 namespace ebpf {
 
+class FuncSource {
+  class SourceCode {
+   public:
+    SourceCode(const std::string& s1 = "", const std::string& s2 = ""): src_(s1), src_rewritten_(s2) {}
+    std::string src_;
+    std::string src_rewritten_;
+  };
+  std::map<std::string, SourceCode> funcs_;
+ public:
+  FuncSource() {}
+  const char * src(const std::string& name);
+  const char * src_rewritten(const std::string& name);
+  void set_src(const std::string& name, const std::string& src);
+  void set_src_rewritten(const std::string& name, const std::string& src);
+};
+
 class ClangLoader {
  public:
   explicit ClangLoader(llvm::LLVMContext *ctx, unsigned flags);
   ~ClangLoader();
   int parse(std::unique_ptr<llvm::Module> *mod, TableStorage &ts, const std::string &file,
-            bool in_memory, const char *cflags[], int ncflags, const std::string &id);
+            bool in_memory, const char *cflags[], int ncflags, const std::string &id,
+	    FuncSource& func_src);
 
  private:
   static std::map<std::string, std::unique_ptr<llvm::MemoryBuffer>> remapped_files_;

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -89,6 +89,10 @@ int bpf_close_perf_event_fd(int fd);
 
 int bpf_obj_pin(int fd, const char *pathname);
 int bpf_obj_get(const char *pathname);
+int bpf_obj_get_info(int prog_map_fd, void *info, int *info_len);
+int bpf_prog_compute_tag(const struct bpf_insn *insns, int prog_len,
+                         unsigned long long *tag);
+int bpf_prog_get_tag(int fd, unsigned long long *tag);
 
 #define LOG_BUF_SIZE 65536
 


### PR DESCRIPTION
during debug of production systems it's difficult to trace back
the kernel reported 'bpf_prog_3196C6D60BBB8549' symbols to the source code
of the program, hence teach bcc to store the main function source
in the /var/tmp/bcc/bpf_prog_3196C6D60BBB8549/ directory.

This program tag is stable. Every time the script is called the tag
will be the same unless source code of the program changes.
During active development of bcc scripts the /var/tmp/bcc/ dir can
get a bunch of stale tags.
The users have to trim that dir manually.

Python scripts can be modified to use this feature too, but probably
need to be gated by the flag. For c++ api I think it makes sense
to store the source code always, since the cost is minimal and
c++ api is used by long running services.

Example:
$ ./examples/cpp/LLCStat
$ ls -l /var/tmp/bcc/bpf_prog_3196C6D60BBB8549/
total 16
-rw-r--r--. 1 root root 226 Sep  1 17:30 on_cache_miss.c
-rw-r--r--. 1 root root 487 Sep  1 17:30 on_cache_miss.rewritten.c
-rw-r--r--. 1 root root 224 Sep  1 17:30 on_cache_ref.c
-rw-r--r--. 1 root root 484 Sep  1 17:30 on_cache_ref.rewritten.c
$ cat /var/tmp/bcc/bpf_prog_3196C6D60BBB8549/on_cache_miss.c
int on_cache_miss(struct bpf_perf_event_data *ctx) {
    struct event_t key = {};
    get_key(&key);

    u64 zero = 0, *val;
    val = miss_count.lookup_or_init(&key, &zero);
...

Signed-off-by: Alexei Starovoitov <ast@fb.com>