### PR TITLE
Removed unused Mount Namespace helpers

### DIFF
--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -469,15 +469,4 @@ invalid_module:
   }
   return -1;
 }
-
-void *bcc_enter_mount_ns(int pid) {
-  return static_cast<void *>(new ProcMountNSGuard(pid));
-}
-
-void bcc_exit_mount_ns(void **guard) {
-  if (guard && *guard) {
-    delete static_cast<ProcMountNSGuard *>(*guard);
-    *guard = NULL;
-  }
-}
 }

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -82,9 +82,6 @@ int bcc_resolve_symname(const char *module, const char *symname,
                         struct bcc_symbol_option* option,
                         struct bcc_symbol *sym);
 
-void *bcc_enter_mount_ns(int pid);
-void bcc_exit_mount_ns(void **guard);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
They were introduced so C code could use the Mount Namespace logic. No longer used and needed after #1210.