### PR TITLE
Do not calculate syscall prefix proactively in C++ API

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -32,17 +32,13 @@
 #include "common.h"
 #include "libbpf.h"
 #include "perf_reader.h"
+#include "syms.h"
 #include "table_storage.h"
 #include "usdt.h"
 
 #include "BPF.h"
 
 namespace ebpf {
-
-static const char* syscall_prefix[] = {
-    "sys_",
-    "__x64_sys_",
-};
 
 std::string uint_to_hex(uint64_t value) {
   std::stringstream ss;
@@ -62,10 +58,6 @@ StatusTuple BPF::init(const std::string& bpf_program,
                       const std::vector<std::string>& cflags,
                       const std::vector<USDT>& usdt) {
   std::string all_bpf_program;
-  bcc_symbol_option symbol_option = {};
-  void* ksym_cache;
-  uint64_t addr;
-  int ret;
 
   for (auto u : usdt) {
     if (!u.initialized_)
@@ -82,16 +74,6 @@ StatusTuple BPF::init(const std::string& bpf_program,
   all_bpf_program += bpf_program;
   if (bpf_module_->load_string(all_bpf_program, flags, flags_len) != 0)
     return StatusTuple(-1, "Unable to initialize BPF program");
-
-  ksym_cache = bcc_symcache_new(-1, &symbol_option);
-  ret = bcc_symcache_resolve_name(ksym_cache, NULL, "sys_bpf", &addr);
-  if (ret == 0) {
-    syscall_prefix_idx_ = 0;
-  } else {
-    ret = bcc_symcache_resolve_name(ksym_cache, NULL, "__x64_sys_bpf", &addr);
-    syscall_prefix_idx_ = (ret == 0) ? 1 : 0;
-  }
-  bcc_free_symcache(ksym_cache, -1);
 
   return StatusTuple(0);
 };
@@ -567,8 +549,19 @@ StatusTuple BPF::unload_func(const std::string& func_name) {
 }
 
 std::string BPF::get_syscall_fnname(const std::string& name) {
-  std::string fn_name = syscall_prefix[syscall_prefix_idx_] + name;
-  return std::move(fn_name);
+  if (syscall_prefix_ == nullptr) {
+    KSyms ksym;
+    uint64_t addr;
+
+    if (ksym.resolve_name(nullptr, "sys_bpf", &addr))
+      syscall_prefix_.reset(new std::string("sys_"));
+    else if (ksym.resolve_name(nullptr, "__x64_sys_bpf", &addr))
+      syscall_prefix_.reset(new std::string("__x64_sys_"));
+    else
+      syscall_prefix_.reset(new std::string());
+  }
+
+  return *syscall_prefix_ + name;
 }
 
 StatusTuple BPF::check_binary_symbol(const std::string& binary_path,

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -48,7 +48,6 @@ class BPF {
   explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr,
                bool rw_engine_enabled = true)
       : flag_(flag),
-        syscall_prefix_idx_(0),
         bpf_module_(new BPFModule(flag, ts, rw_engine_enabled)) {}
   StatusTuple init(const std::string& bpf_program,
                    const std::vector<std::string>& cflags = {},
@@ -219,7 +218,7 @@ class BPF {
 
   int flag_;
 
-  int syscall_prefix_idx_;
+  std::unique_ptr<std::string> syscall_prefix_;
 
   std::unique_ptr<BPFModule> bpf_module_;
 


### PR DESCRIPTION
Currently do calculate the syscall prefix in `BPF::init`, which requires loading `kallsyms` etc. But a lot of times the functionality will not be used. This commit changes that we only calculate the syscall prefix the first time we call `get_syscall_fnname`

Also change to use the `KSym` class directly for better destruct production