### PR TITLE
fix attach_kretprobe for newer kernels

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -614,7 +614,7 @@ class BPF(object):
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
         ev_name = b"r_" + event.replace(b"+", b"_").replace(b".", b"_")
-        fd = lib.bpf_attach_kprobe(fn.fd, 1, ev_name, event)
+        fd = lib.bpf_attach_kprobe(fn.fd, 1, ev_name, event, 0)
         if fd < 0:
             raise Exception("Failed to attach BPF to kretprobe")
         self._add_kprobe_fd(ev_name, fd)


### PR DESCRIPTION
fix #1921

For newer kernels, bcc tries to fd based kuprobe
attachment. In fd based kprobe attachment,
  config1: for symbol
  config2: for symbol offset

In python API attach_kretprobe, the offset value
is not set in lib.bpf_attach_kprobe and hence it
will be a random value and eventually causing
kretprobe attachment failure.

This is not an issue for old debugfs based attachment
as the offset will not be used if it is a retprobe.

Signed-off-by: Yonghong Song <yhs@fb.com>