### PR TITLE
Modify tools/ext4dist.py for 4.10+

### DIFF
--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -181,7 +181,7 @@ b = BPF(text=bpf_text)
 # if fails and will attach the generic_file_read_iter which used to pre-4.10.
 
 try:
-	b.attach_kprobe(event="ext4_file_read_iter", fn_name="trace_read_entry")
+	b.attach_kprobe(event="ext4_file_read_iter", fn_name="trace_entry")
 except:
 	b.attach_kprobe(event="generic_file_read_iter", fn_name="trace_read_entry")
 b.attach_kprobe(event="ext4_file_write_iter", fn_name="trace_entry")

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -177,12 +177,12 @@ b = BPF(text=bpf_text)
 # Comment by Joe Yin 
 # From Linux 4.10, the function .read_iter at the ext4_file_operations has 
 # changed to ext4_file_read_iter.
-# So, I add the try and except,it will first to attach ext4_file_read_iter,
+# So, I add get_kprobe_functions('ext4_file_read_iter'),it will first to attach ext4_file_read_iter,
 # if fails and will attach the generic_file_read_iter which used to pre-4.10.
 
-try:
+if BPF.get_kprobe_functions('ext4_file_read_iter'):
 	b.attach_kprobe(event="ext4_file_read_iter", fn_name="trace_entry")
-except:
+else:
 	b.attach_kprobe(event="generic_file_read_iter", fn_name="trace_read_entry")
 b.attach_kprobe(event="ext4_file_write_iter", fn_name="trace_entry")
 b.attach_kprobe(event="ext4_file_open", fn_name="trace_entry")

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -178,7 +178,7 @@ b = BPF(text=bpf_text)
 # From Linux 4.10, the function .read_iter at the ext4_file_operations has 
 # changed to ext4_file_read_iter.
 # So, I add the try and except,it will first to attach ext4_file_read_iter,
-# if fails and will attach the generic_file_read_iter which usd to pre-4.10.
+# if fails and will attach the generic_file_read_iter which used to pre-4.10.
 
 try:
 	b.attach_kprobe(event="ext4_file_read_iter", fn_name="trace_read_entry")

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -174,7 +174,16 @@ if debug or args.ebpf:
 b = BPF(text=bpf_text)
 
 # Common file functions. See earlier comment about generic_file_read_iter().
-b.attach_kprobe(event="generic_file_read_iter", fn_name="trace_read_entry")
+# Comment by Joe Yin 
+# From Linux 4.10, the function .read_iter at the ext4_file_operations has 
+# changed to ext4_file_read_iter.
+# So, I add the try and except,it will first to attach ext4_file_read_iter,
+# if fails and will attach the generic_file_read_iter which usd to pre-4.10.
+
+try:
+	b.attach_kprobe(event="ext4_file_read_iter", fn_name="trace_read_entry")
+except:
+	b.attach_kprobe(event="generic_file_read_iter", fn_name="trace_read_entry")
 b.attach_kprobe(event="ext4_file_write_iter", fn_name="trace_entry")
 b.attach_kprobe(event="ext4_file_open", fn_name="trace_entry")
 b.attach_kprobe(event="ext4_sync_file", fn_name="trace_entry")


### PR DESCRIPTION
 From Linux 4.10, the function .read_iter at the ext4_file_operations has 
 changed to ext4_file_read_iter.
 So, I add the try and except,it will first to attach ext4_file_read_iter,
 if fails and will attach the generic_file_read_iter which used to pre-4.10.