### PR TITLE
debian: add python3-bcc package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,8 @@ Build-Depends: debhelper (>= 9), cmake, libllvm3.7 | libllvm3.8,
     libelf-dev, bison, flex, libfl-dev, libedit-dev, zlib1g-dev, git,
     clang-format | clang-format-3.7 | clang-format-3.8, python (>= 2.7),
     python-netaddr, python-pyroute2, luajit, libluajit-5.1-dev, arping,
-    inetutils-ping | iputils-ping, iperf, netperf, ethtool, devscripts
+    inetutils-ping | iputils-ping, iperf, netperf, ethtool, devscripts,
+    python3
 Homepage: https://github.com/iovisor/bcc
 
 Package: libbcc
@@ -27,6 +28,11 @@ Package: python-bcc
 Architecture: all
 Depends: libbcc, python, binutils
 Description: Python wrappers for BPF Compiler Collection (BCC)
+
+Package: python3-bcc
+Architecture: all
+Depends: libbcc, python3, binutils
+Description: Python3 wrappers for BPF Compiler Collection (BCC)
 
 Package: bcc-tools
 Architecture: all

--- a/debian/python-bcc.install
+++ b/debian/python-bcc.install
@@ -1,1 +1,1 @@
-usr/lib/python*
+usr/lib/python2*

--- a/debian/python3-bcc.install
+++ b/debian/python3-bcc.install
@@ -1,0 +1,1 @@
+usr/lib/python3*

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ DEBIAN_REVISION := $(shell dpkg-parsechangelog | sed -rne "s,^Version: ([0-9.]+)
 UPSTREAM_VERSION := $(shell dpkg-parsechangelog | sed -rne "s,^Version: ([0-9.]+)(~|-)(.*),\1,p")
 
 %:
-	dh $@ --buildsystem=cmake --parallel
+	dh $@ --buildsystem=cmake --parallel --with python2,python3
 
 # tests cannot be run in parallel
 override_dh_auto_test:
@@ -17,4 +17,4 @@ override_dh_auto_test:
 
 # FIXME: LLVM_DEFINITIONS is broken somehow in LLVM cmake upstream
 override_dh_auto_configure:
-	dh_auto_configure -- -DREVISION_LAST=$(UPSTREAM_VERSION) -DREVISION=$(UPSTREAM_VERSION) -DLLVM_DEFINITIONS="-D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"
+	dh_auto_configure -- -DREVISION_LAST=$(UPSTREAM_VERSION) -DREVISION=$(UPSTREAM_VERSION) -DLLVM_DEFINITIONS="-D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" -DPYTHON_CMD="python2;python3"

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -11,19 +11,24 @@ if(NOT PYTHON_CMD)
   set(PYTHON_CMD "python")
 endif()
 
-set(PIP_INSTALLABLE "${CMAKE_CURRENT_BINARY_DIR}/dist/bcc-${REVISION}.tar.gz")
 configure_file(setup.py.in ${CMAKE_CURRENT_BINARY_DIR}/setup.py @ONLY)
-# build the pip installable
-add_custom_command(OUTPUT ${PIP_INSTALLABLE}
-  COMMAND ${PYTHON_CMD} setup.py sdist
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bcc/__init__.py ${CMAKE_CURRENT_BINARY_DIR}/setup.py
-  )
-add_custom_target(bcc_py ALL DEPENDS ${PIP_INSTALLABLE})
-
 if(EXISTS "/etc/debian_version")
   set(PYTHON_FLAGS "${PYTHON_FLAGS} --install-layout deb")
 endif()
-install(CODE "execute_process(COMMAND ${PYTHON_CMD} setup.py install -f ${PYTHON_FLAGS}
-  --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})"
-  COMPONENT python)
+
+foreach(PY_CMD ${PYTHON_CMD})
+  string(REPLACE "/" "-" PY_CMD_ESCAPED ${PY_CMD})
+
+  set(PIP_INSTALLABLE "${CMAKE_CURRENT_BINARY_DIR}/dist-${PY_CMD_ESCAPED}/bcc-${REVISION}.tar.gz")
+  # build the pip installable
+  add_custom_command(OUTPUT ${PIP_INSTALLABLE}
+    COMMAND ${PY_CMD} setup.py sdist --dist-dir dist-${PY_CMD_ESCAPED}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bcc/__init__.py ${CMAKE_CURRENT_BINARY_DIR}/setup.py
+    )
+  add_custom_target(bcc_py_${PY_CMD_ESCAPED} ALL DEPENDS ${PIP_INSTALLABLE})
+
+  install(CODE "execute_process(COMMAND ${PY_CMD} setup.py install -f ${PYTHON_FLAGS}
+    --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})"
+    COMPONENT python)
+endforeach()


### PR DESCRIPTION
This patch extends the PYTHON_CMD cmake variable to allow a list of
Python binaries and installs the bcc Python bindings for each Python
installation. The Debian control files are updated to generate bindings
for Python 2 and Python 3. Compiled Python files are excluded from the
Debian packages.