### PR TITLE
add a BPFModule API to disable rw_engine sscanf/snprintf functions

### DIFF
--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -45,8 +45,9 @@ class BPF {
  public:
   static const int BPF_MAX_STACK_DEPTH = 127;
 
-  explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr)
-      : flag_(flag), bpf_module_(new BPFModule(flag, ts)) {}
+  explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr,
+               bool rw_engine_enabled = true)
+      : flag_(flag), bpf_module_(new BPFModule(flag, ts, rw_engine_enabled)) {}
   StatusTuple init(const std::string& bpf_program,
                    const std::vector<std::string>& cflags = {},
                    const std::vector<USDT>& usdt = {});

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -75,7 +75,7 @@ class BPFModule {
                        const void *val);
 
  public:
-  BPFModule(unsigned flags, TableStorage *ts = nullptr);
+  BPFModule(unsigned flags, TableStorage *ts = nullptr, bool rw_engine_enabled = true);
   ~BPFModule();
   int load_b(const std::string &filename, const std::string &proto_filename);
   int load_c(const std::string &filename, const char *cflags[], int ncflags);
@@ -120,6 +120,7 @@ class BPFModule {
 
  private:
   unsigned flags_;  // 0x1 for printing
+  bool rw_engine_enabled_;
   bool used_b_loader_;
   std::string filename_;
   std::string proto_filename_;

--- a/tests/cc/test_array_table.cc
+++ b/tests/cc/test_array_table.cc
@@ -27,7 +27,8 @@ TEST_CASE("test array table", "[array_table]") {
     BPF_TABLE("array", int, int, myarray, 128);
   )";
 
-  ebpf::BPF bpf;
+  // turn off the rw_engine
+  ebpf::BPF bpf(0, nullptr, false);
   ebpf::StatusTuple res(0);
   res = bpf.init(BPF_PROGRAM);
   REQUIRE(res.code() == 0);


### PR DESCRIPTION
Currently, for every table of a module, corresponding
key/value sscanf/snprintf functions will be generated.
These functions are mostly used for python API to
facilitate passing keys between python and C++.

It is a known issue that these sscanf/snprintf functions
can consume a lot of system resources esp. memory for
large arrays. Commit 22eae8c6b29d ("Use late-binding to
finalize snprintf/sscanf") avoids unnecessary code
generation for snprintf/sscanf until they are called.
Even with this commit, however, the overhead can still
be significant for large arrays.

For example, the following large array,
  #define TCP6_RXMIT_BUCKET_BITS 18
  struct tcp6_rxmit_tbl {
    __u64 buckets[1 << TCP6_RXMIT_BUCKET_BITS];
  };
  BPF_ARRAY(rxmit_marking_map, struct tcp6_rxmit_tbl, 1);
is used inside Facebook. The reason to use such a large array
is for performance.

If it is added to examples/cpp/HelloWorld.cpp,
the HelloWorld RSS memory will increase from 7MB to
370MB.

This patch add a BPFModule API to disable rw_engine sscanf/snprintf
function. This is only for advanced user which directly interects
with BPFModule. Most C++ API users may not use sscanf/snprintf
functionalities and if there is a need, we can add a corresponding
C++ API.

Signed-off-by: Yonghong Song <yhs@fb.com>