### PR TITLE
Add a shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -28,8 +28,10 @@ in
       "-DENABLE_CPP_API=ON"
     ];
 
+    dontFixCmake = true;
+
     shellHook = ''
-      ( cd build; cmakeConfigurePhase 2>&1 > /dev/null )
+      cmakeConfigurePhase 2>&1 > /dev/null
       export LD_LIBRARY_PATH="$PWD/build/src/cc:$LD_LIBRARY_PATH"
       export PYTHONPATH="$PWD/src/python:$PYTHONPATH"
     '';


### PR DESCRIPTION
The shell.nix config file captures the build dependencies for BCC and exposes
them on Nix based systems, so that developers can get up and running quickly.