### PR TITLE
tools: remove unnecessary calls to bpf_probe_read

### DIFF
--- a/tools/runqlat.py
+++ b/tools/runqlat.py
@@ -168,11 +168,9 @@ RAW_TRACEPOINT_PROBE(sched_switch)
     struct task_struct *prev = (struct task_struct *)ctx->args[1];
     struct task_struct *next = (struct task_struct *)ctx->args[2];
     u32 pid, tgid;
-    long state;
 
     // ivcsw: treat like an enqueue event and store timestamp
-    bpf_probe_read(&state, sizeof(long), &prev->state);
-    if (state == TASK_RUNNING) {
+    if (prev->state == TASK_RUNNING) {
         tgid = prev->tgid;
         pid = prev->pid;
         if (!(FILTER || pid == 0)) {

--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -145,11 +145,7 @@ RAW_TRACEPOINT_PROBE(sched_wakeup)
 {
     // TP_PROTO(struct task_struct *p)
     struct task_struct *p = (struct task_struct *)ctx->args[0];
-    u32 tgid, pid;
-
-    bpf_probe_read(&tgid, sizeof(tgid), &p->tgid);
-    bpf_probe_read(&pid, sizeof(pid), &p->pid);
-    return trace_enqueue(tgid, pid);
+    return trace_enqueue(p->tgid, p->pid);
 }
 
 RAW_TRACEPOINT_PROBE(sched_wakeup_new)

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -107,16 +107,16 @@ int kretprobe__inet_csk_accept(struct pt_regs *ctx)
     if (sk_lingertime_offset - gso_max_segs_offset == 4) 
         // 4.10+ with little endian
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-            bpf_probe_read(&protocol, 1, (void *)((u64)&newsk->sk_gso_max_segs) - 3);
+        protocol = *(u8 *)((u64)&newsk->sk_gso_max_segs - 3);
     else
         // pre-4.10 with little endian
-            bpf_probe_read(&protocol, 1, (void *)((u64)&newsk->sk_wmem_queued) - 3);
+        protocol = *(u8 *)((u64)&newsk->sk_wmem_queued - 3);
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
         // 4.10+ with big endian
-            bpf_probe_read(&protocol, 1, (void *)((u64)&newsk->sk_gso_max_segs) - 1);
+        protocol = *(u8 *)((u64)&newsk->sk_gso_max_segs - 1);
     else
         // pre-4.10 with big endian
-            bpf_probe_read(&protocol, 1, (void *)((u64)&newsk->sk_wmem_queued) - 1);
+        protocol = *(u8 *)((u64)&newsk->sk_wmem_queued - 1);
 #else
 # error "Fix your compiler's __BYTE_ORDER__?!"
 #endif


### PR DESCRIPTION
Most of these calls have been rendered useless by #1828 ("Recognize context member dereferences despite array accesses").