### PR TITLE
Add usdt support for ARM64

### DIFF
--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -32,7 +32,9 @@
 namespace USDT {
 
 Location::Location(uint64_t addr, const char *arg_fmt) : address_(addr) {
-#ifdef __powerpc64__
+#ifdef __aarch64__
+  ArgumentParser_aarch64 parser(arg_fmt);
+#elif __powerpc64__
   ArgumentParser_powerpc64 parser(arg_fmt);
 #else
   ArgumentParser_x64 parser(arg_fmt);

--- a/tests/cc/test_usdt_args.cc
+++ b/tests/cc/test_usdt_args.cc
@@ -54,7 +54,9 @@ static void verify_register(USDT::ArgumentParser &parser, int arg_size,
 
 TEST_CASE("test usdt argument parsing", "[usdt]") {
   SECTION("parse failure") {
-#ifdef __powerpc64__
+#ifdef __aarch64__
+    USDT::ArgumentParser_aarch64 parser("4@[x32,200]");
+#elif __powerpc64__
     USDT::ArgumentParser_powerpc64 parser("4@-12(42)");
 #elif defined(__x86_64__)
     USDT::ArgumentParser_x64 parser("4@i%ra+1r");
@@ -69,7 +71,13 @@ TEST_CASE("test usdt argument parsing", "[usdt]") {
     REQUIRE(i < 10);
   }
   SECTION("argument examples from the Python implementation") {
-#ifdef __powerpc64__
+#ifdef __aarch64__
+    USDT::ArgumentParser_aarch64 parser("-1@x0 4@5 8@[x12] -4@[x31,-40]");
+    verify_register(parser, -1, "regs[0]");
+    verify_register(parser, 4, 5);
+    verify_register(parser, 8, "regs[12]", 0);
+    verify_register(parser, -4, "regs[31]", -40);
+#elif __powerpc64__
     USDT::ArgumentParser_powerpc64 parser(
         "-4@0 8@%r0 8@i0 4@0(%r0) -2@0(0) "
         "1@0 -2@%r3 -8@i9 -1@0(%r4) -4@16(6) "

--- a/tests/python/include/folly/tracing/StaticTracepoint.h
+++ b/tests/python/include/folly/tracing/StaticTracepoint.h
@@ -16,9 +16,9 @@
 
 #pragma once
 
-#if defined(__ELF__) && \
-      (defined(__powerpc64__) || defined(__powerpc__) || \
-       defined(__x86_64__) || defined(__i386__))
+#if defined(__ELF__) &&                                                        \
+    (defined(__powerpc64__) || defined(__powerpc__) || defined(__aarch64__) || \
+     defined(__x86_64__) || defined(__i386__))
 #include <folly/tracing/StaticTracepoint-ELF.h>
 
 #define FOLLY_SDT(provider, name, ...)                                         \


### PR DESCRIPTION
Specifically the following argument patterns will be
supported:
```
   [-]<size>@<value>
   [-]<size>@<reg>
   [-]<size>@[<reg>]
   [-]<size>@[<reg>,<offset>]
```

I did not use std regex library as the old gcc (e.g. 4.8.5)
does not have a good support for it.

Signed-off-by: Yonghong Song <yhs@fb.com>