### PR TITLE
Fix missing include

### DIFF
--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstring>
+#include <errno.h>
 #include <sys/epoll.h>
 #include <exception>
 #include <map>


### PR DESCRIPTION
This is a followup to #1573. I found one more instance of a missing header that (must) only break the compile on linux with libc++:

This PR fixes this issue for me:

```
In file included from ../tests/cc/test_array_table.cc:17:
In file included from ../src/cc/api/BPF.h:24:
../src/cc/api/BPFTable.h:118:71: error: use of undeclared identifier 'errno'
      return StatusTuple(-1, "Error getting value: %s", std::strerror(errno));
```