### PR TITLE
Fix symbol resolution across mount namespaces (#2029)

### DIFF
--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -122,13 +122,13 @@ int ProcSyms::_add_load_sections(uint64_t v_addr, uint64_t mem_sz,
 }
 
 void ProcSyms::load_exe() {
+  ProcMountNSGuard g(mount_ns_instance_.get());
   std::string exe = ebpf::get_pid_exe(pid_);
   Module module(exe.c_str(), mount_ns_instance_.get(), &symbol_option_);
 
   if (module.type_ != ModuleType::EXEC)
     return;
 
-  ProcMountNSGuard g(mount_ns_instance_.get());
 
   bcc_elf_foreach_load_section(exe.c_str(), &_add_load_sections, &module);
 
@@ -163,6 +163,7 @@ int ProcSyms::_add_module(const char *modname, uint64_t start, uint64_t end,
     // It only gives the mmap offset. We need the real offset for symbol
     // lookup.
     if (module.type_ == ModuleType::SO) {
+      ProcMountNSGuard g(ps->mount_ns_instance_.get());
       if (bcc_elf_get_text_scn_info(modname, &module.elf_so_addr_,
                                     &module.elf_so_offset_) < 0) {
         fprintf(stderr, "WARNING: Couldn't find .text section in %s\n", modname);


### PR DESCRIPTION
 * Symbol lookup fails when the process is running on a different namespace. 
 * ProcSyms already has the capability to switch mount namespaces to resolve symbols. 
 * Identified bug where the BPF doesn't migrate to process mount namespace before opening the symbol files and fails to locate the file. 
* Patch makes sure that 'ProcMountNSGuard g(ps->mount_ns_instance_.get())' is created every single time a text section for the process is loaded. 
* Patch was tested by  1) creating docker container and running the process 2) running "bcc/tools/profile" script on the global PID namespace of the process 

Test - Performed a test by running bcc/tools/profile on a PID running in a container and found the resolution to be working fine. 
`#define  _GNU_SOURCE
#include <link.h>
#include <stdio.h>
#include <unistd.h>
#include <sys/auxv.h>
#include <string.h>

int len;
int baz()
{
   int i=0;
   char a[8192], b[8192];

label:
   for(i=0;i<10000;++i) {
     memcpy(a,b,len);
   }

   goto label;
}

int foo()
{
	baz();
}

int bar()
{
	foo();
}

int main(int argc, char **argv)
{
	printf("Start profiling\n");
         len=8192;
	bar();
	return 1;
}`


python profile -U -p 26966 1
Sampling at 49 Hertz of PID 26966 by user stack for 1 secs.
warning: JITed object file architecture unknown is not compatible with target architecture i386:x86-64.

    [unknown]
    foo
    bar
    main
    __libc_start_main
    -                sampleme (26966)
        1

    baz
    foo
    bar
    main
    __libc_start_main
    -                sampleme (26966)