### PR TITLE
execsnoop: Fix -x handling

### DIFF
--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -191,7 +191,7 @@ def print_event(cpu, data, size):
     if event.type == EventType.EVENT_ARG:
         argv[event.pid].append(event.argv)
     elif event.type == EventType.EVENT_RET:
-        if args.fails and event.retval == 0:
+        if event.retval != 0 and not args.fails:
             skip = True
         if args.name and not re.search(args.name, event.comm):
             skip = True


### PR DESCRIPTION
Execsnoop's documentation says -x/--fails means "also include failed
exec()s". However it was programmed to instead skip successful execs on
-x, and without -x shows all - successful and unsuccessful ones.

The logic was broken in 5b47e0f8 ("execsnoop: use BPF_PERF_OUTPUT
instead of trace pipe").

Fix it.

P.S. current test_tools_smoke.py only provides basic infrastructure for
testing whether tool's BPF program won't break, without anything related
to options handling, so unfortunately the patch comes without
corresponding test.

/cc @brendangregg, @markdrayton