### PR TITLE
fix a memory leak for getline()

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -1014,6 +1014,7 @@ static int bpf_detach_probe(const char *ev_name, const char *event_type)
       found_event = 1;
       break;
     }
+  free(cptr);
   fclose(fp);
   fp = NULL;
 


### PR DESCRIPTION
The memory allocated by getline() is not freed.
This may cause some tool like clang memory
leak sanitizer complain.

Signed-off-by: Yonghong Song <yhs@fb.com>