### PR TITLE
tools/slabratetop: detect the current memory allocator

### DIFF
--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -63,7 +63,11 @@ bpf_text = """
 #include <uapi/linux/ptrace.h>
 #include <linux/mm.h>
 #include <linux/slab.h>
+#ifdef CONFIG_SLUB
 #include <linux/slub_def.h>
+#else
+#include <linux/slab_def.h>
+#endif
 
 #define CACHE_NAME_SIZE 32
 


### PR DESCRIPTION
Currently, slabratetop always included slub_def.h. For the system uses
SLAB, the definition of 'struct kmem_cache' is different and the eBPF
program would fetch the wrong field and print garbages.

Signed-off-by: Gary Lin <glin@suse.com>