### PR TITLE
python: make _decode_table_types aware of __int128

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -378,7 +378,9 @@ class BPF(object):
         u"unsigned long long": ct.c_ulonglong,
         u"float": ct.c_float,
         u"double": ct.c_double,
-        u"long double": ct.c_longdouble
+        u"long double": ct.c_longdouble,
+        u"__int128": ct.c_int64 * 2,
+        u"unsigned __int128": ct.c_uint64 * 2,
     }
     @staticmethod
     def _decode_table_type(desc):

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -7,6 +7,8 @@ import ctypes as ct
 from unittest import main, skipUnless, TestCase
 import os
 import sys
+import socket
+import struct
 from contextlib import contextmanager
 import distutils.version
 
@@ -439,7 +441,7 @@ int process(struct xdp_md *ctx) {
         """
         b = BPF(text=text)
         t = b["jmp"]
-        self.assertEquals(len(t), 32);
+        self.assertEqual(len(t), 32);
 
     def test_update_macro_arg(self):
         text = """
@@ -459,7 +461,7 @@ int process(struct xdp_md *ctx) {
         """
         b = BPF(text=text)
         t = b["act"]
-        self.assertEquals(len(t), 32);
+        self.assertEqual(len(t), 32);
 
     def test_ext_ptr_maps(self):
         bpf_text = """
@@ -653,6 +655,25 @@ struct a {
 BPF_HASH(drops, struct a);
         """
         b = BPF(text=text)
+
+    def test_int128_types(self):
+        text = """
+BPF_HASH(table1, unsigned __int128, __int128);
+"""
+        b = BPF(text=text)
+        table = b['table1']
+        self.assertEqual(ct.sizeof(table.Key), 16)
+        self.assertEqual(ct.sizeof(table.Leaf), 16)
+        table[
+            table.Key.from_buffer_copy(
+                socket.inet_pton(socket.AF_INET6, "2001:db8::"))
+        ] = table.Leaf.from_buffer_copy(struct.pack('LL', 42, 123456789))
+        for k, v in table.items():
+            self.assertEqual(v[0], 42)
+            self.assertEqual(v[1], 123456789)
+            self.assertEqual(socket.inet_ntop(socket.AF_INET6,
+                                              struct.pack('LL', k[0], k[1])),
+                             "2001:db8::")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There are no ctypes types ready for int128. However, recognizing this
type and representing it as an array is better than simply erroring out.

Triggering such crash can easily be reproduced in current tools if one
tries to access the shared maps from python, for example, accessing 
`b["tuplepid_ipv6"]` in [tcptracer](https://github.com/iovisor/bcc/blob/master/tools/tcptracer.py) right before the final
loop crashes with:
```
Tracing TCP established connections. Ctrl-C to end.
T  PID    COMM             IP SADDR            DADDR            SPORT  DPORT
Traceback (most recent call last):
  File "/usr/share/bcc/tools/tcptracer", line 666, in <module>
    b["tuplepid_ipv6"]
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 437, in __getitem__
    self.tables[key] = self.get_table(key)
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 427, in get_table
    keytype = BPF._decode_table_type(json.loads(key_desc.decode()))
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 391, in _decode_table_type
    fields.append((t[0], BPF._decode_table_type(t[1])))
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 386, in _decode_table_type
    return BPF.str2ctype[desc]
KeyError: 'unsigned __int128'
```

The commit:
* Adds mappings between (unsigned) __int128 C types declaration and ctypes
  parsing
* Adds a simple test case in test_clang to recognize and use such types
* Fixes deprecation warnings about self.assertEquals in 2 other test
  cases.