### PR TITLE
capable: add user and kernel stack trace options

### DIFF
--- a/man/man8/capable.8
+++ b/man/man8/capable.8
@@ -2,7 +2,7 @@
 .SH NAME
 capable \- Trace security capability checks (cap_capable()).
 .SH SYNOPSIS
-.B capable [\-h] [\-v] [\-p PID]
+.B capable [\-h] [\-v] [\-p PID] [\-K]
 .SH DESCRIPTION
 This traces security capability checks in the kernel, and prints details for
 each call. This can be useful for general debugging, and also security
@@ -19,6 +19,9 @@ USAGE message.
 Include non-audit capability checks. These are those deemed not interesting and
 not necessary to audit, such as CAP_SYS_ADMIN checks on memory allocation to
 affect the behavior of overcommit.
+.TP
+\-K
+Include kernel stack traces to the output.
 .SH EXAMPLES
 .TP
 Trace all capability checks system-wide:

--- a/man/man8/capable.8
+++ b/man/man8/capable.8
@@ -2,7 +2,7 @@
 .SH NAME
 capable \- Trace security capability checks (cap_capable()).
 .SH SYNOPSIS
-.B capable [\-h] [\-v] [\-p PID] [\-K]
+.B capable [\-h] [\-v] [\-p PID] [\-K] [\-U]
 .SH DESCRIPTION
 This traces security capability checks in the kernel, and prints details for
 each call. This can be useful for general debugging, and also security
@@ -22,6 +22,9 @@ affect the behavior of overcommit.
 .TP
 \-K
 Include kernel stack traces to the output.
+.TP
+\-U
+Include user-space stack traces to the output.
 .SH EXAMPLES
 .TP
 Trace all capability checks system-wide:

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -12,6 +12,7 @@
 # 13-Sep-2016   Brendan Gregg   Created this.
 
 from __future__ import print_function
+from os import getpid
 from functools import partial
 from bcc import BPF
 import argparse
