### PR TITLE
old/tools: Diverse fixes

### DIFF
--- a/tools/old/bashreadline.py
+++ b/tools/old/bashreadline.py
@@ -22,7 +22,7 @@ int printret(struct pt_regs *ctx) {
         return 0;
 
     char str[80] = {};
-    bpf_probe_read(&str, sizeof(str), (void *)ctx->ax);
+    bpf_probe_read(&str, sizeof(str), (void *)PT_REGS_RC(ctx));
     bpf_trace_printk("%s\\n", &str);
 
     return 0;

--- a/tools/old/tcpaccept.py
+++ b/tools/old/tcpaccept.py
@@ -47,7 +47,7 @@ bpf_text = """
 
 int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 {
-    struct sock *newsk = (struct sock *)ctx->ax;
+    struct sock *newsk = (struct sock *)PT_REGS_RC(ctx);
     u32 pid = bpf_get_current_pid_tgid();
 
     if (newsk == NULL)

--- a/tools/old/tcpconnect.py
+++ b/tools/old/tcpconnect.py
@@ -75,12 +75,10 @@ static int trace_connect_return(struct pt_regs *ctx, short ipver)
     struct sock *skp = *skpp;
     u32 saddr = 0, daddr = 0;
     u16 dport = 0;
-    bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+    dport = skp->__sk_common.skc_dport;
     if (ipver == 4) {
-        bpf_probe_read(&saddr, sizeof(saddr),
-            &skp->__sk_common.skc_rcv_saddr);
-        bpf_probe_read(&daddr, sizeof(daddr),
-            &skp->__sk_common.skc_daddr);
+        saddr = skp->__sk_common.skc_rcv_saddr;
+        daddr = skp->__sk_common.skc_daddr;
 
         // output
         bpf_trace_printk("4 %x %x %d\\n", saddr, daddr, ntohs(dport));

--- a/tools/old/tcpconnect.py
+++ b/tools/old/tcpconnect.py
@@ -55,7 +55,7 @@ int trace_connect_entry(struct pt_regs *ctx, struct sock *sk)
 
 static int trace_connect_return(struct pt_regs *ctx, short ipver)
 {
-    int ret = ctx->ax;
+    int ret = PT_REGS_RC(ctx);
     u32 pid = bpf_get_current_pid_tgid();
 
     struct sock **skpp;


### PR DESCRIPTION
I'm not sure whether we want to keep doing minimal maintenance on the `old/tools` scripts. From what I understand/read, we moved old tools to this location if the newer versions require some recent kernel feature. In that case, I'm guessing we should make sure they still run with the last version of bcc.

This pull request makes a few fixes to ensure that is still the case.