### PR TITLE
bpf_probe_read*: src argument should be const void *.

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -234,7 +234,7 @@ Examples in situ:
 
 ### 1. bpf_probe_read()
 
-Syntax: ```int bpf_probe_read(void *dst, int size, void *src)```
+Syntax: ```int bpf_probe_read(void *dst, int size, const void *src)```
 
 Return: 0 on success
 
@@ -246,7 +246,7 @@ Examples in situ:
 
 ### 2. bpf_probe_read_str()
 
-Syntax: ```int bpf_probe_read_str(void *dst, int size, void *src)```
+Syntax: ```int bpf_probe_read_str(void *dst, int size, const void *src)```
 
 Return:
   - \> 0 length of the string including the trailing NUL on success

--- a/src/cc/compat/linux/bpf.h
+++ b/src/cc/compat/linux/bpf.h
@@ -244,7 +244,7 @@ union bpf_attr {
  * int bpf_map_delete_elem(&map, &key)
  *     Return: 0 on success or negative error
  *
- * int bpf_probe_read(void *dst, int size, void *src)
+ * int bpf_probe_read(void *dst, int size, const void *src)
  *     Return: 0 on success or negative error
  *
  * u64 bpf_ktime_get_ns(void)

--- a/src/cc/compat/linux/virtual_bpf.h
+++ b/src/cc/compat/linux/virtual_bpf.h
@@ -245,7 +245,7 @@ union bpf_attr {
  * int bpf_map_delete_elem(&map, &key)
  *     Return: 0 on success or negative error
  *
- * int bpf_probe_read(void *dst, int size, void *src)
+ * int bpf_probe_read(void *dst, int size, const void *src)
  *     Return: 0 on success or negative error
  *
  * u64 bpf_ktime_get_ns(void)

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -185,7 +185,7 @@ static int (*bpf_map_update_elem)(void *map, void *key, void *value, u64 flags) 
   (void *) BPF_FUNC_map_update_elem;
 static int (*bpf_map_delete_elem)(void *map, void *key) =
   (void *) BPF_FUNC_map_delete_elem;
-static int (*bpf_probe_read)(void *dst, u64 size, void *unsafe_ptr) =
+static int (*bpf_probe_read)(void *dst, u64 size, const void *unsafe_ptr) =
   (void *) BPF_FUNC_probe_read;
 static u64 (*bpf_ktime_get_ns)(void) =
   (void *) BPF_FUNC_ktime_get_ns;
@@ -193,7 +193,7 @@ static u32 (*bpf_get_prandom_u32)(void) =
   (void *) BPF_FUNC_get_prandom_u32;
 static int (*bpf_trace_printk_)(const char *fmt, u64 fmt_size, ...) =
   (void *) BPF_FUNC_trace_printk;
-static int (*bpf_probe_read_str)(void *dst, u64 size, void *unsafe_ptr) =
+static int (*bpf_probe_read_str)(void *dst, u64 size, const void *unsafe_ptr) =
   (void *) BPF_FUNC_probe_read_str;
 int bpf_trace_printk(const char *fmt, ...) asm("llvm.bpf.extra");
 static inline __attribute__((always_inline))


### PR DESCRIPTION
For the following program:

    #include <linux/interrupt.h>

    // remember t(last-interrupt) on interface
    int kprobe__handle_irq_event_percpu(struct pt_regs *ctx, struct irq_desc *desc) {
        const char *irqname = desc->action->name;

        char c;

        bpf_probe_read(&c, 1, &irqname[0]);
        if (c != 'e') return 0;

        bpf_probe_read(&c, 1, &irqname[1]);
        if (c != 't') return 0;

        ...

LLVM gives warnings because irqaction->name is `const char *`:

    /virtual/main.c:10:27: warning: passing 'const char *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        bpf_probe_read(&c, 1, &irqname[0]);
                              ^~~~~~~~~~~
    /virtual/main.c:13:27: warning: passing 'const char *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        bpf_probe_read(&c, 1, &irqname[1]);
                              ^~~~~~~~~~~
    ...

Instead of adding casts in source everywhere fix bpf_probe_read* signature to
indicate the memory referenced by src won't be modified, as it should be.

P.S.

bpf_probe_read_str was in fact already marked so in several places in comments
but not in actual signature.