### PR TITLE
fix a verifier failure

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -598,14 +598,14 @@ int tracepoint__##category##__##event(struct tracepoint__##category##__##event *
 
 #define TP_DATA_LOC_READ_CONST(dst, field, length)                        \
         do {                                                              \
-            short __offset = args->data_loc_##field & 0xFFFF;             \
+            unsigned short __offset = args->data_loc_##field & 0xFFFF;    \
             bpf_probe_read((void *)dst, length, (char *)args + __offset); \
         } while (0);
 
 #define TP_DATA_LOC_READ(dst, field)                                        \
         do {                                                                \
-            short __offset = args->data_loc_##field & 0xFFFF;               \
-            short __length = args->data_loc_##field >> 16;                  \
+            unsigned short __offset = args->data_loc_##field & 0xFFFF;      \
+            unsigned short __length = args->data_loc_##field >> 16;         \
             bpf_probe_read((void *)dst, __length, (char *)args + __offset); \
         } while (0);
 


### PR DESCRIPTION
when running with latest linus tree and net-next, the python test
tests/python/test_tracepoint.py failed with the following
symptoms:
```
......
 R0=map_value(id=0,off=0,ks=4,vs=64,imm=0) R6=map_value(id=0,off=0,ks=4,vs=64,imm=0) R7=ctx(id=0,off=0,imm=0) R10=fp0,call_-1
34: (69) r1 = *(u16 *)(r7 +8)
35: (67) r1 <<= 48
36: (c7) r1 s>>= 48
37: (0f) r7 += r1
math between ctx pointer and register with unbounded min value is not allowed
......
```

The reason of failure is due to added tightening in verifier introduced by
the following commit:
```
commit f4be569a429987343e3f424d3854b3622ffae436
Author: Alexei Starovoitov <ast@kernel.org>
Date: Mon Dec 18 20:12:00 2017 -0800

bpf: fix integer overflows
......

```

The patch changes `offset` type in `ctx + offset` from signed to
unsigned so that we do not have `unbounded min value` so the
test trace_tracepoint.py can pass.

Signed-off-by: Yonghong Song <yhs@fb.com>