### PR TITLE
tcptracer: Fix argparse is not defined error

### DIFF
--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -33,7 +33,7 @@ parser.add_argument("-N", "--netns", default=0, type=int,
 parser.add_argument("-v", "--verbose", action="store_true",
                     help="include Network Namespace in the output")
 parser.add_argument("--ebpf", action="store_true",
-                    help=argparse.SUPPRESS)
+                    help=ap.SUPPRESS)
 args = parser.parse_args()
 
 bpf_text = """


### PR DESCRIPTION
argparse is imported as ap, using argparse explicitly results in a name
not defined error.

Signed-off-by: Gal Pressman <galp@mellanox.com>