### PR TITLE
zfsdist: fix for python3

### DIFF
--- a/tools/zfsdist.py
+++ b/tools/zfsdist.py
@@ -137,10 +137,10 @@ if debug or args.ebpf:
 b = BPF(text=bpf_text)
 
 # common file functions
-if BPF.get_kprobe_functions('zpl_iter'):
+if BPF.get_kprobe_functions(b'zpl_iter'):
     b.attach_kprobe(event="zpl_iter_read", fn_name="trace_entry")
     b.attach_kprobe(event="zpl_iter_write", fn_name="trace_entry")
-elif BPF.get_kprobe_functions('zpl_aio'):
+elif BPF.get_kprobe_functions(b'zpl_aio'):
     b.attach_kprobe(event="zpl_aio_read", fn_name="trace_entry")
     b.attach_kprobe(event="zpl_aio_write", fn_name="trace_entry")
 else:
@@ -148,10 +148,10 @@ else:
     b.attach_kprobe(event="zpl_write", fn_name="trace_entry")
 b.attach_kprobe(event="zpl_open", fn_name="trace_entry")
 b.attach_kprobe(event="zpl_fsync", fn_name="trace_entry")
-if BPF.get_kprobe_functions('zpl_iter'):
+if BPF.get_kprobe_functions(b'zpl_iter'):
     b.attach_kretprobe(event="zpl_iter_read", fn_name="trace_read_return")
     b.attach_kretprobe(event="zpl_iter_write", fn_name="trace_write_return")
-elif BPF.get_kprobe_functions('zpl_aio'):
+elif BPF.get_kprobe_functions(b'zpl_aio'):
     b.attach_kretprobe(event="zpl_aio_read", fn_name="trace_read_return")
     b.attach_kretprobe(event="zpl_aio_write", fn_name="trace_write_return")
 else:


### PR DESCRIPTION
The BPF.get_kprobe_functions method tests if the passed argument
matches with a line of kallsyms, which is opened in binary mode.
Therefore the regex pattern must be bytes as well.