### PR TITLE
kbuild_helper.h: Add required #include

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -15,7 +15,6 @@
  */
 #include <fcntl.h>
 #include <stdlib.h>
-#include <ftw.h>
 #include <iostream>
 #include "kbuild_helper.h"
 

--- a/src/cc/frontends/clang/kbuild_helper.h
+++ b/src/cc/frontends/clang/kbuild_helper.h
@@ -19,6 +19,7 @@
 #include <vector>
 #include <unistd.h>
 #include <errno.h>
+#include <ftw.h>
 
 namespace ebpf {
 


### PR DESCRIPTION
I'm trying to use KBuildHelper in another project by including kbuild_helper.h, but get some errors due to this include being missing. 

TmpDir (also defined in kbuild_helper.h) is using a few things from ftw.h, e.g. `::nftw`, `FTW_DEPTH`, which are causing the issues.