### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -193,7 +193,7 @@ apt-get -t jessie-backports install linux-base linux-image-4.9.0-0.bpo.2-amd64 l
 apt-get install debhelper cmake libllvm3.8 llvm-3.8-dev libclang-3.8-dev \
   libelf-dev bison flex libedit-dev clang-format-3.8 python python-netaddr \
   python-pyroute2 luajit libluajit-5.1-dev arping iperf netperf ethtool \
-  devscripts zlib1g-dev
+  devscripts zlib1g-dev libfl-dev
 ```
 
 #### Sudo


### PR DESCRIPTION
Add `libfl-dev` to the dependencies on debian to prevent the following error:
```
[ 16%] Building CXX object src/cc/frontends/b/CMakeFiles/b_frontend.dir/loader.cc.o
In file included from /root/bcc/src/cc/frontends/b/parser.h:21:0,
                 from /root/bcc/src/cc/frontends/b/loader.cc:17:
/root/bcc/src/cc/frontends/b/lexer.h:22:23: fatal error: FlexLexer.h: No such file or directory
 #include <FlexLexer.h>
                       ^
compilation terminated.
```