### PR TITLE
USDT: take into account the result of Probe::enable()

### DIFF
--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -311,10 +311,8 @@ bool Context::enable_probe(const std::string &probe_name,
     }
   }
 
-  if (found_probe != nullptr) {
-    found_probe->enable(fn_name);
-    return true;
-  }
+  if (found_probe != nullptr)
+    return found_probe->enable(fn_name);
 
   return false;
 }


### PR DESCRIPTION
Hi,

Currently Context::enable_probe() discards the result of Probe::enable() even if it fails. This is something that I've already mentioned in #1998 (it didn't show any warning when tried to read semaphore value from unreadable memory location). Today I hit another case when I tried to setup USDT context by passing only path to binary without specifying PID. Here is a tiny patch that fixes this.