### PR TITLE
examples: fixed http_filter example

### DIFF
--- a/examples/networking/http_filter/http-parse-complete.c
+++ b/examples/networking/http_filter/http-parse-complete.c
@@ -92,7 +92,8 @@ int http_filter(struct __sk_buff *skb) {
 	unsigned long p[7];
 	int i = 0;
 	int j = 0;
-	for (i = payload_offset ; i < (payload_offset + 7) ; i++) {
+	const int last_index = payload_offset + 7;
+	for (i = payload_offset ; i < last_index ; i++) {
 		p[j] = load_byte(skb , i);
 		j++;
 	}

--- a/examples/networking/http_filter/http-parse-simple.c
+++ b/examples/networking/http_filter/http-parse-simple.c
@@ -63,7 +63,8 @@ int http_filter(struct __sk_buff *skb) {
 	unsigned long p[7];
 	int i = 0;
 	int j = 0;
-	for (i = payload_offset ; i < (payload_offset + 7) ; i++) {
+	const int last_index = payload_offset + 7;
+	for (i = payload_offset ; i < last_index ; i++) {
 		p[j] = load_byte(skb , i);
 		j++;
 	}


### PR DESCRIPTION
Loop unrolling wasn't happening because of variable upper
bound. Making it const fixes the problem.

Tested with 4.13.0-rc6 on fedora 26