### PR TITLE
bpf: rename helper function bpf_get_stackid

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -246,7 +246,7 @@ static int (*bpf_perf_event_output)(void *ctx, void *map, u64 index, void *data,
 static int (*bpf_skb_load_bytes)(void *ctx, int offset, void *to, u32 len) =
   (void *) BPF_FUNC_skb_load_bytes;
 
-/* bpf_get_stackid will return a negative value in the case of an error
+/* bcc_get_stackid will return a negative value in the case of an error
  *
  * BPF_STACK_TRACE(_name, _size) will allocate space for _size stack traces.
  *  -ENOMEM will be returned when this limit is reached.
@@ -257,11 +257,11 @@ static int (*bpf_skb_load_bytes)(void *ctx, int offset, void *to, u32 len) =
  * kernel context. Given this you can typically ignore -EFAULT errors when
  * retrieving user-space stack traces.
  */
-static int (*bpf_get_stackid_)(void *ctx, void *map, u64 flags) =
+static int (*bcc_get_stackid_)(void *ctx, void *map, u64 flags) =
   (void *) BPF_FUNC_get_stackid;
 static inline __attribute__((always_inline))
-int bpf_get_stackid(uintptr_t map, void *ctx, u64 flags) {
-  return bpf_get_stackid_(ctx, (void *)map, flags);
+int bcc_get_stackid(uintptr_t map, void *ctx, u64 flags) {
+  return bcc_get_stackid_(ctx, (void *)map, flags);
 }
 
 static int (*bpf_csum_diff)(void *from, u64 from_size, void *to, u64 to_size, u64 seed) =

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -363,7 +363,7 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           if (desc->second.type == BPF_MAP_TYPE_STACK_TRACE) {
             string arg0 =
                 rewriter_.getRewrittenText(expansionRange(Call->getArg(0)->getSourceRange()));
-            txt = "bpf_get_stackid(";
+            txt = "bcc_get_stackid(";
             txt += "bpf_pseudo_fd(1, " + fd + "), " + arg0;
             rewrite_end = Call->getArg(0)->getLocEnd();
             } else {


### PR DESCRIPTION
The function bpf_get_stackid is defined in helpers.h:
  int bpf_get_stackid(uintptr_t map, void *ctx, u64 flags)

But the same function is also defined in
linux:include/linux/bpf.h:
  u64 bpf_get_stackid(u64 r1, u64 r2, u64 r3, u64 r4, u64 r5);

If a bpf program also includes, directly or indirectly,
linux/bpf.h, compilation will fail because incompatible
definition.

This patch renames bcc helpers.h definition to
bcc_get_stackid to avoid this issue.

Signed-off-by: Yonghong Song <yhs@fb.com>