### PR TITLE
ucalls: use replace error handler

### DIFF
--- a/tools/lib/ucalls.py
+++ b/tools/lib/ucalls.py
@@ -255,13 +255,15 @@ if args.syscalls:
 def get_data():
     # Will be empty when no language was specified for tracing
     if args.latency:
-        data = list(map(lambda kv: (kv[0].clazz.decode() + "." + \
-                                    kv[0].method.decode(),
+        data = list(map(lambda kv: (kv[0].clazz.decode('utf-8', 'replace') \
+                                    + "." + \
+                                    kv[0].method.decode('utf-8', 'replace'),
                                    (kv[1].num_calls, kv[1].total_ns)),
                    bpf["times"].items()))
     else:
-        data = list(map(lambda kv: (kv[0].clazz.decode() + "." + \
-                                    kv[0].method.decode(),
+        data = list(map(lambda kv: (kv[0].clazz.decode('utf-8', 'replace') \
+                                    + "." + \
+                                    kv[0].method.decode('utf-8', 'replace'),
                                    (kv[1].value, 0)),
                    bpf["counts"].items()))
 


### PR DESCRIPTION
Prevents the following error when tracing a java program that contains
non-ascii method name:
```
Traceback (most recent call last):
  File "/usr/share/bcc/tools/lib/ucalls", line 305, in <module>
    data = get_data()   # [(function, (num calls, latency in ns))]
  File "/usr/share/bcc/tools/lib/ucalls", line 266, in get_data
    bpf["counts"].items()))
  File "/usr/share/bcc/tools/lib/ucalls", line 264, in <lambda>
    kv[0].method.decode(),
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc4 in position 11: ordinal not in range(128)
```
Signed-off-by: Jerome Marchand <jmarchan@redhat.com>