### PR TITLE
use user-provided log_level in bpf_prog_load

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -448,7 +448,8 @@ int bpf_prog_load(enum bpf_prog_type prog_type, const char *name,
     if (tmp_log_buf)
       free(tmp_log_buf);
     tmp_log_buf_size = LOG_BUF_SIZE;
-    attr.log_level = 1;
+    if (attr.log_level == 0)
+      attr.log_level = 1;
     for (;;) {
       tmp_log_buf = malloc(tmp_log_buf_size);
       if (!tmp_log_buf) {


### PR DESCRIPTION
For the case where user provided a log buffer, the
user provided log_level is already been used.

For the case where user provided a log_level and bcc
needs to allocate buffer, the log_level is fixed to 1.
Use user provided log level instead.

Signed-off-by: Yonghong Song <yhs@fb.com>