### PR TITLE
fix python3 py_test_histogram failure

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -313,7 +313,7 @@ class TableBase(MutableMapping):
                 slot = getattr(k, f2)
                 vals[slot] = v.value
 
-            buckets = tmp.keys()
+            buckets = list(tmp.keys())
             if bucket_sort_fn:
                 buckets = bucket_sort_fn(buckets)
 


### PR DESCRIPTION
With python3 (specifically 3.6.3), py_test_histogram failed with:
  Traceback (most recent call last):
  File "./test_histogram.py", line 106, in test_multiple_key
    bucket_sort_fn=bucket_sort)
  File "/usr/lib/python3.6/site-packages/bcc/table.py", line 318, in print_log2_hist
    buckets = bucket_sort_fn(buckets)
  File "./test_histogram.py", line 98, in bucket_sort
    buckets.sort()
  AttributeError: 'dict_keys' object has no attribute 'sort'

The reason is for a dictionary tmp, tmp.keys() returns an object
of keys (a list) instead of the list itself for python3.
Using list(tmp.keys()) seems working for both python2 and python3.

Signed-off-by: Yonghong Song <yhs@fb.com>