### PR TITLE
Fix external pointer propagation in nested dereferences

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -102,7 +102,6 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   bool VisitBinaryOperator(clang::BinaryOperator *E);
   bool VisitUnaryOperator(clang::UnaryOperator *E);
   bool VisitMemberExpr(clang::MemberExpr *E);
-  bool VisitArraySubscriptExpr(clang::ArraySubscriptExpr *E);
   void set_ptreg(std::tuple<clang::Decl *, int> &pt) { ptregs_.insert(pt); }
   void set_ctx(clang::Decl *D) { ctx_ = D; }
   std::set<std::tuple<clang::Decl *, int>> get_ptregs() { return ptregs_; }


### PR DESCRIPTION
This pull request fixes external pointer propagation in nested dereferences and the count of indirections for `addrof`s of member dereferences (`&A->b`).

In nested dereferences, a dereference of an external pointer may give a new external pointer.  For example, if `A` is an external pointer, then `*A` and `A->b` should also be considered as external pointers when appropriate (e.g., in `**A` or `*(A->b)`).

In addition, a member dereference is a dereference, so we need to count it when counting the number of indirections in `ProbeChecker`. If we don't, `*(&A->b)` won't be rewritten correctly as `&A->b` will be
considered a pointer to an external pointer.

@yonghong-song This is a different fix than the one you implemented in #1831. I think it's a more general fix, as it isn't specific to the case of array accesses (I had to revert your fix, `ProbeVisitor::VisitArraySubscriptExpr`, for this to work). It also produces a more appropriate rewrite for tcptop's dereferences:
```c
// Original statement:
ipv6_key.saddr0 = *(u64 *)&sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32[0];
// Rewrote to the following with the ProbeVisitor::VisitArraySubscriptExpr fix:
ipv6_key.saddr0 = *(u64 *)&({ typeof(__be32 [4]) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (u64)&sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32); _val; })[0];
// Rewrote to the following with the current pull request:
ipv6_key.saddr0 = ({ typeof(u64) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (u64)(u64 *)&sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32[0]); _val; });
```

I've opened this as a pull request against #1831, but it might just be easier to directly apply the diff to #1831.