### PR TITLE
Add basic USDT support for powerpc64

### DIFF
--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -74,37 +74,34 @@ public:
   const optional<int> deref_offset() const { return deref_offset_; }
 
   friend class ArgumentParser;
+  friend class ArgumentParser_powerpc64;
+  friend class ArgumentParser_x64;
 };
 
 class ArgumentParser {
+protected:
   const char *arg_;
   ssize_t cur_pos_;
 
   void skip_whitespace_from(size_t pos);
   void skip_until_whitespace_from(size_t pos);
-
-protected:
-  virtual bool normalize_register(std::string *reg, int *reg_size) = 0;
-
-  ssize_t parse_register(ssize_t pos, std::string &name, int &size);
-  ssize_t parse_number(ssize_t pos, optional<int> *number);
-  ssize_t parse_identifier(ssize_t pos, optional<std::string> *ident);
-  ssize_t parse_base_register(ssize_t pos, Argument *dest);
-  ssize_t parse_index_register(ssize_t pos, Argument *dest);
-  ssize_t parse_scale(ssize_t pos, Argument *dest);
-  ssize_t parse_expr(ssize_t pos, Argument *dest);
-  ssize_t parse_1(ssize_t pos, Argument *dest);
-
   void print_error(ssize_t pos);
 
 public:
-  bool parse(Argument *dest);
+  virtual bool parse(Argument *dest) = 0;
   bool done() { return cur_pos_ < 0 || arg_[cur_pos_] == '\0'; }
 
   ArgumentParser(const char *arg) : arg_(arg), cur_pos_(0) {}
 };
 
+class ArgumentParser_powerpc64 : public ArgumentParser {
+public:
+  bool parse(Argument *dest);
+  ArgumentParser_powerpc64(const char *arg) : ArgumentParser(arg) {}
+};
+
 class ArgumentParser_x64 : public ArgumentParser {
+private:
   enum Register {
     REG_A,
     REG_B,
@@ -133,8 +130,17 @@ class ArgumentParser_x64 : public ArgumentParser {
   static const std::unordered_map<std::string, RegInfo> registers_;
   bool normalize_register(std::string *reg, int *reg_size);
   void reg_to_name(std::string *norm, Register reg);
+  ssize_t parse_register(ssize_t pos, std::string &name, int &size);
+  ssize_t parse_number(ssize_t pos, optional<int> *number);
+  ssize_t parse_identifier(ssize_t pos, optional<std::string> *ident);
+  ssize_t parse_base_register(ssize_t pos, Argument *dest);
+  ssize_t parse_index_register(ssize_t pos, Argument *dest);
+  ssize_t parse_scale(ssize_t pos, Argument *dest);
+  ssize_t parse_expr(ssize_t pos, Argument *dest);
+  ssize_t parse_1(ssize_t pos, Argument *dest);
 
 public:
+  bool parse(Argument *dest);
   ArgumentParser_x64(const char *arg) : ArgumentParser(arg) {}
 };
 

--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -31,7 +31,13 @@
 namespace USDT {
 
 Location::Location(uint64_t addr, const char *arg_fmt) : address_(addr) {
+#ifdef __powerpc64__
+  ArgumentParser_powerpc64 parser(arg_fmt);
+#elif defined(__x86_64__)
   ArgumentParser_x64 parser(arg_fmt);
+#else
+#error "bcc does not support this platform yet"
+#endif
   while (!parser.done()) {
     Argument arg;
     if (!parser.parse(&arg))
@@ -173,7 +179,7 @@ bool Probe::usdt_getarg(std::ostream &stream) {
         return false;
       stream << "\n  return 0;\n}\n";
     } else {
-      stream << "  switch(ctx->ip) {\n";
+      stream << "  switch(PT_REGS_IP(ctx)) {\n";
       for (Location &location : locations_) {
         uint64_t global_address;
 

--- a/tests/python/include/folly/tracing/StaticTracepoint-ELF.h
+++ b/tests/python/include/folly/tracing/StaticTracepoint-ELF.h
@@ -18,7 +18,11 @@
 
 // Default constraint for the probe arguments as operands.
 #ifndef FOLLY_SDT_ARG_CONSTRAINT
+#if defined(__powerpc64__) || defined(__powerpc__)
+#define FOLLY_SDT_ARG_CONSTRAINT      "nQr"
+#elif defined(__x86_64__) || defined(__i386__)
 #define FOLLY_SDT_ARG_CONSTRAINT      "nor"
+#endif
 #endif
 
 // Instruction to emit for the probe.
@@ -73,7 +77,14 @@
   FOLLY_SDT_OPERANDS_7(_1, _2, _3, _4, _5, _6, _7), FOLLY_SDT_ARG(8, _8)
 
 // Templates to reference the arguments from operands in note section.
-#define FOLLY_SDT_ARGFMT(no)        %n[FOLLY_SDT_S##no]@%[FOLLY_SDT_A##no]
+#if defined(__powerpc64__ ) || defined(__powerpc__)
+#define FOLLY_SDT_ARGTMPL(id)       %I[id]%[id]
+#elif defined(__i386__)
+#define FOLLY_SDT_ARGTMPL(id)       %w[id]
+#else
+#define FOLLY_SDT_ARGTMPL(id)       %[id]
+#endif
+#define FOLLY_SDT_ARGFMT(no)        %n[FOLLY_SDT_S##no]@FOLLY_SDT_ARGTMPL(FOLLY_SDT_A##no)
 #define FOLLY_SDT_ARG_TEMPLATE_0    /*No arguments*/
 #define FOLLY_SDT_ARG_TEMPLATE_1    FOLLY_SDT_ARGFMT(1)
 #define FOLLY_SDT_ARG_TEMPLATE_2    FOLLY_SDT_ARG_TEMPLATE_1 FOLLY_SDT_ARGFMT(2)

--- a/tests/python/include/folly/tracing/StaticTracepoint.h
+++ b/tests/python/include/folly/tracing/StaticTracepoint.h
@@ -16,8 +16,10 @@
 
 #pragma once
 
-#if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__))
-#include <folly/tracing/StaticTracepoint-ELFx86.h>
+#if defined(__ELF__) && \
+      (defined(__powerpc64__) || defined(__powerpc__) || \
+       defined(__x86_64__) || defined(__i386__))
+#include <folly/tracing/StaticTracepoint-ELF.h>
 
 #define FOLLY_SDT(provider, name, ...)                                         \
   FOLLY_SDT_PROBE_N(                                                           \


### PR DESCRIPTION
Add support for parsing and reading USDT arguments in formats compatible with powerpc64. This also updates some of the USDT related tests such as `test_usdt_args`, `test_usdt` and `test_usdt2` so that they pass on powerpc64 systems.