### PR TITLE
python: add __version__ attribute to bcc module

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -12,6 +12,7 @@ if(NOT PYTHON_CMD)
 endif()
 
 configure_file(setup.py.in ${CMAKE_CURRENT_BINARY_DIR}/setup.py @ONLY)
+configure_file(bcc/version.py.in ${CMAKE_CURRENT_BINARY_DIR}/bcc/version.py @ONLY)
 if(EXISTS "/etc/debian_version")
   set(PYTHON_FLAGS "${PYTHON_FLAGS} --install-layout deb")
 endif()

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -28,6 +28,7 @@ from .libbcc import lib, bcc_symbol, bcc_symbol_option, _SYM_CB_TYPE
 from .table import Table, PerfEventArray
 from .perf import Perf
 from .utils import get_online_cpus, printb, _assert_is_bytes, ArgString
+from .version import __version__
 
 _probe_limit = 1000
 _num_open_probes = 0

--- a/src/python/bcc/version.py.in
+++ b/src/python/bcc/version.py.in
@@ -1,0 +1,1 @@
+__version__ = '@REVISION@'


### PR DESCRIPTION
Uses cmake to create a `version.py` with the `REVISION` from cmake

If the python module should be executable without cmake (at the moment the `__init__.py` imports `version.py` which is created on the fly by cmake), I could rename `version.py.in` to `version.py` and let cmake replace the file in the build process.