### PR TITLE
Explicitly include sys/types.h

### DIFF
--- a/src/cc/ns_guard.h
+++ b/src/cc/ns_guard.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <memory>
+#include <sys/types.h>
 
 #include "file_desc.h"
 


### PR DESCRIPTION
This will help build bcc on Alpine Linux.

See discussion in https://github.com/iovisor/bcc/issues/421#issuecomment-362889861.