### PR TITLE
force linking the whole api-static library into shared library

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -57,24 +57,30 @@ include(clang_libs)
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${clang_lib_exclude_flags}")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${llvm_lib_exclude_flags}")
 
-set(bcc_common_libs b_frontend clang_frontend bpf-static
+# bcc_common_libs_for_a for archive libraries
+# bcc_common_libs_for_s for shared libraries
+set(bcc_common_libs_for_a b_frontend clang_frontend bpf-static
   ${clang_libs} ${llvm_libs} ${LIBELF_LIBRARIES})
+set(bcc_common_libs_for_s ${bcc_common_libs_for_a})
 
 if(ENABLE_CPP_API)
   add_subdirectory(api)
-  list(APPEND bcc_common_libs api-static)
+  list(APPEND bcc_common_libs_for_a api-static)
+  # Keep all API functions
+  list(APPEND bcc_common_libs_for_s -Wl,--whole-archive api-static -Wl,--no-whole-archive)
 endif()
 
 if(ENABLE_USDT)
   add_subdirectory(usdt)
-  list(APPEND bcc_common_libs usdt-static)
+  list(APPEND bcc_common_libs_for_a usdt-static)
+  list(APPEND bcc_common_libs_for_s usdt-static)
 endif()
 
 add_subdirectory(frontends)
 
 # Link against LLVM libraries
-target_link_libraries(bcc-shared ${bcc_common_libs})
-target_link_libraries(bcc-static ${bcc_common_libs} bcc-loader-static)
+target_link_libraries(bcc-shared ${bcc_common_libs_for_s})
+target_link_libraries(bcc-static ${bcc_common_libs_for_a} bcc-loader-static)
 
 install(TARGETS bcc-shared LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${bcc_table_headers} DESTINATION include/bcc)


### PR DESCRIPTION
When a static library is linked to produce a shared library,
only referenced symbols in the static library eventually
gets linked.

api-static library has entry points for C++ API.
Many symbols in this library do not have references
outside of this library and will get dropped during
linking process.

This patch forces the linking of the whole api-static
library in order to procude bcc shared library.

Reported-by: Mauricio Vasquez <mauricio.vasquez@polito.it>
Signed-off-by: Yonghong Song <yhs@fb.com>