### PR TITLE
hardirqs, softirqs: Fix distribution mode units handling

### DIFF
--- a/tools/hardirqs.py
+++ b/tools/hardirqs.py
@@ -109,7 +109,7 @@ int trace_completion(struct pt_regs *ctx)
 # code substitutions
 if args.dist:
     bpf_text = bpf_text.replace('STORE',
-        'irq_key_t key = {.slot = bpf_log2l(delta)};' +
+        'irq_key_t key = {.slot = bpf_log2l(delta / %d)};' % factor +
         'bpf_probe_read(&key.name, sizeof(key.name), name);' +
         'dist.increment(key);')
 else:

--- a/tools/softirqs.py
+++ b/tools/softirqs.py
@@ -103,7 +103,7 @@ TRACEPOINT_PROBE(irq, softirq_exit)
 # code substitutions
 if args.dist:
     bpf_text = bpf_text.replace('STORE',
-        'key.vec = vec; key.slot = bpf_log2l(delta); ' +
+        'key.vec = vec; key.slot = bpf_log2l(delta / %d); ' % factor +
         'dist.increment(key);')
 else:
     bpf_text = bpf_text.replace('STORE',


### PR DESCRIPTION
Even if units was μs and thus factor=1000 `hardirqs -d` and `softirqs
-d` were printing actual data in nanoseconds but with distribution unit
labeled as "usecs", e.g.:

```
    softirq = sched
         usecs               : count     distribution
             0 -> 1          : 0        |                                        |
             2 -> 3          : 0        |                                        |
             4 -> 7          : 0        |                                        |
             8 -> 15         : 0        |                                        |
            16 -> 31         : 0        |                                        |
            32 -> 63         : 0        |                                        |
            64 -> 127        : 0        |                                        |
           128 -> 255        : 0        |                                        |
           256 -> 511        : 0        |                                        |
           512 -> 1023       : 0        |                                        |
          1024 -> 2047       : 6        |*****                                   |
          2048 -> 4095       : 3        |**                                      |
          4096 -> 8191       : 8        |*******                                 |
          8192 -> 16383      : 31       |*****************************           |
         16384 -> 32767      : 42       |****************************************|
         32768 -> 65535      : 18       |*****************                       |
```

Fix it.

NOTE: not putting "/ FACTOR" into common code because for counting mode
we do not want to round intermediate results as e.g. there could be lots
of say 0.5μs interrupts that should be all accounted as N*0.5, not N*0.0.