### PR TITLE
permit symbol resulotion for function with size 0

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -211,8 +211,6 @@ static int list_in_scn(Elf *e, Elf_Scn *section, size_t stridx, size_t symsize,
         continue;
 
       uint32_t st_type = ELF_ST_TYPE(sym.st_info);
-      if (sym.st_size == 0 && (st_type == STT_FUNC || st_type == STT_GNU_IFUNC))
-        continue;
       if (!(option->use_symbol_type & (1 << st_type)))
         continue;
 


### PR DESCRIPTION
The issue comes up when I investigated issue #1641.
A func symbol defined in assembly code will be size of 0,
e.g., http://git.musl-libc.org/cgit/musl/tree/src/thread/x86_64/syscall_cp.s
```
symbol __cp_begin.
  .text
  .global __cp_begin
  .hidden __cp_begin
  ...
  __syscall_cp_asm:

  __cp_begin:
	mov (%rdi),%eax
	test %eax,%eax
```
and __cp_begin cannot be traced through bcc since
symbol resolution rejects any func symbol with size 0.

This patch removed size-must-not-zero restriction so that
the symbol like __cp_begin can be traced.
Command line: `trace.py -p <pid> -U '<binary_path>:__cp_begin'`

Signed-off-by: Yonghong Song <yhs@fb.com>