### PR TITLE
Bug: too many arguments to function call counts.increment()

### DIFF
--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -164,7 +164,7 @@ int oncpu(struct pt_regs *ctx, struct task_struct *prev) {
     key.kernel_stack_id = KERNEL_STACK_GET;
     bpf_get_current_comm(&key.name, sizeof(key.name));
 
-    counts.increment(key, delta);
+    counts.increment(key);
     return 0;
 }
 """

--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -212,7 +212,7 @@ int oncpu(struct pt_regs *ctx, struct task_struct *p) {
         wokeby.delete(&pid);
     }
 
-    counts.increment(key, delta);
+    counts.increment(key);
     return 0;
 }
 """

--- a/tools/wakeuptime.py
+++ b/tools/wakeuptime.py
@@ -139,7 +139,7 @@ int waker(struct pt_regs *ctx, struct task_struct *p) {
     bpf_probe_read(&key.target, sizeof(key.target), p->comm);
     bpf_get_current_comm(&key.waker, sizeof(key.waker));
 
-    counts.increment(key, delta);
+    counts.increment(key);
     return 0;
 }
 """


### PR DESCRIPTION
Reproduce:
root@kemi-desktop:/home/kemi/git/kemi_bcc/bcc# ./tools/wakeuptime.py -f 3
/virtual/main.c:54:27: error: too many arguments to function call, expected
1, have 2
counts.increment(key, delta);
~~~~~~~~~~~~~~~~      ^~~~~
1 error generated.
Traceback (most recent call last):
  File "./tools/wakeuptime.py", line 165, in <module>
      b = BPF(text=bpf_text)
  File "/usr/lib/python2.7/dist-packages/bcc/__init__.py",
	  line 318, in __init__
  raise Exception("Failed to compile BPF text")
Exception: Failed to compile BPF text

root@kemi-desktop:/home/kemi/git/bcc# ./tools/offcputime.py -f 10
/virtual/main.c:55:27: error: too many arguments to function call, expected
1, have 2
counts.increment(key, delta);
~~~~~~~~~~~~~~~~      ^~~~~
1 error generated.
Traceback (most recent call last):
  File "./tools/offcputime.py", line 235, in <module>
     b = BPF(text=bpf_text)
  File "/usr/lib/python2.7/dist-packages/bcc/__init__.py",
 	line 318, in __init__
  raise Exception("Failed to compile BPF text")
Exception: Failed to compile BPF text

Signed-off-by: Kemi Wang <kemi.wang@intel.com>