### PR TITLE
Add missing includes to fix build against libc++

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.h
+++ b/src/cc/frontends/clang/kbuild_helper.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include <unistd.h>
+#include <errno.h>
 
 namespace ebpf {
 

--- a/src/cc/ns_guard.cc
+++ b/src/cc/ns_guard.cc
@@ -16,6 +16,7 @@
  */
 
 #include <fcntl.h>
+#include <sched.h>
 #include <sys/stat.h>
 #include <string>
 


### PR DESCRIPTION
This fixes the compile with `-stdlib=libc++`. Tested on ubuntu precise and LLVM 5.0.0.