### PR TITLE
Fix probe name encoding in Python 3

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -159,7 +159,7 @@ class Probe(object):
                                    else Probe.tgid
                 self.usdt = USDT(path=self.library, pid=target)
                 for probe in self.usdt.enumerate_probes():
-                        if probe.name == self.usdt_name:
+                        if probe.name == self.usdt_name.encode('ascii'):
                                 return  # Found it, will enable later
                 self._bail("unrecognized USDT probe %s" % self.usdt_name)
 


### PR DESCRIPTION
Hi all, I was trying to run tools/trace, filtering by a specific USDT probe, but it was failing:

```bash
$ bcc/tools/trace.py -p $(pidof ruby) 'u:ruby:array__create'
error in probe 'u:ruby:array__create': unrecognized USDT probe array__create
```

I verified that the process was running and that it was compiled with the dtrace probes:
```bash
$ readelf -n /proc/$(pidof ruby)/exe | grep "array__create"
Name: array__create
[...]
```

After some more poking around I realised that the hashbang was set to `/usr/bin/env python`, which in my machine (`Linux taco 4.15.15-1-ARCH #1 SMP PREEMPT Sat Mar 31 23:59:25 UTC 2018 x86_64 GNU/Linux`), it is set to Python 3.

Setting a breakpoint [where this logic lives](https://github.com/iovisor/bcc/blob/dbf0029/tools/trace.py#L162):
```python
 $ sudo python3 bcc/tools/trace.py -p $(pidof ruby) 'u:ruby:array__create'
 > /home/javierhonduco/bcc/tools/trace.py(165)_find_usdt_probe()
 -> if probe.name == self.usdt_name:
 (Pdb) probe.name, self.usdt_name
 (b'array__create', 'array__create')
 (Pdb) probe.name == self.usdt_name
 False
```
As we are comparing the current iteration probe's name and the passed probe name in different encodings, the comparison is never successful, and the error message above is shown. This works fine in Python 2 as they are both bytestrings.

This PR fixes this by encoding the passed probe name in ascii. I've verified it works with Python2 (2.7.14) and with Python3 (3.6.5). 

Let me know if you have some other preferred way of doing this! :)

Thanks! 