### PR TITLE
Improve trace.py formatting and printing options

### DIFF
--- a/man/man8/trace.8
+++ b/man/man8/trace.8
@@ -2,8 +2,8 @@
 .SH NAME
 trace \- Trace a function and print its arguments or return value, optionally evaluating a filter. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B trace [-h] [-p PID] [-L TID] [-v] [-Z STRING_SIZE] [-S]
-         [-M MAX_EVENTS] [-t] [-T] [-K] [-U] [-I header]
+.B trace [-h] [-b BUFFER_PAGES] [-p PID] [-L TID] [-v] [-Z STRING_SIZE] [-S]
+         [-M MAX_EVENTS] [-t] [-T] [-C] [-K] [-U] [-I header]
          probe [probe ...]
 .SH DESCRIPTION
 trace probes functions you specify and displays trace messages if a particular
@@ -44,6 +44,9 @@ Print times relative to the beginning of the trace (offsets), in seconds.
 .TP
 \-T
 Print the time column.
+.TP
+\-C
+Print CPU id.
 .TP
 \-K
 Print the kernel stack for each event.

--- a/tools/trace.py
+++ b/tools/trace.py
@@ -485,13 +485,13 @@ BPF_PERF_OUTPUT(%s);
                              range(0, len(self.values)))
                 msg = self._format_message(bpf, event.tgid, values)
                 if not Probe.print_time:
-                    print("%-6d %-6d %-12s %-16s %s" %
+                    print("%-7d %-7d %-15s %-16s %s" %
                           (event.tgid, event.pid, event.comm.decode(),
                            self._display_function(), msg))
                 else:
                     time = strftime("%H:%M:%S") if Probe.use_localtime else \
                            Probe._time_off_str(event.timestamp_ns)
-                    print("%-8s %-6d %-6d %-12s %-16s %s" %
+                    print("%-8s %-7d %-7d %-15s %-16s %s" %
                           (time[:8], event.tgid, event.pid,
                            event.comm.decode(), self._display_function(), msg))
 
@@ -685,11 +685,11 @@ trace -I 'kernel/sched/sched.h' \\
 
                 # Print header
                 if self.args.timestamp or self.args.time:
-                    print("%-8s %-6s %-6s %-12s %-16s %s" %
+                    print("%-8s %-7s %-7s %-15s %-16s %s" %
                           ("TIME", "PID", "TID", "COMM", "FUNC",
                           "-" if not all_probes_trivial else ""))
                 else:
-                    print("%-6s %-6s %-12s %-16s %s" %
+                    print("%-7s %-7s %-15s %-16s %s" %
                           ("PID", "TID", "COMM", "FUNC",
                           "-" if not all_probes_trivial else ""))
 

--- a/tools/trace_example.txt
+++ b/tools/trace_example.txt
@@ -108,14 +108,17 @@ predicate and trace arguments.
 
 More and more high-level libraries are instrumented with USDT probe support.
 These probes can be traced by trace just like kernel tracepoints. For example,
-trace new threads being created and their function name:
+trace new threads being created and their function name, include time column
+and on which CPU it happened:
 
-# trace 'u:pthread:pthread_create "%U", arg3' -T
-TIME     PID    COMM         FUNC             -
-02:07:29 4051   contentions  pthread_create   primes_thread+0x0
-02:07:29 4051   contentions  pthread_create   primes_thread+0x0
-02:07:29 4051   contentions  pthread_create   primes_thread+0x0
-02:07:29 4051   contentions  pthread_create   primes_thread+0x0
+# trace 'u:pthread:pthread_create "%U", arg3' -T -C
+TIME     CPU PID     TID     COMM            FUNC             -
+13:22:01 25  2627    2629    automount       pthread_create   expire_proc_indirect+0x0 [automount]
+13:22:01 5   21360   21414   osqueryd        pthread_create   [unknown] [osqueryd]
+13:22:03 25  2627    2629    automount       pthread_create   expire_proc_indirect+0x0 [automount]
+13:22:04 15  21360   21414   osqueryd        pthread_create   [unknown] [osqueryd]
+13:22:07 25  2627    2629    automount       pthread_create   expire_proc_indirect+0x0 [automount]
+13:22:07 4   21360   21414   osqueryd        pthread_create   [unknown] [osqueryd]
 ^C
 
 The "%U" format specifier tells trace to resolve arg3 as a user-space symbol,
@@ -245,6 +248,7 @@ optional arguments:
                         number of events to print before quitting
   -t, --timestamp       print timestamp column (offset from trace start)
   -T, --time            print time column
+  -C, --print_cpu       print CPU id 
   -K, --kernel-stack    output kernel stack trace
   -U, --user-stack      output user stack trace
   -I header, --include header


### PR DESCRIPTION
This PR:
- Improves `trace.py` formatting. PID / TGID could easily be 7-digits long, increase the column width. Process COMM could be 15 characters long, increase the column width.
- Add `-C` / `--print_cpu` option that would optionally print the CPU ID of the event, which is useful when debugging CPU affinity.

Tested with no options, `-t`, `-T`, `-t -C`, `-T -C` and `-C`. Example output:
```
$ trace.py c:strchr -t -C
TIME     CPU PID     TID     COMM            FUNC
0.997841 15  533191  533191  sshd            strchr
0.998253 15  533191  533191  sshd            strchr
1.008683 18  533193  533193  unix_chkpwd     strchr
1.009422 19  533191  533191  sshd            strchr
1.010921 19  533191  533191  sshd            strchr
1.029421 23  533194  533194  (systemd)       strchr
1.092944 17  533196  533196  sh              strchr
```