### PR TITLE
Fix exception handling in python3

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -527,7 +527,7 @@ class PerfEventArray(ArrayBase):
         def raw_cb_(_, data, size):
             try:
                 callback(cpu, data, size)
-            except IOError, e:
+            except IOError as e:
                 if e.errno == errno.EPIPE:
                     exit()
                 else:
@@ -535,7 +535,7 @@ class PerfEventArray(ArrayBase):
         def lost_cb_(lost):
             try:
                 lost_cb(lost)
-            except IOError, e:
+            except IOError as e:
                 if e.errno == errno.EPIPE:
                     exit()
                 else:


### PR DESCRIPTION
This patch fixes the following error when installing bcc from source:

Writing /usr/local/lib/python3.6/site-packages/bcc-0.4.0-py3.6.egg-info
  File "/usr/local/lib/python3.6/site-packages/bcc/table.py", line 530
    except IOError, e:
                  ^
SyntaxError: invalid syntax
