### PR TITLE
Fix BPFModule allocation / de-allocation mismatch

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -142,7 +142,7 @@ BPFModule::~BPFModule() {
 
   if (!rw_engine_enabled_) {
     for (auto section : sections_)
-      delete get<0>(section.second);
+      delete[] get<0>(section.second);
   }
 
   engine_.reset();


### PR DESCRIPTION
This memory is allocated in `finalize()`:
```
      if (strncmp("maps/", section.first.c_str(), 5)) {
        uint8_t *addr = get<0>(section.second);
        tmp_p = new uint8_t[size];
        memcpy(tmp_p, addr, size);
      }
      sections_[fname] = make_tuple(tmp_p, size);
```
and should be freed with `delete[]` instead of `delete`
