### PR TITLE
Misc fixes for C++ USDT class

### DIFF
--- a/examples/cpp/FollyRequestContextSwitch.cc
+++ b/examples/cpp/FollyRequestContextSwitch.cc
@@ -88,6 +88,8 @@ int main(int argc, char** argv) {
   if (attach_res.code() != 0) {
     std::cerr << attach_res.msg() << std::endl;
     return 1;
+  } else {
+    std::cout << "Attached to USDT " << u[0];
   }
 
   auto open_res = bpf->open_perf_buffer("events", &handle_output);

--- a/examples/cpp/FollyRequestContextSwitch.cc
+++ b/examples/cpp/FollyRequestContextSwitch.cc
@@ -74,10 +74,16 @@ int main(int argc, char** argv) {
   }
   std::string binary_path(argv[1]);
 
-  bpf = new ebpf::BPF();
   std::vector<ebpf::USDT> u;
   u.emplace_back(binary_path, "folly", "request_context_switch_before",
                  "on_context_switch");
+  auto usdt_init_res = u[0].init();
+  if (usdt_init_res.code() != 0) {
+    std::cerr << usdt_init_res.msg() << std::endl;
+    return 1;
+  }
+
+  bpf = new ebpf::BPF();
   auto init_res = bpf->init(BPF_PROGRAM, {}, u);
   if (init_res.code() != 0) {
     std::cerr << init_res.msg() << std::endl;

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -244,6 +244,8 @@ class USDT {
         name_(name),
         probe_func_(probe_func) {}
 
+  StatusTuple init();
+
   bool operator==(const USDT& other) const {
     return (provider_ == other.provider_) && (name_ == other.name_) &&
            (binary_path_ == other.binary_path_) &&
@@ -261,7 +263,6 @@ class USDT {
   }
 
  private:
-  StatusTuple init();
   bool initialized_;
 
   std::string binary_path_;

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -19,6 +19,7 @@
 #include <cctype>
 #include <cstdint>
 #include <memory>
+#include <ostream>
 #include <string>
 
 #include "BPFTable.h"
@@ -47,8 +48,7 @@ class BPF {
 
   explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr,
                bool rw_engine_enabled = true)
-      : flag_(flag),
-        bpf_module_(new BPFModule(flag, ts, rw_engine_enabled)) {}
+      : flag_(flag), bpf_module_(new BPFModule(flag, ts, rw_engine_enabled)) {}
   StatusTuple init(const std::string& bpf_program,
                    const std::vector<std::string>& cflags = {},
                    const std::vector<USDT>& usdt = {});
@@ -251,7 +251,13 @@ class USDT {
   }
 
   std::string print_name() const {
-    return provider_ + ":" + name_ + " from " + binary_path_;
+    return provider_ + ":" + name_ + " from " + binary_path_ + " for probe " +
+           "probe_func_";
+  }
+
+  friend std::ostream& operator<<(std::ostream& out, const USDT& usdt) {
+    return out << usdt.provider_ << ":" << usdt.name_ << " from "
+               << usdt.binary_path_ << " for probe " << usdt.probe_func_;
   }
 
  private:


### PR DESCRIPTION
This PR:
- Adds `ostream` logging for USDT debug message
- Expose `init()` so that user could proactively check validness of the USDT