### PR TITLE
Fix 'tools/syscount' from using incorrect fallback values

### DIFF
--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -15,6 +15,7 @@ import argparse
 import itertools
 import subprocess
 import sys
+import platform
 
 if sys.version_info.major < 3:
     izip_longest = itertools.izip_longest
@@ -362,7 +363,10 @@ try:
     out = subprocess.check_output('ausyscall --dump | tail -n +2', shell=True)
     syscalls = dict(map(parse_syscall, out.strip().split('\n')))
 except Exception as e:
-    pass
+    if platform.machine() == "x86_64":
+        pass
+    else:
+        raise Exception("ausyscall: command not found")
 
 parser = argparse.ArgumentParser(
     description="Summarize syscall counts and latencies.")


### PR DESCRIPTION
This prevents `tools/syscount` from using incorrect system call names if the 'ausyscall' command is not found. This is because it does not come pre-installed in all distros. In this case, it uses a lookup table as a fallback but this table is usable for `x86_64` only. For now, we fix this by raising an exception and exiting if the `ausyscall` executable is not available for non-`x86_64` systems instead of having additional lookup tables for other architectures.