### PR TITLE
Discourage use of str() type strings in python API

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -27,7 +27,7 @@ basestring = (unicode if sys.version_info[0] < 3 else str)
 from .libbcc import lib, _CB_TYPE, bcc_symbol, bcc_symbol_option, _SYM_CB_TYPE
 from .table import Table, PerfEventArray
 from .perf import Perf
-from .utils import get_online_cpus
+from .utils import get_online_cpus, printb, _assert_is_bytes, ArgString
 
 _kprobe_limit = 1000
 _num_open_probes = 0
@@ -76,21 +76,21 @@ class SymbolCache(object):
         if res < 0:
             if sym.module and sym.offset:
                 return (None, sym.offset,
-                        ct.cast(sym.module, ct.c_char_p).value.decode())
+                        ct.cast(sym.module, ct.c_char_p).value)
             return (None, addr, None)
         if demangle:
-            name_res = sym.demangle_name.decode()
+            name_res = sym.demangle_name
             lib.bcc_symbol_free_demangle_name(ct.byref(sym))
         else:
-            name_res = sym.name.decode()
-        return (name_res, sym.offset,
-                ct.cast(sym.module, ct.c_char_p).value.decode())
+            name_res = sym.name
+        return (name_res, sym.offset, ct.cast(sym.module, ct.c_char_p).value)
 
     def resolve_name(self, module, name):
+        module = _assert_is_bytes(module)
+        name = _assert_is_bytes(name)
         addr = ct.c_ulonglong()
-        if lib.bcc_symcache_resolve_name(
-                    self.cache, module.encode("ascii") if module else None,
-                    name.encode("ascii"), ct.byref(addr)) < 0:
+        if lib.bcc_symcache_resolve_name(self.cache, module, name,
+                ct.byref(addr)) < 0:
             return -1
         return addr.value
 
@@ -142,7 +142,7 @@ class BPF(object):
     XDP_PASS = 2
     XDP_TX = 3
 
