### PR TITLE
correct certain tracepoint types in tp frontend action

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -427,13 +427,13 @@ static struct bpf_sock *(*bpf_sk_lookup_udp)(void *ctx,
   (void *) BPF_FUNC_sk_lookup_udp;
 static int (*bpf_sk_release)(struct bpf_sock *sk) =
   (void *) BPF_FUNC_sk_release;
-static int bpf_map_push_elem(struct bpf_map *map, const void *value, u64 flags) =
+static int (*bpf_map_push_elem)(void *map, const void *value, u64 flags) =
   (void *) BPF_FUNC_map_push_elem;
-static int bpf_map_pop_elem(struct bpf_map *map, void *value) =
+static int (*bpf_map_pop_elem)(void *map, void *value) =
   (void *) BPF_FUNC_map_pop_elem;
-static int bpf_map_peek_elem(struct bpf_map *map, void *value) =
+static int (*bpf_map_peek_elem)(void *map, void *value) =
   (void *) BPF_FUNC_map_peek_elem;
-static int bpf_msg_push_data(struct sk_buff *skb, u32 start, u32 len, u64 flags) =
+static int (*bpf_msg_push_data)(void *skb, u32 start, u32 len, u64 flags) =
   (void *) BPF_FUNC_msg_push_data;
 
 /* llvm builtin functions that eBPF C program may use to

--- a/src/cc/frontends/clang/tp_frontend_action.cc
+++ b/src/cc/frontends/clang/tp_frontend_action.cc
@@ -121,11 +121,13 @@ static inline field_kind_t _get_field_kind(string const& line,
   } else if (size == 8) {
     if (field_type == "char" || field_type == "short" || field_type == "int" ||
         field_type == "int8_t" || field_type == "int16_t" ||
-        field_type == "int32_t")
+        field_type == "int32_t" || field_type == "pid_t")
       field_type = "s64";
     if (field_type == "unsigned char" || field_type == "unsigned short" ||
         field_type == "unsigned int" || field_type == "uint8_t" ||
-        field_type == "uint16_t" || field_type == "uint32_t")
+        field_type == "uint16_t" || field_type == "uint32_t" ||
+        field_type == "unsigned" || field_type == "u32" ||
+        field_type == "uid_t" || field_type == "gid_t")
       field_type = "u64";
   }
 


### PR DESCRIPTION
Fix issue #2010.

Alastair reported some missing cases in tp frontend action
where certain types are not adjusted.
For example, for tracepoint `syscalls:sys_enter_kill`,
the kernel format:
```
        ...
        field:int __syscall_nr; offset:8;       size:4; signed:1;
        field:pid_t pid;        offset:16;      size:8; signed:0;
        field:int sig;  offset:24;      size:8; signed:0;
```
The size for "pid_t pid" is 8 bytes, but the kernel pid_t
is "int", so it is needed to change its type to "s64"
to be consistent to its size.

This patch also added conversion for gid_t and uid_t as Alastair
discovered that they are also used in some tracepoints with size 8.
For type gid_t and uid_t, the corresponding kernel type is "unsigned int",
so it should be converted to "u64".

Signed-off-by: Yonghong Song <yhs@fb.com>