### PR TITLE
fix a trace_pipe output issue

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -950,7 +950,16 @@ class BPF(object):
                 ts_end = line.find(":")
                 pid, cpu, flags, ts = line[:ts_end].split()
                 cpu = cpu[1:-1]
-                msg = line[ts_end + 4:]
+                # line[ts_end:] will have ": [sym_or_addr]: msgs"
+                # For trace_pipe debug output, the addr typically
+                # is invalid (e.g., 0x1). For kernel 4.12 or earlier,
+                # if address is not able to match a kernel symbol,
+                # nothing will be printed out. For kernel 4.13 and later,
+                # however, the illegal address will be printed out.
+                # Hence, both cases are handled here.
+                line = line[ts_end + 1:]
+                sym_end = line.find(":")
+                msg = line[sym_end + 2:]
                 return (task, int(pid), int(cpu), flags, float(ts), msg)
         except KeyboardInterrupt:
             exit()


### PR DESCRIPTION
For trace_pipe output, the /sys/kernel/debug/tracing/trace_pipe
output format looks like below for kernel 4.12 and earlier:
```
 <COMM>-<PID> [CPU] FLAGS TIMESTAMP: [SYMBOL]: USER_MESSAGES
```
where if an internal address is not able to be resolved to
a kernel symbol, `SYMBOL` will not be printed out at all.

kernel 4.13 and later will have format like:
```
 <COMM>-<PID> [CPU] FLAGS TIMESTAMP: [SYMBOL_OR_ADDR]: USER_MESSAGES
```
Basically, if an address is not able to resolved into a
kernel symbol, the address itself will be printed out.
The change was introduced by below commit:
```
commit feaf1283d11794b9d518fcfd54b6bf8bee1f0b4b
Author: Steven Rostedt (VMware) <rostedt@goodmis.org>
Date:   Thu Jun 22 17:04:55 2017 -0400

    tracing: Show address when function names are not found

    Currently, when a function is not found in kallsyms, instead of simply
    showing the function address, it shows nothing at all:

     # echo ':mod:kvm_intel' > /sys/kernel/tracing/set_ftrace_filter
     # echo function > /sys/kernel/tracing/set_ftrace_filter
     # qemu -enable-kvm /home/my-qemu-image
       <Ctrl-C>
     # rmmod kvm_intel
     # cat /sys/kernel/tracing/trace
     qemu-system-x86-2408  [001] d..2   135.013238:  <-kvm_arch_hardware_enable
     qemu-system-x86-2408  [001] ....   135.014574:  <-kvm_arch_vm_ioctl
     qemu-system-x86-2408  [001] ....   135.015420:  <-kvm_vm_ioctl_check_extension
     qemu-system-x86-2408  [001] ....   135.045411:  <-__do_cpuid_ent
     qemu-system-x86-2408  [001] ....   135.045412:  <-__do_cpuid_ent
     qemu-system-x86-2408  [001] ....   135.045412:  <-__do_cpuid_ent
     qemu-system-x86-2408  [001] ....   135.045412:  <-__do_cpuid_ent
     qemu-system-x86-2408  [001] ...1   135.045413:  <-__do_cpuid_ent
     qemu-system-x86-2408  [001] ....   135.045413:  <-__do_cpuid_ent

    When it should show:

     qemu-system-x86-2408  [001] d..2   135.013238: 0xffffffffa02a39f0 <-kvm_arch_hardware_enable
     qemu-system-x86-2408  [001] ....   135.014574: 0xffffffffa02a2ba0 <-kvm_arch_vm_ioctl
     qemu-system-x86-2408  [001] ....   135.015420: 0xffffffffa029e4e0 <-kvm_vm_ioctl_check_extension
     qemu-system-x86-2408  [001] ....   135.045411: 0xffffffffa02a1380 <-__do_cpuid_ent
     qemu-system-x86-2408  [001] ....   135.045412: 0xffffffffa029e160 <-__do_cpuid_ent
     qemu-system-x86-2408  [001] ....   135.045412: 0xffffffffa029e180 <-__do_cpuid_ent
     qemu-system-x86-2408  [001] ....   135.045412: 0xffffffffa029e520 <-__do_cpuid_ent
     qemu-system-x86-2408  [001] ...1   135.045413: 0xffffffffa02a13b0 <-__do_cpuid_ent
     qemu-system-x86-2408  [001] ....   135.045413: 0xffffffffa02a1380 <-__do_cpuid_ent

    instead.
```

This patch fixed the issue by parsing the trace_pipe output considering the
`SYMBOL_OR_ADDRESS` field may or may not be empty.

Signed-off-by: Yonghong Song <yhs@fb.com>