### PR TITLE
Return number of CPUs with data for BPFPerfBufferTable::poll()

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -495,11 +495,11 @@ BPFPerfBuffer* BPF::get_perf_buffer(const std::string& name) {
   return (it == perf_buffers_.end()) ? nullptr : it->second;
 }
 
-void BPF::poll_perf_buffer(const std::string& name, int timeout_ms) {
+int BPF::poll_perf_buffer(const std::string& name, int timeout_ms) {
   auto it = perf_buffers_.find(name);
   if (it == perf_buffers_.end())
-    return;
-  it->second->poll(timeout_ms);
+    return -1;
+  return it->second->poll(timeout_ms);
 }
 
 StatusTuple BPF::load_func(const std::string& func_name, bpf_prog_type type,

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -155,7 +155,11 @@ class BPF {
   BPFPerfBuffer* get_perf_buffer(const std::string& name);
   // Poll an opened Perf Buffer of given name with given timeout, using callback
   // provided when opening. Do nothing if such open Perf Buffer doesn't exist.
-  void poll_perf_buffer(const std::string& name, int timeout_ms = -1);
+  // Returns: 
+  //   -1 on error or if perf buffer with such name doesn't exist; 
+  //   0, if no data was available before timeout; 
+  //   number of CPUs that have new data, otherwise.
+  int poll_perf_buffer(const std::string& name, int timeout_ms = -1);
 
   StatusTuple load_func(const std::string& func_name, enum bpf_prog_type type,
                         int& fd);

--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -306,14 +306,13 @@ StatusTuple BPFPerfBuffer::close_all_cpu() {
   return StatusTuple(0);
 }
 
-void BPFPerfBuffer::poll(int timeout_ms) {
+int BPFPerfBuffer::poll(int timeout_ms) {
   if (epfd_ < 0)
-    return;
+    return -1;
   int cnt = epoll_wait(epfd_, ep_events_.get(), cpu_readers_.size(), timeout_ms);
-  if (cnt <= 0)
-    return;
   for (int i = 0; i < cnt; i++)
     perf_reader_event_read(static_cast<perf_reader*>(ep_events_[i].data.ptr));
+  return cnt;
 }
 
 BPFPerfBuffer::~BPFPerfBuffer() {

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -310,7 +310,7 @@ class BPFPerfBuffer : public BPFTableBase<int, int> {
   StatusTuple open_all_cpu(perf_reader_raw_cb cb, perf_reader_lost_cb lost_cb,
                            void* cb_cookie, int page_cnt);
   StatusTuple close_all_cpu();
-  void poll(int timeout_ms);
+  int poll(int timeout_ms);
 
  private:
   StatusTuple open_on_cpu(perf_reader_raw_cb cb, perf_reader_lost_cb lost_cb,


### PR DESCRIPTION
Currently `BPFPerfBuffer::poll` doesn't return anything. In some cases, though, it's important to know whether poll returned due to reaching timeout or due to new data being available.

For instance, when doing profiling/tracing for some predefined period of time, it's useful to keep reading/processing data until timeout, then detach kprobe/tracepoint to stop tracing, but after that there might be still some data left in perf buffer, so one needs to drain buffer until no more data remain. For the latter part we need to know when to stop, which might not be simple to do right now.

This change passes result of `epoll_wait` through, so it's possible to know when there was an error (-1 will be returned), when there was no data received (0), and some data was read (result >0).