### PR TITLE
examples/http_filter: Add pointer offset accounting for variable ip header len

### DIFF
--- a/examples/networking/http_filter/http-parse-complete.c
+++ b/examples/networking/http_filter/http-parse-complete.c
@@ -56,6 +56,19 @@ int http_filter(struct __sk_buff *skb) {
 	struct Key 	key;
 	struct Leaf zero = {0};
 
+        //calculate ip header length
+        //value to multiply * 4
+        //e.g. ip->hlen = 5 ; IP Header Length = 5 x 4 byte = 20 byte
+        ip_header_length = ip->hlen << 2;    //SHL 2 -> *4 multiply
+
+        //check ip header length against minimum
+        if (ip_header_length < sizeof(*ip)) {
+                goto DROP;
+        }
+
+        //shift cursor forward for dynamic ip header size
+        void *_ = cursor_advance(cursor, (ip_header_length-sizeof(*ip)));
+
 	struct tcp_t *tcp = cursor_advance(cursor, sizeof(*tcp));
 
 	//retrieve ip src/dest and port src/dest of current packet
@@ -64,11 +77,6 @@ int http_filter(struct __sk_buff *skb) {
 	key.src_ip = ip->src;
 	key.dst_port = tcp->dst_port;
 	key.src_port = tcp->src_port;
-
-	//calculate ip header length
-	//value to multiply * 4
-	//e.g. ip->hlen = 5 ; IP Header Length = 5 x 4 byte = 20 byte
-	ip_header_length = ip->hlen << 2;    //SHL 2 -> *4 multiply
 
 	//calculate tcp header length
 	//value to multiply *4

--- a/examples/networking/http_filter/http-parse-simple.c
+++ b/examples/networking/http_filter/http-parse-simple.c
@@ -34,12 +34,20 @@ int http_filter(struct __sk_buff *skb) {
 	u32  payload_offset = 0;
 	u32  payload_length = 0;
 
-	struct tcp_t *tcp = cursor_advance(cursor, sizeof(*tcp));
-
 	//calculate ip header length
 	//value to multiply * 4
 	//e.g. ip->hlen = 5 ; IP Header Length = 5 x 4 byte = 20 byte
 	ip_header_length = ip->hlen << 2;    //SHL 2 -> *4 multiply
+
+        //check ip header length against minimum
+	if (ip_header_length < sizeof(*ip)) {
+		goto DROP;
+	}
+
+        //shift cursor forward for dynamic ip header size
+        void *_ = cursor_advance(cursor, (ip_header_length-sizeof(*ip)));
+
+	struct tcp_t *tcp = cursor_advance(cursor, sizeof(*tcp));
 
 	//calculate tcp header length
 	//value to multiply *4


### PR DESCRIPTION
This fix adds additional accounting logic to the http_filter examples ("simple" and "complete") that make sure to shift the pointer for the IP body/payload to the correct offset before accessing TCP header fields. This is done by taking into account the IP header length field. Previously, the IP header length field was used, but it was done later in processing, after TCP header values were extracted using the size of the BCC `proto.h` `struct ip_t` a static offset.

Prior to this, it was possible to evade HTTP detection by injecting IP options data into the IP header that (may spoof parts of the TCP header and) shift the real TCP header one down, as done in the scapy snippet below:

```Python
IP(
  dst=target[0],
  options=struct.pack(">BBHHHB",130,11,8080,0,0,0),
)/TCP(
  ...
)
```

I'm also not 100% sure on the model of how packets get into this subsystem and to what degree the networking stack has already validated/processed them, so I added in a minimum length sanity check as well. It may be completely unnecessary, but I don't know enough to conclusively say that (it was also unclear if there was an API to get the full packet length out-of-band from the packet data itself or in an otherwise secure manner).