### PR TITLE
using get_syscall_fnname to get kprobe func name for tools

### DIFF
--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -66,7 +66,7 @@ class SmokeTests(TestCase):
         pass
 
     def test_argdist(self):
-        self.run_with_duration("argdist.py -C 'p::SyS_open()' -n 1 -i 1")
+        self.run_with_duration("argdist.py -C 'p::do_sys_open()' -n 1 -i 1")
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
     def test_bashreadline(self):
@@ -322,7 +322,7 @@ class SmokeTests(TestCase):
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
     def test_trace(self):
-        self.run_with_int("trace.py SyS_open")
+        self.run_with_int("trace.py do_sys_open")
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
     def test_ttysnoop(self):

--- a/tools/deadlock_detector.py
+++ b/tools/deadlock_detector.py
@@ -465,10 +465,10 @@ def main():
             print('%s. Is the process (pid=%d) running?' % (str(e), args.pid))
             sys.exit(1)
 
-    bpf = BPF(src_file='deadlock_detector.c')
+    bpf = BPF(src_file=b'deadlock_detector.c')
 
     # Trace where threads are created
-    bpf.attach_kretprobe(event='sys_clone', fn_name='trace_clone')
+    bpf.attach_kretprobe(event=bpf.get_syscall_fnname('clone'), fn_name='trace_clone')
 
     # We must trace unlock first, otherwise in the time we attached the probe
     # on lock() and have not yet attached the probe on unlock(), a thread can

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -98,7 +98,7 @@ static int submit_arg(struct pt_regs *ctx, void *ptr, struct data_t *data)
     return 0;
 }
 
-int kprobe__sys_execve(struct pt_regs *ctx,
+int do_sys_execve(struct pt_regs *ctx,
     const char __user *filename,
     const char __user *const __user *__argv,
     const char __user *const __user *__envp)
@@ -125,7 +125,7 @@ out:
     return 0;
 }
 
-int kretprobe__sys_execve(struct pt_regs *ctx)
+int do_ret_sys_execve(struct pt_regs *ctx)
 {
     struct data_t data = {};
     data.pid = bpf_get_current_pid_tgid() >> 32;
@@ -145,6 +145,9 @@ if args.ebpf:
 
 # initialize BPF
 b = BPF(text=bpf_text)
+execve_fnname = b.get_syscall_fnname("execve")
+b.attach_kprobe(event=execve_fnname, fn_name="do_sys_execve")
+b.attach_kretprobe(event=execve_fnname, fn_name="do_ret_sys_execve")
 
 # header
 if args.timestamp:

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -60,7 +60,7 @@ struct data_t {
 BPF_HASH(infotmp, u32, struct val_t);
 BPF_PERF_OUTPUT(events);
 
-int kprobe__sys_kill(struct pt_regs *ctx, int tpid, int sig)
+int do_sys_kill(struct pt_regs *ctx, int tpid, int sig)
 {
     u32 pid = bpf_get_current_pid_tgid();
     FILTER
@@ -75,7 +75,7 @@ int kprobe__sys_kill(struct pt_regs *ctx, int tpid, int sig)
     return 0;
 };
 
-int kretprobe__sys_kill(struct pt_regs *ctx)
+int do_ret_sys_kill(struct pt_regs *ctx)
 {
     struct data_t data = {};
     struct val_t *valp;
@@ -111,6 +111,10 @@ if debug or args.ebpf:
 
 # initialize BPF
 b = BPF(text=bpf_text)
+kill_fnname = b.get_syscall_fnname("kill")
+b.attach_kprobe(event=kill_fnname, fn_name="do_sys_kill")
+b.attach_kretprobe(event=kill_fnname, fn_name="do_ret_sys_kill")
+
 
 TASK_COMM_LEN = 16    # linux/sched.h
 

--- a/tools/statsnoop.py
+++ b/tools/statsnoop.py
@@ -114,17 +114,20 @@ b = BPF(text=bpf_text)
 # system calls but the name of the actual entry point may
 # be different for which we must check if the entry points
 # actually exist before attaching the probes
-if BPF.ksymname("sys_stat") != -1:
-    b.attach_kprobe(event="sys_stat", fn_name="trace_entry")
-    b.attach_kretprobe(event="sys_stat", fn_name="trace_return")
+syscall_fnname = b.get_syscall_fnname("stat")
+if BPF.ksymname(syscall_fnname) != -1:
+    b.attach_kprobe(event=syscall_fnname, fn_name="trace_entry")
+    b.attach_kretprobe(event=syscall_fnname, fn_name="trace_return")
 
-if BPF.ksymname("sys_statfs") != -1:
-    b.attach_kprobe(event="sys_statfs", fn_name="trace_entry")
-    b.attach_kretprobe(event="sys_statfs", fn_name="trace_return")
+syscall_fnname = b.get_syscall_fnname("statfs")
+if BPF.ksymname(syscall_fnname) != -1:
+    b.attach_kprobe(event=syscall_fnname, fn_name="trace_entry")
+    b.attach_kretprobe(event=syscall_fnname, fn_name="trace_return")
 
-if BPF.ksymname("sys_newstat") != -1:
-    b.attach_kprobe(event="sys_newstat", fn_name="trace_entry")
-    b.attach_kretprobe(event="sys_newstat", fn_name="trace_return")
+syscall_fnname = b.get_syscall_fnname("newstat")
+if BPF.ksymname(syscall_fnname) != -1:
+    b.attach_kprobe(event=syscall_fnname, fn_name="trace_entry")
+    b.attach_kretprobe(event=syscall_fnname, fn_name="trace_return")
 
 TASK_COMM_LEN = 16    # linux/sched.h
 NAME_MAX = 255        # linux/limits.h

--- a/tools/syncsnoop.py
+++ b/tools/syncsnoop.py
@@ -25,12 +25,14 @@ struct data_t {
 
 BPF_PERF_OUTPUT(events);
 
-void kprobe__sys_sync(void *ctx) {
+void do_sys_sync(void *ctx) {
     struct data_t data = {};
     data.ts = bpf_ktime_get_ns() / 1000;
     events.perf_submit(ctx, &data, sizeof(data));
 };
 """)
+b.attach_kprobe(event=b.get_syscall_fnname("sync"),
+                fn_name="do_sys_sync")
 
 class Data(ct.Structure):
     _fields_ = [


### PR DESCRIPTION
Fixed tools which are attached to syscall entry functions
"sys_*". Instead, use get_syscall_fnname to get
proper names.

Signed-off-by: Yonghong Song <yhs@fb.com>