### PR TITLE
fixing bpflist

### DIFF
--- a/tools/bpflist.py
+++ b/tools/bpflist.py
@@ -72,8 +72,10 @@ def find_bpf_fds(pid):
 
 for pdir in os.listdir('/proc'):
     if re.match('\\d+', pdir):
-        find_bpf_fds(int(pdir))
-
+        try:
+            find_bpf_fds(int(pdir))
+        except OSError:
+            continue
 print("%-6s %-16s %-8s %s" % ("PID", "COMM", "TYPE", "COUNT"))
 for (pid, typ), count in sorted(counts.items(), key=lambda t: t[0][0]):
     comm = comm_for_pid(pid)


### PR DESCRIPTION
when you have lots of shortlived progs, there is posibillity of
race condition during proc scanning. you could get pid of this
shortlived prog, but when you will start to read it's fd/ dir
it will fail, as prog would be already terminated

example of such exception:
  File "/root/bpflist.py", line 75, in <module>
    find_bpf_fds(int(pdir))
  File "/root/bpflist.py", line 63, in find_bpf_fds
    for fd in os.listdir(root):
OSError: [Errno 2] No such file or directory: '/proc/2432151/fd'

in this diff i'm fixing this by guarding /prox/X/fd reading in try/catch block