### PR TITLE
Update SDT argument constraints

### DIFF
--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -34,10 +34,8 @@ namespace USDT {
 Location::Location(uint64_t addr, const char *arg_fmt) : address_(addr) {
 #ifdef __powerpc64__
   ArgumentParser_powerpc64 parser(arg_fmt);
-#elif defined(__x86_64__)
-  ArgumentParser_x64 parser(arg_fmt);
 #else
-#error "bcc does not support this platform yet"
+  ArgumentParser_x64 parser(arg_fmt);
 #endif
   while (!parser.done()) {
     Argument arg;

--- a/tests/python/include/folly/tracing/StaticTracepoint-ELF.h
+++ b/tests/python/include/folly/tracing/StaticTracepoint-ELF.h
@@ -19,7 +19,7 @@
 // Default constraint for the probe arguments as operands.
 #ifndef FOLLY_SDT_ARG_CONSTRAINT
 #if defined(__powerpc64__) || defined(__powerpc__)
-#define FOLLY_SDT_ARG_CONSTRAINT      "nQr"
+#define FOLLY_SDT_ARG_CONSTRAINT      "nZr"
 #else
 #define FOLLY_SDT_ARG_CONSTRAINT      "nor"
 #endif

--- a/tests/python/include/folly/tracing/StaticTracepoint-ELF.h
+++ b/tests/python/include/folly/tracing/StaticTracepoint-ELF.h
@@ -20,7 +20,7 @@
 #ifndef FOLLY_SDT_ARG_CONSTRAINT
 #if defined(__powerpc64__) || defined(__powerpc__)
 #define FOLLY_SDT_ARG_CONSTRAINT      "nQr"
-#elif defined(__x86_64__) || defined(__i386__)
+#else
 #define FOLLY_SDT_ARG_CONSTRAINT      "nor"
 #endif
 #endif


### PR DESCRIPTION
Update SDT argument constraints, that is, `FOLLY_SDT_ARG_CONSTRAINT` in the folly tracing header `tests/python/include/folly/tracing/StaticTracepoint-ELF.h`, to support all architectures as discussed with @palmtenor in #1365. Also, we update the constraint for `powerpc` as the new constraint allows register indexed or indirect operands as well.

[Update 10/10] This also sets the default argument parser to that of `x86_64`.