### PR TITLE
Fix uprobes on powerpc64

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -184,10 +184,49 @@ int bcc_elf_foreach_usdt(const char *path, bcc_elf_probecb callback,
   return res;
 }
 
+static Elf_Scn * get_section(Elf *e, const char *section_name,
+                             GElf_Shdr *section_hdr, size_t *section_idx) {
+  Elf_Scn *section = NULL;
+  GElf_Shdr header;
+  char *name;
+
+  size_t stridx;
+  if (elf_getshdrstrndx(e, &stridx) != 0)
+    return NULL;
+
+  size_t index;
+  for (index = 1; (section = elf_nextscn(e, section)) != 0; index++) {
+    if (!gelf_getshdr(section, &header))
+      continue;
+
+    name = elf_strptr(e, stridx, header.sh_name);
+    if (name && !strcmp(name, section_name)) {
+      if (section_hdr)
+        *section_hdr = header;
+      if (section_idx)
+        *section_idx = index;
+      return section;
+    }
+  }
+
+  return NULL;
+}
+
 static int list_in_scn(Elf *e, Elf_Scn *section, size_t stridx, size_t symsize,
                        struct bcc_symbol_option *option,
                        bcc_elf_symcb callback, void *payload) {
   Elf_Data *data = NULL;
+
+#if defined(__powerpc64__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  size_t opdidx = 0;
+  Elf_Scn *opdsec = NULL;
+  GElf_Shdr opdshdr = {};
+  Elf_Data *opddata = NULL;
+
+  opdsec = get_section(e, ".opd", &opdshdr, &opdidx);
+  if (opdsec && opdshdr.sh_type == SHT_PROGBITS)
+    opddata = elf_getdata(opdsec, NULL);
+#endif
 
   while ((data = elf_getdata(section, data)) != 0) {
     size_t i, symcount = data->d_size / symsize;
@@ -213,6 +252,16 @@ static int list_in_scn(Elf *e, Elf_Scn *section, size_t stridx, size_t symsize,
       uint32_t st_type = ELF_ST_TYPE(sym.st_info);
       if (!(option->use_symbol_type & (1 << st_type)))
         continue;
+
+#if defined(__powerpc64__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+      if (opddata && sym.st_shndx == opdidx) {
+        size_t offset = sym.st_value - opdshdr.sh_addr;
+        /* Find the function descriptor */
+        uint64_t *descr = opddata->d_buf + offset;
+        /* Read the actual entry point address from the descriptor */
+        sym.st_value = *descr;
+      }
+#endif
 
       if (callback(name, sym.st_value, sym.st_size, payload) < 0)
         return 1;      // signal termination to caller
@@ -248,24 +297,9 @@ static int listsymbols(Elf *e, bcc_elf_symcb callback, void *payload,
 }
 
 static Elf_Data * get_section_elf_data(Elf *e, const char *section_name) {
-  Elf_Scn *section = NULL;
-  GElf_Shdr header;
-  char *name;
-
-  size_t stridx;
-  if (elf_getshdrstrndx(e, &stridx) != 0)
-    return NULL;
-
-  while ((section = elf_nextscn(e, section)) != 0) {
-    if (!gelf_getshdr(section, &header))
-      continue;
-
-    name = elf_strptr(e, stridx, header.sh_name);
-    if (name && !strcmp(name, section_name)) {
-      return elf_getdata(section, NULL);
-    }
-  }
-
+  Elf_Scn *section = get_section(e, section_name, NULL, NULL);
+  if (section)
+    return elf_getdata(section, NULL);
   return NULL;
 }
 

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -500,7 +500,11 @@ int bcc_resolve_symname(const char *module, const char *symname,
   static struct bcc_symbol_option default_option = {
     .use_debug_file = 1,
     .check_debug_file_crc = 1,
+#if defined(__powerpc64__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    .use_symbol_type = BCC_SYM_ALL_TYPES | (1 << STT_PPC64LE_SYM_LEP),
+#else
     .use_symbol_type = BCC_SYM_ALL_TYPES,
+#endif
   };
 
   if (module == NULL)

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -34,6 +34,13 @@ typedef int (*SYM_CB)(const char *symname, uint64_t addr);
 #ifndef STT_GNU_IFUNC
 #define STT_GNU_IFUNC 10
 #endif
+
+#if defined(__powerpc64__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+// Indicate if the Local Entry Point (LEP) should be used as a symbol's
+// start address
+#define STT_PPC64LE_SYM_LEP 31
+#endif
+
 static const uint32_t BCC_SYM_ALL_TYPES = 65535;
 struct bcc_symbol_option {
   int use_debug_file;


### PR DESCRIPTION
This makes sure that the correct entry point addresses are used when attaching `uprobes` to functions on `powerpc64` (both big and little endian).