### PR TITLE
table: remove NotImplementedError on LpmTrie __delitem__ calls

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -733,10 +733,6 @@ class LpmTrie(TableBase):
     def __len__(self):
         raise NotImplementedError
 
-    def __delitem__(self, key):
-        # Not implemented for lpm trie as of kernel commit
-        # b95a5c4db09bc7c253636cb84dc9b12c577fd5a0
-        raise NotImplementedError
 
 class StackTrace(TableBase):
     MAX_DEPTH = 127


### PR DESCRIPTION
BPF_MAP_TYPE_LPM_TRIE supports element deletion since kernel commit
e454cf595853 ("bpf: Implement map_delete_elem for BPF_MAP_TYPE_LPM_TRIE")
which is available in 4.15 kernels onwards.

Signed-off-by: Eyal Birger <eyal.birger@gmail.com>