### PR TITLE
execsnoop: Retrieve PPID on kernel side with bpf_get_current_task

### DIFF
--- a/tools/old/execsnoop.py
+++ b/tools/old/execsnoop.py
@@ -63,7 +63,6 @@ enum event_type {
 
 struct data_t {
     u32 pid;  // PID as in the userspace term (i.e. task->tgid in kernel)
-    int ppid;
     char comm[TASK_COMM_LEN];
     enum event_type type;
     char argv[ARGSIZE];
@@ -120,10 +119,6 @@ int kretprobe__sys_execve(struct pt_regs *ctx)
 {
     struct data_t data = {};
     data.pid = bpf_get_current_pid_tgid() >> 32;
-    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
-    if (task) {
-        data.ppid = task->real_parent->pid;
-    }
     bpf_get_current_comm(&data.comm, sizeof(data.comm));
     data.type = EVENT_RET;
     data.retval = PT_REGS_RC(ctx);
@@ -147,7 +142,6 @@ ARGSIZE = 128           # should match #define in C above
 class Data(ct.Structure):
     _fields_ = [
         ("pid", ct.c_uint),
-        ("ppid", ct.c_int),
         ("comm", ct.c_char * TASK_COMM_LEN),
         ("type", ct.c_int),
         ("argv", ct.c_char * ARGSIZE),
@@ -160,6 +154,19 @@ class EventType(object):
 
 start_ts = time.time()
 argv = defaultdict(list)
+
+# TODO: This is best-effort PPID matching. Short-lived processes may exit
+# before we get a chance to read the PPID. This should be replaced with
+# fetching PPID via C when available (#364).
+def get_ppid(pid):
+    try:
+        with open("/proc/%d/status" % pid) as status:
+            for line in status:
+                if line.startswith("PPid:"):
+                    return int(line.split()[1])
+    except IOError:
+        pass
+    return 0
 
 # process event
 def print_event(cpu, data, size):
@@ -181,8 +188,9 @@ def print_event(cpu, data, size):
         if not skip:
             if args.timestamp:
                 print("%-8.3f" % (time.time() - start_ts), end="")
+            ppid = get_ppid(event.pid)
             print("%-16s %-6s %-6s %3s %s" % (event.comm.decode(), event.pid,
-                    event.ppid, event.retval,
+                    ppid if ppid > 0 else "?", event.retval,
                     b' '.join(argv[event.pid]).decode()))
         try:
             del(argv[event.pid])


### PR DESCRIPTION
Retrieve the PPID on kernel side through the `bpf_get_current_task` helper as discussed in the comments of `execsnoop.py`:

https://github.com/iovisor/bcc/blob/a44d26ed3e5e40eaad8e69d630562fb389266bee/tools/execsnoop.py#L158-L161

This new version of execsnoop requires Linux 4.8 minimum.

/cc @brendangregg 