### PR TITLE
Minor correction to Ubuntu build documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -251,7 +251,7 @@ wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
 
 # All versions
-sudo apt-get -y install bison build-essential cmake3 flex git libedit-dev \
+sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
   libllvm3.7 llvm-3.7-dev libclang-3.7-dev python zlib1g-dev libelf-dev
 
 # For Lua support


### PR DESCRIPTION
`cmake3` was throwing an error that the package did not exist. `cmake` exists and the build was successful using it. 