### PR TITLE
Add C++ helper to clear BPF tables

### DIFF
--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -106,6 +106,12 @@ BPFStackTable::~BPFStackTable() {
     bcc_free_symcache(it.second, it.first);
 }
 
+void BPFStackTable::clear_table_non_atomic() {
+  for (int i = 0; i < capacity(); i++) {
+    remove(&i);
+  }
+}
+
 std::vector<uintptr_t> BPFStackTable::get_stack_addr(int stack_id) {
   std::vector<uintptr_t> res;
   stacktrace_t stack;

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -196,6 +196,20 @@ class BPFHashTable : public BPFTableBase<KeyType, ValueType> {
 
     return res;
   }
+
+  StatusTuple clear_table_non_atomic() {
+    KeyType cur;
+    if (!this->first(&cur))
+      return StatusTuple(0);
+
+    while (true) {
+      TRY2(remove_value(cur));
+      if (!this->next(&cur, &cur))
+        break;
+    }
+
+    return StatusTuple(0);
+  }
 };
 
 // From src/cc/export/helpers.h
@@ -211,6 +225,7 @@ class BPFStackTable : public BPFTableBase<int, stacktrace_t> {
                 bool check_debug_file_crc);
   ~BPFStackTable();
 
+  void clear_table_non_atomic();
   std::vector<uintptr_t> get_stack_addr(int stack_id);
   std::vector<std::string> get_stack_symbol(int stack_id, int pid);
 


### PR DESCRIPTION
In production we often want to clear BPF tables during continuous profiling.

To make the use case easier, this PR adds a wrapped helper that iterates through Hash and Stack tables and clear all values.

This PR also adds some test for C++ API's Hash and Stack table, for both existing and this new feature.