-    _probe_repl = re.compile("[^a-zA-Z0-9_]")
+    _probe_repl = re.compile(b"[^a-zA-Z0-9_]")
     _sym_caches = {}
 
     _auto_includes = {
@@ -207,7 +207,8 @@ class BPF(object):
         """ If filename is invalid, search in ./ of argv[0] """
         if filename:
             if not os.path.isfile(filename):
-                t = "/".join([os.path.abspath(os.path.dirname(sys.argv[0])), filename])
+                argv0 = ArgString(sys.argv[0])
+                t = b"/".join([os.path.abspath(os.path.dirname(argv0)), filename])
                 if os.path.isfile(t):
                     filename = t
                 else:
@@ -243,7 +244,7 @@ class BPF(object):
                     return exe_file
         return None
 
-    def __init__(self, src_file="", hdr_file="", text=None, cb=None, debug=0,
+    def __init__(self, src_file=b"", hdr_file=b"", text=None, cb=None, debug=0,
             cflags=[], usdt_contexts=[]):
         """Create a new BPF module with the given source code.
 
@@ -259,6 +260,10 @@ class BPF(object):
                                    See "Debug flags" for explanation
         """
 
+        src_file = _assert_is_bytes(src_file)
+        hdr_file = _assert_is_bytes(hdr_file)
+        text = _assert_is_bytes(text)
+
         self.open_kprobes = {}
         self.open_uprobes = {}
         self.open_tracepoints = {}
@@ -271,12 +276,14 @@ class BPF(object):
         self.debug = debug
         self.funcs = {}
         self.tables = {}
+        self.module = None
         cflags_array = (ct.c_char_p * len(cflags))()
-        for i, s in enumerate(cflags): cflags_array[i] = s.encode("ascii")
+        for i, s in enumerate(cflags): cflags_array[i] = bytes(ArgString(s))
         if text:
             ctx_array = (ct.c_void_p * len(usdt_contexts))()
-            for i, usdt in enumerate(usdt_contexts): ctx_array[i] = ct.c_void_p(usdt.get_context())
-            usdt_text = lib.bcc_usdt_genargs(ctx_array, len(usdt_contexts)).decode()
+            for i, usdt in enumerate(usdt_contexts):
+                ctx_array[i] = ct.c_void_p(usdt.get_context())
+            usdt_text = lib.bcc_usdt_genargs(ctx_array, len(usdt_contexts))
             if usdt_text is None:
                 raise Exception("can't generate USDT probe arguments; " +
                                 "possible cause is missing pid when a " +
@@ -285,19 +292,19 @@ class BPF(object):
             text = usdt_text + text
 
         if text:
-            self.module = lib.bpf_module_create_c_from_string(text.encode("ascii"),
+            self.module = lib.bpf_module_create_c_from_string(text,
                     self.debug, cflags_array, len(cflags_array))
             if not self.module:
                 raise Exception("Failed to compile BPF text:\n%s" % text)
         else:
             src_file = BPF._find_file(src_file)
             hdr_file = BPF._find_file(hdr_file)
-            if src_file.endswith(".b"):
-                self.module = lib.bpf_module_create_b(src_file.encode("ascii"),
-                        hdr_file.encode("ascii"), self.debug)
+            if src_file.endswith(b".b"):
+                self.module = lib.bpf_module_create_b(src_file, hdr_file,
+                        self.debug)
             else:
-                self.module = lib.bpf_module_create_c(src_file.encode("ascii"),
-                        self.debug, cflags_array, len(cflags_array))
+                self.module = lib.bpf_module_create_c(src_file, self.debug,
+                        cflags_array, len(cflags_array))
             if not self.module:
                 raise Exception("Failed to compile BPF module %s" % src_file)
 
@@ -316,25 +323,25 @@ class BPF(object):
 
         fns = []
         for i in range(0, lib.bpf_num_functions(self.module)):
-            func_name = lib.bpf_function_name(self.module, i).decode()
+            func_name = lib.bpf_function_name(self.module, i)
             fns.append(self.load_func(func_name, prog_type))
 
         return fns
 
     def load_func(self, func_name, prog_type):
+        func_name = _assert_is_bytes(func_name)
         if func_name in self.funcs:
             return self.funcs[func_name]
-        if not lib.bpf_function_start(self.module, func_name.encode("ascii")):
+        if not lib.bpf_function_start(self.module, func_name):
             raise Exception("Unknown program %s" % func_name)
         log_level = 0
         if (self.debug & DEBUG_BPF_REGISTER_STATE):
             log_level = 2
         elif (self.debug & DEBUG_BPF):
             log_level = 1
-        fd = lib.bpf_prog_load(prog_type,
-                func_name.encode("ascii"),
-                lib.bpf_function_start(self.module, func_name.encode("ascii")),
-                lib.bpf_function_size(self.module, func_name.encode("ascii")),
+        fd = lib.bpf_prog_load(prog_type, func_name,
+                lib.bpf_function_start(self.module, func_name),
+                lib.bpf_function_size(self.module, func_name),
                 lib.bpf_module_license(self.module),
                 lib.bpf_module_kern_version(self.module),
                 log_level, None, 0);
@@ -357,11 +364,12 @@ class BPF(object):
         """
         Return the eBPF bytecodes for the specified function as a string
         """
-        if not lib.bpf_function_start(self.module, func_name.encode("ascii")):
+        func_name = _assert_is_bytes(func_name)
+        if not lib.bpf_function_start(self.module, func_name):
             raise Exception("Unknown program %s" % func_name)
 
-        start, = lib.bpf_function_start(self.module, func_name.encode("ascii")),
-        size, = lib.bpf_function_size(self.module, func_name.encode("ascii")),
+        start, = lib.bpf_function_start(self.module, func_name),
+        size, = lib.bpf_function_size(self.module, func_name),
         return ct.string_at(start, size)
 
     str2ctype = {
@@ -419,20 +427,21 @@ class BPF(object):
         return cls
 
     def get_table(self, name, keytype=None, leaftype=None, reducer=None):
-        map_id = lib.bpf_table_id(self.module, name.encode("ascii"))
-        map_fd = lib.bpf_table_fd(self.module, name.encode("ascii"))
+        name = _assert_is_bytes(name)
+        map_id = lib.bpf_table_id(self.module, name)
+        map_fd = lib.bpf_table_fd(self.module, name)
         if map_fd < 0:
             raise KeyError
         if not keytype:
-            key_desc = lib.bpf_table_key_desc(self.module, name.encode("ascii"))
+            key_desc = lib.bpf_table_key_desc(self.module, name)
             if not key_desc:
                 raise Exception("Failed to load BPF Table %s key desc" % name)
-            keytype = BPF._decode_table_type(json.loads(key_desc.decode()))
+            keytype = BPF._decode_table_type(json.loads(key_desc))
         if not leaftype:
-            leaf_desc = lib.bpf_table_leaf_desc(self.module, name.encode("ascii"))
+            leaf_desc = lib.bpf_table_leaf_desc(self.module, name)
             if not leaf_desc:
                 raise Exception("Failed to load BPF Table %s leaf desc" % name)
-            leaftype = BPF._decode_table_type(json.loads(leaf_desc.decode()))
+            leaftype = BPF._decode_table_type(json.loads(leaf_desc))
         return Table(self, map_id, map_fd, keytype, leaftype, reducer=reducer)
 
     def __getitem__(self, key):
@@ -459,9 +468,10 @@ class BPF(object):
 
     @staticmethod
     def attach_raw_socket(fn, dev):
+        dev = _assert_is_bytes(dev)
         if not isinstance(fn, BPF.Function):
             raise Exception("arg 1 must be of type BPF.Function")
-        sock = lib.bpf_open_raw_sock(dev.encode("ascii"))
+        sock = lib.bpf_open_raw_sock(dev)
         if sock < 0:
             errstr = os.strerror(ct.get_errno())
             raise Exception("Failed to open raw device %s: %s" % (dev, errstr))
@@ -474,14 +484,13 @@ class BPF(object):
 
     @staticmethod
     def get_kprobe_functions(event_re):
-        with open("%s/../kprobes/blacklist" % TRACEFS) as blacklist_file:
-            blacklist = set([line.rstrip().split()[1] for line in
-                    blacklist_file])
+        with open("%s/../kprobes/blacklist" % TRACEFS, "rb") as blacklist_f:
+            blacklist = set([line.rstrip().split()[1] for line in blacklist_f])
         fns = []
-        with open("/proc/kallsyms") as avail_file:
+        with open("/proc/kallsyms", "rb") as avail_file:
             for line in avail_file:
                 (_, t, fn) = line.rstrip().split()[:3]
-                if (t.lower() in ['t', 'w']) and re.match(event_re, fn) \
+                if (t.lower() in [b't', b'w']) and re.match(event_re, fn) \
                     and fn not in blacklist:
                     fns.append(fn)
         return set(fns)     # Some functions may appear more than once
@@ -501,7 +510,10 @@ class BPF(object):
         del self.open_kprobes[name]
         _num_open_probes -= 1
 
-    def attach_kprobe(self, event="", fn_name="", event_re=""):
+    def attach_kprobe(self, event=b"", fn_name=b"", event_re=b""):
+        event = _assert_is_bytes(event)
+        fn_name = _assert_is_bytes(fn_name)
+        event_re = _assert_is_bytes(event_re)
 
         # allow the caller to glob multiple functions together
         if event_re:
@@ -514,13 +526,11 @@ class BPF(object):
                     pass
             return
 
-        event = str(event)
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
-        ev_name = "p_" + event.replace("+", "_").replace(".", "_")
-        res = lib.bpf_attach_kprobe(fn.fd, 0, ev_name.encode("ascii"),
-                event.encode("ascii"), self._reader_cb_impl,
-                ct.cast(id(self), ct.py_object))
+        ev_name = b"p_" + event.replace(b"+", b"_").replace(b".", b"_")
+        res = lib.bpf_attach_kprobe(fn.fd, 0, ev_name, event,
+                self._reader_cb_impl, ct.cast(id(self), ct.py_object))
         res = ct.cast(res, ct.c_void_p)
         if not res:
             raise Exception("Failed to attach BPF to kprobe")
@@ -528,17 +538,20 @@ class BPF(object):
         return self
 
     def detach_kprobe(self, event):
-        event = str(event)
-        ev_name = "p_" + event.replace("+", "_").replace(".", "_")
+        event = _assert_is_bytes(event)
+        ev_name = b"p_" + event.replace(b"+", b"_").replace(b".", b"_")
         if ev_name not in self.open_kprobes:
             raise Exception("Kprobe %s is not attached" % event)
         lib.perf_reader_free(self.open_kprobes[ev_name])
-        res = lib.bpf_detach_kprobe(ev_name.encode("ascii"))
+        res = lib.bpf_detach_kprobe(ev_name)
         if res < 0:
             raise Exception("Failed to detach BPF from kprobe")
         self._del_kprobe(ev_name)
 
-    def attach_kretprobe(self, event="", fn_name="", event_re=""):
+    def attach_kretprobe(self, event=b"", fn_name=b"", event_re=b""):
+        event = _assert_is_bytes(event)
+        fn_name = _assert_is_bytes(fn_name)
+        event_re = _assert_is_bytes(event_re)
 
         # allow the caller to glob multiple functions together
         if event_re:
@@ -549,12 +562,11 @@ class BPF(object):
                     pass
             return
 
-        event = str(event)
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
-        ev_name = "r_" + event.replace("+", "_").replace(".", "_")
-        res = lib.bpf_attach_kprobe(fn.fd, 1, ev_name.encode("ascii"),
-                event.encode("ascii"), self._reader_cb_impl,
+        ev_name = b"r_" + event.replace(b"+", b"_").replace(b".", b"_")
+        res = lib.bpf_attach_kprobe(fn.fd, 1, ev_name, event,
+                self._reader_cb_impl,
                 ct.cast(id(self), ct.py_object))
         res = ct.cast(res, ct.c_void_p)
         if not res:
@@ -563,12 +575,12 @@ class BPF(object):
         return self
 
     def detach_kretprobe(self, event):
-        event = str(event)
-        ev_name = "r_" + event.replace("+", "_").replace(".", "_")
+        event = _assert_is_bytes(event)
+        ev_name = b"r_" + event.replace(b"+", b"_").replace(b".", b"_")
         if ev_name not in self.open_kprobes:
             raise Exception("Kretprobe %s is not attached" % event)
         lib.perf_reader_free(self.open_kprobes[ev_name])
-        res = lib.bpf_detach_kprobe(ev_name.encode("ascii"))
+        res = lib.bpf_detach_kprobe(ev_name)
         if res < 0:
             raise Exception("Failed to detach BPF from kprobe")
         self._del_kprobe(ev_name)
@@ -579,9 +591,10 @@ class BPF(object):
             This function attaches a BPF function to a device on the device
             driver level (XDP)
         '''
+        dev = _assert_is_bytes(dev)
         if not isinstance(fn, BPF.Function):
             raise Exception("arg 1 must be of type BPF.Function")
-        res = lib.bpf_attach_xdp(dev.encode("ascii"), fn.fd, flags)
+        res = lib.bpf_attach_xdp(dev, fn.fd, flags)
         if res < 0:
             err_no = ct.get_errno()
             if err_no == errno.EBADMSG:
@@ -598,7 +611,8 @@ class BPF(object):
             This function removes any BPF function from a device on the
             device driver level (XDP)
         '''
-        res = lib.bpf_attach_xdp(dev.encode("ascii"), -1, flags)
+        dev = _assert_is_bytes(dev)
+        res = lib.bpf_attach_xdp(dev, -1, flags)
         if res < 0:
             errstr = os.strerror(ct.get_errno())
             raise Exception("Failed to detach BPF from device %s: %s"
@@ -608,25 +622,28 @@ class BPF(object):
 
     @classmethod
     def _check_path_symbol(cls, module, symname, addr, pid):
+        module = _assert_is_bytes(module)
+        symname = _assert_is_bytes(symname)
         sym = bcc_symbol()
         c_pid = 0 if pid == -1 else pid
         if lib.bcc_resolve_symname(
-            module.encode("ascii"), symname.encode("ascii"),
+            module, symname,
             addr or 0x0, c_pid,
             ct.cast(None, ct.POINTER(bcc_symbol_option)),
             ct.byref(sym),
         ) < 0:
             raise Exception("could not determine address of symbol %s" % symname)
-        module_path = ct.cast(sym.module, ct.c_char_p).value.decode()
+        module_path = ct.cast(sym.module, ct.c_char_p).value
         lib.bcc_procutils_free(sym.module)
         return module_path, sym.offset
 
     @staticmethod
     def find_library(libname):
-        res = lib.bcc_procutils_which_so(libname.encode("ascii"), 0)
+        libname = _assert_is_bytes(libname)
+        res = lib.bcc_procutils_which_so(libname, 0)
         if not res:
             return None
-        libpath = ct.cast(res, ct.c_char_p).value.decode()
+        libpath = ct.cast(res, ct.c_char_p).value
         lib.bcc_procutils_free(res)
         return libpath
 
@@ -651,7 +668,7 @@ class BPF(object):
         evt_dir = os.path.join(TRACEFS, "events", category, event)
         return os.path.isdir(evt_dir)
 
-    def attach_tracepoint(self, tp="", tp_re="", fn_name=""):
+    def attach_tracepoint(self, tp=b"", tp_re=b"", fn_name=b""):
         """attach_tracepoint(tp="", tp_re="", fn_name="")
 
         Run the bpf function denoted by fn_name every time the kernel tracepoint
@@ -672,23 +689,25 @@ class BPF(object):
             BPF(text).attach_tracepoint(tp_re="sched:.*", fn_name="on_switch")
         """
 
+        tp = _assert_is_bytes(tp)
+        tp_re = _assert_is_bytes(tp_re)
+        fn_name = _assert_is_bytes(fn_name)
         if tp_re:
             for tp in BPF.get_tracepoints(tp_re):
                 self.attach_tracepoint(tp=tp, fn_name=fn_name)
             return
 
         fn = self.load_func(fn_name, BPF.TRACEPOINT)
-        (tp_category, tp_name) = tp.split(':')
-        res = lib.bpf_attach_tracepoint(fn.fd, tp_category.encode("ascii"),
-                tp_name.encode("ascii"), self._reader_cb_impl,
-                ct.cast(id(self), ct.py_object))
+        (tp_category, tp_name) = tp.split(b':')
+        res = lib.bpf_attach_tracepoint(fn.fd, tp_category, tp_name,
+                self._reader_cb_impl, ct.cast(id(self), ct.py_object))
         res = ct.cast(res, ct.c_void_p)
         if not res:
             raise Exception("Failed to attach BPF to tracepoint")
         self.open_tracepoints[tp] = res
         return self
 
-    def detach_tracepoint(self, tp=""):
+    def detach_tracepoint(self, tp=b""):
         """detach_tracepoint(tp="")
 
         Stop running a bpf function that is attached to the kernel tracepoint
@@ -697,12 +716,12 @@ class BPF(object):
         Example: bpf.detach_tracepoint("sched:sched_switch")
         """
 
+        tp = _assert_is_bytes(tp)
         if tp not in self.open_tracepoints:
             raise Exception("Tracepoint %s is not attached" % tp)
         lib.perf_reader_free(self.open_tracepoints[tp])
-        (tp_category, tp_name) = tp.split(':')
-        res = lib.bpf_detach_tracepoint(tp_category.encode("ascii"),
-                                        tp_name.encode("ascii"))
+        (tp_category, tp_name) = tp.split(b':')
+        res = lib.bpf_detach_tracepoint(tp_category, tp_name)
         if res < 0:
             raise Exception("Failed to detach BPF from tracepoint")
         del self.open_tracepoints[tp]
@@ -715,8 +734,9 @@ class BPF(object):
             raise Exception("Failed to attach BPF to perf event")
         return res
 
-    def attach_perf_event(self, ev_type=-1, ev_config=-1, fn_name="",
+    def attach_perf_event(self, ev_type=-1, ev_config=-1, fn_name=b"",
             sample_period=0, sample_freq=0, pid=-1, cpu=-1, group_fd=-1):
+        fn_name = _assert_is_bytes(fn_name)
         fn = self.load_func(fn_name, BPF.PERF_EVENT)
         res = {}
         if cpu >= 0:
@@ -772,29 +792,30 @@ class BPF(object):
 
     @staticmethod
     def get_user_functions_and_addresses(name, sym_re):
+        name = _assert_is_bytes(name)
+        sym_re = _assert_is_bytes(sym_re)
         addresses = []
         def sym_cb(sym_name, addr):
-            dname = sym_name.decode()
+            dname = sym_name
             if re.match(sym_re, dname):
                 addresses.append((dname, addr))
             return 0
 
-        res = lib.bcc_foreach_function_symbol(
-                name.encode('ascii'), _SYM_CB_TYPE(sym_cb))
+        res = lib.bcc_foreach_function_symbol(name, _SYM_CB_TYPE(sym_cb))
         if res < 0:
             raise Exception("Error %d enumerating symbols in %s" % (res, name))
         return addresses
 
     def _get_uprobe_evname(self, prefix, path, addr, pid):
         if pid == -1:
-            return "%s_%s_0x%x" % (prefix, self._probe_repl.sub("_", path), addr)
+            return b"%s_%s_0x%x" % (prefix, self._probe_repl.sub(b"_", path), addr)
         else:
             # if pid is valid, put pid in the name, so different pid
             # can have different event names
-            return "%s_%s_0x%x_%d" % (prefix, self._probe_repl.sub("_", path), addr, pid)
+            return b"%s_%s_0x%x_%d" % (prefix, self._probe_repl.sub(b"_", path), addr, pid)
 
-    def attach_uprobe(self, name="", sym="", sym_re="", addr=None,
-            fn_name="", pid=-1):
+    def attach_uprobe(self, name=b"", sym=b"", sym_re=b"", addr=None,
+            fn_name=b"", pid=-1):
         """attach_uprobe(name="", sym="", sym_re="", addr=None, fn_name=""
                          pid=-1)
 
@@ -816,7 +837,10 @@ class BPF(object):
                  BPF(text).attach_uprobe("/usr/bin/python", "main")
         """
 
-        name = str(name)
+        name = _assert_is_bytes(name)
+        sym = _assert_is_bytes(sym)
+        sym_re = _assert_is_bytes(sym_re)
+        fn_name = _assert_is_bytes(fn_name)
 
         if sym_re:
             addresses = BPF.get_user_addresses(name, sym_re)
@@ -830,36 +854,36 @@ class BPF(object):
 
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
-        ev_name = self._get_uprobe_evname("p", path, addr, pid)
-        res = lib.bpf_attach_uprobe(fn.fd, 0, ev_name.encode("ascii"),
-                path.encode("ascii"), addr, pid, self._reader_cb_impl,
-                ct.cast(id(self), ct.py_object))
+        ev_name = self._get_uprobe_evname(b"p", path, addr, pid)
+        res = lib.bpf_attach_uprobe(fn.fd, 0, ev_name, path, addr, pid,
+                self._reader_cb_impl, ct.cast(id(self), ct.py_object))
         res = ct.cast(res, ct.c_void_p)
         if not res:
             raise Exception("Failed to attach BPF to uprobe")
         self._add_uprobe(ev_name, res)
         return self
 
-    def detach_uprobe(self, name="", sym="", addr=None, pid=-1):
+    def detach_uprobe(self, name=b"", sym=b"", addr=None, pid=-1):
         """detach_uprobe(name="", sym="", addr=None, pid=-1)
 
         Stop running a bpf function that is attached to symbol 'sym' in library
         or binary 'name'.
         """
 
-        name = str(name)
+        name = _assert_is_bytes(name)
+        sym = _assert_is_bytes(sym)
         (path, addr) = BPF._check_path_symbol(name, sym, addr, pid)
-        ev_name = self._get_uprobe_evname("p", path, addr, pid)
+        ev_name = self._get_uprobe_evname(b"p", path, addr, pid)
         if ev_name not in self.open_uprobes:
             raise Exception("Uprobe %s is not attached" % ev_name)
         lib.perf_reader_free(self.open_uprobes[ev_name])
-        res = lib.bpf_detach_uprobe(ev_name.encode("ascii"))
+        res = lib.bpf_detach_uprobe(ev_name)
         if res < 0:
             raise Exception("Failed to detach BPF from uprobe")
         self._del_uprobe(ev_name)
 
-    def attach_uretprobe(self, name="", sym="", sym_re="", addr=None,
-            fn_name="", pid=-1):
+    def attach_uretprobe(self, name=b"", sym=b"", sym_re=b"", addr=None,
+            fn_name=b"", pid=-1):
         """attach_uretprobe(name="", sym="", sym_re="", addr=None, fn_name=""
                             pid=-1)
 
@@ -868,57 +892,62 @@ class BPF(object):
         meaning of additional parameters.
         """
 
+        name = _assert_is_bytes(name)
+        sym = _assert_is_bytes(sym)
+        sym_re = _assert_is_bytes(sym_re)
+        fn_name = _assert_is_bytes(fn_name)
+
         if sym_re:
             for sym_addr in BPF.get_user_addresses(name, sym_re):
                 self.attach_uretprobe(name=name, addr=sym_addr,
                                       fn_name=fn_name, pid=pid)
             return
 
-        name = str(name)
         (path, addr) = BPF._check_path_symbol(name, sym, addr, pid)
 
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
-        ev_name = self._get_uprobe_evname("r", path, addr, pid)
-        res = lib.bpf_attach_uprobe(fn.fd, 1, ev_name.encode("ascii"),
-                path.encode("ascii"), addr, pid, self._reader_cb_impl,
-                ct.cast(id(self), ct.py_object))
+        ev_name = self._get_uprobe_evname(b"r", path, addr, pid)
+        res = lib.bpf_attach_uprobe(fn.fd, 1, ev_name, path, addr, pid,
+                self._reader_cb_impl, ct.cast(id(self), ct.py_object))
         res = ct.cast(res, ct.c_void_p)
         if not res:
             raise Exception("Failed to attach BPF to uprobe")
         self._add_uprobe(ev_name, res)
         return self
 
-    def detach_uretprobe(self, name="", sym="", addr=None, pid=-1):
+    def detach_uretprobe(self, name=b"", sym=b"", addr=None, pid=-1):
         """detach_uretprobe(name="", sym="", addr=None, pid=-1)
 
         Stop running a bpf function that is attached to symbol 'sym' in library
         or binary 'name'.
         """
 
-        name = str(name)
+        name = _assert_is_bytes(name)
+        sym = _assert_is_bytes(sym)
+
         (path, addr) = BPF._check_path_symbol(name, sym, addr, pid)
-        ev_name = self._get_uprobe_evname("r", path, addr, pid)
+        ev_name = self._get_uprobe_evname(b"r", path, addr, pid)
         if ev_name not in self.open_uprobes:
             raise Exception("Uretprobe %s is not attached" % ev_name)
         lib.perf_reader_free(self.open_uprobes[ev_name])
-        res = lib.bpf_detach_uprobe(ev_name.encode("ascii"))
+        res = lib.bpf_detach_uprobe(ev_name)
         if res < 0:
             raise Exception("Failed to detach BPF from uprobe")
         self._del_uprobe(ev_name)
 
     def _trace_autoload(self):
         for i in range(0, lib.bpf_num_functions(self.module)):
-            func_name = str(lib.bpf_function_name(self.module, i).decode())
-            if func_name.startswith("kprobe__"):
+            func_name = lib.bpf_function_name(self.module, i)
+            if func_name.startswith(b"kprobe__"):
                 fn = self.load_func(func_name, BPF.KPROBE)
                 self.attach_kprobe(event=fn.name[8:], fn_name=fn.name)
-            elif func_name.startswith("kretprobe__"):
+            elif func_name.startswith(b"kretprobe__"):
                 fn = self.load_func(func_name, BPF.KPROBE)
                 self.attach_kretprobe(event=fn.name[11:], fn_name=fn.name)
-            elif func_name.startswith("tracepoint__"):
+            elif func_name.startswith(b"tracepoint__"):
                 fn = self.load_func(func_name, BPF.TRACEPOINT)
-                tp = fn.name[len("tracepoint__"):].replace("__", ":")
+                tp = fn.name[len(b"tracepoint__"):].replace(b"__", b":")
                 self.attach_tracepoint(tp=tp, fn_name=fn.name)
 
     def trace_open(self, nonblocking=False):
@@ -927,7 +956,7 @@ class BPF(object):
         Open the trace_pipe if not already open
         """
         if not self.tracefile:
-            self.tracefile = open("%s/trace_pipe" % TRACEFS)
+            self.tracefile = open("%s/trace_pipe" % TRACEFS, "rb")
             if nonblocking:
                 fd = self.tracefile.fileno()
                 fl = fcntl.fcntl(fd, fcntl.F_GETFL)
@@ -946,10 +975,10 @@ class BPF(object):
                 line = self.trace_readline(nonblocking)
                 if not line and nonblocking: return (None,) * 6
                 # don't print messages related to lost events
-                if line.startswith("CPU:"): continue
+                if line.startswith(b"CPU:"): continue
                 task = line[:16].lstrip()
                 line = line[17:]
-                ts_end = line.find(":")
+                ts_end = line.find(b":")
                 pid, cpu, flags, ts = line[:ts_end].split()
                 cpu = cpu[1:-1]
                 # line[ts_end:] will have ": [sym_or_addr]: msgs"
@@ -1037,11 +1066,11 @@ class BPF(object):
             "start_thread"
         """
         name, offset, module = BPF._sym_cache(pid).resolve(addr, demangle)
-        offset = "+0x%x" % offset if show_offset and name is not None else ""
-        name = name or "[unknown]"
+        offset = b"+0x%x" % offset if show_offset and name is not None else b""
+        name = name or b"[unknown]"
         name = name + offset
-        module = " [%s]" % os.path.basename(module) \
-            if show_module and module is not None else ""
+        module = b" [%s]" % os.path.basename(module) \
+            if show_module and module is not None else b""
         return name + module
 
     @staticmethod
@@ -1073,7 +1102,7 @@ class BPF(object):
         event_re is used while attaching and detaching probes. Excludes
         perf_events readers.
         """
-        return len([k for k in self.open_kprobes.keys() if isinstance(k, str)])
+        return len([k for k in self.open_kprobes.keys() if type(k) is bytes])
 
     def num_open_uprobes(self):
         """num_open_uprobes()
@@ -1109,9 +1138,9 @@ class BPF(object):
     def cleanup(self):
         for k, v in list(self.open_kprobes.items()):
             # non-string keys here include the perf_events reader
-            if isinstance(k, str):
+            if isinstance(k, bytes):
                 lib.perf_reader_free(v)
-                lib.bpf_detach_kprobe(str(k).encode("ascii"))
+                lib.bpf_detach_kprobe(bytes(k))
                 self._del_kprobe(k)
         # clean up opened perf ring buffer and perf events
         table_keys = list(self.tables.keys())
@@ -1120,13 +1149,12 @@ class BPF(object):
                 del self.tables[key]
         for k, v in list(self.open_uprobes.items()):
             lib.perf_reader_free(v)
-            lib.bpf_detach_uprobe(str(k).encode("ascii"))
+            lib.bpf_detach_uprobe(bytes(k))
             self._del_uprobe(k)
         for k, v in self.open_tracepoints.items():
             lib.perf_reader_free(v)
-            (tp_category, tp_name) = k.split(':')
-            lib.bpf_detach_tracepoint(tp_category.encode("ascii"),
-                    tp_name.encode("ascii"))
+            (tp_category, tp_name) = k.split(b':')
+            lib.bpf_detach_tracepoint(tp_category, tp_name)
         self.open_tracepoints.clear()
         for (ev_type, ev_config) in list(self.open_perf_events.keys()):
             self.detach_perf_event(ev_type, ev_config)

--- a/src/python/bcc/utils.py
+++ b/src/python/bcc/utils.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import ctypes as ct
+import sys
+import traceback
+import warnings
 
 from .libbcc import lib
 
@@ -39,3 +42,57 @@ def detect_language(candidates, pid):
     res = lib.bcc_procutils_language(pid)
     language = ct.cast(res, ct.c_char_p).value.decode()
     return language if language in candidates else None
+
+FILESYSTEMENCODING = sys.getfilesystemencoding()
+
+def printb(s, file=sys.stdout):
+    """
+    printb(s)
+
+    print a bytes object to stdout and flush
+    """
+    buf = file.buffer if hasattr(file, "buffer") else file
+
+    buf.write(s)
+    buf.write(b"\n")
+    file.flush()
+
+class ArgString(object):
+    """
+    ArgString(arg)
+
+    encapsulate a system argument that can be easily coerced to a bytes()
+    object, which is better for comparing to kernel or probe data (which should
+    never be en/decode()'ed).
+    """
+    def __init__(self, arg):
+        if sys.version_info[0] >= 3:
+            self.s = arg
+        else:
+            self.s = arg.decode(FILESYSTEMENCODING)
+
+    def __bytes__(self):
+        return self.s.encode(FILESYSTEMENCODING)
+
+    def __str__(self):
+        return self.__bytes__()
+
+def warn_with_traceback(message, category, filename, lineno, file=None, line=None):
+    log = file if hasattr(file, "write") else sys.stderr
+    traceback.print_stack(f=sys._getframe(2), file=log)
+    log.write(warnings.formatwarning(message, category, filename, lineno, line))
+
+# uncomment to get full tracebacks for invalid uses of python3+str in arguments
+#warnings.showwarning = warn_with_traceback
+
+_strict_bytes = False
+def _assert_is_bytes(arg):
+    if arg is None:
+        return arg
+    if _strict_bytes:
+        assert type(arg) is bytes, "not a bytes object: %r" % arg
+    elif type(arg) is not bytes:
+        warnings.warn("not a bytes object: %r" % arg, DeprecationWarning, 2)
+        return ArgString(arg).__bytes__()
+    return arg
+

--- a/tests/python/test_probe_count.py
+++ b/tests/python/test_probe_count.py
@@ -2,7 +2,7 @@
 # Copyright (c) Suchakra Sharma <suchakrapani.sharma@polymtl.ca>
 # Licensed under the Apache License, Version 2.0 (the "License")
 
-from bcc import BPF, _get_num_open_probes
+from bcc import BPF, _get_num_open_probes, TRACEFS
 import os
 import sys
 from unittest import main, TestCase
@@ -18,9 +18,9 @@ class TestKprobeCnt(TestCase):
 
     def test_attach1(self):
         actual_cnt = 0
-        with open("/sys/kernel/debug/tracing/available_filter_functions") as f:
+        with open("%s/available_filter_functions" % TRACEFS, "rb") as f:
             for line in f:
-                if str(line).startswith("vfs_"):
+                if line.startswith(b"vfs_"):
                     actual_cnt += 1
         open_cnt = self.b.num_open_kprobes()
         self.assertEqual(actual_cnt, open_cnt)

--- a/tests/python/test_stackid.py
+++ b/tests/python/test_stackid.py
@@ -47,7 +47,7 @@ int kprobe__htab_map_lookup_elem(struct pt_regs *ctx, struct bpf_map *map, u64 *
         stackid = stack_entries[k]
         self.assertIsNotNone(stackid)
         stack = stack_traces[stackid].ip
-        self.assertEqual(b.ksym(stack[0]), "htab_map_lookup_elem")
+        self.assertEqual(b.ksym(stack[0]), b"htab_map_lookup_elem")
 
 
 if __name__ == "__main__":

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -52,12 +52,12 @@ class SmokeTests(TestCase):
                         or (rc == 137 and kill), "rc was %d" % rc)
 
     def kmod_loaded(self, mod):
-        mods = open("/proc/modules", "r")
-        reg = re.compile("^%s\s" % mod)
-        for line in mods:
-            if reg.match(line):
-                return 1
-            return 0
+        with open("/proc/modules", "r") as mods:
+            reg = re.compile("^%s\s" % mod)
+            for line in mods:
+                if reg.match(line):
+                    return 1
+                return 0
 
     def setUp(self):
         pass

--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -138,16 +138,16 @@ while 1:
     counts = b.get_table("counts")
     for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
 
-        if re.match('mark_page_accessed', b.ksym(k.ip)) is not None:
+        if re.match(b'mark_page_accessed', b.ksym(k.ip)) is not None:
             mpa = max(0, v.value)
 
-        if re.match('mark_buffer_dirty', b.ksym(k.ip)) is not None:
+        if re.match(b'mark_buffer_dirty', b.ksym(k.ip)) is not None:
             mbd = max(0, v.value)
 
-        if re.match('add_to_page_cache_lru', b.ksym(k.ip)) is not None:
+        if re.match(b'add_to_page_cache_lru', b.ksym(k.ip)) is not None:
             apcl = max(0, v.value)
 
-        if re.match('account_page_dirtied', b.ksym(k.ip)) is not None:
+        if re.match(b'account_page_dirtied', b.ksym(k.ip)) is not None:
             apd = max(0, v.value)
 
         # access = total cache access incl. reads(mpa) and writes(mbd)

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -18,6 +18,8 @@
 
 from __future__ import print_function
 from bcc import BPF
+from bcc.utils import ArgString, printb
+import bcc.utils as utils
 import argparse
 import ctypes as ct
 import re
@@ -41,8 +43,10 @@ parser.add_argument("-t", "--timestamp", action="store_true",
 parser.add_argument("-x", "--fails", action="store_true",
     help="include failed exec()s")
 parser.add_argument("-n", "--name",
+    type=ArgString,
     help="only print commands matching this name (regex), any arg")
 parser.add_argument("-l", "--line",
+    type=ArgString,
     help="only print commands where arg contains this line (regex)")
 parser.add_argument("--max-args", default="20",
     help="maximum number of arguments parsed and displayed, defaults to 20")
@@ -186,19 +190,19 @@ def print_event(cpu, data, size):
     elif event.type == EventType.EVENT_RET:
         if event.retval != 0 and not args.fails:
             skip = True
-        if args.name and not re.search(args.name, event.comm):
+        if args.name and not re.search(bytes(args.name), event.comm):
             skip = True
-        if args.line and not re.search(args.line,
-                                       b' '.join(argv[event.pid]).decode()):
+        if args.line and not re.search(bytes(args.line),
+                                       b' '.join(argv[event.pid])):
             skip = True
 
         if not skip:
             if args.timestamp:
                 print("%-8.3f" % (time.time() - start_ts), end="")
             ppid = get_ppid(event.pid)
-            print("%-16s %-6s %-6s %3s %s" % (event.comm.decode(), event.pid,
-                    ppid if ppid > 0 else "?", event.retval,
-                    b' '.join(argv[event.pid]).decode()))
+            ppid = b"%d" % ppid if ppid > 0 else b"?"
+            printb(b"%-16s %-6d %-6s %3d %s" % (event.comm, event.pid,
+                   ppid, event.retval, b' '.join(argv[event.pid])))
         try:
             del(argv[event.pid])
         except Exception:

--- a/tools/funccount.py
+++ b/tools/funccount.py
@@ -16,7 +16,7 @@
 # 18-Oct-2016   Sasha Goldshtein    Generalized for uprobes, tracepoints, USDT.
 
 from __future__ import print_function
-from bcc import BPF, USDT
+from bcc import ArgString, BPF, USDT
 from time import sleep, strftime
 import argparse
 import os
@@ -49,15 +49,15 @@ class Probe(object):
             t:cat:event     -- probe a kernel tracepoint
             u:lib:probe     -- probe a USDT tracepoint
         """
-        parts = pattern.split(':')
+        parts = bytes(pattern).split(b':')
         if len(parts) == 1:
-            parts = ["p", "", parts[0]]
+            parts = [b"p", b"", parts[0]]
         elif len(parts) == 2:
-            parts = ["p", parts[0], parts[1]]
+            parts = [b"p", parts[0], parts[1]]
         elif len(parts) == 3:
-            if parts[0] == "t":
-                parts = ["t", "", "%s:%s" % tuple(parts[1:])]
-            if parts[0] not in ["p", "t", "u"]:
+            if parts[0] == b"t":
+                parts = [b"t", b"", b"%s:%s" % tuple(parts[1:])]
+            if parts[0] not in [b"p", b"t", b"u"]:
                 raise Exception("Type must be 'p', 't', or 'u', but got %s" %
                                 parts[0])
         else:
@@ -66,10 +66,10 @@ class Probe(object):
 
         (self.type, self.library, self.pattern) = parts
         if not use_regex:
-            self.pattern = self.pattern.replace('*', '.*')
-            self.pattern = '^' + self.pattern + '$'
+            self.pattern = self.pattern.replace(b'*', b'.*')
+            self.pattern = b'^' + self.pattern + b'$'
 
-        if (self.type == "p" and self.library) or self.type == "u":
+        if (self.type == b"p" and self.library) or self.type == b"u":
             libpath = BPF.find_library(self.library)
             if libpath is None:
                 # This might be an executable (e.g. 'bash')
@@ -83,46 +83,46 @@ class Probe(object):
         self.trace_functions = {}   # map location number to function name
 
     def is_kernel_probe(self):
-        return self.type == "t" or (self.type == "p" and self.library == "")
+        return self.type == b"t" or (self.type == b"p" and self.library == b"")
 
     def attach(self):
-        if self.type == "p" and not self.library:
+        if self.type == b"p" and not self.library:
             for index, function in self.trace_functions.items():
                 self.bpf.attach_kprobe(
                         event=function,
                         fn_name="trace_count_%d" % index)
-        elif self.type == "p" and self.library:
+        elif self.type == b"p" and self.library:
             for index, function in self.trace_functions.items():
                 self.bpf.attach_uprobe(
                         name=self.library,
                         sym=function,
                         fn_name="trace_count_%d" % index,
                         pid=self.pid or -1)
-        elif self.type == "t":
+        elif self.type == b"t":
             for index, function in self.trace_functions.items():
                 self.bpf.attach_tracepoint(
                         tp=function,
                         fn_name="trace_count_%d" % index)
-        elif self.type == "u":
+        elif self.type == b"u":
             pass    # Nothing to do -- attach already happened in `load`
 
     def _add_function(self, template, probe_name):
-        new_func = "trace_count_%d" % self.matched
-        text = template.replace("PROBE_FUNCTION", new_func)
-        text = text.replace("LOCATION", str(self.matched))
+        new_func = b"trace_count_%d" % self.matched
+        text = template.replace(b"PROBE_FUNCTION", new_func)
+        text = text.replace(b"LOCATION", b"%d" % self.matched)
         self.trace_functions[self.matched] = probe_name
         self.matched += 1
         return text
 
     def _generate_functions(self, template):
         self.usdt = None
-        text = ""
-        if self.type == "p" and not self.library:
+        text = b""
+        if self.type == b"p" and not self.library:
             functions = BPF.get_kprobe_functions(self.pattern)
             verify_limit(len(functions))
             for function in functions:
                 text += self._add_function(template, function)
-        elif self.type == "p" and self.library:
+        elif self.type == b"p" and self.library:
             # uprobes are tricky because the same function may have multiple
             # addresses, and the same address may be mapped to multiple
             # functions. We aren't allowed to create more than one uprobe
@@ -139,12 +139,12 @@ class Probe(object):
                 addresses.add(address)
                 functions.add(function)
                 text += self._add_function(template, function)
-        elif self.type == "t":
+        elif self.type == b"t":
             tracepoints = BPF.get_tracepoints(self.pattern)
             verify_limit(len(tracepoints))
             for tracepoint in tracepoints:
                 text += self._add_function(template, tracepoint)
-        elif self.type == "u":
+        elif self.type == b"u":
             self.usdt = USDT(path=self.library, pid=self.pid)
             matches = []
             for probe in self.usdt.enumerate_probes():
@@ -154,7 +154,7 @@ class Probe(object):
                     matches.append(probe.name)
             verify_limit(len(matches))
             for match in matches:
-                new_func = "trace_count_%d" % self.matched
+                new_func = b"trace_count_%d" % self.matched
                 text += self._add_function(template, match)
                 self.usdt.enable_probe(match, new_func)
             if debug:
@@ -162,7 +162,7 @@ class Probe(object):
         return text
 
     def load(self):
-        trace_count_text = """
+        trace_count_text = b"""
 int PROBE_FUNCTION(void *ctx) {
     FILTER
     int loc = LOCATION;
@@ -174,7 +174,7 @@ int PROBE_FUNCTION(void *ctx) {
     return 0;
 }
         """
-        bpf_text = """#include <uapi/linux/ptrace.h>
+        bpf_text = b"""#include <uapi/linux/ptrace.h>
 
 BPF_ARRAY(counts, u64, NUMLOCATIONS);
         """
@@ -182,15 +182,15 @@ BPF_ARRAY(counts, u64, NUMLOCATIONS);
         # We really mean the tgid from the kernel's perspective, which is in
         # the top 32 bits of bpf_get_current_pid_tgid().
         if self.pid:
-            trace_count_text = trace_count_text.replace('FILTER',
-                """u32 pid = bpf_get_current_pid_tgid() >> 32;
+            trace_count_text = trace_count_text.replace(b'FILTER',
+                b"""u32 pid = bpf_get_current_pid_tgid() >> 32;
                    if (pid != %d) { return 0; }""" % self.pid)
         else:
-            trace_count_text = trace_count_text.replace('FILTER', '')
+            trace_count_text = trace_count_text.replace(b'FILTER', b'')
 
         bpf_text += self._generate_functions(trace_count_text)
-        bpf_text = bpf_text.replace("NUMLOCATIONS",
-                                    str(len(self.trace_functions)))
+        bpf_text = bpf_text.replace(b"NUMLOCATIONS",
+                                    b"%d" % len(self.trace_functions))
         if debug:
             print(bpf_text)
 
@@ -242,6 +242,7 @@ class Tool(object):
         parser.add_argument("-D", "--debug", action="store_true",
             help="print BPF program before starting (for debugging purposes)")
         parser.add_argument("pattern",
+            type=ArgString,
             help="search expression for events")
         self.args = parser.parse_args()
         global debug
@@ -260,7 +261,7 @@ class Tool(object):
         self.probe.load()
         self.probe.attach()
         print("Tracing %d functions for \"%s\"... Hit Ctrl-C to end." %
-              (self.probe.matched, self.args.pattern))
+              (self.probe.matched, bytes(self.args.pattern)))
         exiting = 0 if self.args.interval else 1
         seconds = 0
         while True:

--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -471,7 +471,7 @@ def print_outstanding():
                          key=lambda a: a.size)[-top_stacks:]
         for alloc in to_show:
                 print("\t%d bytes in %d allocations from stack\n\t\t%s" %
-                      (alloc.size, alloc.count, "\n\t\t".join(alloc.stack)))
+                      (alloc.size, alloc.count, b"\n\t\t".join(alloc.stack)))
 
 def print_outstanding_combined():
         stack_traces = bpf["stack_traces"]

--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -17,6 +17,7 @@
 
 from __future__ import print_function
 from bcc import BPF
+from bcc.utils import printb
 from time import sleep, strftime
 import argparse
 import signal
@@ -124,7 +125,7 @@ while 1:
     line = 0
     for k, v in reversed(sorted(counts.items(),
                                 key=lambda counts: counts[1].size)):
-        print("%-32s %6d %10d" % (k.name.decode(), v.count, v.size))
+        printb(b"%-32s %6d %10d" % (k.name, v.count, v.size))
 
         line += 1
         if line >= maxrows:


### PR DESCRIPTION
This PR attempts to remove use of the python2 str() type object in favor of the more explicit bytes(), which has a consistent behavior between python2/3. Any unknown or command line arguments which are meant to be compared against kernel strings (e.g. things on the ring buffer) should be of this object type. There should be no more use of encode/decode to mangle data coming from an untrusted source, as this has been shown to confuse the utf encoder.

The approach that this change takes does put a burden on tools authors, since it requires use of `b""` type strings for any arguments that are fed to a c API. This includes the text of the program to be compiled itself.

As an aid to conversion, all python APIs that wrap a C api have added a sanity check to the arguments that are expected to be c-strings, `_assert_is_bytes()`. For now, this helper will check and silently convert, in the safest way feasible, a utf string to a ascii string. The assertion internally has a warning that will report incorrect API usage with a command-line configurable check. For instance, running `python -W default ./killsnoop.py` will report 2 incorrect uses:
```
/usr/lib/python3.6/site-packages/bcc/__init__.py:265: DeprecationWarning: not a bytes object: '\n#include <uapi/linux/ptrace.h>\n#inclu ...'
  text = _assert_is_bytes(text)
TIME      PID    COMM             SIG  TPID   RESULT
/usr/lib/python3.6/site-packages/bcc/__init__.py:430: DeprecationWarning: not a bytes object: 'events'
```

Follow-on commits should attempt to clean up these warnings on a tool-by-tool basis.
