### PR TITLE
Fix funcslower stack traces when using arguments

### DIFF
--- a/tools/funcslower.py
+++ b/tools/funcslower.py
@@ -94,15 +94,15 @@ struct data_t {
     u64 duration_ns;
     u64 retval;
     char comm[TASK_COMM_LEN];
+#ifdef GRAB_ARGS
+    u64 args[6];
+#endif
 #ifdef USER_STACKS
     int user_stack_id;
 #endif
 #ifdef KERNEL_STACKS
     int kernel_stack_id;
     u64 kernel_ip;
-#endif
-#ifdef GRAB_ARGS
-    u64 args[6];
 #endif
 };
 


### PR DESCRIPTION
This reorders the `struct data_t` members so that the definition is consistent across the c code and the corresponding python `ct.Structure`.

Upon running the script with the arguments option, the user and kernel stack ids read from the stack maps are incorrect as they are read off the wrong structure offsets. When a stack walk is attempted on an incorrect stack id, we end up with a `KeyError`.

This has been verified as shown below.
```sh
  $ sudo ./funcslower.py c:inet_pton -u1 -a1 -UK
  $ ping -6 ::1
```
Before:
```
  Tracing function calls slower than 1 us... Ctrl+C to quit.
  COMM           PID    LAT(us)             RVAL FUNC ARGS
  ping           33541    47.93                1 c:inet_pton 0xfffffff2000001a0
  Traceback (most recent call last):
    File "_ctypes/callbacks.c", line 315, in 'calling callback function'
    File "/usr/lib/python2.7/site-packages/bcc/table.py", line 573, in raw_cb_
      callback(cpu, data, size)
    File "./funcslower.py", line 337, in print_event
      print_stack(event)
    File "./funcslower.py", line 301, in print_stack
      user_stack = stack_traces.walk(event.user_stack_id)
    File "/usr/lib/python2.7/site-packages/bcc/table.py", line 768, in walk
      return StackTrace.StackWalker(self[self.Key(stack_id)], resolve)
    File "/usr/lib/python2.7/site-packages/bcc/table.py", line 212, in __getitem__
      raise KeyError
  KeyError
```
After:
```
  Tracing function calls slower than 1 us... Ctrl+C to quit.
  COMM           PID    LAT(us)             RVAL FUNC ARGS
  ping           34672    48.20                1 c:inet_pton 0xa
      gaih_inet.constprop.7
      [unknown]
      getaddrinfo
      [unknown]
      generic_start_main.isra.0
      __libc_start_main
```
Fixes: 925bac8 ("Adding user and kernel stack frames option to funcslower")