### PR TITLE
libbpf: Enable the creation of unbound raw socket

### DIFF
--- a/examples/networking/dns_matching/dns_matching.py
+++ b/examples/networking/dns_matching/dns_matching.py
@@ -39,9 +39,10 @@ def add_cache_entry(cache, name):
 parser = argparse.ArgumentParser(usage='For detailed information about usage,\
  try with -h option')
 req_args = parser.add_argument_group("Required arguments")
-req_args.add_argument("-i", "--interface", type=str, required=True, help="Interface name")
+req_args.add_argument("-i", "--interface", type=str, default="",
+                      help="Interface name, defaults to all if unspecified.")
 req_args.add_argument("-d", "--domains", type=str, required=True, nargs="+",
-    help='List of domain names separated by space. For example: -d "abc.def xyz.mno"')
+    help='List of domain names separated by space. For example: -d abc.def xyz.mno')
 args = parser.parse_args()
 
 # initialize BPF - load source code from http-parse-simple.c

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -500,6 +500,10 @@ int bpf_open_raw_sock(const char *name)
     return -1;
   }
 
+  /* Do not bind on empty interface names */
+  if (!name || *name == '\0')
+    return sock;
+
   memset(&sll, 0, sizeof(sll));
   sll.sll_family = AF_PACKET;
   sll.sll_ifindex = if_nametoindex(name);

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -61,7 +61,8 @@ int bpf_prog_load(enum bpf_prog_type prog_type, const char *name,
 
 int bpf_attach_socket(int sockfd, int progfd);
 
-/* create RAW socket and bind to interface 'name' */
+/* create RAW socket. If name is not NULL/a non-empty null-terminated string,
+ * bind the raw socket to the interface 'name' */
 int bpf_open_raw_sock(const char *name);
 
 typedef void (*perf_reader_cb)(void *cb_cookie, int pid, uint64_t callchain_num,


### PR DESCRIPTION
By checking for a NULL or empty char string in bpf_open_raw_sock(), we can detect whether
we should try to bind on an interface or not.
The dns_matching example has been updated to illustrate this behavior.