### PR TITLE
Update bindings for custom offset kprobes

### DIFF
--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -211,9 +211,10 @@ function Bpf:attach_kprobe(args)
   local event = args.event or ""
   local ptype = args.retprobe and "r" or "p"
   local ev_name = string.format("%s_%s", ptype, event:gsub("[%+%.]", "_"))
+  local offset = args.fn_offset or 0
   local retprobe = args.retprobe and 1 or 0
 
-  local res = libbcc.bpf_attach_kprobe(fn.fd, retprobe, ev_name, event)
+  local res = libbcc.bpf_attach_kprobe(fn.fd, retprobe, ev_name, event, offset)
 
   assert(res >= 0, "failed to attach BPF to kprobe")
   self:probe_store("kprobe", ev_name, res)

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -43,7 +43,7 @@ typedef void (*perf_reader_raw_cb)(void *cb_cookie, void *raw, int raw_size);
 typedef void (*perf_reader_lost_cb)(void *cb_cookie, uint64_t lost);
 
 int bpf_attach_kprobe(int progfd, int attach_type, const char *ev_name,
-                      const char *fn_name);
+                      const char *fn_name, uint64_t fn_offset);
 
 int bpf_detach_kprobe(const char *ev_name);
 

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -88,7 +88,8 @@ lib.bpf_prog_load.argtypes = [ct.c_int, ct.c_char_p, ct.c_void_p,
 _RAW_CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_void_p, ct.c_int)
 _LOST_CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_ulonglong)
 lib.bpf_attach_kprobe.restype = ct.c_int
-lib.bpf_attach_kprobe.argtypes = [ct.c_int, ct.c_int, ct.c_char_p, ct.c_char_p]
+lib.bpf_attach_kprobe.argtypes = [ct.c_int, ct.c_int, ct.c_char_p, ct.c_char_p,
+        ct.c_ulonglong]
 lib.bpf_detach_kprobe.restype = ct.c_int
 lib.bpf_detach_kprobe.argtypes = [ct.c_char_p]
 lib.bpf_attach_uprobe.restype = ct.c_int


### PR DESCRIPTION
This updates the python and lua bindings for libbcc to be able to support attaching kprobes at custom offsets.

Update 03/11: Change title and description. Remove `uprobe` related changes.

~~This adds support for custom offset `uprobes`. The changes made previously for custom offset `kprobes` were also missing a few bits for the Python and Lua APIs. This also provides fixes for `powerpc64` to ensure `uprobe` events work as expected.~~
