### PR TITLE
Limit dereference rewriter to tracing contexts

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -911,7 +911,16 @@ void BTypeConsumer::HandleTranslationUnit(ASTContext &Context) {
       if (fe_.is_rewritable_ext_func(F)) {
         for (auto arg : F->parameters()) {
           if (arg == F->getParamDecl(0)) {
-            probe_visitor1_.set_ctx(arg);
+            /**
+             * Limit tracing of pointers from context to tracing contexts.
+             * We're whitelisting instead of blacklisting to avoid issues with
+             * existing programs if new context types are added in the future.
+             */
+            string type = arg->getType().getAsString();
+            if (type == "struct pt_regs *" ||
+                type == "struct bpf_raw_tracepoint_args *" ||
+                type.substr(0, 19) == "struct tracepoint__")
+              probe_visitor1_.set_ctx(arg);
           } else if (!arg->getType()->isFundamentalType()) {
             probe_visitor1_.set_ptreg(arg);
           }


### PR DESCRIPTION
We should only track and rewrite external pointers from the context pointer for tracing programs.  Other types of context pointers point to e.g. packets and do not require a rewrite to a `bpf_probe_read` call.

I should have done this before, in #1724.