### PR TITLE
attempt to compile with system bpf.h if default compile failed

### DIFF
--- a/src/cc/frontends/clang/CMakeLists.txt
+++ b/src/cc/frontends/clang/CMakeLists.txt
@@ -5,5 +5,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_DIR='\"${BCC_KERNEL_MOD
 if(DEFINED BCC_CUR_CPU_IDENTIFIER)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCUR_CPU_IDENTIFIER='\"${BCC_CUR_CPU_IDENTIFIER}\"'")
 endif()
+if(DEFINED BCC_BACKUP_COMPILE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBCC_BACKUP_COMPILE='${BCC_BACKUP_COMPILE}'")
+endif()
 
 add_library(clang_frontend STATIC loader.cc b_frontend_action.cc tp_frontend_action.cc kbuild_helper.cc ../../common.cc)

--- a/src/cc/frontends/clang/loader.h
+++ b/src/cc/frontends/clang/loader.h
@@ -40,6 +40,7 @@ class FuncSource {
   std::map<std::string, SourceCode> funcs_;
  public:
   FuncSource() {}
+  void clear() { funcs_.clear(); }
   const char * src(const std::string& name);
   const char * src_rewritten(const std::string& name);
   void set_src(const std::string& name, const std::string& src);
@@ -54,6 +55,15 @@ class ClangLoader {
             const std::string &file, bool in_memory, const char *cflags[],
             int ncflags, const std::string &id, FuncSource &func_src,
             std::string &mod_src);
+
+ private:
+  int do_compile(std::unique_ptr<llvm::Module> *mod, TableStorage &ts,
+                 bool in_memory, const std::vector<const char *> &flags_cstr_in,
+                 const std::vector<const char *> &flags_cstr_rem,
+                 const std::string &main_path,
+                 const std::unique_ptr<llvm::MemoryBuffer> &main_buf,
+                 const std::string &id, FuncSource &func_src,
+                 std::string &mod_src, bool use_internal_bpfh);
 
  private:
   static std::map<std::string, std::unique_ptr<llvm::MemoryBuffer>> remapped_files_;


### PR DESCRIPTION
Currently, bcc uses its own version of bpf.h which tries to
sync with upstream header regularly. If the host bpf.h version
is lower, bcc can still compile as some bcc codes may requires
a higher version of bpf.h.

Such an approach does have a drawback. Suppose service A,
statically linked with bcc, runs on kernel version X.
Now, the kernel upgrades to version Y. After kernel upgrade/reboot,
service A may not be able to compile since old bcc bpf.h
may not align with the new kernel headers.
For such cases, new version of service A needs rollout.

This patch addresses this issue by attempting a second
compilation using system bpf.h instead.

Signed-off-by: Yonghong Song <yhs@fb.com>