### PR TITLE
fix a bug in tracepoint struct rewriter

### DIFF
--- a/src/cc/frontends/clang/tp_frontend_action.cc
+++ b/src/cc/frontends/clang/tp_frontend_action.cc
@@ -98,6 +98,9 @@ static inline field_kind_t _get_field_kind(string const& line,
     return field_kind_t::data_loc;
   if (field_name.find("common_") == 0)
     return field_kind_t::common;
+  // do not change type definition for array
+  if (field_name.find("[") != string::npos)
+    return field_kind_t::regular;
 
   // adjust the field_type based on the size of field
   // otherwise, incorrect value may be retrieved for big endian


### PR DESCRIPTION
Fix issue #1853.

Commit 7c489469a7dc ("adjust tracepoint field type
based on size") tried to fix the tracepoint format
descrepancy between declared type and actual size is 8.
The type has to be promoted to match the size.

The commit introduced a bug if the field is an array.
For exmaple, `block:block_rq_complete` tracepoint has
field rwbs:
```
  field:char rwbs[8];	offset:32;	size:8;	signed:1;
```
The current implementation will incorrectly translate it
into
```
  s64 rwbs[8];
```
since it considers the type is "char".

This patch fixed this issue by checking the field name
and if it is an array, rewriting will be skipped.

Signed-off-by: Yonghong Song <yhs@fb.com>