### PR TITLE
Added -q option to execsnoop to quote individual arguments. 

### DIFF
--- a/man/man8/execsnoop.8
+++ b/man/man8/execsnoop.8
@@ -30,6 +30,10 @@ Include a timestamp column.
 \-x
 Include failed exec()s
 .TP
+\-q
+Add "quotemarks" around arguments. Escape quotemarks in arguments with a
+backslash. For tracing empty arguments or arguments that contain whitespace. 
+.TP
 \-n NAME
 Only print command lines matching this name (regex)
 .TP
@@ -51,6 +55,10 @@ Trace all exec() syscalls, and include timestamps:
 Include failed exec()s:
 #
 .B execsnoop \-x
+.TP
+Put quotemarks around arguments. 
+#
+.B execsnoop \-q
 .TP
 Only trace exec()s where the filename contains "mount":
 #

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -42,6 +42,9 @@ parser.add_argument("-t", "--timestamp", action="store_true",
     help="include timestamp on output")
 parser.add_argument("-x", "--fails", action="store_true",
     help="include failed exec()s")
+parser.add_argument("-q", "--quote", action="store_true",
+    help="Add quotemarks (\") around arguments."
+    )
 parser.add_argument("-n", "--name",
     type=ArgString,
     help="only print commands matching this name (regex), any arg")
@@ -192,6 +195,11 @@ def print_event(cpu, data, size):
             skip = True
         if args.name and not re.search(bytes(args.name), event.comm):
             skip = True
+        if args.quote:
+            argv[event.pid] = [
+                "\"" + arg.replace("\"", "\\\"") + "\""
+                for arg in argv[event.pid]
+            ]
         if args.line and not re.search(bytes(args.line),
                                        b' '.join(argv[event.pid])):
             skip = True

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -195,14 +195,14 @@ def print_event(cpu, data, size):
             skip = True
         if args.name and not re.search(bytes(args.name), event.comm):
             skip = True
+        if args.line and not re.search(bytes(args.line),
+                                       b' '.join(argv[event.pid])):
+            skip = True
         if args.quote:
             argv[event.pid] = [
                 "\"" + arg.replace("\"", "\\\"") + "\""
                 for arg in argv[event.pid]
             ]
-        if args.line and not re.search(bytes(args.line),
-                                       b' '.join(argv[event.pid])):
-            skip = True
 
         if not skip:
             if args.timestamp:

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -31,6 +31,7 @@ examples = """examples:
     ./execsnoop           # trace all exec() syscalls
     ./execsnoop -x        # include failed exec()s
     ./execsnoop -t        # include timestamps
+    ./execsnoop -q        # add "quotemarks" around arguments
     ./execsnoop -n main   # only print command lines containing "main"
     ./execsnoop -l tpkg   # only print command where arguments contains "tpkg"
 """


### PR DESCRIPTION
This helps when working with arguments that contain spaces. It also enables to trace calls that contain empty arguments. As discussed in issue #1668 