### PR TITLE
fix test_libbcc failure with 4.15.

### DIFF
--- a/tests/cc/test_perf_event.cc
+++ b/tests/cc/test_perf_event.cc
@@ -131,7 +131,11 @@ TEST_CASE("test attach perf event", "[bpf_perf_event]") {
   auto ret = bpf.get_hash_table<int, int>("ret");
   REQUIRE(ret[0] == 0);
   REQUIRE(counter.counter >= 0);
-  REQUIRE(counter.enabled >= 1000000000);
+  // the program slept one second between perf_event attachment and detachment
+  // in the above, so the enabled counter should be 1000000000ns or
+  // more. But in reality, most of counters (if not all) are 9xxxxxxxx,
+  // and I also saw one 8xxxxxxxx. So let us a little bit conservative here.
+  REQUIRE(counter.enabled >= 800000000);
   REQUIRE(counter.running >= 0);
   REQUIRE(counter.running <= counter.enabled);
 #endif


### PR DESCRIPTION
The test sleeps one second and expects the perf counter to
be one second or more. But in reality (probably esp. in VM
which I conducted my experiments), I mostly saw counters
between 0.9s - 1s and occasionally 0.8s - 0.9s.

So be a little bit conservative here when checking the
result.

Signed-off-by: Yonghong Song <yhs@fb.com>