### PR TITLE
within tc_perf_event.py,ping command fix

### DIFF
--- a/examples/networking/tc_perf_event.py
+++ b/examples/networking/tc_perf_event.py
@@ -77,7 +77,7 @@ try:
            parent="ffff:fff3", classid=1, direct_action=True)
 
     b["skb_events"].open_perf_buffer(print_skb_event)
-    print('Try: "ping -6 ff02::1%me"\n')
+    print('Try: "ping6 ff02::1%me"\n')
     print("%-3s %-32s %-12s %-10s" % ("CPU", "SRC IP", "DST IP", "Magic"))
     while True:
         b.perf_buffer_poll()


### PR DESCRIPTION
The **ping** command has no '-6' option, so use **ping6** to send IPv6 icmp.