### PR TITLE
Clean-up unused parameter in tracing APIs

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -172,7 +172,7 @@ StatusTuple BPF::attach_kprobe(const std::string& kernel_func,
 
   void* res =
       bpf_attach_kprobe(probe_fd, attach_type, probe_event.c_str(), kernel_func.c_str(),
-                        pid, cpu, group_fd, cb, cb_cookie);
+                        cb, cb_cookie);
 
   if (!res) {
     TRY2(unload_func(probe_func));
@@ -208,7 +208,7 @@ StatusTuple BPF::attach_uprobe(const std::string& binary_path,
 
   void* res =
       bpf_attach_uprobe(probe_fd, attach_type, probe_event.c_str(), binary_path.c_str(),
-                        offset, pid, cpu, group_fd, cb, cb_cookie);
+                        offset, pid, cb, cb_cookie);
 
   if (!res) {
     TRY2(unload_func(probe_func));
@@ -275,8 +275,8 @@ StatusTuple BPF::attach_tracepoint(const std::string& tracepoint,
   TRY2(load_func(probe_func, BPF_PROG_TYPE_TRACEPOINT, probe_fd));
 
   void* res =
-      bpf_attach_tracepoint(probe_fd, tp_category.c_str(), tp_name.c_str(), pid,
-                            cpu, group_fd, cb, cb_cookie);
+      bpf_attach_tracepoint(probe_fd, tp_category.c_str(), tp_name.c_str(), cb,
+                            cb_cookie);
 
   if (!res) {
     TRY2(unload_func(probe_func));

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -42,7 +42,7 @@ struct open_probe_t {
 class USDT;
 
 class BPF {
-public:
+ public:
   static const int BPF_MAX_STACK_DEPTH = 127;
 
   explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr)
@@ -54,33 +54,31 @@ public:
   ~BPF();
   StatusTuple detach_all();
 
-  StatusTuple attach_kprobe(
-      const std::string& kernel_func, const std::string& probe_func,
-      bpf_probe_attach_type = BPF_PROBE_ENTRY,
-      pid_t pid = -1, int cpu = 0, int group_fd = -1,
-      perf_reader_cb cb = nullptr, void* cb_cookie = nullptr);
+  StatusTuple attach_kprobe(const std::string& kernel_func,
+                            const std::string& probe_func,
+                            bpf_probe_attach_type = BPF_PROBE_ENTRY,
+                            perf_reader_cb cb = nullptr,
+                            void* cb_cookie = nullptr);
   StatusTuple detach_kprobe(
       const std::string& kernel_func,
       bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY);
 
-  StatusTuple attach_uprobe(
-      const std::string& binary_path, const std::string& symbol,
-      const std::string& probe_func, uint64_t symbol_addr = 0,
-      bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY,
-      pid_t pid = -1, int cpu = 0, int group_fd = -1,
-      perf_reader_cb cb = nullptr, void* cb_cookie = nullptr);
-  StatusTuple detach_uprobe(
-      const std::string& binary_path, const std::string& symbol,
-      uint64_t symbol_addr = 0,
-      bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY,
-      pid_t pid = -1);
-  StatusTuple attach_usdt(const USDT& usdt, pid_t pid = -1, int cpu = 0,
-                          int group_fd = -1);
+  StatusTuple attach_uprobe(const std::string& binary_path,
+                            const std::string& symbol,
+                            const std::string& probe_func,
+                            uint64_t symbol_addr = 0,
+                            bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY,
+                            pid_t pid = -1, perf_reader_cb cb = nullptr,
+                            void* cb_cookie = nullptr);
+  StatusTuple detach_uprobe(const std::string& binary_path,
+                            const std::string& symbol, uint64_t symbol_addr = 0,
+                            bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY,
+                            pid_t pid = -1);
+  StatusTuple attach_usdt(const USDT& usdt, pid_t pid = -1);
   StatusTuple detach_usdt(const USDT& usdt);
 
   StatusTuple attach_tracepoint(const std::string& tracepoint,
                                 const std::string& probe_func,
-                                pid_t pid = -1, int cpu = 0, int group_fd = -1,
                                 perf_reader_cb cb = nullptr,
                                 void* cb_cookie = nullptr);
   StatusTuple detach_tracepoint(const std::string& tracepoint);
@@ -121,14 +119,12 @@ public:
                                 bool use_debug_file = true,
                                 bool check_debug_file_crc = true);
 
-  StatusTuple open_perf_event(const std::string& name,
-                              uint32_t type,
+  StatusTuple open_perf_event(const std::string& name, uint32_t type,
                               uint64_t config);
 
   StatusTuple close_perf_event(const std::string& name);
 
-  StatusTuple open_perf_buffer(const std::string& name,
-                               perf_reader_raw_cb cb,
+  StatusTuple open_perf_buffer(const std::string& name, perf_reader_raw_cb cb,
                                perf_reader_lost_cb lost_cb = nullptr,
                                void* cb_cookie = nullptr,
                                int page_cnt = DEFAULT_PERF_BUFFER_PAGE_CNT);
@@ -139,7 +135,7 @@ public:
                         int& fd);
   StatusTuple unload_func(const std::string& func_name);
 
-private:
+ private:
   std::string get_kprobe_event(const std::string& kernel_func,
                                bpf_probe_attach_type type);
   std::string get_uprobe_event(const std::string& binary_path, uint64_t offset,
@@ -181,9 +177,8 @@ private:
 
   StatusTuple check_binary_symbol(const std::string& binary_path,
                                   const std::string& symbol,
-                                  uint64_t symbol_addr,
-                                  std::string &module_res,
-                                  uint64_t &offset_res);
+                                  uint64_t symbol_addr, std::string& module_res,
+                                  uint64_t& offset_res);
 
   int flag_;
 
@@ -202,7 +197,7 @@ private:
 };
 
 class USDT {
-public:
+ public:
   USDT(const std::string& binary_path, const std::string& provider,
        const std::string& name, const std::string& probe_func)
       : initialized_(false),
@@ -221,7 +216,7 @@ public:
     return provider_ + ":" + name_ + " from " + binary_path_;
   }
 
-private:
+ private:
   StatusTuple init();
   bool initialized_;
 

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -70,23 +70,22 @@ typedef void (*perf_reader_cb)(void *cb_cookie, int pid, uint64_t callchain_num,
 typedef void (*perf_reader_raw_cb)(void *cb_cookie, void *raw, int raw_size);
 typedef void (*perf_reader_lost_cb)(uint64_t lost);
 
-void * bpf_attach_kprobe(int progfd, enum bpf_probe_attach_type attach_type,
+void *bpf_attach_kprobe(int progfd, enum bpf_probe_attach_type attach_type,
                         const char *ev_name, const char *fn_name,
-                        pid_t pid, int cpu, int group_fd,
                         perf_reader_cb cb, void *cb_cookie);
 
 int bpf_detach_kprobe(const char *ev_name);
 
-void * bpf_attach_uprobe(int progfd, enum bpf_probe_attach_type attach_type,
-                        const char *ev_name, const char *binary_path, uint64_t offset,
-                        pid_t pid, int cpu, int group_fd,
-                        perf_reader_cb cb, void *cb_cookie);
+void *bpf_attach_uprobe(int progfd, enum bpf_probe_attach_type attach_type,
+                        const char *ev_name, const char *binary_path,
+                        uint64_t offset, pid_t pid, perf_reader_cb cb,
+                        void *cb_cookie);
 
 int bpf_detach_uprobe(const char *ev_name);
 
-void * bpf_attach_tracepoint(int progfd, const char *tp_category,
-                             const char *tp_name, int pid, int cpu,
-                             int group_fd, perf_reader_cb cb, void *cb_cookie);
+void *bpf_attach_tracepoint(int progfd, const char *tp_category,
+                            const char *tp_name, perf_reader_cb cb,
+                            void *cb_cookie);
 int bpf_detach_tracepoint(const char *tp_category, const char *tp_name);
 
 void * bpf_open_perf_buffer(perf_reader_raw_cb raw_cb,

--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -189,9 +189,7 @@ function Bpf:attach_uprobe(args)
   local retprobe = args.retprobe and 1 or 0
 
   local res = libbcc.bpf_attach_uprobe(fn.fd, retprobe, ev_name, path, addr,
-    args.pid or -1,
-    args.cpu or 0,
-    args.group_fd or -1, nil, nil) -- TODO; reader callback
+    args.pid or -1, nil, nil) -- TODO; reader callback
 
   assert(res ~= nil, "failed to attach BPF to uprobe")
   self:probe_store("uprobe", ev_name, res)
@@ -209,9 +207,7 @@ function Bpf:attach_kprobe(args)
   local retprobe = args.retprobe and 1 or 0
 
   local res = libbcc.bpf_attach_kprobe(fn.fd, retprobe, ev_name, event,
-    args.pid or -1,
-    args.cpu or 0,
-    args.group_fd or -1, nil, nil) -- TODO; reader callback
+    nil, nil) -- TODO; reader callback
 
   assert(res ~= nil, "failed to attach BPF to kprobe")
   self:probe_store("kprobe", ev_name, res)

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -43,16 +43,14 @@ typedef void (*perf_reader_cb)(void *cb_cookie, int pid, uint64_t callchain_num,
 typedef void (*perf_reader_raw_cb)(void *cb_cookie, void *raw, int raw_size);
 typedef void (*perf_reader_lost_cb)(uint64_t lost);
 
-void * bpf_attach_kprobe(int progfd, int attach_type, const char *ev_name,
-                        const char *fn_name,
-                        int pid, int cpu, int group_fd,
-                        perf_reader_cb cb, void *cb_cookie);
+void *bpf_attach_kprobe(int progfd, int attach_type, const char *ev_name,
+                        const char *fn_name, perf_reader_cb cb,
+                        void *cb_cookie);
 
 int bpf_detach_kprobe(const char *ev_name);
 
-void * bpf_attach_uprobe(int progfd, int attach_type, const char *ev_name,
-                        const char *binary_path, uint64_t offset,
-                        int pid, int cpu, int group_fd,
+void *bpf_attach_uprobe(int progfd, int attach_type, const char *ev_name,
+                        const char *binary_path, uint64_t offset, int pid,
                         perf_reader_cb cb, void *cb_cookie);
 
 int bpf_detach_uprobe(const char *ev_name);

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -519,8 +519,8 @@ class BPF(object):
         fn = self.load_func(fn_name, BPF.KPROBE)
         ev_name = "p_" + event.replace("+", "_").replace(".", "_")
         res = lib.bpf_attach_kprobe(fn.fd, 0, ev_name.encode("ascii"),
-                event.encode("ascii"), pid, cpu, group_fd,
-                self._reader_cb_impl, ct.cast(id(self), ct.py_object))
+                event.encode("ascii"), self._reader_cb_impl,
+                ct.cast(id(self), ct.py_object))
         res = ct.cast(res, ct.c_void_p)
         if not res:
             raise Exception("Failed to attach BPF to kprobe")
@@ -556,8 +556,8 @@ class BPF(object):
         fn = self.load_func(fn_name, BPF.KPROBE)
         ev_name = "r_" + event.replace("+", "_").replace(".", "_")
         res = lib.bpf_attach_kprobe(fn.fd, 1, ev_name.encode("ascii"),
-                event.encode("ascii"), pid, cpu, group_fd,
-                self._reader_cb_impl, ct.cast(id(self), ct.py_object))
+                event.encode("ascii"), self._reader_cb_impl,
+                ct.cast(id(self), ct.py_object))
         res = ct.cast(res, ct.c_void_p)
         if not res:
             raise Exception("Failed to attach BPF to kprobe")
@@ -680,8 +680,8 @@ class BPF(object):
         fn = self.load_func(fn_name, BPF.TRACEPOINT)
         (tp_category, tp_name) = tp.split(':')
         res = lib.bpf_attach_tracepoint(fn.fd, tp_category.encode("ascii"),
-                tp_name.encode("ascii"), pid, cpu, group_fd,
-                self._reader_cb_impl, ct.cast(id(self), ct.py_object))
+                tp_name.encode("ascii"), self._reader_cb_impl,
+                ct.cast(id(self), ct.py_object))
         res = ct.cast(res, ct.c_void_p)
         if not res:
             raise Exception("Failed to attach BPF to tracepoint")
@@ -833,8 +833,8 @@ class BPF(object):
         fn = self.load_func(fn_name, BPF.KPROBE)
         ev_name = self._get_uprobe_evname("p", path, addr, pid)
         res = lib.bpf_attach_uprobe(fn.fd, 0, ev_name.encode("ascii"),
-                path.encode("ascii"), addr, pid, cpu, group_fd,
-                self._reader_cb_impl, ct.cast(id(self), ct.py_object))
+                path.encode("ascii"), addr, pid, self._reader_cb_impl,
+                ct.cast(id(self), ct.py_object))
         res = ct.cast(res, ct.c_void_p)
         if not res:
             raise Exception("Failed to attach BPF to uprobe")
@@ -883,8 +883,8 @@ class BPF(object):
         fn = self.load_func(fn_name, BPF.KPROBE)
         ev_name = self._get_uprobe_evname("r", path, addr, pid)
         res = lib.bpf_attach_uprobe(fn.fd, 1, ev_name.encode("ascii"),
-                path.encode("ascii"), addr, pid, cpu, group_fd,
-                self._reader_cb_impl, ct.cast(id(self), ct.py_object))
+                path.encode("ascii"), addr, pid, self._reader_cb_impl,
+                ct.cast(id(self), ct.py_object))
         res = ct.cast(res, ct.c_void_p)
         if not res:
             raise Exception("Failed to attach BPF to uprobe")

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -499,8 +499,7 @@ class BPF(object):
         del self.open_kprobes[name]
         _num_open_probes -= 1
 
-    def attach_kprobe(self, event="", fn_name="", event_re="",
-            pid=-1, cpu=0, group_fd=-1):
+    def attach_kprobe(self, event="", fn_name="", event_re=""):
 
         # allow the caller to glob multiple functions together
         if event_re:
@@ -508,8 +507,7 @@ class BPF(object):
             self._check_probe_quota(len(matches))
             for line in matches:
                 try:
-                    self.attach_kprobe(event=line, fn_name=fn_name, pid=pid,
-                            cpu=cpu, group_fd=group_fd)
+                    self.attach_kprobe(event=line, fn_name=fn_name)
                 except:
                     pass
             return
@@ -538,15 +536,13 @@ class BPF(object):
             raise Exception("Failed to detach BPF from kprobe")
         self._del_kprobe(ev_name)
 
-    def attach_kretprobe(self, event="", fn_name="", event_re="",
-            pid=-1, cpu=0, group_fd=-1):
+    def attach_kretprobe(self, event="", fn_name="", event_re=""):
 
         # allow the caller to glob multiple functions together
         if event_re:
             for line in BPF.get_kprobe_functions(event_re):
                 try:
-                    self.attach_kretprobe(event=line, fn_name=fn_name, pid=pid,
-                            cpu=cpu, group_fd=group_fd)
+                    self.attach_kretprobe(event=line, fn_name=fn_name)
                 except:
                     pass
             return
@@ -648,10 +644,8 @@ class BPF(object):
                         results.append(tp)
         return results
 
-    def attach_tracepoint(self, tp="", tp_re="", fn_name="", pid=-1,
-                          cpu=0, group_fd=-1):
-        """attach_tracepoint(tp="", tp_re="", fn_name="", pid=-1,
-                             cpu=0, group_fd=-1)
+    def attach_tracepoint(self, tp="", tp_re="", fn_name=""):
+        """attach_tracepoint(tp="", tp_re="", fn_name="")
 
         Run the bpf function denoted by fn_name every time the kernel tracepoint
         specified by 'tp' is hit. The optional parameters pid, cpu, and group_fd
@@ -673,8 +667,7 @@ class BPF(object):
 
         if tp_re:
             for tp in BPF.get_tracepoints(tp_re):
-                self.attach_tracepoint(tp=tp, fn_name=fn_name, pid=pid,
-                                       cpu=cpu, group_fd=group_fd)
+                self.attach_tracepoint(tp=tp, fn_name=fn_name)
             return
 
         fn = self.load_func(fn_name, BPF.TRACEPOINT)
@@ -794,9 +787,9 @@ class BPF(object):
             return "%s_%s_0x%x_%d" % (prefix, self._probe_repl.sub("_", path), addr, pid)
 
     def attach_uprobe(self, name="", sym="", sym_re="", addr=None,
-            fn_name="", pid=-1, cpu=0, group_fd=-1):
+            fn_name="", pid=-1):
         """attach_uprobe(name="", sym="", sym_re="", addr=None, fn_name=""
-                         pid=-1, cpu=0, group_fd=-1)
+                         pid=-1)
 
         Run the bpf function denoted by fn_name every time the symbol sym in
         the library or binary 'name' is encountered. The real address addr may
@@ -823,8 +816,7 @@ class BPF(object):
             self._check_probe_quota(len(addresses))
             for sym_addr in addresses:
                 self.attach_uprobe(name=name, addr=sym_addr,
-                                   fn_name=fn_name, pid=pid, cpu=cpu,
-                                   group_fd=group_fd)
+                                   fn_name=fn_name, pid=pid)
             return
 
         (path, addr) = BPF._check_path_symbol(name, sym, addr, pid)
@@ -860,9 +852,9 @@ class BPF(object):
         self._del_uprobe(ev_name)
 
     def attach_uretprobe(self, name="", sym="", sym_re="", addr=None,
-            fn_name="", pid=-1, cpu=0, group_fd=-1):
+            fn_name="", pid=-1):
         """attach_uretprobe(name="", sym="", sym_re="", addr=None, fn_name=""
-                            pid=-1, cpu=0, group_fd=-1)
+                            pid=-1)
 
         Run the bpf function denoted by fn_name every time the symbol sym in
         the library or binary 'name' finishes execution. See attach_uprobe for
