### PR TITLE
 Track all external values of 64 bits instead of pointers only

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -47,10 +47,10 @@ class MapVisitor : public clang::RecursiveASTVisitor<MapVisitor> {
  public:
   explicit MapVisitor(std::set<clang::Decl *> &m);
   bool VisitCallExpr(clang::CallExpr *Call);
-  void set_ptreg(std::tuple<clang::Decl *, int> &pt) { ptregs_.insert(pt); }
+  void set_extreg(std::tuple<clang::Decl *, int> &ext) { extregs_.insert(ext); }
  private:
   std::set<clang::Decl *> &m_;
-  std::set<std::tuple<clang::Decl *, int>> ptregs_;
+  std::set<std::tuple<clang::Decl *, int>> extregs_;
 };
 
 // Type visitor and rewriter for B programs.
@@ -95,9 +95,9 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   bool VisitBinaryOperator(clang::BinaryOperator *E);
   bool VisitUnaryOperator(clang::UnaryOperator *E);
   bool VisitMemberExpr(clang::MemberExpr *E);
-  void set_ptreg(std::tuple<clang::Decl *, int> &pt) { ptregs_.insert(pt); }
+  void set_extreg(std::tuple<clang::Decl *, int> &ext) { extregs_.insert(ext); }
   void set_ctx(clang::Decl *D) { ctx_ = D; }
-  std::set<std::tuple<clang::Decl *, int>> get_ptregs() { return ptregs_; }
+  std::set<std::tuple<clang::Decl *, int>> get_extregs() { return extregs_; }
  private:
   bool IsContextMemberExpr(clang::Expr *E);
   clang::SourceRange expansionRange(clang::SourceRange range);
@@ -108,7 +108,7 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   clang::Rewriter &rewriter_;
   std::set<clang::Decl *> fn_visited_;
   std::set<clang::Expr *> memb_visited_;
-  std::set<std::tuple<clang::Decl *, int>> ptregs_;
+  std::set<std::tuple<clang::Decl *, int>> extregs_;
   std::set<clang::Decl *> &m_;
   clang::Decl *ctx_;
   bool track_helpers_;

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -875,6 +875,101 @@ int test(struct __sk_buff *ctx) {
         b = BPF(text=text)
         fn = b.load_func("test", BPF.SCHED_CLS)
 
+    def test_probe_read_ptr_addition1(self):
+        text = """
+#define KBUILD_MODNAME "foo"
+#include <linux/sched.h>
+#include <linux/tcp.h>
+int test(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
+    struct tcphdr *th = (struct tcphdr *)(skb->head + skb->transport_header);
+    return th->seq;
+}
+"""
+        b = BPF(text=text)
+        fn = b.load_func("test", BPF.KPROBE)
+
+    def test_probe_read_ptr_addition2(self):
+        text = """
+#define KBUILD_MODNAME "foo"
+#include <linux/sched.h>
+#include <linux/tcp.h>
+int test(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
+    struct tcphdr *th;
+    th = (struct tcphdr *)(skb->head + skb->transport_header);
+    return th->seq;
+}
+"""
+        b = BPF(text=text)
+        fn = b.load_func("test", BPF.KPROBE)
+
+    def test_probe_read_u64_through_map(self):
+        bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+#include <bcc/proto.h>
+
+BPF_HASH(currsock, u32, u64);
+
+int trace_entry(struct pt_regs *ctx, u64 sk,
+    struct sockaddr *uaddr, int addr_len) {
+    u32 pid = bpf_get_current_pid_tgid();
+    currsock.update(&pid, &sk);
+    return 0;
+};
+
+int trace_exit(struct pt_regs *ctx) {
+    u32 pid = bpf_get_current_pid_tgid();
+    u64 *skpp;
+    skpp = currsock.lookup(&pid);
+    if (skpp) {
+        struct sock *skp = (struct sock *)(*skpp);
+        return skp->__sk_common.skc_dport;
+    }
+    return 0;
+}
+        """
+        b = BPF(text=bpf_text)
+        b.load_func("trace_entry", BPF.KPROBE)
+        b.load_func("trace_exit", BPF.KPROBE)
+
+    @skipUnless(kernel_version_ge(4,8), "requires kernel >= 4.8")
+    def test_probe_read_u64_from_helper(self):
+        text = """
+#include <linux/sched.h>
+int test(struct pt_regs *ctx) {
+    struct task_struct *task;
+    u64 t = bpf_get_current_task();
+    task = (struct task_struct *)t;
+    return task->prio;
+}
+"""
+        b = BPF(text=text)
+        fn = b.load_func("test", BPF.KPROBE)
+
+    def test_probe_read_u64_from_args(self):
+        text = """
+#include <net/inet_sock.h>
+int test(struct pt_regs *ctx, u64 sk) {
+    u16 sport = ((struct inet_sock *)sk)->inet_sport;
+    return sport;
+}
+ """
+        b = BPF(text=text)
+        fn = b.load_func("test", BPF.KPROBE)
+
+    def test_probe_read_nested_deref_u64(self):
+        text = """
+#include <net/inet_sock.h>
+int test(struct pt_regs *ctx, struct sock *sk) {
+    u64 *ptr1;
+    u64 **ptr2 = &ptr1;
+    *ptr2 = (u64 *)sk;
+    return ((struct sock *)(*ptr2))->sk_daddr;
+}
+"""
+        b = BPF(text=text)
+        fn = b.load_func("test", BPF.KPROBE)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The last pull request for the bcc rewriter in my recent series. I've submitted #1724, #1733, and #1752 to be able to submit this one :tada: 

Currently, the bcc rewriter only tracks external pointers if they are actually of type pointer. External pointers may however have other types before being casted to pointers and dereferenced.
For example, the rewriter is unable to recognize that th is a pointer to a kernel address in the following code snippet because `skb->head` and `skb->transport_header` are of types `unsigned char` and `u16` respectively.
```c
int test(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
  struct tcphdr *th = (struct tcphdr *)(skb->head + skb->transport_header);
  return th->seq;
}
```
This pull request fixes it by verifying variables are size 64 bits instead of verifying their type.

There is a large number of changed lines because I renamed `ptregs` into `extregs`. This pull request initially tracked all external values regardless of their size; that approach works too, but I preferred a more conservative approach. I can separate the actual changes from the rest or even remove the renaming if you think that makes more sense.

With this, #1683 is fully fixed and shouldn't require any manual call to `bpf_probe_read` anymore.