### PR TITLE
Correction of an ipdb initdb issue

### DIFF
--- a/examples/networking/simulation.py
+++ b/examples/networking/simulation.py
@@ -66,7 +66,6 @@ class Simulation(object):
 
         if out_ifc: out_ifc.up().commit()
         ns_ipdb.interfaces.lo.up().commit()
-        ns_ipdb.initdb()
         in_ifc = ns_ipdb.interfaces[in_ifname]
         with in_ifc as v:
             v.ifname = ns_ifc


### PR DESCRIPTION
When using ns_ipdb.initdb(), the NetNS object should be given as a
parameter. In this case, the IPDB object is attached to the default ns.
Therefore, there is a key error exception in the next line :
in_ifc = ns_ipdb.interfaces[in_ifname]
however IPDB is updated asynchronously but the commit() operation is synchronous
So there is no risk to remove the initdb instruction