### PR TITLE
Allow for sharing of python tools/ scripts

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -287,6 +287,8 @@ class BPF(object):
         if text:
             self.module = lib.bpf_module_create_c_from_string(text.encode("ascii"),
                     self.debug, cflags_array, len(cflags_array))
+            if not self.module:
+                raise Exception("Failed to compile BPF text:\n%s" % text)
         else:
             src_file = BPF._find_file(src_file)
             hdr_file = BPF._find_file(hdr_file)
@@ -296,9 +298,8 @@ class BPF(object):
             else:
                 self.module = lib.bpf_module_create_c(src_file.encode("ascii"),
                         self.debug, cflags_array, len(cflags_array))
-
-        if not self.module:
-            raise Exception("Failed to compile BPF module %s" % src_file)
+            if not self.module:
+                raise Exception("Failed to compile BPF module %s" % src_file)
 
         for usdt_context in usdt_contexts:
             usdt_context.attach_uprobes(self)

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -4,7 +4,7 @@
 # biolatency    Summarize block device I/O latency as a histogram.
 #       For Linux, uses BCC, eBPF.
 #
-# USAGE: biolatency [-h] [-T] [-Q] [-m] [-D] [-e] [interval] [count]
+# USAGE: biolatency [-h] [-T] [-Q] [-m] [-D] [interval] [count]
 #
 # Copyright (c) 2015 Brendan Gregg.
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -27,7 +27,7 @@ examples = """examples:
 parser = argparse.ArgumentParser(
     description="Summarize block device I/O latency as a histogram",
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    epilog=examples)
+    epilog=examples, allow_abbrev=False)
 parser.add_argument("-T", "--timestamp", action="store_true",
     help="include timestamp on output")
 parser.add_argument("-Q", "--queued", action="store_true",
@@ -36,12 +36,12 @@ parser.add_argument("-m", "--milliseconds", action="store_true",
     help="millisecond histogram")
 parser.add_argument("-D", "--disks", action="store_true",
     help="print a histogram per disk device")
-parser.add_argument("-e", "--ebpf", action="store_true",
-    help="report the eBPF program and exit")
 parser.add_argument("interval", nargs="?", default=99999999,
     help="output interval, in seconds")
 parser.add_argument("count", nargs="?", default=99999999,
     help="number of outputs")
+parser.add_argument("--ebpf", action="store_true",
+    help=argparse.SUPPRESS)
 args = parser.parse_args()
 countdown = int(args.count)
 debug = 0

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -27,7 +27,7 @@ examples = """examples:
 parser = argparse.ArgumentParser(
     description="Summarize block device I/O latency as a histogram",
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    epilog=examples, allow_abbrev=False)
+    epilog=examples)
 parser.add_argument("-T", "--timestamp", action="store_true",
     help="include timestamp on output")
 parser.add_argument("-Q", "--queued", action="store_true",

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -4,7 +4,7 @@
 # biolatency    Summarize block device I/O latency as a histogram.
 #       For Linux, uses BCC, eBPF.
 #
-# USAGE: biolatency [-h] [-T] [-Q] [-m] [-D] [interval] [count]
+# USAGE: biolatency [-h] [-T] [-Q] [-m] [-D] [-e] [interval] [count]
 #
 # Copyright (c) 2015 Brendan Gregg.
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -36,6 +36,8 @@ parser.add_argument("-m", "--milliseconds", action="store_true",
     help="millisecond histogram")
 parser.add_argument("-D", "--disks", action="store_true",
     help="print a histogram per disk device")
+parser.add_argument("-e", "--ebpf", action="store_true",
+    help="report the eBPF program and exit")
 parser.add_argument("interval", nargs="?", default=99999999,
     help="output interval, in seconds")
 parser.add_argument("count", nargs="?", default=99999999,
@@ -103,8 +105,10 @@ else:
     bpf_text = bpf_text.replace('STORAGE', 'BPF_HISTOGRAM(dist);')
     bpf_text = bpf_text.replace('STORE',
         'dist.increment(bpf_log2l(delta));')
-if debug:
+if debug or args.ebpf:
     print(bpf_text)
+    if args.ebpf:
+        exit()
 
 # load BPF program
 b = BPF(text=bpf_text)

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -31,7 +31,7 @@ examples = """examples:
 parser = argparse.ArgumentParser(
     description="Block device (disk) I/O by process",
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    epilog=examples, allow_abbrev=False)
+    epilog=examples)
 parser.add_argument("-C", "--noclear", action="store_true",
     help="don't clear the screen")
 parser.add_argument("-r", "--maxrows", default=20,

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -4,7 +4,7 @@
 # biotop  block device (disk) I/O by process.
 #         For Linux, uses BCC, eBPF.
 #
-# USAGE: biotop.py [-h] [-C] [-r MAXROWS] [-e] [interval] [count]
+# USAGE: biotop.py [-h] [-C] [-r MAXROWS] [interval] [count]
 #
 # This uses in-kernel eBPF maps to cache process details (PID and comm) by I/O
 # request, as well as a starting timestamp for calculating I/O latency.
@@ -31,17 +31,17 @@ examples = """examples:
 parser = argparse.ArgumentParser(
     description="Block device (disk) I/O by process",
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    epilog=examples)
+    epilog=examples, allow_abbrev=False)
 parser.add_argument("-C", "--noclear", action="store_true",
     help="don't clear the screen")
 parser.add_argument("-r", "--maxrows", default=20,
     help="maximum rows to print, default 20")
-parser.add_argument("-e", "--ebpf", action="store_true",
-    help="report the eBPF program and exit")
 parser.add_argument("interval", nargs="?", default=1,
     help="output interval, in seconds")
 parser.add_argument("count", nargs="?", default=99999999,
     help="number of outputs")
+parser.add_argument("--ebpf", action="store_true",
+    help=argparse.SUPPRESS)
 args = parser.parse_args()
 interval = int(args.interval)
 countdown = int(args.count)

--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -43,7 +43,7 @@ examples = """examples:
 parser = argparse.ArgumentParser(
     description="Trace the lifespan of TCP sessions and summarize",
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    epilog=examples)
+    epilog=examples, allow_abbrev=False)
 parser.add_argument("-T", "--time", action="store_true",
     help="include time column on output (HH:MM:SS)")
 parser.add_argument("-t", "--timestamp", action="store_true",
@@ -58,8 +58,8 @@ parser.add_argument("-L", "--localport",
     help="comma-separated list of local ports to trace.")
 parser.add_argument("-D", "--remoteport",
     help="comma-separated list of remote ports to trace.")
-parser.add_argument("-e", "--ebpf", action="store_true",
-    help="report the eBPF program and exit")
+parser.add_argument("--ebpf", action="store_true",
+    help=argparse.SUPPRESS)
 args = parser.parse_args()
 debug = 0
 

--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -43,7 +43,7 @@ examples = """examples:
 parser = argparse.ArgumentParser(
     description="Trace the lifespan of TCP sessions and summarize",
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    epilog=examples, allow_abbrev=False)
+    epilog=examples)
 parser.add_argument("-T", "--time", action="store_true",
     help="include time column on output (HH:MM:SS)")
 parser.add_argument("-t", "--timestamp", action="store_true",

--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -58,6 +58,8 @@ parser.add_argument("-L", "--localport",
     help="comma-separated list of local ports to trace.")
 parser.add_argument("-D", "--remoteport",
     help="comma-separated list of remote ports to trace.")
+parser.add_argument("-e", "--ebpf", action="store_true",
+    help="report the eBPF program and exit")
 args = parser.parse_args()
 debug = 0
 
@@ -375,8 +377,10 @@ bpf_text = bpf_text.replace('FILTER_PID', '')
 bpf_text = bpf_text.replace('FILTER_DPORT', '')
 bpf_text = bpf_text.replace('FILTER_LPORT', '')
 
-if debug:
+if debug or args.ebpf:
     print(bpf_text)
+    if args.ebpf:
+        exit()
 
 # event data
 TASK_COMM_LEN = 16      # linux/sched.h


### PR DESCRIPTION
It would be extremely helpful to the PCP (pcp.io) project, and probably others,
if the eBPF programs in tools/*.py were more readily accessible outside of the
python scripts.  This commit suggests a simple way to achieve this, such that
we can use it in PCP ( https://github.com/performancecopilot/pcp/pull/409 ).

If this approach is generally favourable, we'd update more scripts to follow the
same pattern established here.

Also fixes a little bug in BCC python class constructor error reporting.