### PR TITLE
Implement get_text for Python USDT class

### DIFF
--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -165,6 +165,11 @@ tplist tool.""")
     def get_context(self):
         return self.context
 
+    def get_text(self):
+        ctx_array = (ct.c_void_p * 1)()
+        ctx_array[0] = ct.c_void_p(self.context)
+        return lib.bcc_usdt_genargs(ctx_array, 1).decode()
+
     def get_probe_arg_ctype(self, probe_name, arg_index):
         return lib.bcc_usdt_get_probe_argctype(
             self.context, probe_name, arg_index)


### PR DESCRIPTION
In #1263 Python's `USDT.get_text` was replaced by `USDT.get_context` in order to support multiple attaching. The change is good for that purpose. However there are still plenty of tools uses `USDT.get_context` for debugging purposes (like `--verbose`/`--debug` options to print the full program):
```
examples/tracing/nodejs_http_server.py:38:    print(u.get_text())
examples/tracing/mysqld_query.py:45:    print(u.get_text())
tools/funccount.py:161:                print(self.usdt.get_text())
tools/argdist.py:669:                        for text in [probe.usdt_ctx.get_text()
tools/stackcount.py:196:                print(self.usdt.get_text())
tools/dbstat.py:92:    print('\n'.join(map(lambda u: u.get_text(), usdts)))
tools/lib/uflow.py:162:    print(usdt.get_text())
tools/lib/ugc.py:208:    print(usdt.get_text())
tools/lib/uobjnew.py:145:    print(usdt.get_text())
tools/lib/uthreads.py:92:    print(usdt.get_text())
tools/lib/ucalls.py:243:        print(usdt.get_text())
tools/mysqld_qslower.py:101:    print(u.get_text())
tools/dbslower.py:197:        print('\n'.join(map(lambda u: u.get_text(), usdts)))
tools/trace.py:710:                                print(probe.usdt.get_text())
```
This commit re-implements `USDT.get_text` to support these call sites.