### PR TITLE
fix compilation error with llvm trunk (8.0.0)

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -154,7 +154,12 @@ void SourceDebugger::dump() {
   }
 
   // bcc has only one compilation unit
+  // getCompileUnitAtIndex() was gone in llvm 8.0 (https://reviews.llvm.org/D49741)
+#if LLVM_MAJOR_VERSION >= 8
+  DWARFCompileUnit *CU = cast<DWARFCompileUnit>(DwarfCtx->getUnitAtIndex(0));
+#else
   DWARFCompileUnit *CU = DwarfCtx->getCompileUnitAtIndex(0);
+#endif
   if (!CU) {
     errs() << "Debug Error: dwarf context failed to get compile unit\n";
     return;


### PR DESCRIPTION
LLVM commit https://reviews.llvm.org/D49741 removed
function DEARFContext::getCompileUnitAtIndex() and caused
the bcc compilation failure.

Change usage of getCompileUnitAtIndex() to the one
recommended in the above llvm commit.

Signed-off-by: Yonghong Song <yhs@fb.com>