### PR TITLE
Use print function for Python3 compatibility

### DIFF
--- a/examples/tracing/bitehist.py
+++ b/examples/tracing/bitehist.py
@@ -13,6 +13,7 @@
 #
 # 15-Aug-2015	Brendan Gregg	Created this.
 
+from __future__ import print_function
 from bcc import BPF
 from time import sleep
 
@@ -37,7 +38,7 @@ print("Tracing... Hit Ctrl-C to end.")
 try:
 	sleep(99999999)
 except KeyboardInterrupt:
-	print
+	print()
 
 # output
 b["dist"].print_log2_hist("kbytes")

--- a/examples/tracing/trace_fields.py
+++ b/examples/tracing/trace_fields.py
@@ -6,6 +6,7 @@
 # run in project examples directory with:
 # sudo ./trace_fields.py"
 
+from __future__ import print_function
 from bcc import BPF
 
 prog = """
@@ -16,5 +17,5 @@ int hello(void *ctx) {
 """
 b = BPF(text=prog)
 b.attach_kprobe(event=b.get_syscall_fnname("clone"), fn_name="hello")
-print "PID MESSAGE"
+print("PID MESSAGE")
 b.trace_print(fmt="{1} {5}")

--- a/examples/tracing/vfsreadlat.py
+++ b/examples/tracing/vfsreadlat.py
@@ -15,6 +15,7 @@
 #
 # 15-Aug-2015	Brendan Gregg	Created this.
 
+from __future__ import print_function
 from bcc import BPF
 from ctypes import c_ushort, c_int, c_ulonglong
 from time import sleep
@@ -58,7 +59,7 @@ while (1):
 	except KeyboardInterrupt:
 		pass; do_exit = 1
 
-	print
+	print()
 	b["dist"].print_log2_hist("usecs")
 	b["dist"].clear()
 	if do_exit:

--- a/src/cc/frontends/p4/compiler/topoSorting.py
+++ b/src/cc/frontends/p4/compiler/topoSorting.py
@@ -20,6 +20,7 @@
 
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 
 class Node(object):
     def __init__(self, n):
@@ -55,7 +56,7 @@ class Graph(object):
                 sequence += [str(node)]
             if node._behavioral_topo_sorting_mark == 1:
                 if sequence is not None:
-                    print "cycle", sequence
+                    print("cycle", sequence)
                 return False
             if node._behavioral_topo_sorting_mark != 2:
                 node._behavioral_topo_sorting_mark = 1

--- a/src/cc/frontends/p4/test/testP4toEbpf.py
+++ b/src/cc/frontends/p4/test/testP4toEbpf.py
@@ -6,6 +6,7 @@
 # Runs the compiler on all files in the 'testprograms' folder
 # Writes outputs in the 'testoutputs' folder
 
+from __future__ import print_function
 from bcc import BPF
 import os, sys
 sys.path.append("../compiler") # To get hold of p4toEbpf
@@ -37,9 +38,9 @@ def main():
     errors = 0
 
     if not is_root():
-        print "Loading EBPF programs requires root privilege."
-        print "Will only test compilation, not loading."
-        print "(Run with sudo to test program loading.)"
+        print("Loading EBPF programs requires root privilege.")
+        print("Will only test compilation, not loading.")
+        print("(Run with sudo to test program loading.)")
 
     for f in files:
         path = os.path.join(testpath, f)
@@ -57,7 +58,7 @@ def main():
         result = p4toEbpf.process(args)
         if result.kind != "OK":
             errors += 1
-            print path, result.error
+            print(path, result.error)
             set_error(result.kind, path, result.error)
         else:
             # Try to load the compiled function
@@ -72,11 +73,11 @@ def main():
 
         filesDone += 1
 
-    print "Compiled", filesDone, "files", errors, "errors"
+    print("Compiled", filesDone, "files", errors, "errors")
     for key in sorted(filesFailed):
-        print key, ":", len(filesFailed[key]), "programs"
+        print(key, ":", len(filesFailed[key]), "programs")
         for v in filesFailed[key]:
-            print "\t", v
+            print("\t", v)
     exit(len(filesFailed) != 0)
 
 


### PR DESCRIPTION
Hi!

After bumping into some minor Python3 incompatibilities that are already fixed upstream (thanks a bunch!! 😄), I decided to have a look to see if there were more! 

This PR replaces the `print` statement with the Python3 printing function. It also adds `from __future__ import print_function` where needed to have the same print semantics in Python2.

Thanks! :)

PS: I also checked scripts that don't have the import, but didn't submit a PR because these cases work fine in Python3, although the semantics are different and it might be needed in the future. These changes are [here](https://github.com/javierhonduco/bcc/commit/cd5fad2454680a853b632afa0f7514d7dad0b49e), let me know if you think it would be worth merging :).