### PR TITLE
fix bcc build failure with latest llvm/clang trunk

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -306,7 +306,7 @@ int ClangLoader::do_compile(unique_ptr<llvm::Module> *mod, TableStorage &ts,
   }
 
   // Initialize a compiler invocation object from the clang (-cc1) arguments.
-  const driver::ArgStringList &ccargs = cmd.getArguments();
+  const llvm::opt::ArgStringList &ccargs = cmd.getArguments();
 
   if (flags_ & DEBUG_PREPROCESSOR) {
     llvm::errs() << "clang";


### PR DESCRIPTION
The clang commit
  commit 247be3e41c41201641af01888ff0d84484c4e0f4
  Author: Simon Pilgrim <llvm-dev@redking.me.uk>
  Date:   Fri Oct 12 19:14:43 2018 +0000

    Fix a clang::driver::ArgStringList usage I missed in rL344398. NFCI.
removed
  using ArgStringList = llvm::opt::ArgStringList;
in clang:include/clang/Driver/Job.h,
and makes bcc compilation failure.

Using llvm::opt::ArgStringList fixed the issue and should
still work with previous llvm versions.

Signed-off-by: Yonghong Song <yhs@fb.com>