### PR TITLE
[profile.py]: adding support to collect profile only from specified CPU

### DIFF
--- a/man/man8/profile.8
+++ b/man/man8/profile.8
@@ -54,6 +54,9 @@ Show stacks from kernel space only (no user space stacks).
 The maximum number of unique stack traces that the kernel will count (default
 16384). If the sampled count exceeds this, a warning will be printed.
 .TP
+\-C cpu
+Collect stacks only from specified cpu.
+.TP
 duration
 Duration to trace, in seconds.
 .SH EXAMPLES

--- a/tools/profile_example.txt
+++ b/tools/profile_example.txt
@@ -574,7 +574,7 @@ You can also restrict profiling to just kernel stacks (-K) or user stacks (-U).
 For example, just user stacks:
 
 # ./profile -C 7 2
-Sampling at 49 Hertz of all threads by user + kernel stack for 2 secs.
+Sampling at 49 Hertz of all threads by user + kernel stack on CPU#7 for 2 secs.
 
     PyEval_EvalFrameEx
     [unknown]

--- a/tools/profile_example.txt
+++ b/tools/profile_example.txt
@@ -573,6 +573,41 @@ Sampling at 9 Hertz of all threads by user + kernel stack... Hit Ctrl-C to end.
 You can also restrict profiling to just kernel stacks (-K) or user stacks (-U).
 For example, just user stacks:
 
+# ./profile -C 7 2
+Sampling at 49 Hertz of all threads by user + kernel stack for 2 secs.
+
+    PyEval_EvalFrameEx
+    [unknown]
+    [unknown]
+    -                python (2827439)
+        1
+
+    PyDict_GetItem
+    [unknown]
+    -                python (2827439)
+        1
+
+    [unknown]
+    -                python (2827439)
+        1
+
+    PyEval_EvalFrameEx
+    [unknown]
+    [unknown]
+    -                python (2827439)
+        1
+
+    PyEval_EvalFrameEx
+    -                python (2827439)
+        1
+
+    [unknown]
+    [unknown]
+    -                python (2827439)
+
+in this example python application was busylooping on a single core/cpu (#7)
+we were collecting stack traces only from it
+
 # ./profile -U
 Sampling at 49 Hertz of all threads by user stack... Hit Ctrl-C to end.
 ^C
@@ -733,6 +768,7 @@ optional arguments:
   --stack-storage-size STACK_STORAGE_SIZE
                         the number of unique stack traces that can be stored
                         and displayed (default 2048)
+  -C CPU, --cpu CPU     cpu number to run profile on
 
 examples:
     ./profile             # profile stack traces at 49 Hertz until Ctrl-C


### PR DESCRIPTION
Summary:
sometime it is usefull to collect stack only from single cpu
for example you have single core saturated while others dont and you
want to know whats going on there. in this diff i'm adding this ability
(network related code could be example of when single core is saturated
as usually you have 1 to 1 mappng between rx queue and cpu)

example of generated code w/ CPU specified:
```
./tools/profile.py -C 14 2 --ebpf
Sampling at 49 Hertz of all threads by user + kernel stack for 2 secs.

struct key_t {
    u32 pid;
    u64 kernel_ip;
    u64 kernel_ret_ip;
    int user_stack_id;
    int kernel_stack_id;
    char name[TASK_COMM_LEN];
};
BPF_HASH(counts, struct key_t);
BPF_STACK_TRACE(stack_traces, 16384);

// This code gets a bit complex. Probably not suitable for casual hacking.

int do_perf_event(struct bpf_perf_event_data *ctx) {

    if (bpf_get_smp_processor_id() != 14)
        return 0;

    u32 pid = bpf_get_current_pid_tgid() >> 32;
...
```
and w/o
```
./tools/profile.py  2 --ebpf
Sampling at 49 Hertz of all threads by user + kernel stack for 2 secs.

struct key_t {
    u32 pid;
    u64 kernel_ip;
    u64 kernel_ret_ip;
    int user_stack_id;
    int kernel_stack_id;
    char name[TASK_COMM_LEN];
};
BPF_HASH(counts, struct key_t);
BPF_STACK_TRACE(stack_traces, 16384);

// This code gets a bit complex. Probably not suitable for casual hacking.

int do_perf_event(struct bpf_perf_event_data *ctx) {

    u32 pid = bpf_get_current_pid_tgid() >> 32;
    if (!(1))
        return 0;
...
```