### PR TITLE
use long key fingerprint to prevent collisions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,7 +57,7 @@ The stable and the nightly packages are built for Ubuntu Xenial (16.04), Ubuntu 
 **Stable and Signed Packages**
 
 ```bash
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D4284CDD
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4052245BD4284CDD
 echo "deb https://repo.iovisor.org/apt/xenial xenial main" | sudo tee /etc/apt/sources.list.d/iovisor.list
 sudo apt-get update
 sudo apt-get install bcc-tools libbcc-examples linux-headers-$(uname -r)


### PR DESCRIPTION
Using the short key fingerprint as documented imports two keys:

```text
Executing: /tmp/apt-key-gpghome.hCaMwcAFSC/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-keys D4284CDD
gpg: key 4052245BD4284CDD: public key "Brenden Blanco <bblanco@plumgrid.com>" imported
gpg: key 27E8E08BD4284CDD: public key "Totally Legit Signing Key <mallory@example.org>" imported
gpg: Total number processed: 2
gpg:               imported: 2
```

Although this particular key [may not be malicious](https://dev.gnupg.org/T4136), it scared the hell out of me. I guess the `bblanco@plumgrid.com` key is the right one?