### PR TITLE
xfsslower: Fix compilation error due to rewriter update

### DIFF
--- a/tools/xfsslower.py
+++ b/tools/xfsslower.py
@@ -187,10 +187,7 @@ static int trace_return(struct pt_regs *ctx, int type)
     bpf_get_current_comm(&data.task, sizeof(data.task));
 
     // workaround (rewriter should handle file to d_name in one step):
-    struct dentry *de = NULL;
-    struct qstr qs = {};
-    bpf_probe_read(&de, sizeof(de), &valp->fp->f_path.dentry);
-    bpf_probe_read(&qs, sizeof(qs), (void *)&de->d_name);
+    struct qstr qs = valp->fp->f_path.dentry->d_name;
     if (qs.len == 0)
         return 0;
     bpf_probe_read(&data.file, sizeof(data.file), (void *)qs.name);

--- a/tools/zfsslower.py
+++ b/tools/zfsslower.py
@@ -190,11 +190,7 @@ static int trace_return(struct pt_regs *ctx, int type)
     data.offset = valp->offset;
     bpf_get_current_comm(&data.task, sizeof(data.task));
 
-    // workaround (rewriter should handle file to d_name in one step):
-    struct dentry *de = NULL;
-    struct qstr qs = {};
-    bpf_probe_read(&de, sizeof(de), &valp->fp->f_path.dentry);
-    bpf_probe_read(&qs, sizeof(qs), (void *)&de->d_name);
+    struct qstr qs = valp->fp->f_path.dentry->d_name;
     if (qs.len == 0)
         return 0;
     bpf_probe_read(&data.file, sizeof(data.file), (void *)qs.name);


### PR DESCRIPTION
Since #1737, the bcc rewriter is able to track more external pointers going through maps.  xfsslower was relying on the rewriter not being able to replace some dereferences.  This commit takes this
into account and removes two unnecessary calls to `bpf_probe_read`.

Fixes #1766.

/cc @bobrik 