### PR TITLE
scripts: avoid check-helpers.sh's writes to disk

### DIFF
--- a/scripts/check-helpers.sh
+++ b/scripts/check-helpers.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 ret=0
 
-grep -oP '(?<={")\w+(?=", "\d\.\d+")' src/cc/libbpf.c | sort > /tmp/libbpf.txt
-grep -oP "(?<=BPF_FUNC_)\w+" docs/kernel-versions.md | sort > /tmp/doc.txt
-dif=`diff /tmp/libbpf.txt /tmp/doc.txt`
+libbpf=$(grep -oP '(?<={")\w+(?=", "\d\.\d+")' src/cc/libbpf.c | sort)
+doc=$(grep -oP "(?<=BPF_FUNC_)\w+" docs/kernel-versions.md | sort)
+dif=$(diff <(echo "$doc") <(echo "$libbpf"))
 if [ $? -ne 0 ]; then
 	echo "The lists of helpers in src/cc/libbpf.c and docs/kernel-versions.md differ:"
 	echo -e "$dif\n"
 	((ret++))
 fi
 
-grep -oP "(?<=^\sFN\()\w+" src/cc/compat/linux/bpf.h | tail -n +2 | sort > /tmp/compat.txt
-dif=`diff /tmp/doc.txt /tmp/compat.txt`
+compat=$(grep -oP "(?<=^\sFN\()\w+" src/cc/compat/linux/bpf.h | tail -n +2 | sort)
+dif=$(diff <(echo "$doc") <(echo "$compat"))
 if [ $? -ne 0 ]; then
 	echo "The lists of helpers in docs/kernel-versions.md and src/cc/compat/linux/bpf.h differ:"
 	echo -e "$dif\n"
 	((ret++))
 fi
 
-grep -oP "(?<=BPF_FUNC_)\w+" src/cc/export/helpers.h | sort -u > /tmp/export.txt
-dif=`diff /tmp/compat.txt /tmp/export.txt`
+export=$(grep -oP "(?<=BPF_FUNC_)\w+" src/cc/export/helpers.h | sort -u)
+dif=$(diff <(echo "$compat") <(echo "$export"))
 if [ $? -ne 0 ]; then
 	echo "The lists of helpers in src/cc/compat/linux/bpf.h and src/cc/export/helpers.h differ:"
 	echo "$dif"


### PR DESCRIPTION
As a follow up to #1592, @qmonnet suggested the `diff <(ls dir1) <(ls dir2)` syntax to avoid writing to disk to compare the lists of helpers. This pull request implements this and also replaces backticks for command substitution with the recommended parenthesis syntax (`$(diff ...)`).

/cc @yonghong-song @qmonnet 