### PR TITLE
Fix incorrect lost_cb type in Python

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -532,7 +532,7 @@ class PerfEventArray(ArrayBase):
                     exit()
                 else:
                     raise e
-        def lost_cb_(lost):
+        def lost_cb_(_, lost):
             try:
                 lost_cb(lost)
             except IOError as e:


### PR DESCRIPTION
This is a bug fix for #1496, sorry for the mistake.
Added `lost_cb` in test cases so this won't happen in the future.