@@ -872,8 +864,7 @@ class BPF(object):
         if sym_re:
             for sym_addr in BPF.get_user_addresses(name, sym_re):
                 self.attach_uretprobe(name=name, addr=sym_addr,
-                                      fn_name=fn_name, pid=pid, cpu=cpu,
-                                      group_fd=group_fd)
+                                      fn_name=fn_name, pid=pid)
             return
 
         name = str(name)

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -90,18 +90,18 @@ _CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_int,
         ct.c_ulonglong, ct.POINTER(ct.c_ulonglong))
 _RAW_CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_void_p, ct.c_int)
 _LOST_CB_TYPE = ct.CFUNCTYPE(None, ct.c_ulonglong)
-lib.bpf_attach_kprobe.argtypes = [ct.c_int, ct.c_int, ct.c_char_p, ct.c_char_p, ct.c_int,
-        ct.c_int, ct.c_int, _CB_TYPE, ct.py_object]
+lib.bpf_attach_kprobe.argtypes = [ct.c_int, ct.c_int, ct.c_char_p, ct.c_char_p,
+        _CB_TYPE, ct.py_object]
 lib.bpf_detach_kprobe.restype = ct.c_int
 lib.bpf_detach_kprobe.argtypes = [ct.c_char_p]
 lib.bpf_attach_uprobe.restype = ct.c_void_p
 lib.bpf_attach_uprobe.argtypes = [ct.c_int, ct.c_int, ct.c_char_p, ct.c_char_p,
-        ct.c_ulonglong, ct.c_int, ct.c_int, ct.c_int, _CB_TYPE, ct.py_object]
+        ct.c_ulonglong, ct.c_int, _CB_TYPE, ct.py_object]
 lib.bpf_detach_uprobe.restype = ct.c_int
 lib.bpf_detach_uprobe.argtypes = [ct.c_char_p]
 lib.bpf_attach_tracepoint.restype = ct.c_void_p
