### PR TITLE
Use /proc/kallsyms for regex filtering

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -477,10 +477,11 @@ class BPF(object):
             blacklist = set([line.rstrip().split()[1] for line in
                     blacklist_file])
         fns = []
-        with open("%s/available_filter_functions" % TRACEFS) as avail_file:
+        with open("/proc/kallsyms") as avail_file:
             for line in avail_file:
-                fn = line.rstrip().split()[0]
-                if re.match(event_re, fn) and fn not in blacklist:
+                (_, t, fn) = line.rstrip().split()[:3]
+                if (t.lower() in ['t', 'w']) and re.match(event_re, fn) \
+                    and fn not in blacklist:
                     fns.append(fn)
         return set(fns)     # Some functions may appear more than once
 


### PR DESCRIPTION
Implements @palmtenor's suggestion, from #1537.

Use `/proc/kallsyms` instead of
`/sys/kernel/debug/tracing/available_filter_functions`.
`available_filter_functions` does not contain all traceable functions,
only those ftrace can use.

Not sure we should filter on `t` and `w`...?

Fixes #1537.

/cc @liu-song-6 @yonghong-song @palmtenor 