### PR TITLE
Recognize context member dereferences despite array accesses 

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -382,18 +382,24 @@ bool ProbeVisitor::IsContextMemberExpr(Expr *E) {
   if (!E->getType()->isPointerType())
     return false;
 
-  MemberExpr *Memb = dyn_cast<MemberExpr>(E->IgnoreParenCasts());
   Expr *base;
-  SourceLocation rhs_start, member;
+  SourceLocation member;
   bool found = false;
   MemberExpr *M;
-  for (M = Memb; M; M = dyn_cast<MemberExpr>(M->getBase())) {
-    rhs_start = M->getLocEnd();
-    base = M->getBase();
-    member = M->getMemberLoc();
-    if (M->isArrow()) {
-      found = true;
-      break;
+  Expr *Ex = E->IgnoreParenCasts();
+  while (Ex->getStmtClass() == Stmt::ArraySubscriptExprClass
+         || Ex->getStmtClass() == Stmt::MemberExprClass) {
+    if (Ex->getStmtClass() == Stmt::ArraySubscriptExprClass) {
+      Ex = dyn_cast<ArraySubscriptExpr>(Ex)->getBase()->IgnoreParenCasts();
+    } else if (Ex->getStmtClass() == Stmt::MemberExprClass) {
+      M = dyn_cast<MemberExpr>(Ex);
+      base = M->getBase()->IgnoreParenCasts();
+      member = M->getMemberLoc();
+      if (M->isArrow()) {
+        found = true;
+        break;
+      }
+      Ex = base;
     }
   }
   if (!found) {
@@ -403,7 +409,7 @@ bool ProbeVisitor::IsContextMemberExpr(Expr *E) {
     return false;
   }
 
-  if (DeclRefExpr *base_expr = dyn_cast<DeclRefExpr>(base->IgnoreImplicit())) {
+  if (DeclRefExpr *base_expr = dyn_cast<DeclRefExpr>(base)) {
     if (base_expr->getDecl() == ctx_) {
       return true;
     }

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -921,6 +921,18 @@ int test(struct pt_regs *ctx) {
         b = BPF(text=text)
         fn = b.load_func("test", BPF.KPROBE)
 
+    def test_probe_read_ctx_array(self):
+        text = """
+#include <linux/sched.h>
+#include <net/inet_sock.h>
+int test(struct pt_regs *ctx) {
+    struct sock *newsk = (struct sock *)PT_REGS_RC(ctx);
+    return newsk->__sk_common.skc_rcv_saddr;
+}
+"""
+        b = BPF(text=text)
+        fn = b.load_func("test", BPF.KPROBE)
+
     @skipUnless(kernel_version_ge(4,7), "requires kernel >= 4.7")
     def test_probe_read_tc_ctx(self):
         text = """

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -88,16 +88,14 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 
     // pull in details
     u16 family = 0, lport = 0;
-    bpf_probe_read(&family, sizeof(family), &newsk->__sk_common.skc_family);
-    bpf_probe_read(&lport, sizeof(lport), &newsk->__sk_common.skc_num);
+    family = newsk->__sk_common.skc_family;
+    lport = newsk->__sk_common.skc_num;
 
     if (family == AF_INET) {
         struct ipv4_data_t data4 = {.pid = pid, .ip = 4};
         data4.ts_us = bpf_ktime_get_ns() / 1000;
-        bpf_probe_read(&data4.saddr, sizeof(u32),
-            &newsk->__sk_common.skc_rcv_saddr);
-        bpf_probe_read(&data4.daddr, sizeof(u32),
-            &newsk->__sk_common.skc_daddr);
+        data4.saddr = newsk->__sk_common.skc_rcv_saddr;
+        data4.daddr = newsk->__sk_common.skc_daddr;
         data4.lport = lport;
         bpf_get_current_comm(&data4.task, sizeof(data4.task));
         ipv4_events.perf_submit(ctx, &data4, sizeof(data4));


### PR DESCRIPTION
This pull request updates the rewriter's `IsContextMemberExpr` method to recognize context member dereferences despite array accesses. For example, the rewriter should recognize, in the following, that `prev` is an external pointer retrieved from the context pointer, despite the access to the second element of the `args` array.
```c
struct task_struct *prev = (struct task_struct *)ctx->args[1];
```
The same could be done for the translation of member dereferences to `bpf_probe_read` calls (cf. `ProbeVisitor::VisitMemberExpr`), but that would be a little bit more complex (to retrieve the correct base) and there's currently no tool I could see that would benefit from it, so I'm not sure it's worth it.