### PR TITLE
Fix and improvement for perf_reader's lost_cb

### DIFF
--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -68,7 +68,7 @@ int bpf_open_raw_sock(const char *name);
 typedef void (*perf_reader_cb)(void *cb_cookie, int pid, uint64_t callchain_num,
                                void *callchain);
 typedef void (*perf_reader_raw_cb)(void *cb_cookie, void *raw, int raw_size);
-typedef void (*perf_reader_lost_cb)(uint64_t lost);
+typedef void (*perf_reader_lost_cb)(void *cb_cookie, uint64_t lost);
 
 void *bpf_attach_kprobe(int progfd, enum bpf_probe_attach_type attach_type,
                         const char *ev_name, const char *fn_name,

--- a/src/cc/perf_reader.c
+++ b/src/cc/perf_reader.c
@@ -253,7 +253,7 @@ void perf_reader_event_read(struct perf_reader *reader) {
        */
       uint64_t lost = *(uint64_t *)(ptr + sizeof(*e) + sizeof(uint64_t));
       if (reader->lost_cb) {
-        reader->lost_cb(lost);
+        reader->lost_cb(reader->cb_cookie, lost);
       } else {
         fprintf(stderr, "Possibly lost %" PRIu64 " samples\n", lost);
       }

--- a/src/cc/perf_reader.c
+++ b/src/cc/perf_reader.c
@@ -243,7 +243,15 @@ void perf_reader_event_read(struct perf_reader *reader) {
     }
 
     if (e->type == PERF_RECORD_LOST) {
-      uint64_t lost = *(uint64_t *)(ptr + sizeof(*e));
+      /*
+       * struct {
+       *    struct perf_event_header    header;
+       *    u64                id;
+       *    u64                lost;
+       *    struct sample_id        sample_id;
+       * };
+       */
+      uint64_t lost = *(uint64_t *)(ptr + sizeof(*e) + sizeof(uint64_t));
       if (reader->lost_cb) {
         reader->lost_cb(lost);
       } else {

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -41,7 +41,7 @@ int bpf_open_raw_sock(const char *name);
 
 typedef void (*perf_reader_cb)(void *cb_cookie, int pid, uint64_t callchain_num, void *callchain);
 typedef void (*perf_reader_raw_cb)(void *cb_cookie, void *raw, int raw_size);
-typedef void (*perf_reader_lost_cb)(uint64_t lost);
+typedef void (*perf_reader_lost_cb)(void *cb_cookie, uint64_t lost);
 
 void *bpf_attach_kprobe(int progfd, int attach_type, const char *ev_name,
                         const char *fn_name, perf_reader_cb cb,

--- a/src/lua/bcc/table.lua
+++ b/src/lua/bcc/table.lua
@@ -252,8 +252,8 @@ function PerfEventArray:_open_perf_buffer(cpu, callback, ctype, page_cnt, lost_c
   local _lost_cb = nil
   if lost_cb then
     _lost_cb = ffi.cast("perf_reader_lost_cb",
-      function (lost)
-        lost_cb(lost)
+      function (cookie, lost)
+        lost_cb(cookie, lost)
       end)
   end
 

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -89,7 +89,7 @@ lib.bpf_attach_kprobe.restype = ct.c_void_p
 _CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_int,
         ct.c_ulonglong, ct.POINTER(ct.c_ulonglong))
 _RAW_CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_void_p, ct.c_int)
-_LOST_CB_TYPE = ct.CFUNCTYPE(None, ct.c_ulonglong)
+_LOST_CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_ulonglong)
 lib.bpf_attach_kprobe.argtypes = [ct.c_int, ct.c_int, ct.c_char_p, ct.c_char_p,
         _CB_TYPE, ct.py_object]
 lib.bpf_detach_kprobe.restype = ct.c_int


### PR DESCRIPTION
From `uapi/linux/perf_event.h`, the `PERF_RECORD_LOST` sample format looks like:
```
/*
 * struct {
 *	struct perf_event_header	header;
 *	u64				id;
 *	u64				lost;
 * 	struct sample_id		sample_id;
 * };
 */
```
However, when we add the ability to consume such sample in https://github.com/iovisor/bcc/commit/8207d10e99f0b6bd2aa13d7f44adc4af5c803fe4, we incorrect calculated the offset to read the field `id` where we actually want to read the field `lost` for the count of samples lost. The same bug was inherited in https://github.com/iovisor/bcc/commit/4b764de6bcb3655b29b2fb6df6c9c65b7a31338c.

This PR fixes the issue by using the correct offset.

Also, user feedback shows that the `lost_cb` is not very useful unless it could take a `cb_cookie` as the `raw_cb` does, so that necessary context could be added when the lost event happens. Therefore, this PR also adds `cb_cookie` to `lost_cb`'s parameter. It will share the same `cb_cookie` from the `perf_reader` as `raw_cb` uses. This functionality is only added in #1092 and no tool is using it yet.  

Tested both Python and C++ tools. Example of lost samples by tracing high-frequency events.
Before:
```
$ trace.py t:sched:sched_switch -t -C
......
1.505114 11  0       0       swapper/11      sched_switch
Possibly lost 13576517 samples
1.505150 11  0       0       swapper/11      sched_switch
Possibly lost 13576517 samples
1.505185 11  0       0       swapper/11      sched_switch
1.505233 11  997252  997252  sshd            sched_switch
......
```
After:
```
$ trace.py t:sched:sched_switch -t -C
......
1.494558 11  0       0       swapper/11      sched_switch
Possibly lost 1 samples
1.494607 11  997252  997252  sshd            sched_switch
Possibly lost 2 samples
1.494650 11  0       0       swapper/11      sched_switch
Possibly lost 1 samples
......
```