-lib.bpf_attach_tracepoint.argtypes = [ct.c_int, ct.c_char_p, ct.c_char_p, ct.c_int,
-        ct.c_int, ct.c_int, _CB_TYPE, ct.py_object]
+lib.bpf_attach_tracepoint.argtypes = [ct.c_int, ct.c_char_p, ct.c_char_p,
+        _CB_TYPE, ct.py_object]
 lib.bpf_detach_tracepoint.restype = ct.c_int
 lib.bpf_detach_tracepoint.argtypes = [ct.c_char_p, ct.c_char_p]
 lib.bpf_open_perf_buffer.restype = ct.c_void_p

--- a/tests/python/test_trace1.py
+++ b/tests/python/test_trace1.py
@@ -27,9 +27,9 @@ class TestKprobe(TestCase):
     def setUp(self):
         b = BPF(arg1, arg2, debug=0)
         self.stats = b.get_table("stats", Key, Leaf)
-        b.attach_kprobe(event="sys_write", fn_name="sys_wr", pid=0, cpu=-1)
-        b.attach_kprobe(event="sys_read", fn_name="sys_rd", pid=0, cpu=-1)
-        b.attach_kprobe(event="htab_map_get_next_key", fn_name="sys_rd", pid=0, cpu=-1)
+        b.attach_kprobe(event="sys_write", fn_name="sys_wr")
+        b.attach_kprobe(event="sys_read", fn_name="sys_rd")
+        b.attach_kprobe(event="htab_map_get_next_key", fn_name="sys_rd")
 
     def test_trace1(self):
         with open("/dev/null", "a") as f:

