### PR TITLE
profile: update --stack-storage-size default value in help message

### DIFF
--- a/man/man8/profile.8
+++ b/man/man8/profile.8
@@ -52,7 +52,7 @@ Show stacks from kernel space only (no user space stacks).
 .TP
 \-\-stack-storage-size COUNT
 The maximum number of unique stack traces that the kernel will count (default
-10240). If the sampled count exceeds this, a warning will be printed.
+16384). If the sampled count exceeds this, a warning will be printed.
 .TP
 duration
 Duration to trace, in seconds.

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -99,7 +99,7 @@ parser.add_argument("-a", "--annotations", action="store_true",
     help="add _[k] annotations to kernel frames")
 parser.add_argument("-f", "--folded", action="store_true",
     help="output folded format, one line per stack (for flame graphs)")
-parser.add_argument("--stack-storage-size", default=10240,
+parser.add_argument("--stack-storage-size", default=16384,
     type=positive_nonzero_int,
     help="the number of unique stack traces that can be stored and "
         "displayed (default %(default)s)")

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -102,7 +102,7 @@ parser.add_argument("-f", "--folded", action="store_true",
 parser.add_argument("--stack-storage-size", default=10240,
     type=positive_nonzero_int,
     help="the number of unique stack traces that can be stored and "
-        "displayed (default 2048)")
+        "displayed (default %(default)s)")
 parser.add_argument("duration", nargs="?", default=99999999,
     type=positive_nonzero_int,
     help="duration of trace, in seconds")


### PR DESCRIPTION
While looking at the code of `profile.py` I noticed that the help message for `--stack-storage-size` was not in line with the current default value.