### PR TITLE
execsnoop: don't print newlines in argv

### DIFF
--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -213,8 +213,9 @@ def print_event(cpu, data, size):
                 print("%-8.3f" % (time.time() - start_ts), end="")
             ppid = get_ppid(event.pid)
             ppid = b"%d" % ppid if ppid > 0 else b"?"
+            argv_text = b' '.join(argv[event.pid]).replace(b'\n', b'\\n')
             printb(b"%-16s %-6d %-6s %3d %s" % (event.comm, event.pid,
-                   ppid, event.retval, b' '.join(argv[event.pid])))
+                   ppid, event.retval, argv_text))
         try:
             del(argv[event.pid])
         except Exception:


### PR DESCRIPTION
by escaping newlines. Fixes #1037

* Before:
```
$ sudo /usr/share/bcc/tools/execsnoop
PCOMM            PID    PPID   RET ARGS
awk              9910   7831     0 /usr/bin/awk
BEGIN { print "hi" }
```

* With this patch:
```
$ sudo /usr/share/bcc/tools/execsnoop
PCOMM            PID    PPID   RET ARGS
awk              10033  7831     0 /usr/bin/awk \nBEGIN { print "hi" }
```

:warning: I haven't tested this in Python2 as I haven't managed to make it work BCC with Python2 on my machine
