### PR TITLE
Handle unknown user in cachetop

### DIFF
--- a/tools/cachetop.py
+++ b/tools/cachetop.py
@@ -222,11 +222,20 @@ def handle_loop(stdscr, args):
         )
         (height, width) = stdscr.getmaxyx()
         for i, stat in enumerate(process_stats):
+            uid = int(stat[1])
+            try:
+                username = pwd.getpwuid(uid)[0]
+            except KeyError as ex:
+                # `pwd` throws a KeyError if the user cannot be found. This can
+                # happen e.g. when the process is running in a cgroup that has
+                # different users from the host.
+                username = 'UNKNOWN({})'.format(uid)
+
             stdscr.addstr(
                 i + 2, 0,
                 "{0:8} {username:8.8} {2:16} {3:8} {4:8} "
                 "{5:8} {6:9.1f}% {7:9.1f}%".format(
-                    *stat, username=pwd.getpwuid(int(stat[1]))[0]
+                    *stat, username=username
                 )
             )
             if i > height - 4:


### PR DESCRIPTION
If running on a system that uses cgroups the process owner uid may not exist on
the host system and `pwd.getpwuid` throws a KeyError.

This patch defaults to a uid of `UNKNOWN(id)` when we're unable to look up the
username.

...and I just noticed that columns are truncated to 8 characters meaning that the `id` won't be shown -- should I leave it like it is and wait for variable column width (if that's on the drawing board?), or would you prefer another format?