### PR TITLE
Building from source on openSUSE Tumbleweed requires the clang-devel …

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -310,7 +310,7 @@ sudo make install
 
 ```
 sudo zypper in bison cmake flex gcc gcc-c++ git libelf-devel libstdc++-devel \
-  llvm-devel pkg-config python-devel python-setuptools python3-devel \
+  llvm-devel clang-devel pkg-config python-devel python-setuptools python3-devel \
   python3-setuptools
 sudo zypper in luajit-devel       # for lua support in openSUSE Leap 42.2 or later
 sudo zypper in lua51-luajit-devel # for lua support in openSUSE Tumbleweed


### PR DESCRIPTION
It fixes below error while building bcc from source on openSUSE Tumbleweed

fatal error: clang/AST/ASTConsumer.h: No such file or directory
 #include <clang/AST/ASTConsumer.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~

