### PR TITLE
Rename kprobe_poll to perf_buffer_poll

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -64,7 +64,7 @@ This guide is incomplete. If something feels missing, check the bcc and kernel s
         - [1. trace_print()](#1-trace_print)
         - [2. trace_fields()](#2-trace_fields)
     - [Output](#output)
-        - [1. kprobe_poll()](#1-kprobe_poll)
+        - [1. perf_buffer_poll()](#1-perf_buffer_poll)
     - [Maps](#maps)
         - [1. get_table()](#1-get_table)
         - [2. open_perf_buffer()](#2-open_perf_buffer)
@@ -1023,14 +1023,14 @@ Examples in situ:
 
 Normal output from a BPF program is either:
 
-- per-event: using PERF_EVENT_OUTPUT, open_perf_buffer(), and kprobe_poll().
+- per-event: using PERF_EVENT_OUTPUT, open_perf_buffer(), and perf_buffer_poll().
 - map summary: using items(), or print_log2_hist(), covered in the Maps section.
 
-### 1. kprobe_poll()
+### 1. perf_buffer_poll()
 
-Syntax: ```BPF.kprobe_poll()```
+Syntax: ```BPF.perf_buffer_poll()```
 
-This polls from the ring buffers for all of the open kprobes, calling the callback function that was given in the BPF constructor for each entry, usually via ```open_perf_buffer()```.
+This polls from all open perf ring buffers, calling the callback function that was provided when calling open_perf_buffer for each entry.
 
 Example:
 
@@ -1038,13 +1038,13 @@ Example:
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()
 ```
 
 Examples in situ:
 [code](https://github.com/iovisor/bcc/blob/08fbceb7e828f0e3e77688497727c5b2405905fd/examples/tracing/hello_perf_output.py#L61),
-[search /examples](https://github.com/iovisor/bcc/search?q=kprobe_poll+path%3Aexamples+language%3Apython&type=Code),
-[search /tools](https://github.com/iovisor/bcc/search?q=kprobe_poll+path%3Atools+language%3Apython&type=Code)
+[search /examples](https://github.com/iovisor/bcc/search?q=perf_buffer_poll+path%3Aexamples+language%3Apython&type=Code),
+[search /tools](https://github.com/iovisor/bcc/search?q=perf_buffer_poll+path%3Atools+language%3Apython&type=Code)
 
 ## Maps
 
@@ -1083,7 +1083,7 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()
 ```
 
 Note that the data structure transferred will need to be declared in C in the BPF program, and in Python. For example:

--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -305,7 +305,7 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()
 ```
 
 Things to learn:
@@ -319,7 +319,7 @@ Things to learn:
 1. ```class Data(ct.Structure)```: Now define the Python version of the C data structure.
 1. ```def print_event()```: Define a Python function that will handle reading events from the ```events``` stream.
 1. ```b["events"].open_perf_buffer(print_event)```: Associate the Python ```print_event``` function with the ```events``` stream.
-1. ```while 1: b.kprobe_poll()```: Block waiting for events.
+1. ```while 1: b.perf_buffer_poll()```: Block waiting for events.
 
 This may be improved in future bcc versions. Eg, the Python data struct could be auto-generated from the C code.
 

--- a/examples/lua/bashreadline.lua
+++ b/examples/lua/bashreadline.lua
@@ -27,5 +27,5 @@ return function(BPF)
   b:get_table("events"):open_perf_buffer(print_readline, "struct { uint64_t pid; char str[80]; }", nil)
 
   print("%-9s %-6s %s" % {"TIME", "PID", "COMMAND"})
-  b:kprobe_poll_loop()
+  b:perf_buffer_poll_loop()
 end

--- a/examples/networking/tc_perf_event.py
+++ b/examples/networking/tc_perf_event.py
@@ -80,6 +80,6 @@ try:
     print('Try: "ping -6 ff02::1%me"\n')
     print("%-3s %-32s %-12s %-10s" % ("CPU", "SRC IP", "DST IP", "Magic"))
     while True:
-        b.kprobe_poll()
+        b.perf_buffer_poll()
 finally:
     if "me" in locals(): ipr.link("del", index=me)

--- a/examples/tracing/hello_perf_output.py
+++ b/examples/tracing/hello_perf_output.py
@@ -58,4 +58,4 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/examples/tracing/stacksnoop.py
+++ b/examples/tracing/stacksnoop.py
@@ -120,4 +120,4 @@ def print_event(cpu, data, size):
 
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/examples/tracing/trace_perf_output.py
+++ b/examples/tracing/trace_perf_output.py
@@ -51,4 +51,4 @@ def print_counter():
 print("Tracing sys_write, try `dd if=/dev/zero of=/dev/null`")
 print("Tracing... Hit Ctrl-C to end.")
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/examples/usdt_sample/scripts/latency.py
+++ b/examples/usdt_sample/scripts/latency.py
@@ -114,4 +114,4 @@ print("%-18s %-10s %-32s %-32s %16s %16s %16s" % ("time(s)", "id", "input", "out
 # Output latency events
 bpf_ctx["operation_event"].open_perf_buffer(print_event)
 while 1:
-    bpf_ctx.kprobe_poll()
+    bpf_ctx.perf_buffer_poll()

--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -276,7 +276,7 @@ function Bpf:_perf_buffer_array()
   return readers, n
 end
 
-function Bpf:kprobe_poll_loop()
+function Bpf:perf_buffer_poll_loop()
   local perf_buffers, perf_buffer_count = self:_perf_buffer_array()
   return pcall(function()
     while true do
@@ -285,9 +285,17 @@ function Bpf:kprobe_poll_loop()
   end)
 end
 
-function Bpf:kprobe_poll(timeout)
+function Bpf:kprobe_poll_loop()
+  return self:perf_buffer_poll_loop()
+end
+
+function Bpf:perf_buffer_poll(timeout)
   local perf_buffers, perf_buffer_count = self:_perf_buffer_array()
   libbcc.perf_reader_poll(perf_buffer_count, perf_buffers, timeout or -1)
+end
+
+function Bpf:kprobe_poll(timeout)
+  self:perf_buffer_poll(timeout)
 end
 
 return Bpf

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1100,11 +1100,11 @@ class BPF(object):
         """
         return len(self.tracepoint_fds)
 
-    def kprobe_poll(self, timeout = -1):
-        """kprobe_poll(self)
+    def perf_buffer_poll(self, timeout = -1):
+        """perf_buffer_poll(self)
 
-        Poll from the ring buffers for all of the open kprobes, calling the
-        cb() that was given in the BPF constructor for each entry.
+        Poll from all open perf ring buffers, calling the callback that was
+        provided when calling open_perf_buffer for each entry.
         """
         try:
             readers = (ct.c_void_p * len(self.perf_buffers))()
@@ -1113,6 +1113,13 @@ class BPF(object):
             lib.perf_reader_poll(len(readers), readers, timeout)
         except KeyboardInterrupt:
             exit()
+
+    def kprobe_poll(self, timeout = -1):
+        """kprobe_poll(self)
+
+        Deprecated. Use perf_buffer_poll instead.
+        """
+        self.perf_buffer_poll(timeout)
 
     def donothing(self):
         """the do nothing exit handler"""

--- a/tests/python/test_array.py
+++ b/tests/python/test_array.py
@@ -65,7 +65,7 @@ int kprobe__sys_nanosleep(void *ctx) {
         b = BPF(text=text)
         b["events"].open_perf_buffer(cb, lost_cb=lost_cb)
         time.sleep(0.1)
-        b.kprobe_poll()
+        b.perf_buffer_poll()
         self.assertGreater(self.counter, 0)
         b.cleanup()
 
@@ -98,7 +98,7 @@ int kprobe__sys_nanosleep(void *ctx) {
         online_cpus = get_online_cpus()
         for cpu in online_cpus:
             subprocess.call(['taskset', '-c', str(cpu), 'sleep', '0.1'])
-        b.kprobe_poll()
+        b.perf_buffer_poll()
         b.cleanup()
         self.assertGreaterEqual(len(self.events), len(online_cpus), 'Received only {}/{} events'.format(len(self.events), len(online_cpus)))
 

--- a/tests/python/test_usdt.py
+++ b/tests/python/test_usdt.py
@@ -213,7 +213,7 @@ int do_trace5(struct pt_regs *ctx) {
 
         # three iterations to make sure we get some probes and have time to process them
         for i in range(3):
-            b.kprobe_poll()
+            b.perf_buffer_poll()
         self.assertTrue(self.evt_st_1 == 1 and self.evt_st_2 == 1 and self.evt_st_3 == 1)
 
     def tearDown(self):

--- a/tests/python/test_usdt2.py
+++ b/tests/python/test_usdt2.py
@@ -150,7 +150,7 @@ int do_trace3(struct pt_regs *ctx) {
 
         # three iterations to make sure we get some probes and have time to process them
         for i in range(3):
-            b.kprobe_poll()
+            b.perf_buffer_poll()
 
         # note that event1 and event4 do not really fire, so their state should be 0
         # use separate asserts so that if test fails we know which one is the culprit

--- a/tests/python/test_usdt3.py
+++ b/tests/python/test_usdt3.py
@@ -132,7 +132,7 @@ int do_trace(struct pt_regs *ctx) {
 
         b["event"].open_perf_buffer(print_event)
         for i in range(10):
-            b.kprobe_poll()
+            b.perf_buffer_poll()
 
         self.assertTrue(self.probe_value_1 != 0)
         self.assertTrue(self.probe_value_2 != 0)

--- a/tools/bashreadline.py
+++ b/tools/bashreadline.py
@@ -61,4 +61,4 @@ def print_event(cpu, data, size):
 
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/biosnoop.lua
+++ b/tools/biosnoop.lua
@@ -189,5 +189,5 @@ return function(BPF, utils)
       char name[$];
     }
   ]], {DISK_NAME_LEN, TASK_COMM_LEN}, 64)
-  bpf:kprobe_poll_loop()
+  bpf:perf_buffer_poll_loop()
 end

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -185,4 +185,4 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/btrfsslower.py
+++ b/tools/btrfsslower.py
@@ -350,4 +350,4 @@ else:
 # read events
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -154,4 +154,4 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/cpuunclaimed.py
+++ b/tools/cpuunclaimed.py
@@ -218,7 +218,7 @@ while 1:
             sleep(wakeup_s)
     except KeyboardInterrupt:
         exiting = 1
-    b.kprobe_poll()
+    b.perf_buffer_poll()
     slept += wakeup_s
 
     if slept < 0.999 * interval:   # floating point workaround

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -230,4 +230,4 @@ print("%-14s %-6s %8s %s" % ("TIME(s)", "PID", "MS", "QUERY"))
 
 bpf["events"].open_perf_buffer(print_event, page_cnt=64)
 while True:
-    bpf.kprobe_poll()
+    bpf.perf_buffer_poll()

--- a/tools/dcsnoop.py
+++ b/tools/dcsnoop.py
@@ -161,4 +161,4 @@ print("%-11s %-6s %-16s %1s %s" % ("TIME(s)", "PID", "COMM", "T", "FILE"))
 
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -212,4 +212,4 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -344,4 +344,4 @@ else:
 # read events
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/filelife.py
+++ b/tools/filelife.py
@@ -140,4 +140,4 @@ def print_event(cpu, data, size):
 
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/fileslower.py
+++ b/tools/fileslower.py
@@ -249,4 +249,4 @@ def print_event(cpu, data, size):
 
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/funcslower.py
+++ b/tools/funcslower.py
@@ -231,4 +231,4 @@ def print_event(cpu, data, size):
 
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while True:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/gethostlatency.py
+++ b/tools/gethostlatency.py
@@ -135,4 +135,4 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -140,4 +140,4 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/lib/uflow.py
+++ b/tools/lib/uflow.py
@@ -188,4 +188,4 @@ def print_event(cpu, data, size):
 
 bpf["calls"].open_perf_buffer(print_event)
 while 1:
-    bpf.kprobe_poll()
+    bpf.perf_buffer_poll()

--- a/tools/lib/ugc.py
+++ b/tools/lib/ugc.py
@@ -239,4 +239,4 @@ def print_event(cpu, data, size):
 
 bpf["gcs"].open_perf_buffer(print_event)
 while 1:
-    bpf.kprobe_poll()
+    bpf.perf_buffer_poll()

--- a/tools/lib/uthreads.py
+++ b/tools/lib/uthreads.py
@@ -120,4 +120,4 @@ def print_event(cpu, data, size):
 
 bpf["threads"].open_perf_buffer(print_event)
 while 1:
-    bpf.kprobe_poll()
+    bpf.perf_buffer_poll()

--- a/tools/mdflush.py
+++ b/tools/mdflush.py
@@ -77,4 +77,4 @@ def print_event(cpu, data, size):
 # read events
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -408,7 +408,7 @@ def main():
     print('{:16} {:<7} {:<7} {:<11} {}'.format(
         'COMM', 'PID', 'TID', 'MNT_NS', 'CALL'))
     while True:
-        b.kprobe_poll()
+        b.perf_buffer_poll()
 
 
 if __name__ == '__main__':

--- a/tools/mysqld_qslower.py
+++ b/tools/mysqld_qslower.py
@@ -130,4 +130,4 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/nfsslower.py
+++ b/tools/nfsslower.py
@@ -325,4 +325,4 @@ else:
 
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-        b.kprobe_poll()
+        b.perf_buffer_poll()

--- a/tools/oomkill.py
+++ b/tools/oomkill.py
@@ -76,4 +76,4 @@ b = BPF(text=bpf_text)
 print("Tracing OOM kills... Ctrl-C to stop.")
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -192,4 +192,4 @@ def print_event(cpu, data, size):
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 start_time = datetime.now()
 while not args.duration or datetime.now() - start_time < args.duration:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/solisten.py
+++ b/tools/solisten.py
@@ -210,4 +210,4 @@ if __name__ == "__main__":
 
     # Read events
     while 1:
-        b.kprobe_poll()
+        b.perf_buffer_poll()

--- a/tools/sslsniff.py
+++ b/tools/sslsniff.py
@@ -210,4 +210,4 @@ def print_event(cpu, data, size, rw):
 b["perf_SSL_write"].open_perf_buffer(print_event_write)
 b["perf_SSL_read"].open_perf_buffer(print_event_read)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/stacksnoop.lua
+++ b/tools/stacksnoop.lua
@@ -103,5 +103,5 @@ return function(BPF, utils)
   bpf:get_table("events"):open_perf_buffer(print_event,
     "struct { uint64_t stack_id; uint32_t pid; char comm[$]; }",
     {TASK_COMM_LEN})
-  bpf:kprobe_poll_loop()
+  bpf:perf_buffer_poll_loop()
 end

--- a/tools/statsnoop.py
+++ b/tools/statsnoop.py
@@ -175,4 +175,4 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/syncsnoop.py
+++ b/tools/syncsnoop.py
@@ -48,4 +48,4 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -194,4 +194,4 @@ start_ts = 0
 b["ipv4_events"].open_perf_buffer(print_ipv4_event)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -237,4 +237,4 @@ start_ts = 0
 b["ipv4_events"].open_perf_buffer(print_ipv4_event)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/tcpconnlat.py
+++ b/tools/tcpconnlat.py
@@ -265,4 +265,4 @@ print("%-6s %-12s %-2s %-16s %-16s %-5s %s" % ("PID", "COMM", "IP", "SADDR",
 b["ipv4_events"].open_perf_buffer(print_ipv4_event)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/tcplife.lua
+++ b/tools/tcplife.lua
@@ -435,5 +435,5 @@ return function(BPF, utils)
     }
    ]], {TASK_COMM_LEN}, 64)
 
-   bpf:kprobe_poll_loop()
+   bpf:perf_buffer_poll_loop()
 end

--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -497,4 +497,4 @@ start_ts = 0
 b["ipv4_events"].open_perf_buffer(print_ipv4_event, page_cnt=64)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event, page_cnt=64)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/tcpretrans.py
+++ b/tools/tcpretrans.py
@@ -300,4 +300,4 @@ else:
     b["ipv4_events"].open_perf_buffer(print_ipv4_event)
     b["ipv6_events"].open_perf_buffer(print_ipv6_event)
     while 1:
-        b.kprobe_poll()
+        b.perf_buffer_poll()

--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -670,4 +670,4 @@ def inet_ntoa(addr):
 b["tcp_ipv4_event"].open_perf_buffer(print_ipv4_event)
 b["tcp_ipv6_event"].open_perf_buffer(print_ipv6_event)
 while True:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/trace.py
+++ b/tools/trace.py
@@ -729,7 +729,7 @@ trace -I 'linux/fs_struct.h' 'mntns_install "users = %d", $task->fs->users'
                       "-" if not all_probes_trivial else ""))
 
                 while True:
-                        self.bpf.kprobe_poll()
+                        self.bpf.perf_buffer_poll()
 
         def run(self):
                 try:

--- a/tools/ttysnoop.py
+++ b/tools/ttysnoop.py
@@ -121,4 +121,4 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/xfsslower.py
+++ b/tools/xfsslower.py
@@ -299,4 +299,4 @@ else:
 # read events
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()

--- a/tools/zfsslower.py
+++ b/tools/zfsslower.py
@@ -317,4 +317,4 @@ else:
 # read events
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.kprobe_poll()
+    b.perf_buffer_poll()


### PR DESCRIPTION
After #1607, it makes sense for the interface to be renamed to `perf_buffer_poll`, since it would be more informative for users that the perf buffer is not only for kprobes, but for all other kinds of events.

Still kept the `kprobe_poll` interface in Python and Lua to avoid breaking existing tools