### PR TITLE
tcplife: switch to the new sock:inet_sock_set_state tracepoint

### DIFF
--- a/man/man8/tcplife.8
+++ b/man/man8/tcplife.8
@@ -10,10 +10,10 @@ duration, and throughput for the session. This is useful for workload
 characterisation and flow accounting: identifying what connections are
 happening, with the bytes transferred.
 
-This tool works using the tcp:tcp_set_state tracepoint if it exists, added
-to Linux 4.15, and switches to using kernel dynamic tracing for older kernels.
-Only TCP state changes are traced, so it is expected that the overhead of
-this tool is much lower than typical send/receive tracing.
+This tool works using the sock:inet_sock_set_state tracepoint if it exists,
+added to Linux 4.16, and switches to using kernel dynamic tracing for older
+kernels. Only TCP state changes are traced, so it is expected that the
+overhead of this tool is much lower than typical send/receive tracing.
 
 Since this uses BPF, only the root user can use this tool.
 .SH REQUIREMENTS


### PR DESCRIPTION
The tcp:tcp_set_state tracepoint appeared in 4.15, and has been disabled in 4.16, replaced by sock:inet_sock_set_state. See:

https://github.com/torvalds/linux/commit/563e0bb0dc74b3ca888e24f8c08f0239fe4016b0

By supporting sock:inet_sock_set_state, tcplife on 4.15 will now revert back to kprobes of tcp_set_state(), which should be fine.