### PR TITLE
Python build: copy files instead of creating link

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 
-macro(symlink_file SRC DST)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${SRC} ${DST})
-endmacro()
+set(PYTHON_SRC __init__.py perf.py tcp.py utils.py libbcc.py table.py usdt.py)
 
-symlink_file(${CMAKE_CURRENT_SOURCE_DIR}/bcc ${CMAKE_CURRENT_BINARY_DIR}/bcc)
+foreach (PY_SRC ${PYTHON_SRC})
+  configure_file(bcc/${PY_SRC} ${CMAKE_CURRENT_BINARY_DIR}/bcc/${PY_SRC} COPYONLY)
+endforeach()
 
 if(NOT PYTHON_CMD)
   set(PYTHON_CMD "python")

--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -8,7 +8,7 @@ name=$1; shift
 kind=$1; shift
 cmd=$1; shift
 
-PYTHONPATH=@CMAKE_SOURCE_DIR@/src/python
+PYTHONPATH=@CMAKE_BINARY_DIR@/src/python
 LD_LIBRARY_PATH=@CMAKE_BINARY_DIR@:@CMAKE_BINARY_DIR@/src/cc
 
 ns=$name


### PR DESCRIPTION
Fix for https://github.com/iovisor/bcc/issues/1964, more details in commit message.
