### PR TITLE
make tcpdrop and zfsslower python3 compatible

### DIFF
--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -202,7 +202,7 @@ def print_ipv6_event(cpu, data, size):
 
 # initialize BPF
 b = BPF(text=bpf_text)
-if b.get_kprobe_functions("tcp_drop"):
+if b.get_kprobe_functions(b"tcp_drop"):
     b.attach_kprobe(event="tcp_drop", fn_name="trace_tcp_drop")
 else:
     print("ERROR: tcp_drop() kernel function not found or traceable. "

--- a/tools/zfsslower.py
+++ b/tools/zfsslower.py
@@ -276,10 +276,10 @@ def print_event(cpu, data, size):
 b = BPF(text=bpf_text)
 
 # common file functions
-if BPF.get_kprobe_functions('zpl_iter'):
+if BPF.get_kprobe_functions(b'zpl_iter'):
     b.attach_kprobe(event="zpl_iter_read", fn_name="trace_rw_entry")
     b.attach_kprobe(event="zpl_iter_write", fn_name="trace_rw_entry")
-elif BPF.get_kprobe_functions('zpl_aio'):
+elif BPF.get_kprobe_functions(b'zpl_aio'):
     b.attach_kprobe(event="zpl_aio_read", fn_name="trace_rw_entry")
     b.attach_kprobe(event="zpl_aio_write", fn_name="trace_rw_entry")
 else:
@@ -287,10 +287,10 @@ else:
     b.attach_kprobe(event="zpl_write", fn_name="trace_rw_entry")
 b.attach_kprobe(event="zpl_open", fn_name="trace_open_entry")
 b.attach_kprobe(event="zpl_fsync", fn_name="trace_fsync_entry")
-if BPF.get_kprobe_functions('zpl_iter'):
+if BPF.get_kprobe_functions(b'zpl_iter'):
     b.attach_kretprobe(event="zpl_iter_read", fn_name="trace_read_return")
     b.attach_kretprobe(event="zpl_iter_write", fn_name="trace_write_return")
-elif BPF.get_kprobe_functions('zpl_aio'):
+elif BPF.get_kprobe_functions(b'zpl_aio'):
     b.attach_kretprobe(event="zpl_aio_read", fn_name="trace_read_return")
     b.attach_kretprobe(event="zpl_aio_write", fn_name="trace_write_return")
 else:


### PR DESCRIPTION
Make the input string of get_kprobe_functions as
bytes literal in tcpdrop and zfsslower so the
tool can be python3 compatible.

Signed-off-by: Yonghong Song <yhs@fb.com>