### PR TITLE
fix map a type parsing issue for export/extern types

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -778,7 +778,8 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
       return false;
     }
 
-    fe_.table_storage().VisitMapType(table, C, key_type, leaf_type);
+    if (!table.is_extern)
+      fe_.table_storage().VisitMapType(table, C, key_type, leaf_type);
     fe_.table_storage().Insert(local_path, move(table));
   } else if (const PointerType *P = Decl->getType()->getAs<PointerType>()) {
     // if var is a pointer to a packet type, clone the annotation into the var

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -400,6 +400,7 @@ BPF_ARRAY(t3, union emptyu, 1);
     def test_exported_maps(self):
         b1 = BPF(text="""BPF_TABLE_PUBLIC("hash", int, int, table1, 10);""")
         b2 = BPF(text="""BPF_TABLE("extern", int, int, table1, 10);""")
+        t = b2["table1"]
 
     def test_syntax_error(self):
         with self.assertRaises(Exception):


### PR DESCRIPTION
Fix issue #1562.

Currently, bcc allows a map defined in one module and
used in the same or a different module. At tests/python directory,
test_clang.py and test_shared_table.py have such an example.
  ...
  b1 = BPF(text="""BPF_TABLE_PUBLIC("hash", int, int, table1, 10);""")
  b2 = BPF(text="""BPF_TABLE("extern", int, int, table1, 10);""")
  t = b2["table"]
  ...

With current implementation, the map key/value types are parsed
twice, resulting a type "int int" instead of "int". When type
is retrieved through `t = b2["table"]`, python decoding error
will appear.

The issue is fixed by preventing the second map key/value type
parsing if the map is `extern`. Also add `t = b2["table"]`
so the issue will be triggered if bcc clang frontend fix is not there.

Signed-off-by: Yonghong Song <yhs@fb.com>