### PR TITLE
tools: Skip backward time entries v2

### DIFF
--- a/tools/xfsslower.py
+++ b/tools/xfsslower.py
@@ -173,8 +173,15 @@ static int trace_return(struct pt_regs *ctx, int type)
 
     // calculate delta
     u64 ts = bpf_ktime_get_ns();
-    u64 delta_us = (ts - valp->ts) / 1000;
+    u64 delta_us = ts - valp->ts;
     entryinfo.delete(&id);
+
+    // Skip entries with backwards time: temp workaround for #728
+    if ((s64) delta_us < 0)
+        return 0;
+
+    delta_us /= 1000;
+
     if (FILTER_US)
         return 0;
 


### PR DESCRIPTION
On RHEL7 we are facing timing issues in some bcc-tools
scripts. The time subsystem might return backward timestamp
via bpf_ktime_get_ns and thus screw up latency computation.

This seems to be RHEL7 kernel issue and needs to be fixed,
however meanwhile it'd be nice if affected scripts display
sane values despite the kernel issue.

This patchset harden 2 scripts (xfsslower and ext4dist)
we saw this behaviour so far, to ensure the latency is
always > 0.