### PR TITLE
Fix parsing of /proc/pid/maps

### DIFF
--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -92,14 +92,14 @@ int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
   if (!procmap)
     return -1;
 
-  char buf[PATH_MAX + 1], perm[5], dev[6];
+  char buf[PATH_MAX + 1], perm[5], dev[8];
   char *name;
   uint64_t begin, end, inode;
   unsigned long long offset;
   while (true) {
     buf[0] = '\0';
     // From fs/proc/task_mmu.c:show_map_vma
-    if (fscanf(procmap, "%lx-%lx %4s %llx %5s %lu%[^\n]", &begin, &end, perm,
+    if (fscanf(procmap, "%lx-%lx %4s %llx %7s %lu%[^\n]", &begin, &end, perm,
                &offset, dev, &inode, buf) != 7)
       break;
 


### PR DESCRIPTION
PR #2003 broke `/proc/pid/maps` parsing. Particularly I have the following mapping:

```
562bd52ee000-562bd5397000 r--p 00000000 103:03 49684469                  /home/zilder/pg10/bin/postgres
562bd5397000-562bd59cb000 r-xp 000a9000 103:03 49684469                  /home/zilder/pg10/bin/postgres
562bd59cb000-562bd5c58000 r--p 006dd000 103:03 49684469                  /home/zilder/pg10/bin/postgres
...
```

which can't be parsed by suggested format string as both major and minor device numbers can contain up to 3 characters.