### PR TITLE
Fix 'tools/statsnoop' from failing to attach kprobes

### DIFF
--- a/tools/statsnoop.py
+++ b/tools/statsnoop.py
@@ -105,12 +105,22 @@ if debug:
 
 # initialize BPF
 b = BPF(text=bpf_text)
-b.attach_kprobe(event="sys_stat", fn_name="trace_entry")
-b.attach_kprobe(event="sys_statfs", fn_name="trace_entry")
-b.attach_kprobe(event="sys_newstat", fn_name="trace_entry")
-b.attach_kretprobe(event="sys_stat", fn_name="trace_return")
-b.attach_kretprobe(event="sys_statfs", fn_name="trace_return")
-b.attach_kretprobe(event="sys_newstat", fn_name="trace_return")
+
+# for POSIX compliance, all architectures implement these
+# system calls but the name of the actual entry point may
+# be different for which we must check if the entry points
+# actually exist before attaching the probes
+if BPF.ksymname("sys_stat") != -1:
+    b.attach_kprobe(event="sys_stat", fn_name="trace_entry")
+    b.attach_kretprobe(event="sys_stat", fn_name="trace_return")
+
+if BPF.ksymname("sys_statfs") != -1:
+    b.attach_kprobe(event="sys_statfs", fn_name="trace_entry")
+    b.attach_kretprobe(event="sys_statfs", fn_name="trace_return")
+
+if BPF.ksymname("sys_newstat") != -1:
+    b.attach_kprobe(event="sys_newstat", fn_name="trace_entry")
+    b.attach_kretprobe(event="sys_newstat", fn_name="trace_return")
 
 TASK_COMM_LEN = 16    # linux/sched.h
 NAME_MAX = 255        # linux/limits.h


### PR DESCRIPTION
This fixes `tools/statsnoop` from failing to attach probes when the expected entry point for a system call cannot be found. This script uses the `stat`, `statfs` and `newstat` system calls, all of which must be implemented to be POSIX compliant. However, the names of the actual entry points for their respective implementations in the kernel might vary across architectures. For example, a `powerpc64` kernel does not define `sys_stat` but still provides the `stat` system call via `sys_newstat`. This causes the script to fail if it tries to attach a probe at `sys_stat`. We avoid this by performing some extra checks to see if these entry points exist.