### PR TITLE
fix fd leakage

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -408,6 +408,8 @@ int bpf_prog_compute_tag(const struct bpf_insn *insns, int prog_len,
     return -1;
   }
   *ptag = __builtin_bswap64(u.tag);
+  close(shafd2);
+  close(shafd);
   return 0;
 }
 


### PR DESCRIPTION
bpf_prog_compute_tag() isn't closing socket fds
before successful return

Signed-off-by: Nirmoy Das <ndas@suse.de>