### PR TITLE
Move BCC debug options to a installed header file

### DIFF
--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -33,6 +33,21 @@ class Type;
 }
 
 namespace ebpf {
+
+// Options to enable different debug logging.
+enum {
+  // Debug output compiled LLVM IR.
+  DEBUG_LLVM_IR = 0x1,
+  // Debug output loaded BPF bytecode and register state on branches.
+  DEBUG_BPF = 0x2,
+  // Debug output pre-processor result.
+  DEBUG_PREPROCESSOR = 0x4,
+  // Debug output ASM instructions embedded with source.
+  DEBUG_SOURCE = 0x8,
+  // Debug output register state on all instructions in addition to DEBUG_BPF.
+  DEBUG_BPF_REGISTER_STATE = 0x10,
+};
+
 class TableDesc;
 class TableStorage;
 class BLoader;

--- a/src/cc/common.h
+++ b/src/cc/common.h
@@ -23,20 +23,6 @@
 
 namespace ebpf {
 
-// debug flags
-enum {
-  // Debug output compiled LLVM IR.
-  DEBUG_LLVM_IR = 0x1,
-  // Debug output loaded BPF bytecode and register state on branches.
-  DEBUG_BPF = 0x2,
-  // Debug output pre-processor result.
-  DEBUG_PREPROCESSOR = 0x4,
-  // Debug output ASM instructions embedded with source.
-  DEBUG_SOURCE = 0x8,
-  // Debug output register state on all instructions in addition to DEBUG_BPF.
-  DEBUG_BPF_REGISTER_STATE = 0x16,
-};
-
 template <class T, class... Args>
 typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type
 make_unique(Args &&... args) {

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -26,8 +26,9 @@
 #include <clang/Rewrite/Core/Rewriter.h>
 
 #include "b_frontend_action.h"
-#include "loader.h"
+#include "bpf_module.h"
 #include "common.h"
+#include "loader.h"
 #include "table_storage.h"
 
 #include "libbpf.h"

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -49,8 +49,8 @@
 
 #include <llvm/IR/Module.h>
 
-#include "common.h"
 #include "bcc_exception.h"
+#include "bpf_module.h"
 #include "exported_files.h"
 #include "kbuild_helper.h"
 #include "b_frontend_action.h"

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -50,7 +50,7 @@ DEBUG_PREPROCESSOR = 0x4
 # Debug output ASM instructions embedded with source.
 DEBUG_SOURCE = 0x8
 #Debug output register state on all instructions in addition to DEBUG_BPF.
-DEBUG_BPF_REGISTER_STATE = 0x16
+DEBUG_BPF_REGISTER_STATE = 0x10
 
 class SymbolCache(object):
     def __init__(self, pid):


### PR DESCRIPTION
Currently BCC debug options are defined in `common.h`, which is not an installed header. Thus, if user want to use those options, they'll need to inspect the code and manually pass the integer value to `BPF` or `BPFModule` constructor.

This commit moves the options to `bpf_module.h` which is installed. Also fix the silly mistake I made  in #1436 that `DEBUG_BPF_REGISTER_STATE` was defined to be `0x16` rather than just `16` (`0x10`).