### PR TITLE
fix python3 issue for ttysnoop.py

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -167,10 +167,10 @@ class BPF(object):
     }
 
     _syscall_prefixes = [
-        "sys_",
-        "__x64_sys_",
-        "__x32_compat_sys_",
-        "__ia32_compat_sys_",
+        b"sys_",
+        b"__x64_sys_",
+        b"__x32_compat_sys_",
+        b"__ia32_compat_sys_",
     ]
 
     # BPF timestamps come from the monotonic clock. To be able to filter


### PR DESCRIPTION
Fix issue #1910

Otherwise, we will have a type mismatch like below:
  [root@aborniakFC tools]# ./ttysnoop 1
  Traceback (most recent call last):
  File "./ttysnoop", line 102, in <module>
  b = BPF(text=bpf_text)
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 337, in __init__
  self._trace_autoload()
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 1030, in _trace_autoload
  event=self.fix_syscall_fnname(func_name[8:]),
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 569, in fix_syscall_fnname
  if name.startswith(prefix):
  TypeError: startswith first arg must be bytes or a tuple of bytes, not str
  [root@aborniakFC tools]#

Signed-off-by: Yonghong Song <yhs@fb.com>