### PR TITLE
cross-compiling: link against target's codegen library

### DIFF
--- a/cmake/clang_libs.cmake
+++ b/cmake/clang_libs.cmake
@@ -1,5 +1,5 @@
 set(llvm_raw_libs bitwriter bpfcodegen debuginfodwarf irreader linker
-  mcjit objcarcopts option passes nativecodegen lto)
+  mcjit objcarcopts option passes codegen lto)
 list(FIND LLVM_AVAILABLE_LIBS "LLVMCoverage" _llvm_coverage)
 if (${_llvm_coverage} GREATER -1)
   list(APPEND llvm_raw_libs coverage)


### PR DESCRIPTION
Trying to link in host's codegen lib instead of target's codegen lib
causes failure during linking stage when cross-compiling:

  aarch64-poky-linux/5.3.0/ld: cannot find -lLLVMX86CodeGen

Signed-off-by: S. Lockwood-Childs <sjl@vctlabs.com>