### PR TITLE
Adding minimum latency filter to tcpconnlat

### DIFF
--- a/man/man8/tcpconnlat.8
+++ b/man/man8/tcpconnlat.8
@@ -2,7 +2,7 @@
 .SH NAME
 tcpconnlat \- Trace TCP active connection latency. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B tcpconnlat [\-h] [\-t] [\-p PID] [-m MIN_MS] [-u MIN_US] [-v]
+.B tcpconnlat [\-h] [\-t] [\-p PID] [-v] [min_ms]
 .SH DESCRIPTION
 This tool traces active TCP connections
 (eg, via a connect() syscall), and shows the latency (time) for the connection
@@ -31,14 +31,11 @@ Include a timestamp column.
 \-p PID
 Trace this process ID only (filtered in-kernel).
 .TP
-\-m MIN_NS
-Minimum duration to trace, in milliseconds.
-.TP
-\-u MIN_US
-Minimum duration to trace, in microseconds.
-.TP
 \-v
 Print the resulting BPF program, for debugging purposes.
+.TP
+min_ns
+Minimum duration to trace, in milliseconds.
 .SH EXAMPLES
 .TP
 Trace all active TCP connections, and show connection latency (SYN->response round trip):
@@ -55,7 +52,7 @@ Trace PID 181 only:
 .TP
 Trace connects with latency longer than 10 ms:
 #
-.B tcpconnlat \-m 10
+.B tcpconnlat 10
 .TP
 Print the BPF program:
 #

--- a/man/man8/tcpconnlat.8
+++ b/man/man8/tcpconnlat.8
@@ -1,8 +1,8 @@
-.TH tcpconnect 8  "2016-02-19" "USER COMMANDS"
+.TH tcpconnlat 8  "2016-02-19" "USER COMMANDS"
 .SH NAME
-tcpconnect \- Trace TCP active connection latency. Uses Linux eBPF/bcc.
+tcpconnlat \- Trace TCP active connection latency. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B tcpconnect [\-h] [\-t] [\-p PID]
+.B tcpconnlat [\-h] [\-t] [\-p PID] [-m MIN_MS] [-u MIN_US] [-v]
 .SH DESCRIPTION
 This tool traces active TCP connections
 (eg, via a connect() syscall), and shows the latency (time) for the connection
@@ -30,19 +30,36 @@ Include a timestamp column.
 .TP
 \-p PID
 Trace this process ID only (filtered in-kernel).
+.TP
+\-m MIN_NS
+Minimum duration to trace, in milliseconds.
+.TP
+\-u MIN_US
+Minimum duration to trace, in microseconds.
+.TP
+\-v
+Print the resulting BPF program, for debugging purposes.
 .SH EXAMPLES
 .TP
 Trace all active TCP connections, and show connection latency (SYN->response round trip):
 #
-.B tcpconnect
+.B tcpconnlat
 .TP
 Include timestamps:
 #
-.B tcpconnect \-t
+.B tcpconnlat \-t
 .TP
 Trace PID 181 only:
 #
-.B tcpconnect \-p 181
+.B tcpconnlat \-p 181
+.TP
+Trace connects with latency longer than 10 ms:
+#
+.B tcpconnlat \-m 10
+.TP
+Print the BPF program:
+#
+.B tcpconnlat \-v
 .SH FIELDS
 .TP
 TIME(s)

--- a/man/man8/tcpconnlat.8
+++ b/man/man8/tcpconnlat.8
@@ -34,7 +34,7 @@ Trace this process ID only (filtered in-kernel).
 \-v
 Print the resulting BPF program, for debugging purposes.
 .TP
-min_ns
+min_ms
 Minimum duration to trace, in milliseconds.
 .SH EXAMPLES
 .TP

--- a/tools/tcpconnlat.py
+++ b/tools/tcpconnlat.py
@@ -144,7 +144,7 @@ int trace_tcp_rcv_state_process(struct pt_regs *ctx, struct sock *skp)
         data4.saddr = skp->__sk_common.skc_rcv_saddr;
         data4.daddr = skp->__sk_common.skc_daddr;
         data4.dport = ntohs(dport);
-        data4.delta_us = (now - ts) / 1000;
+        data4.delta_us = delta_us;
         __builtin_memcpy(&data4.task, infop->task, sizeof(data4.task));
         ipv4_events.perf_submit(ctx, &data4, sizeof(data4));
 
@@ -156,7 +156,7 @@ int trace_tcp_rcv_state_process(struct pt_regs *ctx, struct sock *skp)
         bpf_probe_read(&data6.daddr, sizeof(data6.daddr),
             skp->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
         data6.dport = ntohs(dport);
-        data6.delta_us = (now - ts) / 1000;
+        data6.delta_us = delta_us;
         __builtin_memcpy(&data6.task, infop->task, sizeof(data6.task));
         ipv6_events.perf_submit(ctx, &data6, sizeof(data6));
     }

--- a/tools/tcpconnlat_example.txt
+++ b/tools/tcpconnlat_example.txt
@@ -47,6 +47,6 @@ examples:
     ./tcpconnlat           # trace all TCP connect()s
     ./tcpconnlat -t        # include timestamps
     ./tcpconnlat -p 181    # only trace PID 181
-    ./tcpconnlat -m 1      # only show connects longer than 1 ms
-    ./tcpconnlat -u 100    # only show connects longer than 100 us
+    ./tcpconnlat 1         # only show connects longer than 1 ms
+    ./tcpconnlat 0.1       # only show connects longer than 100 us
     ./tcpconnlat -v        # Show the BPF program

--- a/tools/tcpconnlat_example.txt
+++ b/tools/tcpconnlat_example.txt
@@ -34,9 +34,12 @@ if the response is a RST (port closed).
 USAGE message:
 
 # ./tcpconnlat -h
-usage: tcpconnlat [-h] [-t] [-p PID]
+usage: tcpconnlat [-h] [-t] [-p PID] [min_ms]
 
 Trace TCP connects and show connection latency
+
+positional arguments:
+  min_ms             minimum duration to trace, in ms (default 0)
 
 optional arguments:
   -h, --help         show this help message and exit

--- a/tools/tcpconnlat_example.txt
+++ b/tools/tcpconnlat_example.txt
@@ -47,3 +47,6 @@ examples:
     ./tcpconnlat           # trace all TCP connect()s
     ./tcpconnlat -t        # include timestamps
     ./tcpconnlat -p 181    # only trace PID 181
+    ./tcpconnlat -m 1      # only show connects longer than 1 ms
+    ./tcpconnlat -u 100    # only show connects longer than 100 us
+    ./tcpconnlat -v        # Show the BPF program


### PR DESCRIPTION
I found it useful to filter out all the fast tcp connects so that I can only see slow ones that were causing issues. To solve this I added `-m` and `-u` options to tcpconnlat. The latency filter is only added when the min latency is set to something greater than zero.

I also added the `-v` option to print out the bpf program. I know this was already controlled with the debug setting in the python script, but this makes it a bit more consistent with some of the other scripts here.