### PR TITLE
fix verbose output of tools/argdist.py

### DIFF
--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -66,7 +66,7 @@ class SmokeTests(TestCase):
         pass
 
     def test_argdist(self):
-        self.run_with_duration("argdist.py -C 'p::do_sys_open()' -n 1 -i 1")
+        self.run_with_duration("argdist.py -v -C 'p::do_sys_open()' -n 1 -i 1")
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
     def test_bashreadline(self):

--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -681,8 +681,8 @@ struct __string_t { char s[%d]; };
                 for probe in self.probes:
                         probe.attach(self.bpf)
                 if self.args.verbose:
-                        print("open uprobes: %s" % self.bpf.open_uprobes)
-                        print("open kprobes: %s" % self.bpf.open_kprobes)
+                        print("open uprobes: %s" % list(self.bpf.uprobe_fds.keys()))
+                        print("open kprobes: %s" % list(self.bpf.kprobe_fds.keys()))
 
         def _main_loop(self):
                 count_so_far = 0


### PR DESCRIPTION
Fix issue #1845.

The verbose output of argdist.py is broken.
The bpf.open_uprobes/open_kprobes have been
replaced by bpf.uprobe_fds/kprobe_fds.

Fix the argdist.py and add "-v" to the argdist.py test
in test_tools_smoke.py.

Signed-off-by: Yonghong Song <yhs@fb.com>