### PR TITLE
[tools/syscount.py]: fix total_ns wrong count

### DIFF
--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -481,7 +481,7 @@ TRACEPOINT_PROBE(raw_syscalls, sys_exit) {
 
     val = data.lookup_or_init(&key, &zero);
     val->count++;
-    val->total_ns = bpf_ktime_get_ns() - *start_ns;
+    val->total_ns += bpf_ktime_get_ns() - *start_ns;
 #else
     u64 *val, zero = 0;
     val = data.lookup_or_init(&key, &zero);


### PR DESCRIPTION
It's useful to know each syscall's total latency
in that period, but not the latency of the last time
in that period.

Signed-off-by: Ahao Mu <muahao@linux.alibaba.com>