--- a/tests/python/test_trace2.py
+++ b/tests/python/test_trace2.py
@@ -28,7 +28,7 @@ class TestTracingEvent(TestCase):
     def setUp(self):
         b = BPF(text=text, debug=0)
         self.stats = b.get_table("stats")
-        b.attach_kprobe(event="finish_task_switch", fn_name="count_sched", pid=0, cpu=-1)
+        b.attach_kprobe(event="finish_task_switch", fn_name="count_sched")
 
     def test_sched1(self):
         for i in range(0, 100):

--- a/tests/python/test_trace3.py
+++ b/tests/python/test_trace3.py
@@ -19,9 +19,9 @@ class TestBlkRequest(TestCase):
         b = BPF(arg1, arg2, debug=0)
         self.latency = b.get_table("latency", c_uint, c_ulong)
         b.attach_kprobe(event="blk_start_request",
-                fn_name="probe_blk_start_request", pid=-1, cpu=0)
+                fn_name="probe_blk_start_request")
         b.attach_kprobe(event="blk_update_request",
-                fn_name="probe_blk_update_request", pid=-1, cpu=0)
+                fn_name="probe_blk_update_request")
 
     def test_blk1(self):
         import subprocess

--- a/tools/deadlock_detector.py
+++ b/tools/deadlock_detector.py
@@ -468,9 +468,7 @@ def main():
     bpf = BPF(src_file='deadlock_detector.c')
 
     # Trace where threads are created
