### PR TITLE
Unify DEBUG_BPF logging to be handled in libbpf

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -483,9 +483,8 @@ StatusTuple BPF::load_func(const std::string& func_name,
   fd = bpf_prog_load(type, func_name.c_str(),
                      reinterpret_cast<struct bpf_insn*>(func_start),
                      func_size, bpf_module_->license(),
-                     bpf_module_->kern_version(), nullptr,
-                     0  // BPFModule will handle error printing
-                    );
+                     bpf_module_->kern_version(),
+                     flag_ & DEBUG_BPF ? 1 : 0, nullptr, 0);
 
   if (fd < 0)
     return StatusTuple(-1, "Failed to load %s: %d", func_name.c_str(), fd);

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -46,7 +46,7 @@ public:
   static const int BPF_MAX_STACK_DEPTH = 127;
 
   explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr)
-      : bpf_module_(new BPFModule(flag, ts)) {}
+      : flag_(flag), bpf_module_(new BPFModule(flag, ts)) {}
   StatusTuple init(const std::string& bpf_program,
                    const std::vector<std::string>& cflags = {},
                    const std::vector<USDT>& usdt = {});
@@ -184,6 +184,8 @@ private:
                                   uint64_t symbol_addr,
                                   std::string &module_res,
                                   uint64_t &offset_res);
+
+  int flag_;
 
   std::unique_ptr<BPFModule> bpf_module_;
 

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -38,10 +38,27 @@ int bpf_delete_elem(int fd, void *key);
 int bpf_get_first_key(int fd, void *key, size_t key_size);
 int bpf_get_next_key(int fd, void *key, void *next_key);
 
+/*
+ * Load a BPF program, and return the FD of the loaded program.
+ *
+ * On newer Kernels, the parameter name is used to identify the loaded program
+ * for inspection and debugging. It could be different from the function name.
+ *
+ * If log_level has value greater than 0, or the load failed, it will enable
+ * extra logging of loaded BPF bytecode and register status, and will print the
+ * logging message to stderr. In such cases:
+ *   - If log_buf and log_buf_size are provided, it will use and also write the
+ *     log messages to the provided log_buf. If log_buf is insufficient in size,
+ *     it will not to any additional memory allocation.
+ *   - Otherwise, it will allocate an internal temporary buffer for log message
+ *     printing, and continue to attempt increase that allocated buffer size if
+ *     initial attemp was insufficient in size.
+ */
 int bpf_prog_load(enum bpf_prog_type prog_type, const char *name,
                   const struct bpf_insn *insns, int insn_len,
                   const char *license, unsigned kern_version,
-                  char *log_buf, unsigned log_buf_size);
+                  int log_level, char *log_buf, unsigned log_buf_size);
+
 int bpf_attach_socket(int sockfd, int progfd);
 
 /* create RAW socket and bind to interface 'name' */

--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -160,7 +160,8 @@ function Bpf:load_func(fn_name, prog_type)
     libbcc.bpf_function_start(self.module, fn_name),
     libbcc.bpf_function_size(self.module, fn_name),
     libbcc.bpf_module_license(self.module),
-    libbcc.bpf_module_kern_version(self.module), nil, 0)
+    libbcc.bpf_module_kern_version(self.module),
+    0, nil, 0)
 
   assert(fd >= 0, "failed to load BPF program "..fn_name)
   log.info("loaded %s (%d)", fn_name, fd)

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -32,7 +32,8 @@ int bpf_get_next_key(int fd, void *key, void *next_key);
 
 int bpf_prog_load(enum bpf_prog_type prog_type, const char *name,
   const struct bpf_insn *insns, int insn_len,
-  const char *license, unsigned kern_version, char *log_buf, unsigned log_buf_size);
+  const char *license, unsigned kern_version,
+  int log_level, char *log_buf, unsigned log_buf_size);
 int bpf_attach_socket(int sockfd, int progfd);
 
 /* create RAW socket and bind to interface 'name' */

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -84,7 +84,7 @@ lib.bpf_attach_socket.restype = ct.c_int
 lib.bpf_attach_socket.argtypes = [ct.c_int, ct.c_int]
 lib.bpf_prog_load.restype = ct.c_int
 lib.bpf_prog_load.argtypes = [ct.c_int, ct.c_char_p, ct.c_void_p,
-        ct.c_size_t, ct.c_char_p, ct.c_uint, ct.c_char_p, ct.c_uint]
+        ct.c_size_t, ct.c_char_p, ct.c_uint, ct.c_int, ct.c_char_p, ct.c_uint]
 lib.bpf_attach_kprobe.restype = ct.c_void_p
 _CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_int,
         ct.c_ulonglong, ct.POINTER(ct.c_ulonglong))


### PR DESCRIPTION
In BCC we have a few debug flags. Except for `DEBUG_BPF`, all other debug flags are handled at `ClangLoader` / Clang / LLVM layer.

`DEBUG_BPF` is for log message come from `BPF_PROG_LOAD` syscall, and it's current logic is a bit messy:
- `libbpf`'s `bpf_prog_load` enables this logging (`log_level = 1`) whenever non-empty `log_buf` is provided. On the other hand, the Python API always provide such buffer, causing unnecessary work when debug is not enabled.
- Python API has its own logic to print the message (only when `DEBUG_BPF` is enabled), and to incrementally double the size of the log buffer if the buffer size is insufficient.
- On the other hand, `libbpf`'s `bpf_prog_load` also has the logic to incrementally double the size of the log buffer if the buffer size is insufficient, but it only does it on error, and will print the log message along with some hints. However, it will not copy this buffer to user provided `log_buf` even if provided.
- C++ and Lua API doesn't have the logic to handle `DEBUG_BPF` flag, and if we want, we'll need to replicate the printing logic as Python does.

This PR tries to address these issues:
- Added a new `bpf_prog_load_flag` interface. Instead of `log_buf` and `log_buf_size`, it simply takes a `log_level` argument. When setting to 1, it would automatically create temporary log buffer, increase the size if not sufficient, and print the log message with hints. This way, Python / C++ / Lua / etc. APIs won't need to handle these logic separately, and only need to pass the `log_level` flag correctly. This behavior is more consistent with other debug flags such as `DEBUG_SOURCE`, etc.
- The original `bpf_prog_load` is a very commonly used interface and should not break for this non-critical feature change. So its been kept and behavior remain unchanged, except it will not do the auto-increment of log buffer anymore.

The new interface is applied in Python, C++ and Lua API, and it worked well when tested with different debug flag options.