### PR TITLE
Add support for shared tables

### DIFF
--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -47,8 +47,9 @@ class BPF {
   static const int BPF_MAX_STACK_DEPTH = 127;
 
   explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr,
-               bool rw_engine_enabled = true)
-      : flag_(flag), bpf_module_(new BPFModule(flag, ts, rw_engine_enabled)) {}
+               bool rw_engine_enabled = true, const std::string &maps_ns = "")
+      : flag_(flag),
+      bpf_module_(new BPFModule(flag, ts, rw_engine_enabled, maps_ns)) {}
   StatusTuple init(const std::string& bpf_program,
                    const std::vector<std::string>& cflags = {},
                    const std::vector<USDT>& usdt = {});

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -99,12 +99,14 @@ class MyMemoryManager : public SectionMemoryManager {
   map<string, tuple<uint8_t *, uintptr_t>> *sections_;
 };
 
-BPFModule::BPFModule(unsigned flags, TableStorage *ts, bool rw_engine_enabled)
+BPFModule::BPFModule(unsigned flags, TableStorage *ts, bool rw_engine_enabled,
+                     const std::string &maps_ns)
     : flags_(flags),
       rw_engine_enabled_(rw_engine_enabled),
       used_b_loader_(false),
       ctx_(new LLVMContext),
       id_(std::to_string((uintptr_t)this)),
+      maps_ns_(maps_ns),
       ts_(ts) {
   InitializeNativeTarget();
   InitializeNativeTargetAsmPrinter();
@@ -473,7 +475,7 @@ unique_ptr<ExecutionEngine> BPFModule::finalize_rw(unique_ptr<Module> m) {
 int BPFModule::load_cfile(const string &file, bool in_memory, const char *cflags[], int ncflags) {
   ClangLoader clang_loader(&*ctx_, flags_);
   if (clang_loader.parse(&mod_, *ts_, file, in_memory, cflags, ncflags, id_,
-                         *func_src_, mod_src_))
+                         *func_src_, mod_src_, maps_ns_))
     return -1;
   return 0;
 }
@@ -486,7 +488,7 @@ int BPFModule::load_cfile(const string &file, bool in_memory, const char *cflags
 int BPFModule::load_includes(const string &text) {
   ClangLoader clang_loader(&*ctx_, flags_);
   if (clang_loader.parse(&mod_, *ts_, text, true, nullptr, 0, "", *func_src_,
-                         mod_src_))
+                         mod_src_, ""))
     return -1;
   return 0;
 }
