### PR TITLE
Fix Module display for unreadable Modules

### DIFF
--- a/src/cc/bcc_perf_map.c
+++ b/src/cc/bcc_perf_map.c
@@ -25,9 +25,11 @@
 bool bcc_is_perf_map(const char *path) {
   char* pos = strstr(path, ".map");
   // Path ends with ".map"
-  if (pos == NULL || *(pos + 4) != 0)
-    return false;
-  return access(path, R_OK) == 0;
+  return (pos != NULL) && (*(pos + 4)== 0);
+}
+
+bool bcc_is_valid_perf_map(const char *path) {
+  return bcc_is_perf_map(path) && (access(path, R_OK) == 0);
 }
 
 int bcc_perf_map_nstgid(int pid) {

--- a/src/cc/bcc_perf_map.h
+++ b/src/cc/bcc_perf_map.h
@@ -28,6 +28,7 @@ extern "C" {
 typedef int (*bcc_perf_map_symcb)(const char *, uint64_t, uint64_t, void *);
 
 bool bcc_is_perf_map(const char *path);
+bool bcc_is_valid_perf_map(const char *path);
 
 int bcc_perf_map_nstgid(int pid);
 bool bcc_perf_map_path(char *map_path, size_t map_len, int pid);

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -100,7 +100,6 @@ class ProcSyms : SymbolCache {
 
     Module(const char *name, ProcMountNS *mount_ns,
            struct bcc_symbol_option *option);
-    bool init();
 
     std::string name_;
     std::vector<Range> ranges_;


### PR DESCRIPTION
Currently when BCC symbolizing addresses, if it could not read the file backing up a memory module (due to deleted or any other reason), it won't add the module to `ProcSyms`. This might improve efficiency a little bit. However, due to this, we won't be able to report the module name correctly for addresses belong to these modules, which is often very useful when debugging why the stack trace contains `[unknown]`. This PR fixes the issue by always add module even if it's not readable.

Also, BCC would always add a module for the `perf-PID.map` with address range `(0, INT_MAX)`. This causes that we would always fall back to the perf map module in the end and not report the module name correctly. This PR also fixes the issue by correctly handle `perf-PID.map` and the saved module name.

I locally hacked `profile.py` to always display the module for testing.
Before:
```
    folly::FunctionScheduler::runOneFunction(std::unique_lock<std::mutex>&, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >) [test_bin]
    folly::FunctionScheduler::run() [test_bin]
    [unknown]
    [unknown]
    [unknown]
    -                servicedata-pub (2003)
        1
```
After:
```
    folly::EventBase::loopForever() [test_bin]
    folly::IOThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>) [test_bin]
    void folly::detail::function::FunctionTraits<void ()>::callBig<std::_Bind<std::_Mem_fn<void (folly::ThreadPoolExecutor::*)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)> (folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>)> >(folly::detail::function::Data&) [test_bin]
    [unknown] [libstdc++.so.6.0.21 (deleted)]
    [unknown] [libpthread-2.23.so (deleted)]
    [unknown] [libc-2.23.so (deleted)]
    -                IOThreadPool7 (2003)
        1
```