### PR TITLE
Add name to program too large error message

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -481,8 +481,8 @@ int bpf_prog_load(enum bpf_prog_type prog_type, const char *name,
   if (attr.insn_cnt > BPF_MAXINSNS) {
     errno = EINVAL;
     fprintf(stderr,
-            "bpf: %s. Program too large (%u insns), at most %d insns\n\n",
-            strerror(errno), attr.insn_cnt, BPF_MAXINSNS);
+            "bpf: %s. Program %s too large (%u insns), at most %d insns\n\n",
+            strerror(errno), name, attr.insn_cnt, BPF_MAXINSNS);
     return -1;
   }
 


### PR DESCRIPTION
When loading multiple programs, it's hard to find out which program triggered the error. This commit adds the function name to the error message.