### PR TITLE
bcc/syms: Fix shared library symbol lookup

### DIFF
--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -61,6 +61,9 @@ int bcc_elf_foreach_sym(const char *path, bcc_elf_symcb callback, void *option,
 // Returns -1 on error, and 0 on success or stopped by callback
 int bcc_elf_foreach_vdso_sym(bcc_elf_symcb callback, void *payload);
 
+int bcc_elf_get_text_scn_info(const char *path, uint64_t *addr,
+                              uint64_t *offset);
+
 int bcc_elf_get_type(const char *path);
 int bcc_elf_is_shared_obj(const char *path);
 int bcc_elf_is_exe(const char *path);

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -108,6 +108,10 @@ class ProcSyms : SymbolCache {
     bcc_symbol_option *symbol_option_;
     ModuleType type_;
 
+    // The file offset within the ELF of the SO's first text section.
+    uint64_t elf_so_offset_;
+    uint64_t elf_so_addr_;
+
     std::unordered_set<std::string> symnames_;
     std::vector<Symbol> syms_;
 


### PR DESCRIPTION
Shared library addresses needed to be mapped what the address is expected in the
symbol table. The address offset of the running shared library may be different from
the one in the SO binary file. So we have to map it correctly in order for symbol
look up to work.

Often the address and file offset are the same so it works, however in Android this
is not the case a lot of times. Fix the issue by adjusting the offset with the
file offset from the ELF.

Test: stackcount 'sys_futex' -v

Before patch:
```
  ffffff800814bc14 sys_futex
  775d8e0db0       syscall
  775e149fe8       [unknown]
  775e14a598       [unknown]
  775e16a9e4       android::Parcel::validateReadData(unsigned long) const
  775e05d738       android::Thread::_threadLoop(void*)
  775d942470       __pthread_start(void*)
  775d8e54f8       __start_thread
    Binder:13353_5 [13353]
```
After patch:
```
  ffffff800814bc14 sys_futex
  78ba2e1db0       syscall
  78b97d4fe8       android::IPCThreadState::getAndExecuteCommand()
  78b97d5598       android::IPCThreadState::joinThreadPool(bool)
  78b97f59e4       [unknown]
  78b8dda738       android::Thread::_threadLoop(void*)
  78ba4ffbd0       android::AndroidRuntime::javaThreadShell(void*)
  78ba343470       __pthread_start(void*)
  78ba2e64f8       __start_thread
    Binder:14001_8 [14001]
```
Matches Perf output:
```
        ffffff800814bc14 sys_futex ([kernel.kallsyms])
                   1edb0 syscall (/system/lib64/libc.so)
                   45fe8 android::IPCThreadState::getAndExecuteCommand (/system/lib64/libbinder.so)
                   46598 android::IPCThreadState::joinThreadPool (/system/lib64/libbinder.so)
                   669e4 [unknown] (/system/lib64/libbinder.so)
                   10738 android::Thread::_threadLoop (/system/lib64/libutils.so)
                   7ebd0 android::AndroidRuntime::javaThreadShell (/system/lib64/libandroid_runtime.so)
                   80470 __pthread_start (/system/lib64/libc.so)
                   234f8 __start_thread (/system/lib64/libc.so)
```
Fixes: https://github.com/iovisor/bcc/issues/1628

Signed-off-by: Joel Fernandes <joelaf@google.com>