### PR TITLE
Fix the lua standalone test

### DIFF
--- a/tests/lua/test_standalone.sh
+++ b/tests/lua/test_standalone.sh
@@ -15,7 +15,8 @@ if [[ ! -x bcc-lua ]]; then
     exit 0
 fi
 
-if ldd bcc-lua | grep -q luajit; then
+LIBRARY=$(ldd bcc-lua | grep luajit)
+if [ $? -ne 0 -o -z "$LIBRARY" ] ; then
     fail "bcc-lua depends on libluajit"
 fi
 


### PR DESCRIPTION
This fixes the subtest that checks if `bcc-lua` depends on `libluajit`.