### PR TITLE
fix tcplife.py rewriter issue

### DIFF
--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -311,8 +311,8 @@ TRACEPOINT_PROBE(sock, inet_sock_set_state)
     // get throughput stats. see tcp_get_info().
     u64 rx_b = 0, tx_b = 0, sport = 0;
     struct tcp_sock *tp = (struct tcp_sock *)sk;
-    bpf_probe_read(&rx_b, sizeof(rx_b), &tp->bytes_received);
-    bpf_probe_read(&tx_b, sizeof(tx_b), &tp->bytes_acked);
+    rx_b = tp->bytes_received;
+    tx_b = tp->bytes_acked;
 
     if (args->family == AF_INET) {
         struct ipv4_data_t data4 = {.span_us = delta_us,


### PR DESCRIPTION
rewriter tried to rewrite an argument for a user written
bpf_probe_read and triggers a clang compilation error.
```
  $ tcplife.py
  /virtual/main.c:134:41: error: cannot take the address of an rvalue of type 'typeof(u64)' (aka 'unsigned long long')
    ...&({ typeof(u64) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (u64)&tp->bytes_received); _val; }));
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /virtual/main.c:135:41: error: cannot take the address of an rvalue of type 'typeof(u64)' (aka 'unsigned long long')
    ...&({ typeof(u64) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (u64)&tp->bytes_acked); _val; }));
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  2 errors generated.
```
changing bpf_probe_read to regular pointer access fixed the issue.

Signed-off-by: Yonghong Song <yhs@fb.com>