### PR TITLE
Increase bpf_attach_tracing_event buffer size

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -540,7 +540,7 @@ static int bpf_attach_tracing_event(int progfd, const char *event_path,
                                     struct perf_reader *reader, int pid) {
   int efd, pfd, cpu = 0;
   ssize_t bytes;
-  char buf[256];
+  char buf[PATH_MAX];
   struct perf_event_attr attr = {};
 
   snprintf(buf, sizeof(buf), "%s/id", event_path);


### PR DESCRIPTION
It is awesome that the new probe APIs (#1518) is on the horizon. However most machines with older Kernels would still be using the file-based APIs. In `debugfs`, we put the full binary name as uprobe's event name, hence it would be really long and the current 256 buffer size won't be enough.

This commit increase it to `PATH_MAX`.