### PR TITLE
Fix "'ArgString' object has no attribute 'rfind'" error

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -219,7 +219,7 @@ class BPF(object):
         if filename:
             if not os.path.isfile(filename):
                 argv0 = ArgString(sys.argv[0])
-                t = b"/".join([os.path.abspath(os.path.dirname(argv0)), filename])
+                t = b"/".join([os.path.abspath(os.path.dirname(argv0.__str__())), filename])
                 if os.path.isfile(t):
                     filename = t
                 else:


### PR DESCRIPTION
I am getting the following error when running the tests locally (Python 2.7.14):
```pytb
======================================================================
ERROR: test_complex (__main__.TestClang)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../../tests/python/test_clang.py", line 40, in test_complex
    b = BPF(src_file="test_clang_complex.c", debug=0)
  File "/git/bcc6/src/python/bcc/__init__.py", line 311, in __init__
    src_file = BPF._find_file(src_file)
  File "/git/bcc6/src/python/bcc/__init__.py", line 222, in _find_file
    t = b"/".join([os.path.abspath(os.path.dirname(argv0)), filename])
  File "/usr/lib/python2.7/posixpath.py", line 122, in dirname
    i = p.rfind('/') + 1
AttributeError: 'ArgString' object has no attribute 'rfind'
```
This pull request fixes it by passing `argv0.__str__()` to `dirname()` instead of `argv0` directly.