### PR TITLE
avoid symbol demangling if the symbol is not a mangled symbol

### DIFF
--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -191,7 +191,7 @@ bool ProcSyms::resolve_addr(uint64_t addr, struct bcc_symbol *sym,
     if (mod.contains(addr, offset)) {
       if (mod.find_addr(offset, sym)) {
         if (demangle) {
-          if (sym->name)
+          if (sym->name && (!strncmp(sym->name, "_Z", 2) || !strncmp(sym->name, "___Z", 4)))
             sym->demangle_name =
                 abi::__cxa_demangle(sym->name, nullptr, nullptr, nullptr);
           if (!sym->demangle_name)


### PR DESCRIPTION
Fix issue #1641

The bcc user space stack is not printed out properly.

From https://en.wikipedia.org/wiki/Name_mangling,
all mangled symbols begin with _Z, and an identifier
beginning with an underscore followed by a capital is
a reserved identifier in C, so conflict with user identifiers
is avoided.

Further, from the llvm demangle code
https://github.com/llvm-mirror/libcxxabi/blob/master/src/cxa_demangle.cpp
The demangled name has the following specification:
    <mangled-name> ::= _Z <encoding>
                   ::= <type>
    extension      ::= ___Z <encoding> _block_invoke
    extension      ::= ___Z <encoding> _block_invoke<decimal-digit>+
    extension      ::= ___Z <encoding> _block_invoke_<decimal-digit>+

In the issue #1641, the function name are "f" and "g", which is demangled
to type "float" and "__float128", according to the above implementation.

In bcc case, we only care about functions, so only do demangling
for symbols starting with _Z or ___Z.

Signed-off-by: Yonghong Song <yhs@fb.com>