### PR TITLE
allow packed structure in bpf program in python API

### DIFF
--- a/src/cc/json_map_decl_visitor.cc
+++ b/src/cc/json_map_decl_visitor.cc
@@ -159,8 +159,12 @@ bool BMapDeclVisitor::VisitRecordDecl(RecordDecl *D) {
   result_ += "]";
   if (D->isUnion())
     result_ += ", \"union\"";
-  else if (D->isStruct())
-    result_ += ", \"struct\"";
+  else if (D->isStruct()) {
+    if (SkipPadding)
+      result_ += ", \"struct\"";
+    else
+      result_ += ", \"struct_packed\"";
+  }
   result_ += "]";
   return true;
 }

--- a/src/lua/bcc/table.lua
+++ b/src/lua/bcc/table.lua
@@ -349,8 +349,13 @@ local function _decode_table_type(desc)
       table.insert(fields, f)
     end
 
-    assert(struct == "struct" or struct == "union", "unknown complex type: "..struct)
-    return string.format("%s { %s }", struct, table.concat(fields, " "))
+    assert(struct == "struct" or struct == "struct_packed" or struct == "union",
+           "unknown complex type: "..struct)
+    if struct == "union" then
+      return string.format("union { %s }", table.concat(fields, " "))
+    else
+      return string.format("struct { %s }", table.concat(fields, " "))
+    end
   end
   return _dec(json.parse(json_desc))
 end


### PR DESCRIPTION
Fix issue #2017.

For python programs, the map data passed from C++ library
is parsed through the key/value desc types which are
generated by C++ json map declaration visitor.

The map declaration visitor visits the map key/value
declaration types and generate a string to represent
the type, which is later used by python to reconstruct
the cttype.

The map declaration already tries to add all the padding
to the type string in order to make sure C++ and python
see the same layout.

This patch further added packed support such that if
C++ json map visitor has applied padding, the python
type reconstructor is free to add _pack_=1 for structure
type since the structure is already packed.

For example, for a type,
```
  struct t { char a; int b; }
```
the structure after json visitor will look like
```
  struct t { char a; char __pad[3]; int b; }
```

If the type is
```
  struct t { char a; int b; } __packed;
```
the structure after json visitor will look like
```
  struct t { char a; int b; }
```

In either case, it will be okay to add __packed attribute
for the type generated by json map visitor in order to
match the original declaration.

Thanks Chaitanya for filing the issue and providing the test case!

Signed-off-by: Yonghong Song <yhs@fb.com>