### PR TITLE
fix compilation error with latest llvm

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -302,7 +302,11 @@ bool ProbeVisitor::IsContextMemberExpr(Expr *E) {
 
 SourceRange
 ProbeVisitor::expansionRange(SourceRange range) {
+#if LLVM_MAJOR_VERSION >= 7
+  return rewriter_.getSourceMgr().getExpansionRange(range).getAsRange();
+#else
   return rewriter_.getSourceMgr().getExpansionRange(range);
+#endif
 }
 
 template <unsigned N>
@@ -695,7 +699,11 @@ bool BTypeVisitor::VisitImplicitCastExpr(ImplicitCastExpr *E) {
 
 SourceRange
 BTypeVisitor::expansionRange(SourceRange range) {
+#if LLVM_MAJOR_VERSION >= 7
+  return rewriter_.getSourceMgr().getExpansionRange(range).getAsRange();
+#else
   return rewriter_.getSourceMgr().getExpansionRange(range);
+#endif
 }
 
 template <unsigned N>


### PR DESCRIPTION
The clang commit https://reviews.llvm.org/rL331155
changed the `clang::SourceManager` function prototype
   `SourceRange getExpansionRange(SourceRange Range)`
to
   `CharSourceRange getExpansionRange(SourceRange Range)`
and caused the following compilation failure:
```
  /home/yhs/work/bcc/src/cc/frontends/clang/b_frontend_action.cc:
  In member function ‘clang::SourceRange ebpf::ProbeVisitor::expansionRange(clang::SourceRange)’:
  /home/yhs/work/bcc/src/cc/frontends/clang/b_frontend_action.cc:267:58:
  error: could not convert ‘(&(&((ebpf::ProbeVisitor *)this)->ebpf::ProbeVisitor::rewriter_)
         ->clang::Rewriter::getSourceMgr())->clang::SourceManager::getExpansionRange(range)’
  from ‘clang::CharSourceRange’ to ‘clang::SourceRange’
     return rewriter_.getSourceMgr().getExpansionRange(range);
                                                            ^
  ...
```
It is hard to find a compatible change which works
for both old llvm and the latest change. So this patch
just fixed the problem for clang 7.0.0 and the old code
is used for clang 6.x and lower.

Signed-off-by: Yonghong Song <yhs@fb.com>