### PR TITLE
fix percpu table support in c++ api

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -37,7 +37,7 @@ set(bcc_table_sources table_storage.cc shared_table.cc bpffs_table.cc json_map_d
 set(bcc_util_sources ns_guard.cc common.cc)
 set(bcc_sym_sources bcc_syms.cc bcc_elf.c bcc_perf_map.c bcc_proc.c)
 set(bcc_common_headers libbpf.h perf_reader.h)
-set(bcc_table_headers file_desc.h table_desc.h table_storage.h)
+set(bcc_table_headers common.h file_desc.h table_desc.h table_storage.h)
 set(bcc_api_headers bpf_common.h bpf_module.h bcc_exception.h bcc_syms.h)
 
 if(ENABLE_CLANG_JIT)

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -105,12 +105,28 @@ class BPF {
     return BPFArrayTable<ValueType>({});
   }
 
+  template <class ValueType>
+  BPFPercpuArrayTable<ValueType> get_percpu_array_table(const std::string& name) {
+    TableStorage::iterator it;
+    if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+      return BPFPercpuArrayTable<ValueType>(it->second);
+    return BPFPercpuArrayTable<ValueType>({});
+  }
+
   template <class KeyType, class ValueType>
   BPFHashTable<KeyType, ValueType> get_hash_table(const std::string& name) {
     TableStorage::iterator it;
     if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
       return BPFHashTable<KeyType, ValueType>(it->second);
     return BPFHashTable<KeyType, ValueType>({});
+  }
+
+  template <class KeyType, class ValueType>
+  BPFPercpuHashTable<KeyType, ValueType> get_percpu_hash_table(const std::string& name) {
+    TableStorage::iterator it;
+    if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+      return BPFPercpuHashTable<KeyType, ValueType>(it->second);
+    return BPFPercpuHashTable<KeyType, ValueType>({});
   }
 
   BPFProgTable get_prog_table(const std::string& name);

--- a/tests/cc/test_array_table.cc
+++ b/tests/cc/test_array_table.cc
@@ -21,6 +21,8 @@
 #include <random>
 #include <iostream>
 
+#include <linux/version.h>
+
 TEST_CASE("test array table", "[array_table]") {
   const std::string BPF_PROGRAM = R"(
     BPF_TABLE("hash", int, int, myhash, 128);
@@ -91,3 +93,55 @@ TEST_CASE("test array table", "[array_table]") {
     REQUIRE(localtable == offlinetable);
   }
 }
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
+TEST_CASE("percpu array table", "[percpu_array_table]") {
+  const std::string BPF_PROGRAM = R"(
+    BPF_TABLE("percpu_hash", int, u64, myhash, 128);
+    BPF_TABLE("percpu_array", int, u64, myarray, 64);
+  )";
+
+  ebpf::BPF bpf;
+  ebpf::StatusTuple res(0);
+  res = bpf.init(BPF_PROGRAM);
+  REQUIRE(res.code() == 0);
+
+  ebpf::BPFPercpuArrayTable<uint64_t> t = bpf.get_percpu_array_table<uint64_t>("myarray");
+  size_t ncpus = ebpf::get_possible_cpus().size();
+
+  SECTION("bad table type") {
+    // try to get table of wrong type
+    auto f1 = [&](){
+      bpf.get_percpu_array_table<uint64_t>("myhash");
+    };
+
+    REQUIRE_THROWS(f1());
+  }
+
+  SECTION("standard methods") {
+    int i;
+    std::vector<uint64_t> v1(ncpus);
+    std::vector<uint64_t> v2;
+
+    for (size_t j = 0; j < ncpus; j++) {
+      v1[j] = 42 * j;
+    }
+
+    i = 1;
+    // update element
+    res = t.update_value(i, v1);
+    REQUIRE(res.code() == 0);
+    res = t.get_value(i, v2);
+    REQUIRE(res.code() == 0);
+    REQUIRE(v2.size() == ncpus);
+    for (size_t j = 0; j < ncpus; j++) {
+      REQUIRE(v2.at(j) == 42 * j);
+    }
+
+    // get non existing element
+    i = 1024;
+    res = t.get_value(i, v2);
+    REQUIRE(res.code() != 0);
+  }
+}
+#endif


### PR DESCRIPTION
Current table C++ API doesn't take into consideration the special structure of percpu maps. Hence all operations performed on those maps have only effect on CPU 0.