### PR TITLE
Improve clear table API in C++

### DIFF
--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -105,6 +105,8 @@ class BPFTable : public BPFTableBase<void, void> {
 
   StatusTuple remove_value(const std::string& key_str);
 
+  StatusTuple clear_table_non_atomic();
+
   static size_t get_possible_cpu_count();
 };
 
@@ -237,14 +239,8 @@ class BPFHashTable : public BPFTableBase<KeyType, ValueType> {
 
   StatusTuple clear_table_non_atomic() {
     KeyType cur;
-    if (!this->first(&cur))
-      return StatusTuple(0);
-
-    while (true) {
+    while (this->first(&cur))
       TRY2(remove_value(cur));
-      if (!this->next(&cur, &cur))
-        break;
-    }
 
     return StatusTuple(0);
   }

--- a/tests/cc/test_bpf_table.cc
+++ b/tests/cc/test_bpf_table.cc
@@ -54,6 +54,16 @@ TEST_CASE("test bpf table", "[bpf_table]") {
   res = t.get_value("0x11", value);
   REQUIRE(res.code() != 0);
 
+  // clear table
+  res = t.update_value("0x15", "0x888");
+  REQUIRE(res.code() == 0);
+  auto elements = bpf->get_hash_table<int, int>("myhash").get_table_offline();
+  REQUIRE(elements.size() == 2);
+  res = t.clear_table_non_atomic();
+  REQUIRE(res.code() == 0);
+  elements = bpf->get_hash_table<int, int>("myhash").get_table_offline();
+  REQUIRE(elements.size() == 0);
+
   // delete bpf_module, call to key/leaf printf/scanf must fail
   delete bpf;
 


### PR DESCRIPTION
- In current `BPFHashTable`'s `clear_table_non_atomic`, we remove the key then do `next` on the same key, which effectively gives us the first key table. This commit changes it to always just find and remove the first key to clear the table.
- Add `clear_table_non_atomic` for the generic `BPFTable` since it doesn't need type information.
- Tests