### PR TITLE
Do not keep Loader instances around

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -101,6 +101,7 @@ class MyMemoryManager : public SectionMemoryManager {
 
 BPFModule::BPFModule(unsigned flags, TableStorage *ts)
     : flags_(flags),
+      used_b_loader_(false),
       ctx_(new LLVMContext),
       id_(std::to_string((uintptr_t)this)),
       ts_(ts) {
@@ -464,9 +465,9 @@ unique_ptr<ExecutionEngine> BPFModule::finalize_rw(unique_ptr<Module> m) {
 
 // load an entire c file as a module
 int BPFModule::load_cfile(const string &file, bool in_memory, const char *cflags[], int ncflags) {
-  clang_loader_ = ebpf::make_unique<ClangLoader>(&*ctx_, flags_);
-  if (clang_loader_->parse(&mod_, *ts_, file, in_memory, cflags, ncflags, id_,
-                           *func_src_, mod_src_))
+  ClangLoader clang_loader(&*ctx_, flags_);
+  if (clang_loader.parse(&mod_, *ts_, file, in_memory, cflags, ncflags, id_,
+                         *func_src_, mod_src_))
     return -1;
   return 0;
 }
@@ -477,9 +478,9 @@ int BPFModule::load_cfile(const string &file, bool in_memory, const char *cflags
 // Load in a pre-built list of functions into the initial Module object, then
 // build an ExecutionEngine.
 int BPFModule::load_includes(const string &text) {
-  clang_loader_ = ebpf::make_unique<ClangLoader>(&*ctx_, flags_);
-  if (clang_loader_->parse(&mod_, *ts_, text, true, nullptr, 0, "", *func_src_,
-                           mod_src_))
+  ClangLoader clang_loader(&*ctx_, flags_);
+  if (clang_loader.parse(&mod_, *ts_, text, true, nullptr, 0, "", *func_src_,
+                         mod_src_))
     return -1;
   return 0;
 }
@@ -816,7 +817,7 @@ const char * BPFModule::table_name(size_t id) const {
 }
 
 const char * BPFModule::table_key_desc(size_t id) const {
-  if (b_loader_) return nullptr;
+  if (used_b_loader_) return nullptr;
   if (id >= tables_.size())
     return nullptr;
   return tables_[id]->key_desc.c_str();
@@ -827,7 +828,7 @@ const char * BPFModule::table_key_desc(const string &name) const {
 }
 
 const char * BPFModule::table_leaf_desc(size_t id) const {
-  if (b_loader_) return nullptr;
+  if (used_b_loader_) return nullptr;
   if (id >= tables_.size())
     return nullptr;
   return tables_[id]->leaf_desc.c_str();
@@ -932,8 +933,9 @@ int BPFModule::load_b(const string &filename, const string &proto_filename) {
   if (int rc = load_includes(helpers_h->second))
     return rc;
 
-  b_loader_.reset(new BLoader(flags_));
-  if (int rc = b_loader_->parse(&*mod_, filename, proto_filename, *ts_, id_))
+  BLoader b_loader(flags_);
+  used_b_loader_ = true;
+  if (int rc = b_loader.parse(&*mod_, filename, proto_filename, *ts_, id_))
     return rc;
   if (int rc = annotate())
     return rc;

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -120,14 +120,13 @@ class BPFModule {
 
  private:
   unsigned flags_;  // 0x1 for printing
+  bool used_b_loader_;
   std::string filename_;
   std::string proto_filename_;
   std::unique_ptr<llvm::LLVMContext> ctx_;
   std::unique_ptr<llvm::ExecutionEngine> engine_;
   std::unique_ptr<llvm::ExecutionEngine> rw_engine_;
   std::unique_ptr<llvm::Module> mod_;
-  std::unique_ptr<BLoader> b_loader_;
-  std::unique_ptr<ClangLoader> clang_loader_;
   std::unique_ptr<FuncSource> func_src_;
   std::map<std::string, std::tuple<uint8_t *, uintptr_t>> sections_;
   std::vector<TableDesc *> tables_;

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -64,15 +64,11 @@ using std::vector;
 
 namespace ebpf {
 
-map<string, unique_ptr<llvm::MemoryBuffer>> ClangLoader::remapped_files_;
-
 ClangLoader::ClangLoader(llvm::LLVMContext *ctx, unsigned flags)
     : ctx_(ctx), flags_(flags)
 {
-  if (remapped_files_.empty()) {
-    for (auto f : ExportedFiles::headers())
-      remapped_files_[f.first] = llvm::MemoryBuffer::getMemBuffer(f.second);
-  }
+  for (auto f : ExportedFiles::headers())
+    remapped_files_[f.first] = llvm::MemoryBuffer::getMemBuffer(f.second);
 }
 
 ClangLoader::~ClangLoader() {}

--- a/src/cc/frontends/clang/loader.h
+++ b/src/cc/frontends/clang/loader.h
@@ -66,7 +66,7 @@ class ClangLoader {
                  std::string &mod_src, bool use_internal_bpfh);
 
  private:
-  static std::map<std::string, std::unique_ptr<llvm::MemoryBuffer>> remapped_files_;
+  std::map<std::string, std::unique_ptr<llvm::MemoryBuffer>> remapped_files_;
   llvm::LLVMContext *ctx_;
   unsigned flags_;
 };


### PR DESCRIPTION
After we finish loading the BPF program, we don't need to keep the `ClangLoader` instance around. This commit removes it from `BPFModule`.
Also, for the header files included with `ClangLoader`, have it destruct with the class instance instead of keeping around as static map.