### PR TITLE
C++ API: Allow obtaining BPFPerfBuffer pointer for polling

### DIFF
--- a/examples/cpp/FollyRequestContextSwitch.cc
+++ b/examples/cpp/FollyRequestContextSwitch.cc
@@ -98,8 +98,11 @@ int main(int argc, char** argv) {
 
   signal(SIGINT, signal_handler);
   std::cout << "Started tracing, hit Ctrl-C to terminate." << std::endl;
-  while (true)
-    bpf->poll_perf_buffer("events");
+  auto perf_buffer = bpf->get_perf_buffer("events");
+  if (perf_buffer)
+    while (true)
+      // 100ms timeout
+      perf_buffer->poll(100);
 
   return 0;
 }

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -443,11 +443,11 @@ StatusTuple BPF::close_perf_buffer(const std::string& name) {
   return StatusTuple(0);
 }
 
-void BPF::poll_perf_buffer(const std::string& name, int timeout) {
+void BPF::poll_perf_buffer(const std::string& name, int timeout_ms) {
   auto it = perf_buffers_.find(name);
   if (it == perf_buffers_.end())
     return;
-  it->second->poll(timeout);
+  it->second->poll(timeout_ms);
 }
 
 StatusTuple BPF::load_func(const std::string& func_name, bpf_prog_type type,

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -443,6 +443,11 @@ StatusTuple BPF::close_perf_buffer(const std::string& name) {
   return StatusTuple(0);
 }
 
+BPFPerfBuffer* BPF::get_perf_buffer(const std::string& name) {
+  auto it = perf_buffers_.find(name);
+  return (it == perf_buffers_.end()) ? nullptr : it->second;
+}
+
 void BPF::poll_perf_buffer(const std::string& name, int timeout_ms) {
   auto it = perf_buffers_.find(name);
   if (it == perf_buffers_.end())

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -141,7 +141,7 @@ class BPF {
                                void* cb_cookie = nullptr,
                                int page_cnt = DEFAULT_PERF_BUFFER_PAGE_CNT);
   StatusTuple close_perf_buffer(const std::string& name);
-  void poll_perf_buffer(const std::string& name, int timeout = -1);
+  void poll_perf_buffer(const std::string& name, int timeout_ms = -1);
 
   StatusTuple load_func(const std::string& func_name, enum bpf_prog_type type,
                         int& fd);

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -136,11 +136,20 @@ class BPF {
 
   StatusTuple close_perf_event(const std::string& name);
 
+  // Open a Perf Buffer of given name, providing callback and callback cookie
+  // to use when polling. BPF class owns the opened Perf Buffer and will free
+  // it on-demand or on destruction.
   StatusTuple open_perf_buffer(const std::string& name, perf_reader_raw_cb cb,
                                perf_reader_lost_cb lost_cb = nullptr,
                                void* cb_cookie = nullptr,
                                int page_cnt = DEFAULT_PERF_BUFFER_PAGE_CNT);
+  // Close and free the Perf Buffer of given name.
   StatusTuple close_perf_buffer(const std::string& name);
+  // Obtain an pointer to the opened BPFPerfBuffer instance of given name.
+  // Will return nullptr if such open Perf Buffer doesn't exist.
+  BPFPerfBuffer* get_perf_buffer(const std::string& name);
+  // Poll an opened Perf Buffer of given name with given timeout, using callback
+  // provided when opening. Do nothing if such open Perf Buffer doesn't exist.
   void poll_perf_buffer(const std::string& name, int timeout_ms = -1);
 
   StatusTuple load_func(const std::string& func_name, enum bpf_prog_type type,

--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -295,10 +295,10 @@ StatusTuple BPFPerfBuffer::close_all_cpu() {
   return StatusTuple(0);
 }
 
-void BPFPerfBuffer::poll(int timeout) {
+void BPFPerfBuffer::poll(int timeout_ms) {
   if (epfd_ < 0)
     return;
-  int cnt = epoll_wait(epfd_, ep_events_.get(), cpu_readers_.size(), timeout);
+  int cnt = epoll_wait(epfd_, ep_events_.get(), cpu_readers_.size(), timeout_ms);
   if (cnt <= 0)
     return;
   for (int i = 0; i < cnt; i++)

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -309,7 +309,7 @@ class BPFPerfBuffer : public BPFTableBase<int, int> {
   StatusTuple open_all_cpu(perf_reader_raw_cb cb, perf_reader_lost_cb lost_cb,
                            void* cb_cookie, int page_cnt);
   StatusTuple close_all_cpu();
-  void poll(int timeout);
+  void poll(int timeout_ms);
 
  private:
   StatusTuple open_on_cpu(perf_reader_raw_cb cb, perf_reader_lost_cb lost_cb,


### PR DESCRIPTION
Perf Buffer polling is a high frequency event and normally runs in a loop for continuous profiling. Doing a map lookup every time is not efficient. This commit adds an interface to get a pointer of the `BPFPerfbuffer` instance for polling. Also added some comments on the header file to explain these APIs.

Updated  `FollyRequestContextSwitch` example to use this. The `RandomRead` example still uses `perf_buffer_poll`, just to demonstrate both interfaces.