### PR TITLE
Add move constructor for BPFStackTable

### DIFF
--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -157,6 +157,13 @@ BPFStackTable::BPFStackTable(const TableDesc& desc,
   };
 }
 
+BPFStackTable::BPFStackTable(BPFStackTable&& that) :
+  BPFTableBase<int, stacktrace_t>(that.desc),
+  symbol_option_(std::move(that.symbol_option_)),
+  pid_sym_(std::move(that.pid_sym_)) {
+    that.pid_sym_.clear();
+}
+
 BPFStackTable::~BPFStackTable() {
   for (auto it : pid_sym_)
     bcc_free_symcache(it.second, it.first);

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -289,6 +289,7 @@ class BPFStackTable : public BPFTableBase<int, stacktrace_t> {
   BPFStackTable(const TableDesc& desc,
                 bool use_debug_file,
                 bool check_debug_file_crc);
+  BPFStackTable(BPFStackTable&& that);
   ~BPFStackTable();
 
   void clear_table_non_atomic();


### PR DESCRIPTION
This commit adds Move Constructor to `BPFStackTable`. This makes it easier to keep `BPFStackTable` as a class member or transfer ownership as parameter (with `std::unique_ptr`). Most other tables like hashes and arrays can just use the default copy constructor because they don't have data tracked with class instance. However for `BPFStackTrace` there are the `SymbolCache` instance pointers that need to be held and destructed correctly, thus an implemented Move Constructor would make sense.