### PR TITLE
tools/syscount: convert ausyscall output to string

### DIFF
--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -362,7 +362,7 @@ try:
     # Skip the first line, which is a header. The rest of the lines are simply
     # SYSCALL_NUM\tSYSCALL_NAME pairs.
     out = subprocess.check_output('ausyscall --dump | tail -n +2', shell=True)
-    syscalls = dict(map(parse_syscall, out.strip().split('\n')))
+    syscalls = dict(map(parse_syscall, out.decode().strip().split('\n')))
 except Exception as e:
     if platform.machine() == "x86_64":
         pass


### PR DESCRIPTION
In python3, subprocess.check_output() returns a byte array and it
failed the following split(). Convert the output to string to avoid
the error.

Signed-off-by: Gary Lin <glin@suse.com>