### PR TITLE
Fix two issues in examples

### DIFF
--- a/examples/tracing/sync_timing.py
+++ b/examples/tracing/sync_timing.py
@@ -14,7 +14,6 @@ from bcc import BPF
 # load BPF program
 b = BPF(text="""
 #include <uapi/linux/ptrace.h>
-#include <linux/blkdev.h>
 
 BPF_HASH(last);
 

--- a/examples/tracing/urandomread-explicit.py
+++ b/examples/tracing/urandomread-explicit.py
@@ -33,7 +33,7 @@ struct urandom_read_args {
 int printarg(struct urandom_read_args *args) {
     bpf_trace_printk("%d\\n", args->got_bits);
     return 0;
-};
+}
 """
 
 # load BPF program

--- a/examples/tracing/urandomread.py
+++ b/examples/tracing/urandomread.py
@@ -20,7 +20,7 @@ TRACEPOINT_PROBE(random, urandom_read) {
     // args is from /sys/kernel/debug/tracing/events/random/urandom_read/format
     bpf_trace_printk("%d\\n", args->got_bits);
     return 0;
-};
+}
 """)
 
 # header


### PR DESCRIPTION
Two cosmetic fixes here, they may mislead new users about how to write a tracing script.