-    bpf.attach_kretprobe(
-        event='sys_clone', fn_name='trace_clone', pid=args.pid
-    )
+    bpf.attach_kretprobe(event='sys_clone', fn_name='trace_clone')
 
     # We must trace unlock first, otherwise in the time we attached the probe
     # on lock() and have not yet attached the probe on unlock(), a thread can

--- a/tools/funccount.py
+++ b/tools/funccount.py
@@ -90,8 +90,7 @@ class Probe(object):
             for index, function in self.trace_functions.items():
                 self.bpf.attach_kprobe(
                         event=function,
-                        fn_name="trace_count_%d" % index,
-                        pid=self.pid or -1)
+                        fn_name="trace_count_%d" % index)
         elif self.type == "p" and self.library:
             for index, function in self.trace_functions.items():
                 self.bpf.attach_uprobe(
@@ -103,8 +102,7 @@ class Probe(object):
             for index, function in self.trace_functions.items():
                 self.bpf.attach_tracepoint(
                         tp=function,
-                        fn_name="trace_count_%d" % index,
-                        pid=self.pid or -1)
+                        fn_name="trace_count_%d" % index)
         elif self.type == "u":
             pass    # Nothing to do -- attach already happened in `load`
 

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -90,13 +90,11 @@ class Probe(object):
                 self.matched = self.bpf.num_open_uprobes()
             else:
                 self.bpf.attach_kprobe(event_re=self.pattern,
-                                       fn_name="trace_count",
-                                       pid=self.pid or -1)
+                                       fn_name="trace_count")
                 self.matched = self.bpf.num_open_kprobes()
         elif self.type == "t":
             self.bpf.attach_tracepoint(tp_re=self.pattern,
-                                       fn_name="trace_count",
-                                       pid=self.pid or -1)
+                                       fn_name="trace_count")
             self.matched = self.bpf.num_open_tracepoints()
         elif self.type == "u":
             pass    # Nothing to do -- attach already happened in `load`


### PR DESCRIPTION
BPF tracing events are system-wide and does not support CPU filter. Also among them only uprobes can have PID filter. We are also not using group_fd for BPF programs at all. However, all kprobe, uprobe and Kernel Tracepoint APIs, including C, C++, Python and Lua, all has `cpu`, `pid` and `group_fd` parameters. This causes the APIs to be more complicated and users to be confused because BCC "doesn't" work when they specify `cpu` for uprobes or `pid` for kprobes etc.

This PR removes all the unused parameters from all interfaces.