### PR TITLE
Destruct USDTContext correctly in Python

### DIFF
--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -414,8 +414,10 @@ void *bcc_usdt_new_frompath(const char *path) {
 }
 
 void bcc_usdt_close(void *usdt) {
-  USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
-  delete ctx;
+  if (usdt) {
+    USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
+    delete ctx;
+  }
 }
 
 int bcc_usdt_enable_probe(void *usdt, const char *probe_name,

--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -142,6 +142,9 @@ class USDT(object):
             raise USDTException(
                     "either a pid or a binary path must be specified")
 
+    def __del__(self):
+        lib.bcc_usdt_close(self.context)
+
     def enable_probe(self, probe, fn_name):
         if lib.bcc_usdt_enable_probe(self.context, probe.encode('ascii'),
                 fn_name.encode('ascii')) != 0:


### PR DESCRIPTION
Currently the Python `USDT` class creates a C++ `USDTContext` on construct but does nothing on destruct. This is normally fine. However, for USDT that has Semaphore, this means BCC tools won't decrease / disable the semaphore on exit and leaving the USDT still enabled. This commit fixes the issue.