### PR TITLE
fix profile.py with latest net-next

### DIFF
--- a/tools/profile.py
+++ b/tools/profile.py
@@ -151,13 +151,26 @@ int do_perf_event(struct bpf_perf_event_data *ctx) {
         struct pt_regs regs = {};
         bpf_probe_read(&regs, sizeof(regs), (void *)&ctx->regs);
         u64 ip = PT_REGS_IP(&regs);
+        u64 page_offset;
 
         // if ip isn't sane, leave key ips as zero for later checking
-#ifdef CONFIG_RANDOMIZE_MEMORY
-        if (ip > __PAGE_OFFSET_BASE) {
+#if defined(CONFIG_X86_64) && defined(__PAGE_OFFSET_BASE)
+        // x64, 4.16, ..., 4.11, etc., but some earlier kernel didn't have it
+        page_offset = __PAGE_OFFSET_BASE;
+#elif defined(CONFIG_X86_64) && defined(__PAGE_OFFSET_BASE_L4)
+        // x64, 4.17, and later
+#if defined(CONFIG_DYNAMIC_MEMORY_LAYOUT) && defined(CONFIG_X86_5LEVEL)
+        page_offset = __PAGE_OFFSET_BASE_L5;
 #else
-        if (ip > PAGE_OFFSET) {
+        page_offset = __PAGE_OFFSET_BASE_L4;
 #endif
+#else
+        // earlier x86_64 kernels, e.g., 4.6, comes here
+        // arm64, s390, powerpc, x86_32
+        page_offset = PAGE_OFFSET;
+#endif
+
+        if (ip > page_offset) {
             key.kernel_ip = ip;
         }
     }


### PR DESCRIPTION
The profile.py tries to validate whether the "ip" from the
context register is a kernel ip address or not by comparing
"ip" to the kernel PAGE_OFFSET.

On non-x86_64 architectures, PAGE_OFFSET can be directly used.
On x86_64 architecture, things become more complex.
With 4.17 (latest linus tree), __PAGE_OFFSET_BASE is gone
and replaced with __PAGE_OFFSET_BASE_L5 and __PAGE_OFFSET_BASE_L4
for 5 and 4 level page table respectively.
Running profile.py will have the following error:
    /virtual/main.c:41:18: error: use of undeclared identifier '__PAGE_OFFSET_BASE'
            if (ip > __PAGE_OFFSET_BASE) {
                     ^
    1 error generated.

So, for 4.17, __PAGE_OFFSET_BASE_{L4, L5} should be used.
For 4.16 and some old kernels (e.g., 4.11), which I did not
check earlier one, __PAGE_OFFSET_BASE should be used.
For even older kernels like 4.6, PAGE_OFFSET should be used.

Signed-off-by: Yonghong Song <yhs@fb.com>