### PR TITLE
Serialize python builds

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -20,16 +20,23 @@ endif()
 foreach(PY_CMD ${PYTHON_CMD})
   string(REPLACE "/" "-" PY_CMD_ESCAPED ${PY_CMD})
 
+  set(PY_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bcc/__init__.py ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
+  if (PREVIOUS_PY)
+    set(PY_DEPENDS ${PY_DEPENDS} ${PREVIOUS_PY})
+  endif()
+
   set(PIP_INSTALLABLE "${CMAKE_CURRENT_BINARY_DIR}/dist-${PY_CMD_ESCAPED}/bcc-${REVISION}.tar.gz")
   # build the pip installable
   add_custom_command(OUTPUT ${PIP_INSTALLABLE}
     COMMAND ${PY_CMD} setup.py sdist --dist-dir dist-${PY_CMD_ESCAPED}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bcc/__init__.py ${CMAKE_CURRENT_BINARY_DIR}/setup.py
+    DEPENDS ${PY_DEPENDS}
     )
   add_custom_target(bcc_py_${PY_CMD_ESCAPED} ALL DEPENDS ${PIP_INSTALLABLE})
 
   install(CODE "execute_process(COMMAND ${PY_CMD} setup.py install -f ${PYTHON_FLAGS}
     --prefix=${CMAKE_INSTALL_PREFIX} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})"
     COMPONENT python)
+
+  set(PREVIOUS_PY ${PIP_INSTALLABLE})
 endforeach()


### PR DESCRIPTION
Generating sdist for both python2 and python3 at the same time can fail
as they both use the same temporary files.

Make sure that we generate sdist for each `PYTHON_CMD` sequentially.

Fixes #1934 