### PR TITLE
fix compilation with latest clang/llvm 7.0

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -62,9 +62,11 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${llvm_lib_exclude_f
 # bcc_common_libs_for_a for archive libraries
 # bcc_common_libs_for_s for shared libraries
 set(bcc_common_libs_for_a b_frontend clang_frontend bpf-static
+  -Wl,--whole-archive ${clang_libs} ${llvm_libs} -Wl,--no-whole-archive
+  ${LIBELF_LIBRARIES})
+set(bcc_common_libs_for_s b_frontend clang_frontend bpf-static
   ${clang_libs} ${llvm_libs} ${LIBELF_LIBRARIES})
-set(bcc_common_libs_for_s ${bcc_common_libs_for_a})
-set(bcc_common_libs_for_lua ${bcc_common_libs_for_a})
+set(bcc_common_libs_for_lua ${bcc_common_libs_for_s})
 
 if(ENABLE_CPP_API)
   add_subdirectory(api)


### PR DESCRIPTION
The bcc build with latest clang/llvm 7.0 has the following
compilation error:
```
 /home/yhs/work/llvm/build/install/lib/libclangCodeGen.a(CodeGenAction.cpp.o):
  In function `clang::BackendConsumer::Initialize(clang::ASTContext&)':
  CodeGenAction.cpp:(.text._ZN5clang15BackendConsumer10InitializeERNS_10ASTContextE[_ZN5clang15BackendConsumer10InitializeERNS_10ASTContextE]+0xc): undefined reference to `clang::FrontendTimesIsEnabled'
 ...
```
The latest clang defined clang::FrontendTimesIsEnabled in
libclangFrontend.a and used in libclangCodeGen.a.

Due to the library order specified in clang_libs.cmake:
```
  # order is important
  set(clang_libs
    ${libclangFrontend}
    ...
    ${libclangCodeGen}
```
and the fact clang_libs here is used to build bcc-static,
the definition of clang::FrontendTimesIsEnabled is dropped
since nobody used it before the definition is checked by the compiler.

The fix here is to keep all the definitions/uses for clang_libs/llvm_libs
when buildint static library.

Tested on clang 4.0, 5.0, 6.0 and latest 7.0, all works fine.

Signed-off-by: Yonghong Song <yhs@fb.com>