### PR TITLE
Fix folding option

### DIFF
--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -289,7 +289,7 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
     if folded:
         # print folded stack output
         line = \
-            [k.target] + \
+            [k.target.decode()] + \
             [b.sym(addr, k.tgid)
                 for addr in reversed(list(target_user_stack)[1:])] + \
             (["-"] if args.delimited else [""]) + \
@@ -301,7 +301,7 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
             (["-"] if args.delimited else [""]) + \
             [b.sym(addr, k.tgid)
                 for addr in reversed(list(waker_user_stack))] + \
-            [k.waker]
+            [k.waker.decode()]
         print("%s %d" % (";".join(line), v.value))
 
     else:


### PR DESCRIPTION
Using the "folding" option produces an error.

/usr/share/bcc/tools/offwaketime -f 3 > out.stacks

Traceback (most recent call last):
  File "/usr/share/bcc/tools/offwaketime", line 305, in <module>
    print("%s %d" % (str.join(";", line), v.value))
TypeError: sequence item 0: expected str instance, bytes found

It seems that k.target and k.waker are always type = bytes.  This edit resolves this error.
Thank you for your time.