### PR TITLE
Fix bugs introduced in Lua Perf Buffer handling

### DIFF
--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -246,10 +246,10 @@ function Bpf:probe_store(t, id, fd)
   log.info("%s -> %s", id, fd)
 end
 
-function Bpf:perf_buffer_store(t, id, reader)
+function Bpf:perf_buffer_store(id, reader)
     Bpf.perf_buffers[id] = reader
 
-    log.info("%s -> %s", id, fd)
+    log.info("%s -> %s", id, reader)
 end
 
 function Bpf:probe_lookup(t, id)
@@ -277,7 +277,7 @@ function Bpf:_perf_buffer_array()
 end
 
 function Bpf:kprobe_poll_loop()
-  local perf_buffer, perf_buffer_count = self:_perf_buffer_array()
+  local perf_buffers, perf_buffer_count = self:_perf_buffer_array()
   return pcall(function()
     while true do
       libbcc.perf_reader_poll(perf_buffer_count, perf_buffers, -1)
@@ -286,7 +286,7 @@ function Bpf:kprobe_poll_loop()
 end
 
 function Bpf:kprobe_poll(timeout)
-  local perf_buffer, perf_buffer_count = self:_perf_buffer_array()
+  local perf_buffers, perf_buffer_count = self:_perf_buffer_array()
   libbcc.perf_reader_poll(perf_buffer_count, perf_buffers, timeout or -1)
 end
 

--- a/src/lua/bcc/table.lua
+++ b/src/lua/bcc/table.lua
@@ -258,7 +258,7 @@ function PerfEventArray:_open_perf_buffer(cpu, callback, ctype, page_cnt, lost_c
   end
 
   -- default to 8 pages per buffer
-  local reader = libbcc.bpf_open_perf_buffer(_cb, nil, _lost_cb, -1, cpu, page_cnt or 8)
+  local reader = libbcc.bpf_open_perf_buffer(_cb, _lost_cb, nil, -1, cpu, page_cnt or 8)
   assert(reader, "failed to open perf buffer")
 
   local fd = libbcc.perf_reader_fd(reader)


### PR DESCRIPTION
Most of them were from in #1607. These are pretty trivial and stupid bugs, I feel pretty bad for introducing them, mostly because I didn't really know how to test Lua code. Did some learning and now made sure `stacksnoop.lua` and `biosnoop.lua` (after #1615) runs as expected.

I wish we had Lua tests for these code, but I really don't have enough knowledge to write some:( Again, I'm really sorry for breaking the Lua tools. 