### PR TITLE
fix a rewriter bug for array subscript

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -509,7 +509,7 @@ bool ProbeVisitor::VisitArraySubscriptExpr(ArraySubscriptExpr *E) {
   SourceLocation lbracket_start, lbracket_end;
   SourceRange lbracket_range;
   pre = "({ typeof(" + E->getType().getAsString() + ") _val; __builtin_memset(&_val, 0, sizeof(_val));";
-  pre += " bpf_probe_read(&_val, sizeof(_val), (u64)(";
+  pre += " bpf_probe_read(&_val, sizeof(_val), (u64)((";
   if (isMemberDereference(base)) {
     pre += "&";
     // If the base of the array subscript is a member dereference, we'll rewrite
@@ -530,7 +530,7 @@ bool ProbeVisitor::VisitArraySubscriptExpr(ArraySubscriptExpr *E) {
   lbracket_range = expansionRange(SourceRange(lbracket_start, lbracket_end));
   rewriter_.ReplaceText(lbracket_range, lbracket);
 
-  rbracket = ")); _val; })";
+  rbracket = "))); _val; })";
   rewriter_.ReplaceText(expansionLoc(E->getRBracketLoc()), 1, rbracket);
 
   return true;


### PR DESCRIPTION
additional fix for issue #1850

for the below case in test_clang.py;

```
  int test(struct pt_regs *ctx, struct mm_struct *mm) {
      return mm->rss_stat.count[MM_ANONPAGES].counter;
  }
```
the current rewriter generates:

```
  int test(struct pt_regs *ctx) {
   struct mm_struct *mm = ctx->di;
      return ({ typeof(atomic_long_t) _val;
                __builtin_memset(&_val, 0, sizeof(_val));
                bpf_probe_read(&_val,
                               sizeof(_val),
                               (u64)(&mm->rss_stat.count) + (MM_ANONPAGES));
                _val; }).counter;
  }
```
The third argument of bpf_probe_read() is incorrect.
The correct third argument should be
```
   (u64)((&mm->rss_stat.count) + (MM_ANONPAGES))
```
This patch fixed the issue by adding extra parenthesis for the
outer u64 type casting.
```
  int test(struct pt_regs *ctx) {
   struct mm_struct *mm = ctx->di;
      return ({ typeof(atomic_long_t) _val;
                __builtin_memset(&_val, 0, sizeof(_val));
                bpf_probe_read(&_val,
                               sizeof(_val),
                               (u64)((&mm->rss_stat.count) + (MM_ANONPAGES)));
                _val; }).counter;
  }
```
Signed-off-by: Yonghong Song <yhs@fb.com>