### PR TITLE
tools: syscount: add --errno=EPERM filter

### DIFF
--- a/man/man8/syscount.8
+++ b/man/man8/syscount.8
@@ -2,7 +2,7 @@
 .SH NAME
 syscount \- Summarize syscall counts and latencies.
 .SH SYNOPSIS
-.B syscount [-h] [-p PID] [-i INTERVAL] [-T TOP] [-x] [-L] [-m] [-P] [-l]
+.B syscount [-h] [-p PID] [-i INTERVAL] [-T TOP] [-x] [-e ERRNO] [-L] [-m] [-P] [-l]
 .SH DESCRIPTION
 This tool traces syscall entry and exit tracepoints and summarizes either the
 number of syscalls of each type, or the number of syscalls per process. It can
@@ -29,6 +29,9 @@ Print only this many entries. Default: 10.
 \-x
 Trace only failed syscalls (i.e., the return value from the syscall was < 0).
 .TP
+\-e ERRNO
+Trace only syscalls that failed with that error (e.g. -e EPERM or -e 1).
+.TP
 \-m
 Display times in milliseconds. Default: microseconds.
 .TP
@@ -52,6 +55,10 @@ Summarize all syscalls by process:
 Summarize only failed syscalls:
 #
 .B syscount \-x
+.TP
+Summarize only syscalls that failed with EPERM:
+#
+.B syscount \-e EPERM
 .TP
 Trace PID 181 only:
 #

--- a/tools/syscount_example.txt
+++ b/tools/syscount_example.txt
@@ -106,10 +106,43 @@ access                  1
 pause                   1
 ^C
 
+Similar to -x/--failures, sometimes you only care about certain syscall
+errors like EPERM or ENONET -- these are the ones that might be worth
+investigating with follow-up tools like opensnoop, execsnoop, or
+trace. Use the -e/--errno switch for this; the following example also
+demonstrates the -e switch, for printing ENOENT failures at predefined intervals:
+
+# syscount -e ENOENT -i 5
+Tracing syscalls, printing top 10... Ctrl+C to quit.
+[13:15:57]
+SYSCALL                   COUNT
+stat                       4669
+open                       1951
+access                      561
+lstat                        62
+openat                       42
+readlink                      8
+execve                        4
+newfstatat                    1
+
+[13:16:02]
+SYSCALL                   COUNT
+lstat                     18506
+stat                      13087
+open                       2907
+access                      412
+openat                       19
+readlink                     12
+execve                        7
+connect                       6
+unlink                        1
+rmdir                         1
+^C
+
 USAGE:
 # syscount -h
-usage: syscount.py [-h] [-p PID] [-i INTERVAL] [-T TOP] [-x] [-L] [-m] [-P]
-                   [-l]
+usage: syscount.py [-h] [-p PID] [-i INTERVAL] [-T TOP] [-x] [-e ERRNO] [-L]
+                   [-m] [-P] [-l]
 
 Summarize syscall counts and latencies.
 
@@ -120,6 +153,9 @@ optional arguments:
                         print summary at this interval (seconds)
   -T TOP, --top TOP     print only the top syscalls by count or latency
   -x, --failures        trace only failed syscalls (return < 0)
+  -e ERRNO, --errno ERRNO
+                        trace only syscalls that return this error (numeric or
+                        EPERM, etc.)
   -L, --latency         collect syscall latency
   -m, --milliseconds    display latency in milliseconds (default:
                         microseconds)


### PR DESCRIPTION
Similar to `--filter` which reports all failing syscalls, `--errno=ENOENT` reports syscalls failing with the specified errno value.

```
$ sudo bcc/tools/syscount.py -e ENOENT
Tracing syscalls, printing top 10... Ctrl+C to quit.
^C[12:07:13]
SYSCALL                   COUNT
open                        330
stat                        240
access                       63
execve                       22
readlink                      3
```