### PR TITLE
fix verifier errors in http_filter example

### DIFF
--- a/examples/networking/http_filter/http-parse-complete.c
+++ b/examples/networking/http_filter/http-parse-complete.c
@@ -99,11 +99,8 @@ int http_filter(struct __sk_buff *skb) {
 	//direct access to skb not allowed
 	unsigned long p[7];
 	int i = 0;
-	int j = 0;
-	const int last_index = payload_offset + 7;
-	for (i = payload_offset ; i < last_index ; i++) {
-		p[j] = load_byte(skb , i);
-		j++;
+	for (i = 0; i < 7; i++) {
+		p[i] = load_byte(skb , payload_offset + i);
 	}
 
 	//find a match with an HTTP message

--- a/examples/networking/http_filter/http-parse-simple.c
+++ b/examples/networking/http_filter/http-parse-simple.c
@@ -70,11 +70,8 @@ int http_filter(struct __sk_buff *skb) {
 	//direct access to skb not allowed
 	unsigned long p[7];
 	int i = 0;
-	int j = 0;
-	const int last_index = payload_offset + 7;
-	for (i = payload_offset ; i < last_index ; i++) {
-		p[j] = load_byte(skb , i);
-		j++;
+	for (i = 0; i < 7; i++) {
+		p[i] = load_byte(skb , payload_offset + i);
 	}
 
 	//find a match with an HTTP message


### PR DESCRIPTION
Fix issue #2035.

For code like
```
    int i;
    int j = 0;
    const int last_index = payload_offset + 7;
    for (i = payload_offset ; i < last_index ; i++) {
               p[j] = load_byte(skb , i);
```
Here, the payload_offset is unknown. llvm 7.0 and trunk
compiler seems generating code like
```
   p[0] = load_byte(skb, payload_offset)
   if (payload_offset + 1 < last_index) {
      p[1] = ...
      ...
      p[6] = ...
   } else {
      /* do nothing */
   }
   /* accessing p[0], p[1], ..., p[6] */
```
The compiler did the above transformation because the potential
overflow for `last_index` and/or `payload_offset + 1` in which case
compiler preserved both branches.

This caused a problem for verifier as in the else branch
p[1] is not assigned and the verifier will reject the program.

Changing the loop to simply iterate from 0 to 6 fixed the problem.

Signed-off-by: Yonghong Song <yhs@fb.com>