### PR TITLE
examples: fix dns_matching

### DIFF
--- a/examples/networking/dns_matching/dns_matching.c
+++ b/examples/networking/dns_matching/dns_matching.c
@@ -43,7 +43,7 @@ struct dns_char_t
 } BPF_PACKET_HEADER;
 
 struct Key {
-  unsigned char p[32];
+  unsigned char p[255];
 };
 
 struct Leaf {
@@ -85,8 +85,8 @@ int dns_matching(struct __sk_buff *skb)
         u16 i = 0;
         struct dns_char_t *c;
         // This unroll worked not in latest BCC version.
-        for(u8 j = 0; i<255;i++){
-          if (cursor == sentinel) goto end; c = cursor_advance(cursor, 1); key.p[i++] = c->c;
+        for(i = 0; i<255;i++){
+          if (cursor == sentinel) goto end; c = cursor_advance(cursor, 1); key.p[i] = c->c;
         }
         end:
         {}

--- a/examples/networking/dns_matching/dns_matching.c
+++ b/examples/networking/dns_matching/dns_matching.c
@@ -84,7 +84,7 @@ int dns_matching(struct __sk_buff *skb)
 
         u16 i = 0;
         struct dns_char_t *c;
-        // This unroll worked not in latest BCC version.
+        #pragma unroll
         for(i = 0; i<255;i++){
           if (cursor == sentinel) goto end; c = cursor_advance(cursor, 1); key.p[i] = c->c;
         }

--- a/examples/networking/dns_matching/dns_matching.c
+++ b/examples/networking/dns_matching/dns_matching.c
@@ -70,10 +70,6 @@ int dns_matching(struct __sk_buff *skb)
       struct udp_t *udp = cursor_advance(cursor, sizeof(*udp));
       if(udp->dport == 53){
 
-        // Our Cursor + the length of our udp packet - size of the udp header
-        // - the two 16bit values for QTYPE and QCLASS.
-        u8 *sentinel = cursor + udp->length - sizeof(*udp) - 4;
-
         struct dns_hdr_t *dns_hdr = cursor_advance(cursor, sizeof(*dns_hdr));
 
         // Do nothing if packet is not a request.
@@ -86,15 +82,17 @@ int dns_matching(struct __sk_buff *skb)
         struct dns_char_t *c;
         #pragma unroll
         for(i = 0; i<255;i++){
-          if (cursor == sentinel) goto end; c = cursor_advance(cursor, 1); key.p[i] = c->c;
+          c = cursor_advance(cursor, 1);
+          if (c->c == 0)
+            break;
+          key.p[i] = c->c;
         }
-        end:
-        {}
 
         struct Leaf * lookup_leaf = cache.lookup(&key);
 
         // If DNS name is contained in our map, drop packet.
         if(lookup_leaf) {
+          bpf_trace_printk("Matched1\n");
           return 0;
         }
       }

--- a/examples/networking/dns_matching/dns_matching.py
+++ b/examples/networking/dns_matching/dns_matching.py
@@ -11,8 +11,8 @@ import struct
 
 
 def encode_dns(name):
-  size = 32
-  if len(name) > 253:
+  size = 255
+  if len(name) > 255:
     raise Exception("DNS Name too long.")
   b = bytearray(size)
   i = 0;


### PR DESCRIPTION
Fixed major bugs in this example.

Please note that this example still doesn't work as intended because of its design.
AFAIK original author expected it to drop dns packets having dns names which are also present in map. (see description in .c file).
I will create another PR to make it work as a DNS sniffer.

This will still remain an example of loop unrolling.