### PR TITLE
Improve Kernel symbols loading

### DIFF
--- a/src/cc/bcc_proc.h
+++ b/src/cc/bcc_proc.h
@@ -41,6 +41,8 @@ int bcc_mapping_is_file_backed(const char *mapname);
 // Returns -1 on error, and 0 on success
 int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
                               void *payload);
+// Iterate over all non-data Kernel symbols.
+// Returns -1 on error, and 0 on success
 int bcc_procutils_each_ksym(bcc_procutils_ksymcb callback, void *payload);
 void bcc_procutils_free(const char *ptr);
 const char *bcc_procutils_language(int pid);


### PR DESCRIPTION
- Current logic basically ignores the first line. That could be related to the reason of #1373 / #1377.
- Add some checks.
- Ignore data symbols as we only care about the relationship between Kernel function addresses and function names, for stack-trace symbol resolution and kprobe attaching. Reduces memory and CPU cost. The ignored types come from `man nm`:
```
           "B"
           "b" The symbol is in the uninitialized data section (known as BSS).

           "D"
           "d" The symbol is in the initialized data section.

           "R"
           "r" The symbol is in a read only data section.
```