### PR TITLE
Add support for attaching kprobes at custom offsets

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -161,6 +161,7 @@ StatusTuple BPF::detach_all() {
 
 StatusTuple BPF::attach_kprobe(const std::string& kernel_func,
                                const std::string& probe_func,
+                               uint64_t kernel_func_offset,
                                bpf_probe_attach_type attach_type) {
   std::string probe_event = get_kprobe_event(kernel_func, attach_type);
   if (kprobes_.find(probe_event) != kprobes_.end())
@@ -170,7 +171,7 @@ StatusTuple BPF::attach_kprobe(const std::string& kernel_func,
   TRY2(load_func(probe_func, BPF_PROG_TYPE_KPROBE, probe_fd));
 
   int res_fd = bpf_attach_kprobe(probe_fd, attach_type, probe_event.c_str(),
-                                 kernel_func.c_str());
+                                 kernel_func.c_str(), kernel_func_offset);
 
   if (res_fd < 0) {
     TRY2(unload_func(probe_func));

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -58,6 +58,7 @@ class BPF {
 
   StatusTuple attach_kprobe(const std::string& kernel_func,
                             const std::string& probe_func,
+                            uint64_t kernel_func_offset = 0,
                             bpf_probe_attach_type = BPF_PROBE_ENTRY);
   StatusTuple detach_kprobe(
       const std::string& kernel_func,

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -69,7 +69,7 @@ typedef void (*perf_reader_raw_cb)(void *cb_cookie, void *raw, int raw_size);
 typedef void (*perf_reader_lost_cb)(void *cb_cookie, uint64_t lost);
 
 int bpf_attach_kprobe(int progfd, enum bpf_probe_attach_type attach_type,
-                      const char *ev_name, const char *fn_name);
+                      const char *ev_name, const char *fn_name, uint64_t fn_offset);
 int bpf_detach_kprobe(const char *ev_name);
 
 int bpf_attach_uprobe(int progfd, enum bpf_probe_attach_type attach_type,

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -550,7 +550,7 @@ class BPF(object):
     def get_syscall_fnname(self, name):
         return self.get_syscall_prefix() + name
        
-    def attach_kprobe(self, event=b"", fn_name=b"", event_re=b""):
+    def attach_kprobe(self, event=b"", event_off=0, fn_name=b"", event_re=b""):
         event = _assert_is_bytes(event)
         fn_name = _assert_is_bytes(fn_name)
         event_re = _assert_is_bytes(event_re)
@@ -569,7 +569,7 @@ class BPF(object):
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
         ev_name = b"p_" + event.replace(b"+", b"_").replace(b".", b"_")
-        fd = lib.bpf_attach_kprobe(fn.fd, 0, ev_name, event)
+        fd = lib.bpf_attach_kprobe(fn.fd, 0, ev_name, event, event_off)
         if fd < 0:
             raise Exception("Failed to attach BPF to kprobe")
         self._add_kprobe_fd(ev_name, fd)


### PR DESCRIPTION
Currently, `attach_kprobe()` only allows a `kprobe` to be attached to an arch-dependent default location usually in the prologue of the function corresponding to the event. With these changes, one can attach a `kprobe` at a custom offset from the start of the function.