### PR TITLE
Detect external pointers from context argument

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -95,7 +95,9 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   bool VisitUnaryOperator(clang::UnaryOperator *E);
   bool VisitMemberExpr(clang::MemberExpr *E);
   void set_ptreg(clang::Decl *D) { ptregs_.insert(D); }
+  void set_ctx(clang::Decl *D) { ctx_ = D; }
  private:
+  bool IsContextMemberExpr(clang::Expr *E);
   clang::SourceRange expansionRange(clang::SourceRange range);
   template <unsigned N>
   clang::DiagnosticBuilder error(clang::SourceLocation loc, const char (&fmt)[N]);
@@ -106,6 +108,7 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   std::set<clang::Expr *> memb_visited_;
   std::set<clang::Decl *> ptregs_;
   std::set<clang::Decl *> &m_;
+  clang::Decl *ctx_;
 };
 
 // A helper class to the frontend action, walks the decls

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -704,10 +704,10 @@ BPF_HASH(table1, struct key_t, struct value_t);
     @skipUnless(kernel_version_ge(4,7), "requires kernel >= 4.7")
     def test_probe_read_tracepoint_context(self):
         text = """
-#include <net/inet_sock.h>
-TRACEPOINT_PROBE(tcp, tcp_retransmit_skb) {
-    struct sock *sk = (struct sock *)args->skaddr;
-    return sk->sk_dport;
+#include <linux/netdevice.h>
+TRACEPOINT_PROBE(skb, kfree_skb) {
+    struct sk_buff *skb = (struct sk_buff *)args->skbaddr;
+    return skb->protocol;
 }
 """
         b = BPF(text=text)

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -701,6 +701,30 @@ BPF_HASH(table1, struct key_t, struct value_t);
         self.assertEqual(ct.sizeof(table.Key), 96)
         self.assertEqual(ct.sizeof(table.Leaf), 16)
 
+    @skipUnless(kernel_version_ge(4,7), "requires kernel >= 4.7")
+    def test_probe_read_tracepoint_context(self):
+        text = """
+#include <net/inet_sock.h>
+TRACEPOINT_PROBE(tcp, tcp_retransmit_skb) {
+    struct sock *sk = (struct sock *)args->skaddr;
+    return sk->sk_dport;
+}
+"""
+        b = BPF(text=text)
+
+    def test_probe_read_kprobe_ctx(self):
+        text = """
+#include <linux/sched.h>
+#include <net/inet_sock.h>
+int test(struct pt_regs *ctx) {
+    struct sock *sk;
+    sk = (struct sock *)ctx->di;
+    return sk->sk_dport;
+}
+"""
+        b = BPF(text=text)
+        fn = b.load_func("test", BPF.KPROBE)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The bcc rewriter is currently unable to detect external pointers (i.e., to a memory address that requires calls to `bpf_probe_read`) if they are not declared as arguments, e.g., if they are retrieved through the context argument.
For example, although the two following examples translate to the same C code in the end (the bcc rewriter translates the first into the second), the `sk` pointer is recognized as an external pointer only in the first example.
```c
int test1(struct pt_regs *ctx, struct sock *sk) {
    // sk is correctly recognized as an external pointer.
}
int test2(struct pt_regs *ctx) {
    struct sock *sk = (struct sock *)ctx->di;
    // sk is not recognized as an external pointer.
}
```

This pull request fixes that by detecting member dereferences of the context argument (i.e., the first argument of externally visible functions). It also works for the `TRACEPOINT_PROBE` macro and helps fix #1683.

I committed the tests first because I expect both commits to be squashed, and it makes it easier the see the tests fail without the second commit (see CI builds).