### PR TITLE
ucalls: convert bytes to str

### DIFF
--- a/tools/lib/ucalls.py
+++ b/tools/lib/ucalls.py
@@ -255,11 +255,13 @@ if args.syscalls:
 def get_data():
     # Will be empty when no language was specified for tracing
     if args.latency:
-        data = list(map(lambda kv: (kv[0].clazz + "." + kv[0].method,
+        data = list(map(lambda kv: (kv[0].clazz.decode() + "." + \
+                                    kv[0].method.decode(),
                                    (kv[1].num_calls, kv[1].total_ns)),
                    bpf["times"].items()))
     else:
-        data = list(map(lambda kv: (kv[0].clazz + "." + kv[0].method,
+        data = list(map(lambda kv: (kv[0].clazz.decode() + "." + \
+                                    kv[0].method.decode(),
                                    (kv[1].value, 0)),
                    bpf["counts"].items()))
 


### PR DESCRIPTION
This fixes the following error with python3

Tracing calls in process 2577 (language: python)... Ctrl-C to quit.
^C
Traceback (most recent call last):
  File "/usr/share/bcc/tools/lib/ucalls", line 303, in <module>
    data = get_data()   # [(function, (num calls, latency in ns))]
  File "/usr/share/bcc/tools/lib/ucalls", line 264, in get_data
    bpf["counts"].items()))
  File "/usr/share/bcc/tools/lib/ucalls", line 262, in <lambda>
    data = list(map(lambda kv: (kv[0].clazz + "." + kv[0].method,
TypeError: can't concat str to bytes

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>