### PR TITLE
avoid probe rewriting of p->m in &(p->m)

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -102,6 +102,7 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   bool VisitBinaryOperator(clang::BinaryOperator *E);
   bool VisitUnaryOperator(clang::UnaryOperator *E);
   bool VisitMemberExpr(clang::MemberExpr *E);
+  bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *E);
   void set_ptreg(std::tuple<clang::Decl *, int> &pt) { ptregs_.insert(pt); }
   void set_ctx(clang::Decl *D) { ctx_ = D; }
   std::set<std::tuple<clang::Decl *, int>> get_ptregs() { return ptregs_; }
@@ -123,6 +124,8 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   clang::Decl *ctx_;
   bool track_helpers_;
   std::list<int> ptregs_returned_;
+  const clang::Stmt *addrof_stmt_;
+  bool is_addrof_;
 };
 
 // A helper class to the frontend action, walks the decls

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -951,7 +951,7 @@ TRACEPOINT_PROBE(skb, kfree_skb) {
 #include <net/inet_sock.h>
 int test(struct pt_regs *ctx) {
     struct sock *sk;
-    sk = (struct sock *)ctx->di;
+    sk = (struct sock *)PT_REGS_PARM1(ctx);
     return sk->sk_dport;
 }
 """
@@ -1052,6 +1052,24 @@ static inline struct tcphdr *my_skb_transport_header(struct sk_buff *skb) {
 }
 int test(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
     return my_skb_transport_header(skb)->seq;
+}
+"""
+        b = BPF(text=text)
+        fn = b.load_func("test", BPF.KPROBE)
+
+    def test_no_probe_read_addrof(self):
+        text = """
+#include <linux/sched.h>
+#include <net/inet_sock.h>
+static inline int test_help(__be16 *addr) {
+    __be16 val = 0;
+    bpf_probe_read(&val, sizeof(val), addr);
+    return val;
+}
+int test(struct pt_regs *ctx) {
+    struct sock *sk;
+    sk = (struct sock *)PT_REGS_PARM1(ctx);
+    return test_help(&sk->sk_dport);
 }
 """
         b = BPF(text=text)


### PR DESCRIPTION
Fix issue #1830.

After the rewrite, the code approximately becomes
```
  &(({type _val; bpf_probe_read(&_val, sizeof(_val), &(p->m)); _val)
```
Firstly the rewriting is really unnecessary, and secondly
the compilation will fail since the addressOf cannot take address
of the rvalue _val.

This patch intends to fix the problem by avoiding
the rewriting in the first place. The implementation
assumes no nested addressOf operations which should be
true in most cases if not all.

Signed-off-by: Yonghong Song <yhs@fb.com>