### PR TITLE
Add flag to enable verifier log_level 2

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -480,11 +480,17 @@ StatusTuple BPF::load_func(const std::string& func_name,
                        func_name.c_str());
   size_t func_size = bpf_module_->function_size(func_name);
 
+  int log_level = 0;
+  if (flag_ & DEBUG_BPF_REGISTER_STATE)
+    log_level = 2;
+  else if (flag_ & DEBUG_BPF)
+    log_level = 1;
+
   fd = bpf_prog_load(type, func_name.c_str(),
                      reinterpret_cast<struct bpf_insn*>(func_start),
                      func_size, bpf_module_->license(),
                      bpf_module_->kern_version(),
-                     flag_ & DEBUG_BPF ? 1 : 0, nullptr, 0);
+                     log_level, nullptr, 0);
 
   if (fd < 0)
     return StatusTuple(-1, "Failed to load %s: %d", func_name.c_str(), fd);

--- a/src/cc/common.h
+++ b/src/cc/common.h
@@ -25,10 +25,16 @@ namespace ebpf {
 
 // debug flags
 enum {
+  // Debug output compiled LLVM IR.
   DEBUG_LLVM_IR = 0x1,
+  // Debug output loaded BPF bytecode and register state on branches.
   DEBUG_BPF = 0x2,
+  // Debug output pre-processor result.
   DEBUG_PREPROCESSOR = 0x4,
-  DEBUG_SOURCE = 0x8
+  // Debug output ASM instructions embedded with source.
+  DEBUG_SOURCE = 0x8,
+  // Debug output register state on all instructions in addition to DEBUG_BPF.
+  DEBUG_BPF_REGISTER_STATE = 0x16,
 };
 
 template <class T, class... Args>


### PR DESCRIPTION
Current `DEBUG_BPF` flag only enables register state information on branch. Add an option to enable verifier `log_level` 2 that would have register state on every instruction, which should be helpful for some debugging.

On top of #1433 