### PR TITLE
Add extra_flag option to bpf_attach_perf_event_raw

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -324,7 +324,8 @@ StatusTuple BPF::attach_perf_event(uint32_t ev_type, uint32_t ev_config,
 
 StatusTuple BPF::attach_perf_event_raw(void* perf_event_attr,
                                        const std::string& probe_func, pid_t pid,
-                                       int cpu, int group_fd) {
+                                       int cpu, int group_fd,
+                                       unsigned long extra_flags) {
   auto attr = static_cast<struct perf_event_attr*>(perf_event_attr);
   auto ev_pair = std::make_pair(attr->type, attr->config);
   if (perf_events_.find(ev_pair) != perf_events_.end())
@@ -342,7 +343,8 @@ StatusTuple BPF::attach_perf_event_raw(void* perf_event_attr,
   auto fds = new std::vector<std::pair<int, int>>();
   fds->reserve(cpus.size());
   for (int i : cpus) {
-    int fd = bpf_attach_perf_event_raw(probe_fd, attr, pid, i, group_fd);
+    int fd = bpf_attach_perf_event_raw(probe_fd, attr, pid, i, group_fd,
+                                       extra_flags);
     if (fd < 0) {
       for (const auto& it : *fds)
         close(it.second);

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -88,7 +88,8 @@ class BPF {
   StatusTuple attach_perf_event_raw(void* perf_event_attr,
                                     const std::string& probe_func,
                                     pid_t pid = -1, int cpu = -1,
-                                    int group_fd = -1);
+                                    int group_fd = -1,
+                                    unsigned long extra_flags = 0);
   StatusTuple detach_perf_event(uint32_t ev_type, uint32_t ev_config);
   StatusTuple detach_perf_event_raw(void* perf_event_attr);
   std::string get_syscall_fnname(const std::string& name);

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -1305,9 +1305,9 @@ cleanup:
 }
 
 int bpf_attach_perf_event_raw(int progfd, void *perf_event_attr, pid_t pid,
-                              int cpu, int group_fd) {
+                              int cpu, int group_fd, unsigned long extra_flags) {
   int fd = syscall(__NR_perf_event_open, perf_event_attr, pid, cpu, group_fd,
-                   PERF_FLAG_FD_CLOEXEC);
+                   PERF_FLAG_FD_CLOEXEC | extra_flags);
   if (fd < 0) {
     perror("perf_event_open failed");
     return -1;
@@ -1351,7 +1351,7 @@ int bpf_attach_perf_event(int progfd, uint32_t ev_type, uint32_t ev_config,
     attr.sample_period = sample_period;
   }
 
-  return bpf_attach_perf_event_raw(progfd, &attr, pid, cpu, group_fd);
+  return bpf_attach_perf_event_raw(progfd, &attr, pid, cpu, group_fd, 0);
 }
 
 int bpf_close_perf_event_fd(int fd) {

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -93,7 +93,7 @@ int bpf_attach_xdp(const char *dev_name, int progfd, uint32_t flags);
 // attach a prog expressed by progfd to run on a specific perf event. The perf
 // event will be created using the perf_event_attr pointer provided.
 int bpf_attach_perf_event_raw(int progfd, void *perf_event_attr, pid_t pid,
-                              int cpu, int group_fd);
+                              int cpu, int group_fd, unsigned long extra_flags);
 // attach a prog expressed by progfd to run on a specific perf event, with
 // certain sample period or sample frequency
 int bpf_attach_perf_event(int progfd, uint32_t ev_type, uint32_t ev_config,


### PR DESCRIPTION
The bpf_attach_perf_event_raw API is designed to provide maximum flexibility for people to use advanced features of Kernel Perf Events with BPF. Some times specifying flags is necessary, such as if we want to use `PERF_FLAG_PID_CGROUP` to profile a container. This commit adds `extra_flag` option to C and C++ interface

I fee bad for the interface change after introducing the interface. However it was not so long time ago so I guess it should be find...:)