### PR TITLE
Script to check that the lists of helpers are in sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ install:
   - sudo apt-get install -y python-pip
   - sudo pip install pep8
 script:
+  - ./scripts/check-helpers.sh
   - find tools/ -type f -name "*.py" | xargs pep8 -r --show-source --ignore=E123,E125,E126,E127,E128,E302

--- a/scripts/check-helpers.sh
+++ b/scripts/check-helpers.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+ret=0
+
+grep -oP '(?<={")\w+(?=", "\d\.\d+")' src/cc/libbpf.c | sort > /tmp/libbpf.txt
+grep -oP "(?<=BPF_FUNC_)\w+" docs/kernel-versions.md | sort > /tmp/doc.txt
+dif=`diff /tmp/libbpf.txt /tmp/doc.txt`
+if [ $? -ne 0 ]; then
+	echo "The lists of helpers in src/cc/libbpf.c and docs/kernel-versions.md differ:"
+	echo -e "$dif\n"
+	((ret++))
+fi
+
+grep -oP "(?<=^\sFN\()\w+" src/cc/compat/linux/bpf.h | tail -n +2 | sort > /tmp/compat.txt
+dif=`diff /tmp/doc.txt /tmp/compat.txt`
+if [ $? -ne 0 ]; then
+	echo "The lists of helpers in docs/kernel-versions.md and src/cc/compat/linux/bpf.h differ:"
+	echo -e "$dif\n"
+	((ret++))
+fi
+
+grep -oP "(?<=BPF_FUNC_)\w+" src/cc/export/helpers.h | sort -u > /tmp/export.txt
+dif=`diff /tmp/compat.txt /tmp/export.txt`
+if [ $? -ne 0 ]; then
+	echo "The lists of helpers in src/cc/compat/linux/bpf.h and src/cc/export/helpers.h differ:"
+	echo "$dif"
+	((ret++))
+fi
+
+exit $ret


### PR DESCRIPTION
This `scripts/check-helpers.sh` checks that the lists of helpers in [`src/cc/libbpf.c`](https://github.com/iovisor/bcc/blob/f2354fa5765f6e7ffb370caf92c5d9508add07b4/src/cc/libbpf.c#L93-L150), [`docs/kernel-versions.md`](https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md#helpers), [`src/cc/compat/linux/bpf.h`](https://github.com/iovisor/bcc/blob/f2354fa5765f6e7ffb370caf92c5d9508add07b4/src/cc/compat/linux/bpf.h#L693-L751), and [`src/cc/export/helpers.h`](https://github.com/iovisor/bcc/blob/f2354fa5765f6e7ffb370caf92c5d9508add07b4/src/cc/export/helpers.h#L200-L330) are in sync.

I'm writing the lists to the disk (`/tmp/`) in order to compare them. I couldn't find a solution that doesn't require writing to the disk (any other idea?).