### PR TITLE
tools.py: Allow args dereference

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -393,6 +393,13 @@ BPF_PERF_OUTPUT(%s);
                 bpf_probe_read(&__data.v%d, sizeof(__data.v%d), (void *)%s);
         }
                 """ % (expr, idx, idx, expr)
+                if expr.startswith('*'):
+                    ptr_expr = expr[1:]
+                    return text + """
+        if (%s != 0) {
+            bpf_probe_read(&__data.v%d, sizeof(__data.v%d), (void *)%s);
+        }
+            """ % (ptr_expr, idx, idx, ptr_expr)
                 if field_type in Probe.fmt_types:
                         return text + "        __data.v%d = (%s)%s;\n" % \
                                         (idx, Probe.c_type[field_type], expr)


### PR DESCRIPTION
libc functions like for example eventfd_read()

    int eventfd_read(int fd, eventfd_t *value);

may be passed with pointer argument.

Applying star ('*') to such argument must safely copy a memory location
to the BPF stack.

Signed-off-by: Prasad Joshi <prasadjoshi.linux@gmail.com>