### PR TITLE
link with bpf-static library for bps

### DIFF
--- a/introspection/CMakeLists.txt
+++ b/introspection/CMakeLists.txt
@@ -7,6 +7,6 @@ include_directories(${CMAKE_SOURCE_DIR}/src/cc/api)
 option(INSTALL_INTROSPECTION "Install BPF introspection tools" ON)
 
 add_executable(bps bps.c)
-target_link_libraries(bps bcc-static)
+target_link_libraries(bps bpf-static)
 
 install (TARGETS bps DESTINATION share/bcc/introspection)


### PR DESCRIPTION
the issue is reported at #1759.

bps does not need any C++ library functions in bcc.
It only needs libbpf. So link it with bpf-static instead
of bcc-static. This avoids pulling in any C++ module/symbolization/usdt
functions and llvm libraries.

On my local box, the binary size is reduced from ~60MB to 44KB.

Signed-off-by: Yonghong Song <yhs@fb.com>