### PR TITLE
generate indirect parameter assignment if arch uses syscall wrapper

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -70,6 +70,11 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
  private:
   clang::SourceRange expansionRange(clang::SourceRange range);
   bool checkFormatSpecifiers(const std::string& fmt, clang::SourceLocation loc);
+  void genParamDirectAssign(clang::FunctionDecl *D, std::string& preamble,
+                            const char **calling_conv_regs);
+  void genParamIndirectAssign(clang::FunctionDecl *D, std::string& preamble,
+                              const char **calling_conv_regs);
+  void rewriteFuncParam(clang::FunctionDecl *D);
   template <unsigned N>
   clang::DiagnosticBuilder error(clang::SourceLocation loc, const char (&fmt)[N]);
   template <unsigned N>

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -98,7 +98,7 @@ static int submit_arg(struct pt_regs *ctx, void *ptr, struct data_t *data)
     return 0;
 }
 
-int do_sys_execve(struct pt_regs *ctx,
+int syscall__execve(struct pt_regs *ctx,
     const char __user *filename,
     const char __user *const __user *__argv,
     const char __user *const __user *__envp)
@@ -146,7 +146,7 @@ if args.ebpf:
 # initialize BPF
 b = BPF(text=bpf_text)
 execve_fnname = b.get_syscall_fnname("execve")
-b.attach_kprobe(event=execve_fnname, fn_name="do_sys_execve")
+b.attach_kprobe(event=execve_fnname, fn_name="syscall__execve")
 b.attach_kretprobe(event=execve_fnname, fn_name="do_ret_sys_execve")
 
 # header

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -60,7 +60,7 @@ struct data_t {
 BPF_HASH(infotmp, u32, struct val_t);
 BPF_PERF_OUTPUT(events);
 
-int do_sys_kill(struct pt_regs *ctx, int tpid, int sig)
+int syscall__kill(struct pt_regs *ctx, int tpid, int sig)
 {
     u32 pid = bpf_get_current_pid_tgid();
     FILTER
@@ -112,7 +112,7 @@ if debug or args.ebpf:
 # initialize BPF
 b = BPF(text=bpf_text)
 kill_fnname = b.get_syscall_fnname("kill")
-b.attach_kprobe(event=kill_fnname, fn_name="do_sys_kill")
+b.attach_kprobe(event=kill_fnname, fn_name="syscall__kill")
 b.attach_kretprobe(event=kill_fnname, fn_name="do_ret_sys_kill")
 
 

--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -86,7 +86,7 @@ struct data_t {
 
 BPF_PERF_OUTPUT(events);
 
-int do_sys_mount(struct pt_regs *ctx, char __user *source,
+int syscall__mount(struct pt_regs *ctx, char __user *source,
                       char __user *target, char __user *type,
                       unsigned long flags)
 {
@@ -145,7 +145,7 @@ int do_ret_sys_mount(struct pt_regs *ctx)
     return 0;
 }
 
-int do_sys_umount(struct pt_regs *ctx, char __user *target, int flags)
+int syscall__umount(struct pt_regs *ctx, char __user *target, int flags)
 {
     struct data_t event = {};
     struct task_struct *task;
@@ -404,10 +404,10 @@ def main():
         exit()
     b = bcc.BPF(text=bpf_text)
     mount_fnname = b.get_syscall_fnname("mount")
-    b.attach_kprobe(event=mount_fnname, fn_name="do_sys_mount")
+    b.attach_kprobe(event=mount_fnname, fn_name="syscall__mount")
     b.attach_kretprobe(event=mount_fnname, fn_name="do_ret_sys_mount")
     umount_fnname = b.get_syscall_fnname("umount")
-    b.attach_kprobe(event=umount_fnname, fn_name="do_sys_umount")
+    b.attach_kprobe(event=umount_fnname, fn_name="syscall__umount")
     b.attach_kretprobe(event=umount_fnname, fn_name="do_ret_sys_umount")
     b['events'].open_perf_buffer(
         functools.partial(print_event, mounts, umounts))

--- a/tools/statsnoop.py
+++ b/tools/statsnoop.py
@@ -61,7 +61,7 @@ BPF_HASH(args_filename, u32, const char *);
 BPF_HASH(infotmp, u32, struct val_t);
 BPF_PERF_OUTPUT(events);
 
-int trace_entry(struct pt_regs *ctx, const char __user *filename)
+int syscall__entry(struct pt_regs *ctx, const char __user *filename)
 {
     struct val_t val = {};
     u32 pid = bpf_get_current_pid_tgid();
@@ -116,17 +116,17 @@ b = BPF(text=bpf_text)
 # actually exist before attaching the probes
 syscall_fnname = b.get_syscall_fnname("stat")
 if BPF.ksymname(syscall_fnname) != -1:
-    b.attach_kprobe(event=syscall_fnname, fn_name="trace_entry")
+    b.attach_kprobe(event=syscall_fnname, fn_name="syscall__entry")
     b.attach_kretprobe(event=syscall_fnname, fn_name="trace_return")
 
 syscall_fnname = b.get_syscall_fnname("statfs")
 if BPF.ksymname(syscall_fnname) != -1:
-    b.attach_kprobe(event=syscall_fnname, fn_name="trace_entry")
+    b.attach_kprobe(event=syscall_fnname, fn_name="syscall__entry")
     b.attach_kretprobe(event=syscall_fnname, fn_name="trace_return")
 
 syscall_fnname = b.get_syscall_fnname("newstat")
 if BPF.ksymname(syscall_fnname) != -1:
-    b.attach_kprobe(event=syscall_fnname, fn_name="trace_entry")
+    b.attach_kprobe(event=syscall_fnname, fn_name="syscall__entry")
     b.attach_kretprobe(event=syscall_fnname, fn_name="trace_return")
 
 TASK_COMM_LEN = 16    # linux/sched.h

--- a/tools/syncsnoop.py
+++ b/tools/syncsnoop.py
@@ -25,14 +25,14 @@ struct data_t {
 
 BPF_PERF_OUTPUT(events);
 
-void do_sys_sync(void *ctx) {
+void syscall__sync(void *ctx) {
     struct data_t data = {};
     data.ts = bpf_ktime_get_ns() / 1000;
     events.perf_submit(ctx, &data, sizeof(data));
 };
 """)
 b.attach_kprobe(event=b.get_syscall_fnname("sync"),
-                fn_name="do_sys_sync")
+                fn_name="syscall__sync")
 
 class Data(ct.Structure):
     _fields_ = [


### PR DESCRIPTION
Fix issue #1802.

On x64, the following commit (in 4.17) changed the raw parameter passed to
the syscall entry function from a list of parameters supplied in user space
to a single `pt_regs *` parameter. Also in 4.17, x64 syscall entry function
is changed from `sys_<name>` to `__x64_sys_<name>`.

```
commit fa697140f9a20119a9ec8fd7460cc4314fbdaff3
Author: Dominik Brodowski <linux@dominikbrodowski.net>
Date:   Thu Apr 5 11:53:02 2018 +0200

    syscalls/x86: Use 'struct pt_regs' based syscall calling convention for 64-bit syscalls

    Let's make use of ARCH_HAS_SYSCALL_WRAPPER=y on pure 64-bit x86-64 systems:

    Each syscall defines a stub which takes struct pt_regs as its only
    argument. It decodes just those parameters it needs, e.g:

            asmlinkage long sys_xyzzy(const struct pt_regs *regs)
            {
                    return SyS_xyzzy(regs->di, regs->si, regs->dx);
            }

    This approach avoids leaking random user-provided register content down
    the call chain.

    ...
```

In bcc, we support kprobe function signatures in the bpf program.
The rewriter will automatically generate proper assignment to
these parameters. With the above function signature change, the
original method does not work any more.

This patch enhanced rewriter to generate two version codes guarded
with CONFIG_ARCH_HAS_SYSCALL_WRAPPER. But we need to identify
whether a function will be attached to syscall entry function
or not during prog load time at which time the program has not
attached to any event.

The prefix `kprobe__` is used for kprobe autoload, we can use
`kprobe____x64_sys_` as the prefix to identify x64 syscall entry
functions. To support other architecture or not-autoloading program,
the prefix `syscall__` is introduced to signal it is a syscall
entry function.

trace.py and other tools which uses kprobe syscall entry functions
are also modified with the new interface so that they can
work properly with 4.17.

Signed-off-by: Yonghong Song <yhs@fb.com>