### PR TITLE
tcplife: fix dport byte order

### DIFF
--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -202,7 +202,7 @@ int kprobe__tcp_set_state(struct pt_regs *ctx, struct sock *sk, int state)
         data4.daddr = sk->__sk_common.skc_daddr;
         // a workaround until data4 compiles with separate lport/dport
         data4.pid = pid;
-        data4.ports = ntohs(dport) + ((0ULL + lport) << 32);
+        data4.ports = dport + ((0ULL + lport) << 32);
         if (mep == 0) {
             bpf_get_current_comm(&data4.task, sizeof(data4.task));
         } else {
@@ -219,7 +219,7 @@ int kprobe__tcp_set_state(struct pt_regs *ctx, struct sock *sk, int state)
         bpf_probe_read(&data6.daddr, sizeof(data6.daddr),
             sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
         // a workaround until data6 compiles with separate lport/dport
-        data6.ports = ntohs(dport) + ((0ULL + lport) << 32);
+        data6.ports = dport + ((0ULL + lport) << 32);
         data6.pid = pid;
         if (mep == 0) {
             bpf_get_current_comm(&data6.task, sizeof(data6.task));


### PR DESCRIPTION
commit 95b3d8c fixed the dport filtering of the kprobes variant by
moving the network byte order to host byte order conversation before the
filtering. Before submitting the perf event the byte order of the dport
was again converted - this commit removes this double conversion.