### PR TITLE
Deduplicate USDT probe locations after initilization

### DIFF
--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -181,6 +181,7 @@ public:
     return largest_arg_type(arg_index);
   }
 
+  void finalize_locations();
   bool need_enable() const { return semaphore_ != 0x0; }
   bool enable(const std::string &fn_name);
   bool disable();


### PR DESCRIPTION
We noticed duplicated location notes for the same USDT probe in some of our production binaries. That is probably caused by aggressive inlined and/or link-time optimizations. BCC fails in such cases due to duplication of generated code.

While we fix the root cause in the binaries, patch BCC to deduplicate probe locations after initialization to avoid such failure.