### PR TITLE
introduce C++ get_syscall_fnname API

### DIFF
--- a/examples/cpp/HelloWorld.cc
+++ b/examples/cpp/HelloWorld.cc
@@ -27,8 +27,9 @@ int main() {
 
   std::ifstream pipe("/sys/kernel/debug/tracing/trace_pipe");
   std::string line;
+  std::string clone_fnname = bpf.get_syscall_fnname("clone");
 
-  auto attach_res = bpf.attach_kprobe("sys_clone", "on_sys_clone");
+  auto attach_res = bpf.attach_kprobe(clone_fnname, "on_sys_clone");
   if (attach_res.code() != 0) {
     std::cerr << attach_res.msg() << std::endl;
     return 1;
@@ -38,7 +39,7 @@ int main() {
     if (std::getline(pipe, line)) {
       std::cout << line << std::endl;
       // Detach the probe if we got at least one line.
-      auto detach_res = bpf.detach_kprobe("sys_clone");
+      auto detach_res = bpf.detach_kprobe(clone_fnname);
       if (detach_res.code() != 0) {
         std::cerr << detach_res.msg() << std::endl;
         return 1;

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -47,7 +47,8 @@ class BPF {
 
   explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr,
                bool rw_engine_enabled = true)
-      : flag_(flag), bpf_module_(new BPFModule(flag, ts, rw_engine_enabled)) {}
+      : flag_(flag), syscall_prefix_idx_(0),
+        bpf_module_(new BPFModule(flag, ts, rw_engine_enabled)) {}
   StatusTuple init(const std::string& bpf_program,
                    const std::vector<std::string>& cflags = {},
                    const std::vector<USDT>& usdt = {});
@@ -90,6 +91,7 @@ class BPF {
                                     int group_fd = -1);
   StatusTuple detach_perf_event(uint32_t ev_type, uint32_t ev_config);
   StatusTuple detach_perf_event_raw(void* perf_event_attr);
+  std::string get_syscall_fnname(const std::string &name);
 
   BPFTable get_table(const std::string& name) {
     TableStorage::iterator it;
@@ -211,6 +213,8 @@ class BPF {
                                   uint64_t& offset_res);
 
   int flag_;
+
+  int syscall_prefix_idx_;
 
   std::unique_ptr<BPFModule> bpf_module_;
 

--- a/tests/cc/test_bpf_table.cc
+++ b/tests/cc/test_bpf_table.cc
@@ -178,10 +178,11 @@ TEST_CASE("test bpf stack table", "[bpf_stack_table]") {
   ebpf::StatusTuple res(0);
   res = bpf.init(BPF_PROGRAM);
   REQUIRE(res.code() == 0);
-  res = bpf.attach_kprobe("sys_getuid", "on_sys_getuid");
+  std::string getuid_fnname = bpf.get_syscall_fnname("getuid");
+  res = bpf.attach_kprobe(getuid_fnname, "on_sys_getuid");
   REQUIRE(res.code() == 0);
   REQUIRE(getuid() >= 0);
-  res = bpf.detach_kprobe("sys_getuid");
+  res = bpf.detach_kprobe(getuid_fnname);
   REQUIRE(res.code() == 0);
 
   auto id = bpf.get_hash_table<int, int>("id");

--- a/tests/cc/test_perf_event.cc
+++ b/tests/cc/test_perf_event.cc
@@ -62,10 +62,11 @@ TEST_CASE("test read perf event", "[bpf_perf_event]") {
   res =
       bpf.open_perf_event("cnt", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_CPU_CLOCK);
   REQUIRE(res.code() == 0);
-  res = bpf.attach_kprobe("sys_getuid", "on_sys_getuid");
+  std::string getuid_fnname = bpf.get_syscall_fnname("getuid");
+  res = bpf.attach_kprobe(getuid_fnname, "on_sys_getuid");
   REQUIRE(res.code() == 0);
   REQUIRE(getuid() >= 0);
-  res = bpf.detach_kprobe("sys_getuid");
+  res = bpf.detach_kprobe(getuid_fnname);
   REQUIRE(res.code() == 0);
   res = bpf.close_perf_event("cnt");
   REQUIRE(res.code() == 0);


### PR DESCRIPTION
This fixed issue #1695 for C++. The example
HelloWorld.cc and tests test_libbcc also got fixed.

Signed-off-by: Yonghong Song <yhs@fb.com>