### PR TITLE
bpf: print out the src debug info to a temporary file

### DIFF
--- a/src/cc/bcc_debug.h
+++ b/src/cc/bcc_debug.h
@@ -20,11 +20,13 @@ class SourceDebugger {
   SourceDebugger(
       llvm::Module *mod,
       std::map<std::string, std::tuple<uint8_t *, uintptr_t>> &sections,
-      const std::string &fn_prefix, const std::string &mod_src)
+      const std::string &fn_prefix, const std::string &mod_src,
+      std::map<std::string, std::string> &src_dbg_fmap)
       : mod_(mod),
         sections_(sections),
         fn_prefix_(fn_prefix),
-        mod_src_(mod_src) {}
+        mod_src_(mod_src),
+        src_dbg_fmap_(src_dbg_fmap) {}
 // Only support dump for llvm 6.x and later.
 //
 // The llvm 5.x, but not earlier versions, also supports create
@@ -40,7 +42,7 @@ class SourceDebugger {
   std::vector<std::string> buildLineCache();
   void dumpSrcLine(const std::vector<std::string> &LineCache,
                    const std::string &FileName, uint32_t Line,
-                   uint32_t &CurrentSrcLine);
+                   uint32_t &CurrentSrcLine, llvm::raw_ostream &os);
   void getDebugSections(
       llvm::StringMap<std::unique_ptr<llvm::MemoryBuffer>> &DebugSections);
 #else
@@ -53,6 +55,7 @@ class SourceDebugger {
   const std::map<std::string, std::tuple<uint8_t *, uintptr_t>> &sections_;
   const std::string &fn_prefix_;
   const std::string &mod_src_;
+  std::map<std::string, std::string> &src_dbg_fmap_;
 };
 
 }  // namespace ebpf

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -122,6 +122,7 @@ class BPFModule {
   std::map<llvm::Type *, std::string> writers_;
   std::string id_;
   std::string mod_src_;
+  std::map<std::string, std::string> src_dbg_fmap_;
   TableStorage *ts_;
   std::unique_ptr<TableStorage> local_ts_;
 };


### PR DESCRIPTION
Currently, for C++ API and for each func, the original src
and the rewritten source has been stored in
BCC_PROG_TAG_DIR directory. This patch allows the
source debug info (bytecode embedded by source code)
also stored in the same BCC_PROG_TAG_DIR directory.

This feature is not turned on by default now.
It requires non-zero (debug_flag & DEBUG_SOURCE).
The DEBUG_SOURCE enables "-g", with which a lot of more
llvm insns executed and it may increase application
RSS overhead by 4M (in my test).

As an example, if you modify examples/cpp/RandomRead.cc
to enable DEBUG_SOURCE, as below
-  bpf = new ebpf::BPF();
+  bpf = new ebpf::BPF(8);

After running the application, you can see:
-bash-4.3$ ls /var/tmp/bcc/bpf_prog_7f01346289a53cc3/
on_urandom_read.c  on_urandom_read.dis.txt  on_urandom_read.rewritten.c
-bash-4.3$ cat /var/tmp/bcc/bpf_prog_7f01346289a53cc3/on_urandom_read.dis.txt
; int on_urandom_read(struct urandom_read_args* attr) { // Line  23
   0:	bf 16 00 00 00 00 00 00 	r6 = r1
   1:	b7 01 00 00 00 00 00 00 	r1 = 0
; struct event_t event = {}; // Line  24
   2:	63 1a f8 ff 00 00 00 00 	*(u32 *)(r10 - 8) = r1
   3:	63 1a f4 ff 00 00 00 00 	*(u32 *)(r10 - 12) = r1
.....

Signed-off-by: Yonghong Song <yhs@fb.com>