### PR TITLE
fix a compilation error with latest llvm/clang trunk

### DIFF
--- a/src/cc/frontends/clang/tp_frontend_action.cc
+++ b/src/cc/frontends/clang/tp_frontend_action.cc
@@ -160,7 +160,7 @@ bool TracepointTypeVisitor::VisitFunctionDecl(FunctionDecl *D) {
       auto type = arg->getType();
       if (type->isPointerType() &&
           type->getPointeeType()->isStructureOrClassType()) {
-        auto type_name = QualType::getAsString(type.split());
+        auto type_name = type->getPointeeType().getAsString();
         string tp_cat, tp_evt;
         if (_is_tracepoint_struct_type(type_name, tp_cat, tp_evt)) {
           string tp_struct = GenerateTracepointStruct(


### PR DESCRIPTION
bcc build with latest llvm/clang trunk failed with the
below error:
......
[ 35%] Built target api-static
/home/yhs/work/bcc/src/cc/frontends/clang/tp_frontend_action.cc: In member function ‘bool ebpf::TracepointTypeVisitor::Visit
FunctionDecl(clang::FunctionDecl*)’:
/home/yhs/work/bcc/src/cc/frontends/clang/tp_frontend_action.cc:163:60: error: no matching function for call to ‘clang::Qual
Type::getAsString(clang::SplitQualType)’
         auto type_name = QualType::getAsString(type.split());
                                                            ^
......

The error is caused by the below clang commit:
commit fcc28fd8cc8139cf1e4763459447880768579d8e
Author: Aaron Ballman <aaron@aaronballman.com>
Date:   Thu Dec 21 21:42:42 2017 +0000

    Re-commit r321223, which adds a printing policy to the ASTDumper.
......
-  std::string getAsString() const {
-    return getAsString(split());
+  static std::string getAsString(SplitQualType split,
+                                 const PrintingPolicy &Policy) {
+    return getAsString(split.Ty, split.Quals, Policy);
   }
+  static std::string getAsString(const Type *ty, Qualifiers qs,
+                                 const PrintingPolicy &Policy);

-  static std::string getAsString(SplitQualType split) {
-    return getAsString(split.Ty, split.Quals);
-  }
-
-  static std::string getAsString(const Type *ty, Qualifiers qs);
-
+  std::string getAsString() const;
   std::string getAsString(const PrintingPolicy &Policy) const;
......

The signature of static function getAsString(), which is used
in src/cc/frontends/clang/tp_frontend_action.cc, got changed,
and this caused the compilation error.

The patch chooses a different way to get type_name which works
for llvm 3.8, 4.0, 5.0 and 6.0 (tested).

Signed-off-by: Yonghong Song <yhs@fb.com>