### PR TITLE
remove unnecessary prefix in some prog names

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -468,7 +468,7 @@ int bpf_prog_load(enum bpf_prog_type prog_type, const char *name,
   union bpf_attr attr;
   char *tmp_log_buf = NULL;
   unsigned tmp_log_buf_size = 0;
-  int ret = 0;
+  int ret = 0, name_offset = 0;
 
   memset(&attr, 0, sizeof(attr));
 
@@ -509,7 +509,14 @@ int bpf_prog_load(enum bpf_prog_type prog_type, const char *name,
     }
   }
 
-  memcpy(attr.prog_name, name, min(name_len, BPF_OBJ_NAME_LEN - 1));
+  if (strncmp(name, "kprobe__", 8) == 0)
+    name_offset = 8;
+  else if (strncmp(name, "tracepoint__", 12) == 0)
+    name_offset = 12;
+  else if (strncmp(name, "raw_tracepoint__", 16) == 0)
+    name_offset = 16;
+  memcpy(attr.prog_name, name + name_offset,
+         min(name_len - name_offset, BPF_OBJ_NAME_LEN - 1));
 
   ret = syscall(__NR_bpf, BPF_PROG_LOAD, &attr, sizeof(attr));
   // BPF object name is not supported on older Kernels.


### PR DESCRIPTION
bcc uses some func prefixes for auto load purpose. These
func prefixes include "kprobe__", "tracepoint__" and
"raw_tracepoint__". Currently we also pass this
function name as the program name to the kernel.

The kernel can only accept 16 bytes so long program
name will be truncated. For example, with bps we will see
something like
     287- <raw_tracepoint>       0      2 Jun10/17:07  raw_tracepoint_
     290- tracepoint             0      4 Jun10/17:08  tracepoint__soc
     297- kprobe                 0      2 Jun10/17:09  kprobe__tcp_cle

Such long prefixes are unnecessarily taking the space
for the real function name. This patch removed such prefixes
before giving them to the kernel.
The result will like below:
     311- <raw_tracepoint>       0      2 Jun10/17:44  sched_switch
     321- tracepoint             0      4 Jun10/17:45  sock__inet_sock
     322- kprobe                 0      2 Jun10/17:45  tcp_cleanup_rbu

Signed-off-by: Yonghong Song <yhs@fb.com>