### PR TITLE
fix a trace.py problem

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -390,9 +390,10 @@ BPF_PERF_OUTPUT(%s);
                 if field_type == "s":
                         return text + """
         if (%s != 0) {
-                bpf_probe_read(&__data.v%d, sizeof(__data.v%d), (void *)%s);
+                void *__tmp = (void *)%s;
+                bpf_probe_read(&__data.v%d, sizeof(__data.v%d), __tmp);
         }
-                """ % (expr, idx, idx, expr)
+                """ % (expr, expr, idx, idx)
                 if field_type in Probe.fmt_types:
                         return text + "        __data.v%d = (%s)%s;\n" % \
                                         (idx, Probe.c_type[field_type], expr)


### PR DESCRIPTION
Currently, trace.py failed for the following command:
```
  $ sudo ./trace.py 'filename_lookup(int dfd, struct filename *name) "%s", name->name'
  ...
  0: (bf) r6 = r1
  1: (79) r7 = *(u64 *)(r6 +104)
  ...
  32: (15) if r1 == 0x0 goto pc+5
  R0=inv(id=0) R1=inv(id=0) R6=ctx(id=0,off=0,imm=0) R7=inv(id=0)
  R8=inv0 R10=fp0,call_-1 fp-8=0 fp-16=0 fp-24=0 fp-32=0 fp-40=0 fp-48=0 fp-56=0 fp-64=0 fp-72=0 fp-80=0
  33: (79) r3 = *(u64 *)(r7 +0)
  R7 invalid mem access 'inv'
```
For string format argument, the trace.py generates the below code:
```
        if (name->name != 0) {
                bpf_probe_read(&__data.v0, sizeof(__data.v0), (void *)name->name);
        }
```
Right now, bcc skips the rewriter for the third argument of `bpf_probe_read `to avoid
unnecessary nested `bpf_probe_read` and other potential issues.
This causes `name->name` memory access not transformed with `bpf_probe_read` and hence
the verifier complains.

To fix the issue, this patch did the following transformation using an
temporary variable to hold the src address:
```
        if (name->name != 0) {
                void *__tmp = (void *)name->name;
                bpf_probe_read(&__data.v0, sizeof(__data.v0), __tmp);
        }
```
This way, rewriter can do the work properly.

Signed-off-by: Yonghong Song <yhs@fb.com>