### PR TITLE
tcpretrans: use user-space PID displayed to the user

### DIFF
--- a/tools/tcpretrans.py
+++ b/tools/tcpretrans.py
@@ -98,7 +98,7 @@ static int trace_event(struct pt_regs *ctx, struct sock *skp, int type)
 {
     if (skp == NULL)
         return 0;
-    u32 pid = bpf_get_current_pid_tgid();
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
 
     // pull in details
     u16 family = skp->__sk_common.skc_family;


### PR DESCRIPTION
PID collected in tcpretrans' trace_event() is displayed under the
label of "PID" to the user so it would seem more appropriate to use
TGID as PID not kernel's PID.