### PR TITLE
Fix bpf_trace_printk() for big-endian targets

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -615,7 +615,6 @@ int BPFModule::finalize() {
   std::map<std::string, std::tuple<uint8_t *, uintptr_t>> tmp_sections,
       *sections_p;
 
-  mod->setDataLayout("e-m:e-p:64:64-i64:64-n32:64-S128");
   mod->setTargetTriple("bpf-pc-linux");
   sections_p = rw_engine_enabled_ ? &sections_ : &tmp_sections;
 


### PR DESCRIPTION
The format string for `bpf_trace_printk()` gets garbled during the conversion of the LLVM IR code to the corresponding BPF object. This happens because bcc explicitly sets the data layout of the module to `e-m:e-p:64:64-i64:64-n32:64-S128` which is valid for little-endian targets only. If the arch is set to `bpf`, LLVM selects the correct data layout automatically and there is no need to set this explicitly.

Reported-by: @chandanr
Fixes: #1723