### PR TITLE
Use ELF load sections in address -> symbol resolution

### DIFF
--- a/src/cc/common.cc
+++ b/src/cc/common.cc
@@ -17,6 +17,7 @@
 #include <sstream>
 
 #include "common.h"
+#include "vendor/tinyformat.hpp"
 
 namespace ebpf {
 
@@ -46,6 +47,18 @@ std::vector<int> get_online_cpus() {
 
 std::vector<int> get_possible_cpus() {
   return read_cpu_range("/sys/devices/system/cpu/possible");
+}
+
+std::string get_pid_exe(pid_t pid) {
+  char exe_path[4096];
+  int res;
+
+  std::string exe_link = tfm::format("/proc/%d/exe", pid);
+  res = readlink(exe_link.c_str(), exe_path, sizeof(exe_path));
+  if (res == -1)
+    return "";
+  exe_path[res] = '\0';
+  return std::string(exe_path);
 }
 
 } // namespace ebpf

--- a/src/cc/common.h
+++ b/src/cc/common.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <unistd.h>
 #include <vector>
 
 namespace ebpf {
@@ -30,5 +32,7 @@ make_unique(Args &&... args) {
 std::vector<int> get_online_cpus();
 
 std::vector<int> get_possible_cpus();
+
+std::string get_pid_exe(pid_t pid);
 
 }  // namespace ebpf

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -110,8 +110,11 @@ class ProcSyms : SymbolCache {
     std::vector<Symbol> syms_;
 
     void load_sym_table();
+
+    void add_range(uint64_t st, uint64_t en);
     bool contains(uint64_t addr, uint64_t &offset) const;
     uint64_t start() const { return ranges_.begin()->start; }
+
     bool find_addr(uint64_t offset, struct bcc_symbol *sym);
     bool find_name(const char *symname, uint64_t *addr);
 
@@ -125,8 +128,11 @@ class ProcSyms : SymbolCache {
   std::unique_ptr<ProcMountNS> mount_ns_instance_;
   bcc_symbol_option symbol_option_;
 
+  static int _add_load_sections(uint64_t v_addr, uint64_t mem_sz,
+                                uint64_t file_offset, void *payload);
   static int _add_module(const char *, uint64_t, uint64_t, bool, void *);
-  bool load_modules();
+  void load_exe();
+  void load_modules();
 
 public:
   ProcSyms(int pid, struct bcc_symbol_option *option = nullptr);


### PR DESCRIPTION
Loading executable text into huge-pages is a more and more commonly used technique to reduce iTLB misses and improve software performance.

In Facebook, we do that by performing a run-time re-map of the executable text. Unfortunately that causes the re-mapped memory section becomes anonymous, and BCC code won't be able to map it to a file and hence failed to resolve addresses from that section into symbol name. Here is an example:
```
root@host:/proc/PID {}# head /proc/PID/maps
00400000-00600000 r-xp 00000000 08:03 67112375                           PATH/hhvm
00600000-01000000 r-xp 00000000 00:00 0
01000000-0dbe7000 r-xp 00c00000 08:03 67112375                           PATH/hhvm
0f8bc000-0fa00000 rwxp 00000000 00:00 0                                  [heap]
```
where the ELF load section says:
```
Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  LOAD           0x000000 0x0000000000400000 0x0000000000400000 0xd7e6a00 0xd7e6a00 R E 0x200000
```

Here is another example where Chrome OS had similar issues and how `perf` trying to fix it: [perf: fix hugepage text section problem.](https://groups.google.com/a/chromium.org/forum/#!msg/chromium-os-reviews/ZQz_kQOhkj0/sr_x7ktVBwAJ)

This PR solves the issue by adding logic to `ProcSyms`. When `ProcSyms` constructs, before looping through the Process's memory mapping, it would always look at the Process's binary from `procfs`. If that binary is executable (`ET_EXEC`), `ProcSyms` would add a module with memory range from the ELF's load section, so that later all addresses from that range would be looked against the binary. It utilizes the `bcc_elf_foreach_load_section` helper added in #1375.

cc @markdrayton @myreg