### PR TITLE
Fix for incorrect tool arguments in the man pages

### DIFF
--- a/man/man8/ext4dist.8
+++ b/man/man8/ext4dist.8
@@ -2,7 +2,7 @@
 .SH NAME
 ext4dist \- Summarize ext4 operation latency. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B ext4dist [\-h] [\-T] [\-N] [\-d] [interval] [count]
+.B ext4dist [\-h] [\-T] [\-m] [\-p PID] [interval] [count]
 .SH DESCRIPTION
 This tool summarizes time (latency) spent in common ext4 file operations: reads,
 writes, opens, and syncs, and presents it as a power-of-2 histogram. It uses an

--- a/man/man8/xfsdist.8
+++ b/man/man8/xfsdist.8
@@ -2,7 +2,7 @@
 .SH NAME
 xfsdist \- Summarize XFS operation latency. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B xfsdist [\-h] [\-T] [\-N] [\-d] [interval] [count]
+.B xfsdist [\-h] [\-T] [\-m] [\-p PID] [interval] [count]
 .SH DESCRIPTION
 This tool summarizes time (latency) spent in common XFS file operations: reads,
 writes, opens, and syncs, and presents it as a power-of-2 histogram. It uses an

--- a/man/man8/zfsdist.8
+++ b/man/man8/zfsdist.8
@@ -2,7 +2,7 @@
 .SH NAME
 zfsdist \- Summarize ZFS operation latency. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B zfsdist [\-h] [\-T] [\-N] [\-d] [interval] [count]
+.B zfsdist [\-h] [\-T] [\-m] [\-p PID] [interval] [count]
 .SH DESCRIPTION
 This tool summarizes time (latency) spent in common ZFS file operations: reads,
 writes, opens, and syncs, and presents it as a power-of-2 histogram. It uses an


### PR DESCRIPTION
While writing up the man page for a new nfsdist tool that i hope to commit shortly. I noticed that the man pages for the {ext4,xfs,zfs}dist tools had a small error in their man pages. This PR fixes that. 