@@ -123,6 +124,7 @@ int kprobe__cap_capable(struct pt_regs *ctx, const struct cred *cred,
     u32 pid = __pid_tgid;
     FILTER1
     FILTER2
+    FILTER3
 
     u32 uid = bpf_get_current_uid_gid();
     struct data_t data = {.pid_tgid = __pid_tgid, .tgid = tgid, .pid = pid, .uid = uid, .cap = cap, .audit = audit};
@@ -149,6 +151,8 @@ if args.user_stack:
     bpf_text = "#define USER_STACKS\n" + bpf_text
 bpf_text = bpf_text.replace('FILTER1', '')
 bpf_text = bpf_text.replace('FILTER2', '')
+bpf_text = bpf_text.replace('FILTER3',
+    'if (pid == %s) { return 0; }' % getpid())
 if debug:
     print(bpf_text)
 

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -117,7 +117,7 @@ int kprobe__cap_capable(struct pt_regs *ctx, const struct cred *cred,
     u32 uid = bpf_get_current_uid_gid();
     struct data_t data = {.tgid = __tgid, .pid = __pid, .uid = uid, .cap = cap, .audit = audit};
 #ifdef KERNEL_STACKS
-    data.kernel_stack_id = stacks.get_stackid(ctx, BPF_F_REUSE_STACKID);
+    data.kernel_stack_id = stacks.get_stackid(ctx, 0);
 #endif
     bpf_get_current_comm(&data.comm, sizeof(data.comm));
     events.perf_submit(ctx, &data, sizeof(data));

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -153,8 +153,8 @@ class Data(ct.Structure):
     ] + ([("kernel_stack_id", ct.c_int)] if args.kernel_stack else [])
 
 # header
-print("%-9s %-6s %-6s %-16s %-4s %-20s %s" % (
-    "TIME", "UID", "PID", "COMM", "CAP", "NAME", "AUDIT"))
+print("%-9s %-6s %-6s %-6s %-16s %-4s %-20s %s" % (
+    "TIME", "UID", "PID", "TID", "COMM", "CAP", "NAME", "AUDIT"))
 
 def print_stack(bpf, stack_id, tgid):
     if stack_id < 0:
@@ -173,8 +173,8 @@ def print_event(bpf, cpu, data, size):
         name = capabilities[event.cap]
     else:
         name = "?"
-    print("%-9s %-6d %-6d %-16s %-4d %-20s %d" % (strftime("%H:%M:%S"),
-        event.uid, event.pid, event.comm.decode('utf-8', 'replace'),
+    print("%-9s %-6d %-6d %-6d %-16s %-4d %-20s %d" % (strftime("%H:%M:%S"),
+        event.uid, event.pid, event.tgid, event.comm.decode('utf-8', 'replace'),
         event.cap, name, event.audit))
     if args.kernel_stack:
         print_stack(bpf, event.kernel_stack_id, -1)

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -92,7 +92,6 @@ bpf_text = """
 #include <linux/sched.h>
 
 struct data_t {
-   u64 pid_tgid;
    u32 tgid;
    u32 pid;
    u32 uid;
@@ -104,9 +103,6 @@ struct data_t {
 #endif
 #ifdef USER_STACKS
    int user_stack_id;
-#endif
-#if ((defined(KERNEL_STACKS) && defined(USER_STACKS)) || (!defined(KERNEL_STACKS) && !defined(USER_STACKS)))
-   int __pad;
 #endif
 };
 
@@ -127,7 +123,7 @@ int kprobe__cap_capable(struct pt_regs *ctx, const struct cred *cred,
     FILTER3
 
     u32 uid = bpf_get_current_uid_gid();
-    struct data_t data = {.pid_tgid = __pid_tgid, .tgid = tgid, .pid = pid, .uid = uid, .cap = cap, .audit = audit};
+    struct data_t data = {.tgid = tgid, .pid = pid, .uid = uid, .cap = cap, .audit = audit};
 #ifdef KERNEL_STACKS
     data.kernel_stack_id = stacks.get_stackid(ctx, 0);
 #endif
@@ -163,7 +159,6 @@ TASK_COMM_LEN = 16    # linux/sched.h
 
 class Data(ct.Structure):
     _fields_ = [
-        ("pid_tgid", ct.c_uint64),
         ("tgid", ct.c_uint32),
         ("pid", ct.c_uint32),
         ("uid", ct.c_uint32),

--- a/tools/capable_example.txt
+++ b/tools/capable_example.txt
@@ -63,6 +63,9 @@ TIME      UID    PID    COMM             CAP  NAME                 AUDIT
         do_syscall_64+0x56 [kernel]
         entry_SYSCALL_64_after_hwframe+0x49 [kernel]
 
+Similarly, it is possible to include user-space stack with -U (or they can be
+used both at the same time to include user and kernel stack).
+
 Sometimes capable catches itself starting up:
 
 # ./capable.py 
@@ -82,17 +85,20 @@ These are capability checks from BPF and perf_events syscalls.
 USAGE:
 
 # ./capable.py -h
-usage: capable.py [-h] [-v] [-p PID] [-K]
+usage: capable.py [-h] [-v] [-p PID] [-K] [-U]
 
 Trace security capability checks
 
 optional arguments:
-  -h, --help         show this help message and exit
-  -v, --verbose      include non-audit checks
-  -p PID, --pid PID  trace this PID only
+  -h, --help          show this help message and exit
+  -v, --verbose       include non-audit checks
+  -p PID, --pid PID   trace this PID only
+  -K, --kernel-stack  output kernel stack trace
+  -U, --user-stack    output user stack trace
 
 examples:
     ./capable             # trace capability checks
     ./capable -v          # verbose: include non-audit checks
     ./capable -p 181      # only trace PID 181
     ./capable -K          # add kernel stacks to trace
+    ./capable -U          # add user-space stacks to trace

--- a/tools/capable_example.txt
+++ b/tools/capable_example.txt
@@ -66,22 +66,6 @@ TIME      UID    PID    COMM             CAP  NAME                 AUDIT
 Similarly, it is possible to include user-space stack with -U (or they can be
 used both at the same time to include user and kernel stack).
 
-Sometimes capable catches itself starting up:
-
-# ./capable.py 
-TIME      UID    PID    COMM             CAP  NAME                 AUDIT
-22:22:19  0      21949  capable.py       21   CAP_SYS_ADMIN        1
-22:22:19  0      21949  capable.py       21   CAP_SYS_ADMIN        1
-22:22:19  0      21949  capable.py       21   CAP_SYS_ADMIN        1
-22:22:19  0      21949  capable.py       21   CAP_SYS_ADMIN        1
-22:22:19  0      21949  capable.py       21   CAP_SYS_ADMIN        1
-22:22:19  0      21949  capable.py       21   CAP_SYS_ADMIN        1
-22:22:19  0      21952  run              24   CAP_SYS_RESOURCE     1
-[...]
-
-These are capability checks from BPF and perf_events syscalls.
-
-
 USAGE:
 
 # ./capable.py -h

--- a/tools/capable_example.txt
+++ b/tools/capable_example.txt
@@ -44,6 +44,24 @@ checking CAP_FOWNER, CAP_FSETID, etc.
 To see what each of these capabilities does, check the capabilities(7) man
 page and the kernel source.
 
+It is possible to include a kernel stack trace to the capable events by passing
+-K to the command:
+
+# ./capable.py -K
+TIME      UID    PID    COMM             CAP  NAME                 AUDIT
+15:32:21  1000   10708  fetchmail        7    CAP_SETUID           1
+        cap_capable+0x1 [kernel]
+        ns_capable_common+0x7a [kernel]
+        __sys_setresuid+0xc8 [kernel]
+        do_syscall_64+0x56 [kernel]
+        entry_SYSCALL_64_after_hwframe+0x49 [kernel]
+15:32:21  1000   30047  procmail         6    CAP_SETGID           1
+        cap_capable+0x1 [kernel]
+        ns_capable_common+0x7a [kernel]
+        may_setgroups+0x2f [kernel]
+        __x64_sys_setgroups+0x18 [kernel]
+        do_syscall_64+0x56 [kernel]
+        entry_SYSCALL_64_after_hwframe+0x49 [kernel]
 
 Sometimes capable catches itself starting up:
 
@@ -64,7 +82,7 @@ These are capability checks from BPF and perf_events syscalls.
 USAGE:
 
 # ./capable.py -h
-usage: capable.py [-h] [-v] [-p PID]
+usage: capable.py [-h] [-v] [-p PID] [-K]
 
 Trace security capability checks
 
@@ -77,3 +95,4 @@ examples:
     ./capable             # trace capability checks
     ./capable -v          # verbose: include non-audit checks
     ./capable -p 181      # only trace PID 181
+    ./capable -K          # add kernel stacks to trace


### PR DESCRIPTION
In addition, also prevent capable from reporting itself in the trace.

Signed-off-by: Andrea Righi <righi.andrea@gmail.com>