### PR TITLE
prevent array subscript expression if base/index is not rewritable

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -505,6 +505,12 @@ bool ProbeVisitor::VisitArraySubscriptExpr(ArraySubscriptExpr *E) {
   Expr *idx = E->getIdx();
   memb_visited_.insert(E);
 
+  if (!rewriter_.isRewritable(GET_BEGINLOC(base)))
+    return true;
+  if (!rewriter_.isRewritable(GET_BEGINLOC(idx)))
+    return true;
+
+
   string pre, lbracket, rbracket;
   LangOptions opts;
   SourceLocation lbracket_start, lbracket_end;


### PR DESCRIPTION
The following command failed:
```
  trace.py -U 'r::_do_fork (retval == -11) "%llu", ((struct task_struct *)bpf_get_current_task())->signal->rlim[RLIMIT_NPROC].rlim_cur'
```
as rewriter generates code like
```
  __data.v0 = (unsigned long long)((struct task_struct *)bpf_get_current_task())->signal->rlim[RLIMIT_NPROC))); _val; }).rlim_cur;
```
Let us prevent rewriting if either base or index is not rewritable and this fixed the issue.

Signed-off-by: Yonghong Song <yhs@fb.com>