### PR TITLE
fix compilation error with latest llvm

### DIFF
--- a/src/cc/frontends/b/codegen_llvm.cc
+++ b/src/cc/frontends/b/codegen_llvm.cc
@@ -425,7 +425,11 @@ StatusTuple CodegenLLVM::visit_string_expr_node(StringExprNode *n) {
   Value *global = B.CreateGlobalString(n->val_);
   Value *ptr = make_alloca(resolve_entry_stack(), B.getInt8Ty(), "",
                            B.getInt64(n->val_.size() + 1));
+#if LLVM_MAJOR_VERSION >= 7
+  B.CreateMemCpy(ptr, 1, global, 1, n->val_.size() + 1);
+#else
   B.CreateMemCpy(ptr, global, n->val_.size() + 1, 1);
+#endif
   expr_ = ptr;
 
   return StatusTuple(0);


### PR DESCRIPTION
The latest llvm (7.0) changed the interface for
IRBuilder/CreateMemCpy as in https://reviews.llvm.org/rL328317.
This caused the compilation error like below:
```
  [ 30%] Built target bcc-loader-static
  /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc: In member function ‘virtual ebpf::StatusTuple
  ebpf::cc::CodegenLLVM::visit_string_expr_node(ebpf::cc::StringExprNode*)’:
  /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc:428:52: error: no matching function for call t$
   ‘llvm::IRBuilder<>::CreateMemCpy(llvm::Value*&, llvm::Value*&, std::basic_string<char>::size_type, $
  nt)’
     B.CreateMemCpy(ptr, global, n->val_.size() + 1, 1);
                                                    ^
  /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc:428:52: note: candidates are:
  In file included from /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc:31:0:
  /home/yhs/work/llvm/build/install/include/llvm/IR/IRBuilder.h:422:13: note: llvm::CallInst* llvm::IR$
  uilderBase::CreateMemCpy(llvm::Value*, unsigned int, llvm::Value*, unsigned int, uint64_t, bool, llv$
  ::MDNode*, llvm::MDNode*, llvm::MDNode*, llvm::MDNode*)
     CallInst *CreateMemCpy(Value *Dst, unsigned DstAlign, Value *Src,
             ^
```
Now the interfaces between 7.0 and 6.0 CreateMemCpy
are completely disjoint and we are not able to find a common
interface suitable for both.

This patch fixed the issue by separating two cases based on
llvm compiler version.

Signed-off-by: Yonghong Song <yhs@fb.com>