@@ -979,7 +981,8 @@ int BPFModule::load_b(const string &filename, const string &proto_filename) {
 
   BLoader b_loader(flags_);
   used_b_loader_ = true;
-  if (int rc = b_loader.parse(&*mod_, filename, proto_filename, *ts_, id_))
+  if (int rc = b_loader.parse(&*mod_, filename, proto_filename, *ts_, id_,
+                              maps_ns_))
     return rc;
   if (rw_engine_enabled_) {
     if (int rc = annotate())

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -76,12 +76,14 @@ class BPFModule {
                        const void *val);
 
  public:
-  BPFModule(unsigned flags, TableStorage *ts = nullptr, bool rw_engine_enabled = true);
+  BPFModule(unsigned flags, TableStorage *ts = nullptr, bool rw_engine_enabled = true,
+            const std::string &maps_ns = "");
   ~BPFModule();
   int load_b(const std::string &filename, const std::string &proto_filename);
   int load_c(const std::string &filename, const char *cflags[], int ncflags);
   int load_string(const std::string &text, const char *cflags[], int ncflags);
   std::string id() const { return id_; }
+  std::string maps_ns() const { return maps_ns_; }
   size_t num_functions() const;
   uint8_t * function_start(size_t id) const;
   uint8_t * function_start(const std::string &name) const;
@@ -137,6 +139,7 @@ class BPFModule {
   std::map<llvm::Type *, std::string> readers_;
   std::map<llvm::Type *, std::string> writers_;
   std::string id_;
+  std::string maps_ns_;
   std::string mod_src_;
   std::map<std::string, std::string> src_dbg_fmap_;
   TableStorage *ts_;

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -66,6 +66,12 @@ BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries); \
 __attribute__((section("maps/export"))) \
 struct _name##_table_t __##_name
 
+// define a table that is shared accross the programs in the same namespace
+#define BPF_TABLE_SHARED(_table_type, _key_type, _leaf_type, _name, _max_entries) \
+BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries); \
+__attribute__((section("maps/shared"))) \
+struct _name##_table_t __##_name
+
 // Identifier for current CPU used in perf_submit and perf_read
 // Prefer BPF_F_CURRENT_CPU flag, falls back to call helper for older kernel
 // Can be overridden from BCC

--- a/src/cc/frontends/b/codegen_llvm.cc
+++ b/src/cc/frontends/b/codegen_llvm.cc
@@ -1230,7 +1230,8 @@ StatusTuple CodegenLLVM::visit_func_decl_stmt_node(FuncDeclStmtNode *n) {
   return StatusTuple(0);
 }
 
-StatusTuple CodegenLLVM::visit(Node *root, TableStorage &ts, const string &id) {
+StatusTuple CodegenLLVM::visit(Node *root, TableStorage &ts, const string &id,
+                               const string &maps_ns) {
   scopes_->set_current(scopes_->top_state());
   scopes_->set_current(scopes_->top_var());
 

--- a/src/cc/frontends/b/codegen_llvm.h
+++ b/src/cc/frontends/b/codegen_llvm.h
@@ -65,7 +65,8 @@ class CodegenLLVM : public Visitor {
   EXPAND_NODES(VISIT)
 #undef VISIT
 
-  STATUS_RETURN visit(Node *n, TableStorage &ts, const std::string &id);
+  STATUS_RETURN visit(Node *n, TableStorage &ts, const std::string &id,
+                      const std::string &maps_ns);
 
   int get_table_fd(const std::string &name) const;
 

--- a/src/cc/frontends/b/loader.cc
+++ b/src/cc/frontends/b/loader.cc
@@ -33,7 +33,7 @@ BLoader::~BLoader() {
 }
 
 int BLoader::parse(llvm::Module *mod, const string &filename, const string &proto_filename,
-                   TableStorage &ts, const string &id) {
+                   TableStorage &ts, const string &id, const std::string &maps_ns) {
   int rc;
 
   proto_parser_ = make_unique<ebpf::cc::Parser>(proto_filename);
@@ -61,7 +61,7 @@ int BLoader::parse(llvm::Module *mod, const string &filename, const string &prot
   }
 
   codegen_ = ebpf::make_unique<ebpf::cc::CodegenLLVM>(mod, parser_->scopes_.get(), proto_parser_->scopes_.get());
-  ret = codegen_->visit(parser_->root_node_, ts, id);
+  ret = codegen_->visit(parser_->root_node_, ts, id, maps_ns);
   if (ret.code() != 0 || ret.msg().size()) {
     fprintf(stderr, "Codegen error @line=%d: %s\n", ret.code(), ret.msg().c_str());
     return ret.code();

--- a/src/cc/frontends/b/loader.h
+++ b/src/cc/frontends/b/loader.h
@@ -38,7 +38,7 @@ class BLoader {
   explicit BLoader(unsigned flags);
   ~BLoader();
   int parse(llvm::Module *mod, const std::string &filename, const std::string &proto_filename,
-            TableStorage &ts, const std::string &id);
+            TableStorage &ts, const std::string &id, const std::string &maps_ns);
 
  private:
   unsigned flags_;

--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -152,7 +152,8 @@ class BFrontendAction : public clang::ASTFrontendAction {
   // should be written.
   BFrontendAction(llvm::raw_ostream &os, unsigned flags, TableStorage &ts,
                   const std::string &id, const std::string &main_path,
-                  FuncSource &func_src, std::string &mod_src);
+                  FuncSource &func_src, std::string &mod_src,
+                  const std::string &maps_ns);
 
   // Called by clang when the AST has been completed, here the output stream
   // will be flushed.
@@ -164,6 +165,7 @@ class BFrontendAction : public clang::ASTFrontendAction {
   clang::Rewriter &rewriter() const { return *rewriter_; }
   TableStorage &table_storage() const { return ts_; }
   std::string id() const { return id_; }
+  std::string maps_ns() const { return maps_ns_; }
   bool is_rewritable_ext_func(clang::FunctionDecl *D);
   void DoMiscWorkAround();
 
@@ -172,6 +174,7 @@ class BFrontendAction : public clang::ASTFrontendAction {
   unsigned flags_;
   TableStorage &ts_;
   std::string id_;
+  std::string maps_ns_;
   std::unique_ptr<clang::Rewriter> rewriter_;
   friend class BTypeVisitor;
   std::map<std::string, clang::SourceRange> func_range_;

--- a/src/cc/frontends/clang/loader.h
+++ b/src/cc/frontends/clang/loader.h
@@ -54,7 +54,7 @@ class ClangLoader {
   int parse(std::unique_ptr<llvm::Module> *mod, TableStorage &ts,
             const std::string &file, bool in_memory, const char *cflags[],
             int ncflags, const std::string &id, FuncSource &func_src,
-            std::string &mod_src);
+            std::string &mod_src, const std::string &maps_ns);
 
  private:
   int do_compile(std::unique_ptr<llvm::Module> *mod, TableStorage &ts,
@@ -63,7 +63,8 @@ class ClangLoader {
                  const std::string &main_path,
                  const std::unique_ptr<llvm::MemoryBuffer> &main_buf,
                  const std::string &id, FuncSource &func_src,
-                 std::string &mod_src, bool use_internal_bpfh);
+                 std::string &mod_src, bool use_internal_bpfh,
+                 const std::string &maps_ns);
 
  private:
   std::map<std::string, std::unique_ptr<llvm::MemoryBuffer>> remapped_headers_;

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(test_libbcc
 	test_hash_table.cc
 	test_perf_event.cc
 	test_prog_table.cc
+	test_shared_table.cc
 	test_usdt_args.cc
 	test_usdt_probes.cc
 	utils.cc)

--- a/tests/cc/test_shared_table.cc
+++ b/tests/cc/test_shared_table.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018 Politecnico di Torino
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BPF.h"
+#include "catch.hpp"
+
+const std::string BPF_PROGRAM1 = R"(
+BPF_TABLE_SHARED("array", int, int, mysharedtable, 1024);
+)";
+
+const std::string BPF_PROGRAM2 = R"(
+BPF_TABLE("extern", int, int, mysharedtable, 1024);
+)";
+
+TEST_CASE("test shared table", "[shared_table]") {
+  // deploy 4 ebpf programs: _ns1_a and _ns1_b are in ns1, _ns2_a and _ns2_b in ns2
+  ebpf::BPF bpf_ns1_a(0, nullptr, false, "ns1");
+  ebpf::BPF bpf_ns1_b(0, nullptr, false, "ns1");
+  ebpf::BPF bpf_ns2_a(0, nullptr, false, "ns2");
+  ebpf::BPF bpf_ns2_b(0, nullptr, false, "ns2");
+
+  ebpf::StatusTuple res(0);
+
+  res = bpf_ns1_a.init(BPF_PROGRAM1);
+  REQUIRE(res.code() == 0);
+
+  res = bpf_ns1_b.init(BPF_PROGRAM2);
+  REQUIRE(res.code() == 0);
+
+  res = bpf_ns2_a.init(BPF_PROGRAM1);
+  REQUIRE(res.code() == 0);
+
+  res = bpf_ns2_b.init(BPF_PROGRAM2);
+  REQUIRE(res.code() == 0);
+
+  // get references to all tables
+  ebpf::BPFArrayTable<int> t_ns1_a = bpf_ns1_a.get_array_table<int>("mysharedtable");
+  ebpf::BPFArrayTable<int> t_ns1_b = bpf_ns1_b.get_array_table<int>("mysharedtable");
+  ebpf::BPFArrayTable<int> t_ns2_a = bpf_ns2_a.get_array_table<int>("mysharedtable");
+  ebpf::BPFArrayTable<int> t_ns2_b = bpf_ns2_b.get_array_table<int>("mysharedtable");
+
+  // test that tables within the same ns are shared
+  int v1, v2, v3;
+  res = t_ns1_a.update_value(13, 42);
+  REQUIRE(res.code() == 0);
+
+  res = t_ns1_b.get_value(13, v1);
+  REQUIRE(res.code() == 0);
+  REQUIRE(v1 == 42);
+
+  // test that tables are isolated within different ns
+  res = t_ns2_a.update_value(13, 69);
+  REQUIRE(res.code() == 0);
+
+  res = t_ns2_b.get_value(13, v2);
+  REQUIRE(res.code() == 0);
+  REQUIRE(v2 == 69);
+
+  res = t_ns1_b.get_value(13, v3);
+  REQUIRE(res.code() == 0);
+  REQUIRE(v3 == 42);  // value should still be 42
+}


### PR DESCRIPTION
This PR is basically a rebased version of https://github.com/iovisor/bcc/pull/1172.

At that time, there was the idea of creating a new API for handling public tables, but that was a work that we never did. I am opening this PR because this new feature does not conflict nor changes the existing API, so it can be integrated easily without breaking existing applications.

Just to summarize, the idea is to have an additional visibility level for eBPF tables, a step between `public` and `private`, `shared` maps are visible among the eBPF programs that are in the same namespace defined by the user.  

This is useful when implementing very complex modules that don't fit into a single eBPF program like a firewall, maps are shared among the programs of the same firewall instance but maps on different firewall instances are isolated.

This core of this PR is on `src/cc/frontends/clang/b_frontend_action.cc`, most of modifications in other files are just to pass the namespace around.