### PR TITLE
provide padded structure for table_{key|leaf}_desc API

### DIFF
--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -675,6 +675,28 @@ BPF_HASH(table1, unsigned __int128, __int128);
                                               struct.pack('LL', k[0], k[1])),
                              "2001:db8::")
 
+    def test_padding_types(self):
+        text = """
+struct key_t {
+  u32 f1_1;               /* offset 0 */
+  struct {
+    char f2_1;            /* offset 16 */
+    __int128 f2_2;        /* offset 32 */
+  };
+  u8 f1_3;                /* offset 48 */
+  unsigned __int128 f1_4; /* offset 64 */
+};
+struct value_t {
+  u8 src[4] __attribute__ ((aligned (8))); /* offset 0 */
+  u8 dst[4] __attribute__ ((aligned (8))); /* offset 8 */
+};
+BPF_HASH(table1, struct key_t, struct value_t);
+"""
+        b = BPF(text=text)
+        table = b['table1']
+        self.assertEqual(ct.sizeof(table.Key), 80)
+        self.assertEqual(ct.sizeof(table.Leaf), 12)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This patch intends to fix issue #606.

Currently, the key/value type information is passed from
C++ to Python through a JSON interface. The JSON is
constructed by traversing the struct/field's through clang
AST interface. Once Python gets the JSON, it will
reconstruct the C structure through ctype module.

There are two known issues where Python reconstructed
C structure may not be the same as the original C structure:
  . if user explicitly use "__attribute__ ((align))" to alter
    field alignment and such information is not passed to
    Python.
  . the "__int128" type is a u64[2] array in python.
    So in C, __int128 needs to align on 16 bytes boundary, and
    in Python, it aligns with 8 bytes boundary.

To solve this issue, this patch provided the structure
with added padding fields to Python. For example,
  struct {
    char a;
    __int128 b;
  };
Python will receive
  struct {
    char a;
    char __pad_1[15];
    __int128 b;
  };

Signed-off-by: Yonghong Song <yhs@fb.com>