### PR TITLE
setup some bpf_module data structures correctly when rw_engine is disabled

### DIFF
--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -61,6 +61,7 @@ class BPFModule {
   int parse(llvm::Module *mod);
   int finalize();
   int annotate();
+  void annotate_light();
   std::unique_ptr<llvm::ExecutionEngine> finalize_rw(std::unique_ptr<llvm::Module> mod);
   std::string make_reader(llvm::Module *mod, llvm::Type *type);
   std::string make_writer(llvm::Module *mod, llvm::Type *type);


### PR DESCRIPTION

Commit db7b8eb0c018 ("add a BPFModule API to disable rw_engine
sscanf/snprintf functions") permits to disable rw_engine so that
memory can be saved for structures with large arrays. As a result,
the function BPFModule::annotate(), which is used to generate
"sscanf" module, is not called when rw_engine is disabled.

Besides generating "sscanf" module, however, BPFModule::annotate()
also sets up several other data structures which are used for
map/table manipulation. This patch implements BPFModule::annotate_light(),
which will be called when rw_engine is disabled, to
setup these data structures.

Signed-off-by: Yonghong Song <yhs@fb.com>