### PR TITLE
Fix freezing of 'test_brb' and 'test_brb2' if netperf is not found

### DIFF
--- a/tests/python/test_brb.py
+++ b/tests/python/test_brb.py
@@ -65,6 +65,7 @@ from ctypes import c_uint
 from netaddr import IPAddress, EUI
 from bcc import BPF
 from pyroute2 import IPRoute, NetNS, IPDB, NSPopen
+from utils import NSPopenWithCheck
 import sys
 from time import sleep
 from unittest import main, TestCase
@@ -196,15 +197,15 @@ class TestBPFSocket(TestCase):
             # total 8 packets should be counted
             self.assertEqual(self.pem_stats[c_uint(0)].value, 8)
 
-            nsp_server = NSPopen(ns2_ipdb.nl.netns, ["iperf", "-s", "-xSC"])
+            nsp_server = NSPopenWithCheck(ns2_ipdb.nl.netns, ["iperf", "-s", "-xSC"])
             sleep(1)
             nsp = NSPopen(ns1_ipdb.nl.netns, ["iperf", "-c", self.vm2_ip, "-t", "1", "-xSC"])
             nsp.wait(); nsp.release()
             nsp_server.kill(); nsp_server.wait(); nsp_server.release()
 
-            nsp_server = NSPopen(ns2_ipdb.nl.netns, ["netserver", "-D"])
+            nsp_server = NSPopenWithCheck(ns2_ipdb.nl.netns, ["netserver", "-D"])
             sleep(1)
-            nsp = NSPopen(ns1_ipdb.nl.netns, ["netperf", "-l", "1", "-H", self.vm2_ip, "--", "-m", "65160"])
+            nsp = NSPopenWithCheck(ns1_ipdb.nl.netns, ["netperf", "-l", "1", "-H", self.vm2_ip, "--", "-m", "65160"])
             nsp.wait(); nsp.release()
             nsp = NSPopen(ns1_ipdb.nl.netns, ["netperf", "-l", "1", "-H", self.vm2_ip, "-t", "TCP_RR"])
             nsp.wait(); nsp.release()

--- a/tests/python/test_brb2.py
+++ b/tests/python/test_brb2.py
@@ -57,6 +57,7 @@
 from ctypes import c_uint
 from bcc import BPF
 from pyroute2 import IPRoute, NetNS, IPDB, NSPopen
+from utils import NSPopenWithCheck
 import sys
 from time import sleep
 from unittest import main, TestCase
@@ -174,15 +175,15 @@ class TestBPFSocket(TestCase):
             # one arp request/reply, 2 icmp request/reply per VM, total 6 packets per VM, 12 packets total
             self.assertEqual(self.pem_stats[c_uint(0)].value, 12)
 
-            nsp_server = NSPopen(ns2_ipdb.nl.netns, ["iperf", "-s", "-xSC"])
+            nsp_server = NSPopenWithCheck(ns2_ipdb.nl.netns, ["iperf", "-s", "-xSC"])
             sleep(1)
             nsp = NSPopen(ns1_ipdb.nl.netns, ["iperf", "-c", self.vm2_ip, "-t", "1", "-xSC"])
             nsp.wait(); nsp.release()
             nsp_server.kill(); nsp_server.wait(); nsp_server.release()
 
-            nsp_server = NSPopen(ns2_ipdb.nl.netns, ["netserver", "-D"])
+            nsp_server = NSPopenWithCheck(ns2_ipdb.nl.netns, ["netserver", "-D"])
             sleep(1)
-            nsp = NSPopen(ns1_ipdb.nl.netns, ["netperf", "-l", "1", "-H", self.vm2_ip, "--", "-m", "65160"])
+            nsp = NSPopenWithCheck(ns1_ipdb.nl.netns, ["netperf", "-l", "1", "-H", self.vm2_ip, "--", "-m", "65160"])
             nsp.wait(); nsp.release()
             nsp = NSPopen(ns1_ipdb.nl.netns, ["netperf", "-l", "1", "-H", self.vm2_ip, "-t", "TCP_RR"])
             nsp.wait(); nsp.release()

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -1,6 +1,12 @@
 from pyroute2 import NSPopen
 from distutils.spawn import find_executable
 
+def has_executable(name):
+    path = find_executable(name)
+    if path is None:
+        raise Exception(name + ": command not found")
+    return path
+
 class NSPopenWithCheck(NSPopen):
     """
     A wrapper for NSPopen that additionally checks if the program
@@ -11,8 +17,5 @@ class NSPopenWithCheck(NSPopen):
 
     def __init__(self, nsname, *argv, **kwarg):
         name = list(argv)[0][0]
-        path = find_executable(name)
-        if path is None:
-            raise Exception(name + ": command not found")
-        else:
-            super(NSPopenWithCheck, self).__init__(nsname, *argv, **kwarg)
+        has_executable(name)
+        super(NSPopenWithCheck, self).__init__(nsname, *argv, **kwarg)

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -1,0 +1,18 @@
+from pyroute2 import NSPopen
+from distutils.spawn import find_executable
+
+class NSPopenWithCheck(NSPopen):
+    """
+    A wrapper for NSPopen that additionally checks if the program
+    to be executed is available from the system path or not.
+    If found, it proceeds with the usual NSPopen() call.
+    Otherwise, it raises an exception.
+    """
+
+    def __init__(self, nsname, *argv, **kwarg):
+        name = list(argv)[0][0]
+        path = find_executable(name)
+        if path is None:
+            raise Exception(name + ": command not found")
+        else:
+            super(NSPopenWithCheck, self).__init__(nsname, *argv, **kwarg)


### PR DESCRIPTION
If netperf is not installed or installed at a location that is not in PATH as recognized by Python, then 'test_brb' and 'test_brb2' freeze after an OSError is raised. To avoid this, we proactively check if the 'iperf', 'netserver' and 'netperf' binaries are available before making the corresponding NSPopen() calls.