### PR TITLE
fix flaky test_usdt3.py test

### DIFF
--- a/tests/python/test_usdt3.py
+++ b/tests/python/test_usdt3.py
@@ -131,8 +131,14 @@ int do_trace(struct pt_regs *ctx) {
                 self.probe_value_other = 1
 
         b["event"].open_perf_buffer(print_event)
-        for i in range(10):
-            b.perf_buffer_poll()
+        for i in range(100):
+            if (self.probe_value_1 == 0 or
+                self.probe_value_2 == 0 or
+                self.probe_value_3 == 0 or
+                self.probe_value_other != 0):
+                b.perf_buffer_poll()
+            else:
+                break;
 
         self.assertTrue(self.probe_value_1 != 0)
         self.assertTrue(self.probe_value_2 != 0)


### PR DESCRIPTION
The poll iteration count 10 sometimes not big enough.
Now let us increase to 100 iterations, but will bail out
if the expected data have received. Hopefully this
will fix flakiness of this test.

Signed-off-by: Yonghong Song <yhs@fb.com>