### PR TITLE
add padding to the end of structure

### DIFF
--- a/src/cc/json_map_decl_visitor.cc
+++ b/src/cc/json_map_decl_visitor.cc
@@ -145,6 +145,13 @@ bool BMapDeclVisitor::VisitRecordDecl(RecordDecl *D) {
       Offset = FieldOffset + FieldSize;
       genJSONForField(F);
     }
+
+    /* Additional Padding after the last field so that the Record Size matches */
+    CharUnits RecordSize = Layout.getSize();
+    if (RecordSize > Offset) {
+        result_ += "[\"__pad_end\",\"char\",["
+                + to_string((RecordSize - Offset).getQuantity()) + "]], ";
+    }
   }
 
   if (!D->getDefinition()->field_empty())

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -685,6 +685,7 @@ struct key_t {
   };
   u8 f1_3;                /* offset 48 */
   unsigned __int128 f1_4; /* offset 64 */
+  char f1_5;              /* offset 80 */
 };
 struct value_t {
   u8 src[4] __attribute__ ((aligned (8))); /* offset 0 */
@@ -694,8 +695,8 @@ BPF_HASH(table1, struct key_t, struct value_t);
 """
         b = BPF(text=text)
         table = b['table1']
-        self.assertEqual(ct.sizeof(table.Key), 80)
-        self.assertEqual(ct.sizeof(table.Leaf), 12)
+        self.assertEqual(ct.sizeof(table.Key), 96)
+        self.assertEqual(ct.sizeof(table.Leaf), 16)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Commit 538a84e1f821a ("provide padded structure for
table_{key|leaf}_desc API") added explicit padding, if needed,
before every structure member.

This is not enough as if an array of elements are returned
from C++ to python side, the size of structure must be correct.

This patch also adds padding after the last structure field
to make structure size in python side consistent with C++
side. With this patch, I experimented with the pull request
for tcpretrans.py by Matthias Tafelmeier, the type
  struct ipv6_flow_key_t {
      unsigned __int128 saddr;
      unsigned __int128 daddr;
      u64 lport;
      u64 dport;
  }
can be replaced with
  struct ipv6_flow_key_t {
      unsigned __int128 saddr;
      unsigned __int128 daddr;
      u16 lport;
      u16 dport;
  }
where the original type of lport/dport is u16.
Some other ipv6 related data structures can also be simplified.

Signed-off-by: Yonghong Song <yhs@fb.com>