### PR TITLE
fix flaky test py_test_usdt3

### DIFF
--- a/tests/python/test_usdt3.py
+++ b/tests/python/test_usdt3.py
@@ -73,7 +73,7 @@ int do_trace(struct pt_regs *ctx) {
 """
 
         def _create_file(name, text):
-            text_file = open(name, "w")
+            text_file = open(name, "wb")
             text_file.write(text)
             text_file.close()
 
@@ -131,7 +131,7 @@ int do_trace(struct pt_regs *ctx) {
                 self.probe_value_other = 1
 
         b["event"].open_perf_buffer(print_event)
-        for i in range(6):
+        for i in range(10):
             b.kprobe_poll()
 
         self.assertTrue(self.probe_value_1 != 0)


### PR DESCRIPTION
py_test_usdt3 has shown flakiness recently, and I actually reproduced
it on FC27. This patch increases the iteration number for
kprobe_poll and I ran the test for more than 20 times
without any failure.

Also fix a python3 compability issue. Open the file to write with
attribute "wb" instead of "w" since the text string is a byte array.

Signed-off-by: Yonghong Song <yhs@fb.com>