### PR TITLE
execsnoop: fix the prototype for kprobe__sys_execve

### DIFF
--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -88,7 +88,8 @@ static int submit_arg(struct pt_regs *ctx, void *ptr, struct data_t *data)
     return 0;
 }
 
-int kprobe__sys_execve(struct pt_regs *ctx, struct filename *filename,
+int kprobe__sys_execve(struct pt_regs *ctx,
+    const char __user *filename,
     const char __user *const __user *__argv,
     const char __user *const __user *__envp)
 {


### PR DESCRIPTION
For sys_execve() the type of filename parameter should be
"const char __user *" instead of "struct filename *".

The fix doesn't imply any functional change.