### PR TITLE
Avoid including common.h in BPFTable.h

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -37,7 +37,7 @@ set(bcc_table_sources table_storage.cc shared_table.cc bpffs_table.cc json_map_d
 set(bcc_util_sources ns_guard.cc common.cc)
 set(bcc_sym_sources bcc_syms.cc bcc_elf.c bcc_perf_map.c bcc_proc.c)
 set(bcc_common_headers libbpf.h perf_reader.h)
-set(bcc_table_headers common.h file_desc.h table_desc.h table_storage.h)
+set(bcc_table_headers file_desc.h table_desc.h table_storage.h)
 set(bcc_api_headers bpf_common.h bpf_module.h bcc_exception.h bcc_syms.h)
 
 if(ENABLE_CLANG_JIT)

--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -142,6 +142,10 @@ StatusTuple BPFTable::remove_value(const std::string& key_str) {
   return StatusTuple(0);
 }
 
+size_t BPFTable::get_possible_cpu_count() {
+  return get_possible_cpus().size();
+}
+
 BPFStackTable::BPFStackTable(const TableDesc& desc,
                              bool use_debug_file,
                              bool check_debug_file_crc)

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -29,7 +29,6 @@
 #include "bcc_exception.h"
 #include "bcc_syms.h"
 #include "bpf_module.h"
-#include "common.h"
 #include "libbpf.h"
 #include "perf_reader.h"
 #include "table_desc.h"
@@ -105,6 +104,8 @@ class BPFTable : public BPFTableBase<void, void> {
                            const std::vector<std::string>& value_str);
 
   StatusTuple remove_value(const std::string& key_str);
+
+  static size_t get_possible_cpu_count();
 };
 
 template <class ValueType>
@@ -157,7 +158,7 @@ class BPFPercpuArrayTable : public BPFArrayTable<std::vector<ValueType>> {
  public:
   BPFPercpuArrayTable(const TableDesc& desc)
       : BPFArrayTable<std::vector<ValueType>>(desc),
-      ncpus(get_possible_cpus().size()) {
+        ncpus(BPFTable::get_possible_cpu_count()) {
     if (desc.type != BPF_MAP_TYPE_PERCPU_ARRAY)
       throw std::invalid_argument("Table '" + desc.name + "' is not a percpu array table");
     // leaf structures have to be aligned to 8 bytes as hardcoded in the linux kernel.
@@ -254,7 +255,7 @@ class BPFPercpuHashTable : public BPFHashTable<KeyType, std::vector<ValueType>> 
  public:
   explicit BPFPercpuHashTable(const TableDesc& desc)
       : BPFHashTable<KeyType, std::vector<ValueType>>(desc),
-      ncpus(get_possible_cpus().size()) {
+        ncpus(BPFTable::get_possible_cpu_count()) {
     if (desc.type != BPF_MAP_TYPE_PERCPU_HASH &&
         desc.type != BPF_MAP_TYPE_LRU_PERCPU_HASH)
       throw std::invalid_argument("Table '" + desc.name + "' is not a percpu hash table");

--- a/tests/cc/test_array_table.cc
+++ b/tests/cc/test_array_table.cc
@@ -108,7 +108,7 @@ TEST_CASE("percpu array table", "[percpu_array_table]") {
   REQUIRE(res.code() == 0);
 
   ebpf::BPFPercpuArrayTable<uint64_t> t = bpf.get_percpu_array_table<uint64_t>("myarray");
-  size_t ncpus = ebpf::get_possible_cpus().size();
+  size_t ncpus = ebpf::BPFTable::get_possible_cpu_count();
 
   SECTION("bad table type") {
     // try to get table of wrong type

--- a/tests/cc/test_bpf_table.cc
+++ b/tests/cc/test_bpf_table.cc
@@ -79,7 +79,7 @@ TEST_CASE("test bpf percpu tables", "[bpf_percpu_table]") {
   REQUIRE(res.code() == 0);
 
   ebpf::BPFTable t = bpf.get_table("myhash");
-  size_t ncpus = ebpf::get_possible_cpus().size();
+  size_t ncpus = ebpf::BPFTable::get_possible_cpu_count();
 
   std::vector<std::string> v1(ncpus);
   for (size_t i = 0; i < ncpus; i++) {

--- a/tests/cc/test_hash_table.cc
+++ b/tests/cc/test_hash_table.cc
@@ -101,7 +101,7 @@ TEST_CASE("percpu hash table", "[percpu_hash_table]") {
 
   ebpf::BPFPercpuHashTable<int, uint64_t> t =
     bpf.get_percpu_hash_table<int, uint64_t>("myhash");
-  size_t ncpus = ebpf::get_possible_cpus().size();
+  size_t ncpus = ebpf::BPFTable::get_possible_cpu_count();
 
   SECTION("bad table type") {
     // try to get table of wrong type


### PR DESCRIPTION
#1603 added include of `common.h` in `BPFTable.h` for `get_possible_cpus`. `BPFTable.h` is an installed / exported header hence we needed to export `common.h` as well. I think `common.h` was supposed to be an internal file that shouldn't be exposed to users, so this PR is best effort to hide the logic in the source code file.

Putting it as static method in `BPFTable` class because other classes (like `BPFTableBase`) are templated, and I don't want to put it in just the `ebpf::` scope.