### PR TITLE
Fix USDT probes arguments' encoding in Python3

### DIFF
--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -175,7 +175,7 @@ tplist tool.""")
 
     def get_probe_arg_ctype(self, probe_name, arg_index):
         return lib.bcc_usdt_get_probe_argctype(
-            self.context, probe_name, arg_index)
+            self.context, probe_name.encode('ascii'), arg_index).decode()
 
     def enumerate_probes(self):
         probes = []

--- a/tools/trace.py
+++ b/tools/trace.py
@@ -342,10 +342,10 @@ BPF_PERF_OUTPUT(%s);
                 if self.probe_type == "u" and expr[0:3] == "arg":
                         arg_index = int(expr[3])
                         arg_ctype = self.usdt.get_probe_arg_ctype(
-                                self.usdt_name.encode('ascii'), arg_index - 1)
+                                self.usdt_name, arg_index - 1)
                         text = ("        %s %s = 0;\n" +
                                 "        bpf_usdt_readarg(%s, ctx, &%s);\n") \
-                                % (arg_ctype.decode(), expr, expr[3], expr)
+                                % (arg_ctype, expr, expr[3], expr)
 
                 if field_type == "s":
                         return text + """

--- a/tools/trace.py
+++ b/tools/trace.py
@@ -342,10 +342,10 @@ BPF_PERF_OUTPUT(%s);
                 if self.probe_type == "u" and expr[0:3] == "arg":
                         arg_index = int(expr[3])
                         arg_ctype = self.usdt.get_probe_arg_ctype(
-                                self.usdt_name, arg_index - 1)
+                                self.usdt_name.encode('ascii'), arg_index - 1)
                         text = ("        %s %s = 0;\n" +
                                 "        bpf_usdt_readarg(%s, ctx, &%s);\n") \
-                                % (arg_ctype, expr, expr[3], expr)
+                                % (arg_ctype.decode(), expr, expr[3], expr)
 
                 if field_type == "s":
                         return text + """


### PR DESCRIPTION
Running `trace` on a binary's USDT while fetching some arguments (`$ sudo python3 trace.py -p $(pidof ruby) 'u:ruby:array__create "%d", arg1'`) fails with `argument 2: <class 'TypeError'>: wrong type`.

This PR fixes the encoding of the USDT probe name to the `get_probe_arg_ctype`, by encoding it to a bytestring and decoding it afterwards. I've tested this works in Python2 too 😄 

Cheers!