### PR TITLE
python: Avoid unnecessary pointer object creations

### DIFF
--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -89,7 +89,7 @@ class USDTProbeLocation(object):
     def get_argument(self, index):
         arg = bcc_usdt_argument()
         res = lib.bcc_usdt_get_argument(self.probe.context, self.probe.name,
-                                        self.index, index, ct.pointer(arg))
+                                        self.index, index, ct.byref(arg))
         if res != 0:
             raise USDTException(
                     "error retrieving probe argument %d location %d" %
@@ -116,7 +116,7 @@ class USDTProbe(object):
     def get_location(self, index):
         loc = bcc_usdt_location()
         res = lib.bcc_usdt_get_location(self.context, self.name,
-                                        index, ct.pointer(loc))
+                                        index, ct.byref(loc))
         if res != 0:
             raise USDTException("error retrieving probe location %d" % index)
         return USDTProbeLocation(self, index, loc)


### PR DESCRIPTION
Use ctypes.byref() instead of ctypes.pointer() in cases where we do not
need the actual pointer object itself as it is much lighter.

Quoting the [ctypes documentation §15.17.1.9](https://docs.python.org/2/library/ctypes.html#passing-pointers-or-passing-parameters-by-reference):
> ctypes exports the byref() function which is used to pass parameters by reference. The same effect can be achieved with the pointer() function, although pointer() does a lot more work since it constructs a real pointer object, so it is faster to use byref() if you don’t need the pointer object in Python itself: