### PR TITLE
debian: add llvm6.0 as possible dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,13 +3,15 @@ Maintainer: Brenden Blanco <bblanco@plumgrid.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.5
-Build-Depends: debhelper (>= 9), cmake, libllvm3.7 | libllvm3.8,
-    llvm-3.7-dev | llvm-3.8-dev, libclang-3.7-dev | libclang-3.8-dev,
+Build-Depends: debhelper (>= 9), cmake,
+    libllvm3.7 | libllvm3.8 | libllvm6.0,
+    llvm-3.7-dev | llvm-3.8-dev | llvm-6.0-dev,
+    libclang-3.7-dev | libclang-3.8-dev | libclang-6.0-dev,
+    clang-format | clang-format-3.7 | clang-format-3.8 | clang-format-6.0,
     libelf-dev, bison, flex, libfl-dev, libedit-dev, zlib1g-dev, git,
-    clang-format | clang-format-3.7 | clang-format-3.8, python (>= 2.7),
-    python-netaddr, python-pyroute2, luajit, libluajit-5.1-dev, arping,
-    inetutils-ping | iputils-ping, iperf, netperf, ethtool, devscripts,
-    python3
+    python (>= 2.7), python-netaddr, python-pyroute2, luajit,
+    libluajit-5.1-dev, arping, inetutils-ping | iputils-ping, iperf, netperf,
+    ethtool, devscripts, python3
 Homepage: https://github.com/iovisor/bcc
 
 Package: libbcc


### PR DESCRIPTION
In recent Ubuntu, llvm 6 is available. Use that as control file
dependency option. This is a requirement to enable the Ubuntu 18.04 buildbot.