### PR TITLE
Two minor fixes on Stack-trace table

### DIFF
--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -178,6 +178,8 @@ void BPFStackTable::clear_table_non_atomic() {
 std::vector<uintptr_t> BPFStackTable::get_stack_addr(int stack_id) {
   std::vector<uintptr_t> res;
   stacktrace_t stack;
+  if (stack_id < 0)
+    return res;
   if (!lookup(&stack_id, &stack))
     return res;
   for (int i = 0; (i < BPF_MAX_STACK_DEPTH) && (stack.ip[i] != 0); i++)
@@ -189,6 +191,8 @@ std::vector<std::string> BPFStackTable::get_stack_symbol(int stack_id,
                                                          int pid) {
   auto addresses = get_stack_addr(stack_id);
   std::vector<std::string> res;
+  if (addresses.empty())
+    return res;
   res.reserve(addresses.size());
 
   if (pid < 0)

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -20,6 +20,7 @@ R"********(
 #include <uapi/linux/bpf.h>
 #include <uapi/linux/if_packet.h>
 #include <linux/version.h>
+#include <linux/log2.h>
 
 #ifndef CONFIG_BPF_SYSCALL
 #error "CONFIG_BPF_SYSCALL is undefined, please check your .config or ask your Linux distro to enable this feature"
@@ -184,7 +185,7 @@ struct bpf_stacktrace {
 };
 
 #define BPF_STACK_TRACE(_name, _max_entries) \
-  BPF_TABLE("stacktrace", int, struct bpf_stacktrace, _name, _max_entries)
+  BPF_TABLE("stacktrace", int, struct bpf_stacktrace, _name, roundup_pow_of_two(_max_entries))
 
 #define BPF_PROG_ARRAY(_name, _max_entries) \
   BPF_TABLE("prog", u32, u32, _name, _max_entries)


### PR DESCRIPTION
- In C++ API, if the stack_id is negative (i.e., errorno), do not attempt to do the syscall for lookup.
- In Kernel all hash tables including Stack-table are created with `roundup_pow_of_two` of user-provided size. This is mostly transparent to users. However for stack-table we actually do lookup with the bucket's ID, so it would be confusing to users to see the ID they get is larger than `size()` returned by the table. Also we use `size()` to iterate the stack-table in `clear_table_non_atomic`, not using the real size would make miss some of the buckets.