### PR TITLE
Add "-D __BPF_TRACING__" to frontend compilation flags

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -147,7 +147,11 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
   // Enable -O2 for clang. In clang 5.0, -O0 may result in function marking as
   // noinline and optnone (if not always inlining).
   // Note that first argument is ignored in clang compilation invocation.
+  // "-D __BPF_TRACING__" below is added to suppress a warning in 4.17+.
+  // It can be removed once clang supports asm-goto or the kernel removes
+  // the warning.
   vector<const char *> flags_cstr({"-O0", "-O2", "-emit-llvm", "-I", dstack.cwd(),
+                                   "-D", "__BPF_TRACING__",
                                    "-Wno-deprecated-declarations",
                                    "-Wno-gnu-variable-sized-type-not-at-end",
                                    "-Wno-pragma-once-outside-header",


### PR DESCRIPTION
In 4.17 kernel, x86 build requires compiler asm-goto support. clang
does not support asm-goto and bpf program compilation started to break.
The following kernel commit
```
  commit b1ae32dbab50ed19cfc16d225b0fb0114fb13025
  Author: Alexei Starovoitov <ast@kernel.org>
  Date:   Sun May 13 12:32:22 2018 -0700

      x86/cpufeature: Guard asm_volatile_goto usage for BPF compilation

      Workaround for the sake of BPF compilation which utilizes kernel
      headers, but clang does not support ASM GOTO and fails the build.
```
workarounded the issue by permitting native clang compilation.
A warning message, however, is issued:
```
  ./arch/x86/include/asm/cpufeature.h:150:2: warning: "Compiler lacks ASM_GOTO support.
        Add -D __BPF_TRACING__ to your compiler arguments" [-W#warnings]
  #warning "Compiler lacks ASM_GOTO support. Add -D __BPF_TRACING__ to your compil...
   ^
  1 warning generated.
```
This patch added "-D __BPF_TRACING__" to clang frontend compilation to
suppress the warning.

Signed-off-by: Yonghong Song <yhs@fb.com>