### PR TITLE
filesystem scripts: check filesystem by superblock's magic number

### DIFF
--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -30,9 +30,6 @@ import argparse
 from time import strftime
 import ctypes as ct
 
-# symbols
-kallsyms = "/proc/kallsyms"
-
 # arguments
 examples = """examples:
     ./ext4slower             # trace operations slower than 10 ms (default)
@@ -65,6 +62,7 @@ bpf_text = """
 #include <linux/fs.h>
 #include <linux/sched.h>
 #include <linux/dcache.h>
+#include <uapi/linux/magic.h>
 
 // XXX: switch these to char's when supported
 #define TRACE_READ      0
@@ -99,7 +97,7 @@ BPF_PERF_OUTPUT(events);
 
 // The current ext4 (Linux 4.5) uses generic_file_read_iter(), instead of it's
 // own function, for reads. So we need to trace that and then filter on ext4,
-// which I do by checking file->f_op.
+// which I do by checking file->f_mapping->host->i_sb->s_magic.
 int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 {
     u64 id =  bpf_get_current_pid_tgid();
@@ -108,9 +106,8 @@ int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
     if (FILTER_PID)
         return 0;
 
-    // ext4 filter on file->f_op == ext4_file_operations
     struct file *fp = iocb->ki_filp;
-    if ((u64)fp->f_op != EXT4_FILE_OPERATIONS)
+    if ((u64)fp->f_mapping->host->i_sb->s_magic != EXT4_SUPER_MAGIC)
         return 0;
 
     // store filep and timestamp by id
@@ -254,19 +251,6 @@ int trace_fsync_return(struct pt_regs *ctx)
 """
 
 # code replacements
-with open(kallsyms) as syms:
-    ops = ''
-    for line in syms:
-        (addr, size, name) = line.rstrip().split(" ", 2)
-        name = name.split("\t")[0]
-        if name == "ext4_file_operations":
-            ops = "0x" + addr
-            break
-    if ops == '':
-        print("ERROR: no ext4_file_operations in /proc/kallsyms. Exiting.")
-        print("HINT: the kernel should be built with CONFIG_KALLSYMS_ALL.")
-        exit()
-    bpf_text = bpf_text.replace('EXT4_FILE_OPERATIONS', ops)
 if min_ms == 0:
     bpf_text = bpf_text.replace('FILTER_US', '0')
 else:


### PR DESCRIPTION
Scripts of btrfs and ext4 get updated to use superblock's magic number.