### PR TITLE
biolatency: Fix --disks bpf_probe_read()

### DIFF
--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -99,8 +99,9 @@ if args.disks:
         'BPF_HISTOGRAM(dist, disk_key_t);')
     bpf_text = bpf_text.replace('STORE',
         'disk_key_t key = {.slot = bpf_log2l(delta)}; ' +
-        'bpf_probe_read(&key.disk, sizeof(key.disk), ' +
-        'req->rq_disk->disk_name); dist.increment(key);')
+        'void *__tmp = (void *)req->rq_disk->disk_name; ' +
+        'bpf_probe_read(&key.disk, sizeof(key.disk), __tmp); ' +
+        'dist.increment(key);')
 else:
     bpf_text = bpf_text.replace('STORAGE', 'BPF_HISTOGRAM(dist);')
     bpf_text = bpf_text.replace('STORE',


### PR DESCRIPTION
bpf_probe_read()'s third argument is no longer rewritten. Instead, use a
temporary variable (like #1973) to avoid a memory access error.

Before:

```
$ sudo biolatency -D 1
bpf: Failed to load program: Permission denied
0: (79) r1 = *(u64 *)(r1 +112)
1: (7b) *(u64 *)(r10 -8) = r1
[..]
R1 invalid mem access 'inv'

HINT: The invalid mem access 'inv' error can happen if you try to
dereference memory without first using bpf_probe_read() to copy it to
the BPF stack. Sometimes the bpf_probe_read is automatic by the bcc
rewriter, other times you'll need to be explicit.
```

After, works as expected.