### PR TITLE
Add missing kernel options to Gentoo instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -127,12 +127,17 @@ CONFIG_NET_CLS_BPF=m
 CONFIG_NET_ACT_BPF=m
 CONFIG_BPF_JIT=y
 CONFIG_BPF_EVENTS=y
+CONFIG_FUNCTION_TRACER=y
+CONFIG_DEBUG_INFO=y
+CONFIG_KALLSYMS_ALL=y
 ```
 Finally, you can install bcc with:
 ```
 emerge dev-util/bcc
 ```
 The appropriate dependencies (e.g., ```clang```, ```llvm``` with BPF backend) will be pulled automatically.
+
+If you use ZFS and want to use zfsdist, recompile sys-kernel/spl and sys-fs/zfs-kmod with USE=debug so that emerge does not strip the modules.
 
 ## openSUSE - Binary
 


### PR DESCRIPTION
CONFIG_FUNCTION_TRACER, CONFIG_DEBUG_INFO and CONFIG_KALLSYMS_ALL are
needed by various ${FS}dist tools.

Using zfsdist does not need CONFIG_KALLSYMS_ALL, but it does need the
modules to be unstripped, so special instructions are included as a note
for ZFS users.