### PR TITLE
covscan: fix miscellaneaous errors

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -398,6 +398,7 @@ static int verify_checksum(const char *file, unsigned int crc) {
 static char *find_debug_via_debuglink(Elf *e, const char *binpath,
                                       int check_crc) {
   char fullpath[PATH_MAX];
+  char *tmppath;
   char *bindir = NULL;
   char *res = NULL;
   unsigned int crc;
@@ -406,8 +407,8 @@ static char *find_debug_via_debuglink(Elf *e, const char *binpath,
   if (!find_debuglink(e, &name, &crc))
     return NULL;
 
-  bindir = strdup(binpath);
-  bindir = dirname(bindir);
+  tmppath = strdup(binpath);
+  bindir = dirname(tmppath);
 
   // Search for the file in 'binpath', but ignore the file we find if it
   // matches the binary itself: the binary will always be probed later on,
@@ -434,7 +435,7 @@ static char *find_debug_via_debuglink(Elf *e, const char *binpath,
   }
 
 DONE:
-  free(bindir);
+  free(tmppath);
   if (res && check_crc && !verify_checksum(res, crc)) {
     free(res);
     return NULL;

--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -435,8 +435,10 @@ static char *find_debug_via_debuglink(Elf *e, const char *binpath,
 
 DONE:
   free(bindir);
-  if (res && check_crc && !verify_checksum(res, crc))
+  if (res && check_crc && !verify_checksum(res, crc)) {
+    free(res);
     return NULL;
+  }
   return res;
 }
 

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -92,14 +92,14 @@ int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
   if (!procmap)
     return -1;
 
-  char buf[PATH_MAX + 1], perm[5], dev[8];
+  char buf[PATH_MAX + 1], perm[5], dev[6];
   char *name;
   uint64_t begin, end, inode;
   unsigned long long offset;
   while (true) {
     buf[0] = '\0';
     // From fs/proc/task_mmu.c:show_map_vma
-    if (fscanf(procmap, "%lx-%lx %s %llx %s %lu%[^\n]", &begin, &end, perm,
+    if (fscanf(procmap, "%lx-%lx %4s %llx %5s %lu%[^\n]", &begin, &end, perm,
                &offset, dev, &inode, buf) != 7)
       break;
 

--- a/src/cc/frontends/b/type_check.cc
+++ b/src/cc/frontends/b/type_check.cc
@@ -204,6 +204,7 @@ StatusTuple TypeCheck::visit_binop_expr_node(BinopExprNode *n) {
     case Tok::TCGT:
     case Tok::TCGE:
       n->bit_width_ = 1;
+      break;
     default:
       n->bit_width_ = std::max(n->lhs_->bit_width_, n->rhs_->bit_width_);
   }

--- a/src/cc/frontends/p4/compiler/ebpfTable.py
+++ b/src/cc/frontends/p4/compiler/ebpfTable.py
@@ -110,7 +110,7 @@ class EbpfTableKey(object):
                 ebpfHeader = program.getInstance(instance.name)
                 assert isinstance(ebpfHeader, ebpfInstance.SimpleInstance)
                 basetype = ebpfHeader.type
-                eInstance = program.getInstance(instance.base_name)
+                eInstance = program.getInstance(instance.name)
 
             ebpfField = basetype.getField(fieldname)
             assert isinstance(ebpfField, ebpfStructType.EbpfField)

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -514,14 +514,16 @@ int bpf_prog_load(enum bpf_prog_type prog_type, const char *name,
     }
   }
 
-  if (strncmp(name, "kprobe__", 8) == 0)
-    name_offset = 8;
-  else if (strncmp(name, "tracepoint__", 12) == 0)
-    name_offset = 12;
-  else if (strncmp(name, "raw_tracepoint__", 16) == 0)
-    name_offset = 16;
-  memcpy(attr.prog_name, name + name_offset,
-         min(name_len - name_offset, BPF_OBJ_NAME_LEN - 1));
+  if (name_len) {
+    if (strncmp(name, "kprobe__", 8) == 0)
+      name_offset = 8;
+    else if (strncmp(name, "tracepoint__", 12) == 0)
+      name_offset = 12;
+    else if (strncmp(name, "raw_tracepoint__", 16) == 0)
+      name_offset = 16;
+    memcpy(attr.prog_name, name + name_offset,
+           min(name_len - name_offset, BPF_OBJ_NAME_LEN - 1));
+  }
 
   ret = syscall(__NR_bpf, BPF_PROG_LOAD, &attr, sizeof(attr));
   // BPF object name is not supported on older Kernels.

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -691,7 +691,7 @@ static int bpf_get_retprobe_bit(const char *event_type)
   close(fd);
   if (ret < 0 || ret >= sizeof(buf))
     return -1;
-  if (strlen(buf) < strlen("config:"))
+  if (strncmp(buf, "config:", strlen("config:")))
     return -1;
   errno = 0;
   ret = (int)strtol(buf + strlen("config:"), NULL, 10);


### PR DESCRIPTION
This fixes a few errors discovered by a coverity scan.