### PR TITLE
bpf: make test py_test_tools_smoke pass on arm64

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -566,6 +566,7 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #define PT_REGS_PARM4(ctx)	((ctx)->cx)
 #define PT_REGS_PARM5(ctx)	((ctx)->r8)
 #define PT_REGS_PARM6(ctx)	((ctx)->r9)
+#define PT_REGS_FP(ctx)         ((ctx)->bp) /* Works only with CONFIG_FRAME_POINTER */
 #define PT_REGS_RC(ctx)		((ctx)->ax)
 #define PT_REGS_IP(ctx)		((ctx)->ip)
 #define PT_REGS_SP(ctx)		((ctx)->sp)

--- a/tools/lib/ucalls.py
+++ b/tools/lib/ucalls.py
@@ -185,7 +185,7 @@ int trace_return(struct pt_regs *ctx) {
 #ifdef SYSCALLS
 int syscall_entry(struct pt_regs *ctx) {
     u64 pid = bpf_get_current_pid_tgid();
-    u64 *valp, ip = ctx->ip, val = 0;
+    u64 *valp, ip = PT_REGS_IP(ctx), val = 0;
     PID_FILTER
 #ifdef LATENCY
     struct syscall_entry_t data = {};

--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -14,6 +14,7 @@
 from bcc import BPF
 from time import sleep
 from datetime import datetime
+import resource
 import argparse
 import subprocess
 import os
@@ -366,6 +367,7 @@ if kernel_trace:
 
 bpf_source = bpf_source.replace("SHOULD_PRINT", "1" if trace_all else "0")
 bpf_source = bpf_source.replace("SAMPLE_EVERY_N", str(sample_every_n))
+bpf_source = bpf_source.replace("PAGE_SIZE", str(resource.getpagesize()))
 
 size_filter = ""
 if min_size is not None and max_size is not None:


### PR DESCRIPTION
Changes include:
  . Add PT_REGS_FP to access base(FP) register in x64
  . Use macros, intead of directly ctx-><reg_name>
    in a few places
  . Let userspace fill in the value of PAGE_SIZE.
    Otherwise, arm64 needs additional headers to
    get this value for kernel.
  . In tools/wakeuptime.py, arm64 and x86_64 have
    the same stack walker mechanism. But they
    have different symbol/macro to represent
    kernel start address.
With these changes, the test py_test_tools_smoke
can pass on arm64.

Signed-off-by: Yonghong Song <yhs@fb.com>