### PR TITLE
Adding Fedora 28 to the list of fedora versions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,7 @@ sudo dnf install bcc-tools kernel-headers kernel-devel
 
 **Stable and Signed Packages**
 
-Stable bcc binary packages for Fedora 25, 26, 27, and 27 are hosted at
+Stable bcc binary packages for Fedora 25, 26, 27, and 28 are hosted at
 `https://repo.iovisor.org/yum/main/f{25,26,27}`.
 
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,7 +84,7 @@ sudo dnf update
 
 **Nightly Packages**
 
-Nightly bcc binary packages for Fedora 25, 26, and 27 are hosted at
+Nightly bcc binary packages for Fedora 25, 26, 27, and 28 are hosted at
 `https://repo.iovisor.org/yum/nightly/f{25,26,27}`.
 
 To install:
@@ -95,7 +95,7 @@ sudo dnf install bcc-tools kernel-headers kernel-devel
 
 **Stable and Signed Packages**
 
-Stable bcc binary packages for Fedora 25, 26, and 27 are hosted at
+Stable bcc binary packages for Fedora 25, 26, 27, and 27 are hosted at
 `https://repo.iovisor.org/yum/main/f{25,26,27}`.
 
 ```bash


### PR DESCRIPTION
Looking at the repo location, Fedora 28 appears to be supported as well.  Fixing the documentation to include this.