### PR TITLE
Perf Event interface with raw perf_event_attr argument

### DIFF
--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -36,7 +36,7 @@ namespace ebpf {
 struct open_probe_t {
   int perf_event_fd;
   std::string func;
-  std::map<int, int>* per_cpu_fd;
+  std::vector<std::pair<int, int>>* per_cpu_fd;
 };
 
 class USDT;
@@ -84,7 +84,12 @@ class BPF {
                                 uint64_t sample_period, uint64_t sample_freq,
                                 pid_t pid = -1, int cpu = -1,
                                 int group_fd = -1);
+  StatusTuple attach_perf_event_raw(void* perf_event_attr,
+                                    const std::string& probe_func,
+                                    pid_t pid = -1, int cpu = -1,
+                                    int group_fd = -1);
   StatusTuple detach_perf_event(uint32_t ev_type, uint32_t ev_config);
+  StatusTuple detach_perf_event_raw(void* perf_event_attr);
 
   BPFTable get_table(const std::string& name) {
     TableStorage::iterator it;

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -88,6 +88,10 @@ void * bpf_open_perf_buffer(perf_reader_raw_cb raw_cb,
 /* attached a prog expressed by progfd to the device specified in dev_name */
 int bpf_attach_xdp(const char *dev_name, int progfd, uint32_t flags);
 
+// attach a prog expressed by progfd to run on a specific perf event. The perf
+// event will be created using the perf_event_attr pointer provided.
+int bpf_attach_perf_event_raw(int progfd, void *perf_event_attr, pid_t pid,
+                              int cpu, int group_fd);
 // attach a prog expressed by progfd to run on a specific perf event, with
 // certain sample period or sample frequency
 int bpf_attach_perf_event(int progfd, uint32_t ev_type, uint32_t ev_config,


### PR DESCRIPTION
Attaching BPF programs to Perf Events is a commonly used profiling and tracing tools. However, Kernel Perf Events system interface (i.e., `sys_perf_event_open`) has so many arguments and config combinations. We have recently experimented `pinned` events, events with different `sample_type`, events with difference `pricise_ip`, etc. and those are only small portion of all possible configs.

It is not possible for us to add all those options to either C++ API or `libbpf` interface. But those configs are definitely useful for experts and complex production systems.

Therefore, this PR adds `bpf_attach_perf_event_raw` / `attach_perf_event_raw` interface to `libbpf` and C++ API, that user would just provide a pointer to the raw `perf_event_attr` struct, and our libraries would handle rest of the attaching logic (loading program, opening and enabling, etc.)

Unfortunately on C++ API, the attached Perf Events are still uniquely keyed on `type` / `config` pair, which is not ideal. I am planning to change and improve that in separated PRs.
