### PR TITLE
properly retrieve IP address from array for python2.7

### DIFF
--- a/examples/networking/tc_perf_event.py
+++ b/examples/networking/tc_perf_event.py
@@ -54,8 +54,8 @@ def print_skb_event(cpu, data, size):
 
     # Only print for echo request
     if icmp_type == 128:
-        src_ip = bytes(skb_event.raw[22:38])
-        dst_ip = bytes(skb_event.raw[38:54])
+        src_ip = bytes(bytearray(skb_event.raw[22:38]))
+        dst_ip = bytes(bytearray(skb_event.raw[38:54]))
         print("%-3s %-32s %-12s 0x%08x" %
               (cpu, socket.inet_ntop(socket.AF_INET6, src_ip),
                socket.inet_ntop(socket.AF_INET6, dst_ip),


### PR DESCRIPTION
for python2.7 IP address(src_ip,dst_ip) conversion doesn't work
as expected and throws

Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 315, in 'calling callback function'
  File "/usr/local/lib/python2.7/site-packages/bcc/table.py", line 526, in raw_cb_
    callback(cpu, data, size)
  File "./examples/networking/tc_perf_event.py", line 60, in print_skb_event
    (cpu, socket.inet_ntop(socket.AF_INET6, src_ip),
ValueError: invalid length of packed IP address string

IP string looks like
[254, 128, 0, 0, 0, 0, 0, 0, 156, 237, 12, 255, 254, 42, 90, 31]

Signed-off-by: Nirmoy Das <ndas@suse.de>