### PR TITLE
fix get_table_offline for percpu hash table

### DIFF
--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -232,11 +232,14 @@ class BPFHashTable : public BPFTableBase<KeyType, ValueType> {
     KeyType cur;
     ValueType value;
 
+    StatusTuple r(0);
+
     if (!this->first(&cur))
       return res;
 
     while (true) {
-      if (!this->lookup(&cur, &value))
+      r = get_value(cur, value);
+      if (r.code() != 0)
         break;
       res.emplace_back(cur, value);
       if (!this->next(&cur, &cur))


### PR DESCRIPTION
Use get_value() instead of lookup() as the value as in the case of
percpu tables the ValueType is an std::vector that has to be resized
before performing the lookup function.

Add also some testing for it.

Solves https://github.com/iovisor/bcc/issues/1860

Signed-off-by: Mauricio Vasquez B <mauricio.vasquez@polito.it>