### PR TITLE
execsnoop: argument to change the number of arguments parsed

### DIFF
--- a/man/man8/execsnoop.8
+++ b/man/man8/execsnoop.8
@@ -35,6 +35,9 @@ Only print command lines matching this name (regex)
 .TP
 \-l LINE
 Only print commands where arg contains this line (regex)
+.TP
+\--max-args MAXARGS
+Maximum number of arguments parsed and displayed, defaults to 20
 .SH EXAMPLES
 .TP
 Trace all exec() syscalls:

--- a/tools/execsnoop_example.txt
+++ b/tools/execsnoop_example.txt
@@ -79,7 +79,7 @@ rpm              3345452 4146419   0 /bin/rpm -qa testpkg
 USAGE message:
 
 # ./execsnoop -h
-usage: execsnoop [-h] [-t] [-x] [-n NAME]
+usage: execsnoop [-h] [-t] [-x] [-n NAME] [-l LINE] [--max-args MAX_ARGS]
 
 Trace exec() syscalls
 
@@ -91,10 +91,12 @@ optional arguments:
                         arg
   -l LINE, --line LINE  only print commands where arg contains this line
                         (regex)
+  --max-args MAX_ARGS   maximum number of arguments parsed and displayed,
+                        defaults to 20
 
 examples:
     ./execsnoop           # trace all exec() syscalls
-    ./execsnoop -x        # include failed exec()s 
+    ./execsnoop -x        # include failed exec()s
     ./execsnoop -t        # include timestamps
     ./execsnoop -n main   # only print command lines containing "main"
     ./execsnoop -l tpkg   # only print command where arguments contains "tpkg"


### PR DESCRIPTION
New argument to change the maximum number of arguments parsed and
displayed.

~The maximum number is currently limited to 188 due to the maximum
number of instructions authorized by the verifier. The new smoke test
ensures we get a failing test if the actual maximum decreases.~

~Note: I proactively limited the number of arguments in argparse to
avoid exposing the user to the verifier's error message.~

/cc @brendangregg 