### PR TITLE
Modify trace function from generic_file_read_iter() to ext4_file_read_iter()

### DIFF
--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -23,6 +23,7 @@
 #
 # 11-Feb-2016   Brendan Gregg   Created this.
 # 15-Oct-2016   Dina Goldshtein -p to filter by process ID.
+# 13-Jun-2018   Joe Yin modify generic_file_read_iter to ext4_file_read_iter.
 
 from __future__ import print_function
 from bcc import BPF
@@ -40,6 +41,7 @@ examples = """examples:
     ./ext4slower -j 1        # ... 1 ms, parsable output (csv)
     ./ext4slower 0           # trace all operations (warning: verbose)
     ./ext4slower -p 185      # trace PID 185 only
+    ./ext4slower -n          # trace Linux 4.10+ 
 """
 parser = argparse.ArgumentParser(
     description="Trace common ext4 file operations slower than a threshold",
@@ -49,6 +51,8 @@ parser.add_argument("-j", "--csv", action="store_true",
     help="just print fields: comma-separated values")
 parser.add_argument("-p", "--pid",
     help="trace this PID only")
+parser.add_argument("-n", "--newver", action="store_true",
+    help="trace Linux 4.10+")
 parser.add_argument("min_ms", nargs="?", default='10',
     help="minimum I/O duration to trace, in ms (default 10)")
 parser.add_argument("--ebpf", action="store_true",
@@ -57,6 +61,7 @@ args = parser.parse_args()
 min_ms = int(args.min_ms)
 pid = args.pid
 csv = args.csv
+newver = args.newver
 debug = 0
 
 # define BPF program
@@ -100,6 +105,9 @@ BPF_PERF_OUTPUT(events);
 // The current ext4 (Linux 4.5) uses generic_file_read_iter(), instead of it's
 // own function, for reads. So we need to trace that and then filter on ext4,
 // which I do by checking file->f_op.
+// The new Linux version (since form 4.10) uses ext4_file_read_iter(), And if the 'CONFIG_FS_DAX' 
+// is not set ,it will call generic_file_read_iter(), else it will call ext4_dax_read_iter(), and
+// trace generic_file_read_iter() will fail.
 int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 {
     u64 id =  bpf_get_current_pid_tgid();
@@ -111,7 +119,7 @@ int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
     // ext4 filter on file->f_op == ext4_file_operations
     struct file *fp = iocb->ki_filp;
     if ((u64)fp->f_op != EXT4_FILE_OPERATIONS)
-        return 0;
+       return 0;
 
     // store filep and timestamp by id
     struct val_t val = {};
@@ -321,11 +329,17 @@ def print_event(cpu, data, size):
 b = BPF(text=bpf_text)
 
 # Common file functions. See earlier comment about generic_file_read_iter().
-b.attach_kprobe(event="generic_file_read_iter", fn_name="trace_read_entry")
+if (newver):
+    b.attach_kprobe(event="ext4_file_read_iter", fn_name="trace_read_entry")
+else:
+    b.attach_kprobe(event="generic_file_read_iter", fn_name="trace_read_entry")
 b.attach_kprobe(event="ext4_file_write_iter", fn_name="trace_write_entry")
 b.attach_kprobe(event="ext4_file_open", fn_name="trace_open_entry")
 b.attach_kprobe(event="ext4_sync_file", fn_name="trace_fsync_entry")
-b.attach_kretprobe(event="generic_file_read_iter", fn_name="trace_read_return")
+if (newver):
+    b.attach_kretprobe(event="ext4_file_read_iter", fn_name="trace_read_return")
+else:
+    b.attach_kretprobe(event="generic_file_read_iter", fn_name="trace_read_return")
 b.attach_kretprobe(event="ext4_file_write_iter", fn_name="trace_write_return")
 b.attach_kretprobe(event="ext4_file_open", fn_name="trace_open_return")
 b.attach_kretprobe(event="ext4_sync_file", fn_name="trace_fsync_return")

--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -106,8 +106,8 @@ BPF_PERF_OUTPUT(events);
 // own function, for reads. So we need to trace that and then filter on ext4,
 // which I do by checking file->f_op.
 // The new Linux version (since form 4.10) uses ext4_file_read_iter(), And if the 'CONFIG_FS_DAX' 
-// is not set ,it will call generic_file_read_iter(), else it will call ext4_dax_read_iter(), and
-// trace generic_file_read_iter() will fail.
+// is not set ,then ext4_file_read_iter() will call generic_file_read_iter(), else it will call 
+// ext4_dax_read_iter(), and trace generic_file_read_iter() will fail.
 int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 {
     u64 id =  bpf_get_current_pid_tgid();
@@ -119,7 +119,7 @@ int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
     // ext4 filter on file->f_op == ext4_file_operations
     struct file *fp = iocb->ki_filp;
     if ((u64)fp->f_op != EXT4_FILE_OPERATIONS)
-       return 0;
+        return 0;
 
     // store filep and timestamp by id
     struct val_t val = {};


### PR DESCRIPTION
The new Linux version (since form 4.10) uses ext4_file_read_iter(), And if the 'CONFIG_FS_DAX' 
 is not set ,then ext4_file_read_iter() will call generic_file_read_iter(), else it will call 
 ext4_dax_read_iter(), and trace generic_file_read_iter() will fail.