### PR TITLE
use __builtin_memset instead of memset with frontend rewriter

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -197,7 +197,7 @@ bool ProbeVisitor::VisitUnaryOperator(UnaryOperator *E) {
   Expr *sub = E->getSubExpr();
   string rhs = rewriter_.getRewrittenText(expansionRange(sub->getSourceRange()));
   string text;
-  text = "({ typeof(" + E->getType().getAsString() + ") _val; memset(&_val, 0, sizeof(_val));";
+  text = "({ typeof(" + E->getType().getAsString() + ") _val; __builtin_memset(&_val, 0, sizeof(_val));";
   text += " bpf_probe_read(&_val, sizeof(_val), (u64)";
   text += rhs + "); _val; })";
   rewriter_.ReplaceText(expansionRange(E->getSourceRange()), text);
@@ -233,7 +233,7 @@ bool ProbeVisitor::VisitMemberExpr(MemberExpr *E) {
   string rhs = rewriter_.getRewrittenText(expansionRange(SourceRange(rhs_start, E->getLocEnd())));
   string base_type = base->getType()->getPointeeType().getAsString();
   string pre, post;
-  pre = "({ typeof(" + E->getType().getAsString() + ") _val; memset(&_val, 0, sizeof(_val));";
+  pre = "({ typeof(" + E->getType().getAsString() + ") _val; __builtin_memset(&_val, 0, sizeof(_val));";
   pre += " bpf_probe_read(&_val, sizeof(_val), (u64)&";
   post = rhs + "); _val; })";
   rewriter_.InsertText(E->getLocStart(), pre);
@@ -377,7 +377,7 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           txt += "typeof(" + name + ".leaf) *_leaf = " + lookup + ", &_key); ";
           txt += "if (_leaf) (*_leaf)++; ";
           if (desc->second.type == BPF_MAP_TYPE_HASH) {
-            txt += "else { typeof(" + name + ".leaf) _zleaf; memset(&_zleaf, 0, sizeof(_zleaf)); ";
+            txt += "else { typeof(" + name + ".leaf) _zleaf; __builtin_memset(&_zleaf, 0, sizeof(_zleaf)); ";
             txt += "_zleaf++; ";
             txt += update + ", &_key, &_zleaf, BPF_NOEXIST); } ";
           }


### PR DESCRIPTION
When kernel CONFIG_KASAN is enabled, the function memset becomes
a global function __memset. The bcc application with probe
rewrite will incur an error like:

  error: <unknown>:0:0: in function tracepoint__task__task_newtask i32
         (%struct.tracepoint__task__task_newtask*): A call to global function
         '__memset' is not supported. Only calls to predefined BPF helpers
         are allowed.

Replace memset function with clang __builtin_memset so that
the compiler is able to eventually optimize it away.

Signed-off-by: Yonghong Song <yhs@localhost.localdomain>