### PR TITLE
Upgrade snap llvm toolchain version

### DIFF
--- a/snapcraft/snapcraft.yaml
+++ b/snapcraft/snapcraft.yaml
@@ -336,9 +336,9 @@ parts:
             - cmake
             - flex
             - libedit-dev
-            - libllvm3.7
-            - llvm-3.7-dev
-            - libclang-3.7-dev
+            - libllvm4.0
+            - llvm-4.0-dev
+            - libclang-4.0-dev
             - python
             - zlib1g-dev
             - libelf-dev


### PR DESCRIPTION
`llvm-3.7` toolchain no longer exists in Ubuntu 17.10 (artful). By switching to `llvm-4.0`, this snap builds in both 16.04 and 17.10.