### PR TITLE
filetop: probe vfs_read and vfs_write instead to fix inlining issue

### DIFF
--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -158,12 +158,8 @@ if debug or args.ebpf:
 
 # initialize BPF
 b = BPF(text=bpf_text)
-b.attach_kprobe(event="__vfs_read", fn_name="trace_read_entry")
-try:
-    b.attach_kprobe(event="__vfs_write", fn_name="trace_write_entry")
-except:
-    # older kernels don't have __vfs_write so try vfs_write instead
-    b.attach_kprobe(event="vfs_write", fn_name="trace_write_entry")
+b.attach_kprobe(event="vfs_read", fn_name="trace_read_entry")
+b.attach_kprobe(event="vfs_write", fn_name="trace_write_entry")
 
 DNAME_INLINE_LEN = 32  # linux/dcache.h
 


### PR DESCRIPTION
Filetop was originally designed to probe __vfs_read and __vfs_write,
which are called by vfs_read and vfs_write, respectively. However,
__vfs_read and __vfs_write are at times inlined, leading to these
particular functions never actually being called. Since these functions
are never called, the probes are never hit, and so filetop ends up
registering zero READs and WRITEs.

This patch fixes the issue by attaching the probes to vfs_read and
vfs_write instead, which are guaranteed to be called during file reads
and writes.

Signed-off-by: Jazel Canseco <jcanseco@google.com>

Fixes #1667 