### PR TITLE
Add move constructor to C++ USDT instance

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -59,10 +59,13 @@ StatusTuple BPF::init(const std::string& bpf_program,
                       const std::vector<USDT>& usdt) {
   std::string all_bpf_program;
 
+  usdt_.reserve(usdt.size());
   for (const auto& u : usdt) {
     usdt_.emplace_back(u);
-    TRY2(usdt_.back().init());
-    all_bpf_program += usdt_.back().program_text_;
+  }
+  for (auto& u : usdt_) {
+    TRY2(u.init());
+    all_bpf_program += u.program_text_;
   }
 
   auto flags_len = cflags.size();

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -736,6 +736,18 @@ USDT::USDT(const USDT& usdt)
       name_(usdt.name_),
       probe_func_(usdt.probe_func_) {}
 
+USDT::USDT(USDT&& usdt) noexcept
+    : initialized_(usdt.initialized_),
+      binary_path_(std::move(usdt.binary_path_)),
+      pid_(usdt.pid_),
+      provider_(std::move(usdt.provider_)),
+      name_(std::move(usdt.name_)),
+      probe_func_(std::move(usdt.probe_func_)),
+      probe_(std::move(usdt.probe_)),
+      program_text_(std::move(usdt.program_text_)) {
+  usdt.initialized_ = false;
+}
+
 bool USDT::operator==(const USDT& other) const {
   return (provider_ == other.provider_) && (name_ == other.name_) &&
          (binary_path_ == other.binary_path_) && (pid_ == other.pid_) &&

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -252,7 +252,7 @@ class USDT {
 
   std::string print_name() const {
     return provider_ + ":" + name_ + " from binary " + binary_path_ + " PID " +
-           std::to_string(pid_) + " for probe " + "probe_func_";
+           std::to_string(pid_) + " for probe " + probe_func_;
   }
 
   friend std::ostream& operator<<(std::ostream& out, const USDT& usdt) {

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -245,6 +245,7 @@ class USDT {
   USDT(const std::string& binary_path, pid_t pid, const std::string& provider,
        const std::string& name, const std::string& probe_func);
   USDT(const USDT& usdt);
+  USDT(USDT&& usdt) noexcept;
 
   StatusTuple init();
 


### PR DESCRIPTION
This way, it's easier to move initialized USDT instance around without having to re-read everything.

Piggy-back a small logging fix