### PR TITLE
Fix some compiler warning

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -15,7 +15,8 @@ add_definitions(${LLVM_DEFINITIONS})
 configure_file(libbcc.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libbcc.pc @ONLY)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -DBCC_PROG_TAG_DIR='\"${BCC_PROG_TAG_DIR}\"'")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -Wno-unused-result")
 
 string(REGEX MATCH "^([0-9]+).*" _ ${LLVM_PACKAGE_VERSION})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLLVM_MAJOR_VERSION=${CMAKE_MATCH_1}")

--- a/src/cc/common.cc
+++ b/src/cc/common.cc
@@ -57,7 +57,7 @@ std::string get_pid_exe(pid_t pid) {
   res = readlink(exe_link.c_str(), exe_path, sizeof(exe_path));
   if (res == -1)
     return "";
-  if (res >= sizeof(exe_path))
+  if (res >= static_cast<int>(sizeof(exe_path)))
     res = sizeof(exe_path) - 1;
   exe_path[res] = '\0';
   return std::string(exe_path);

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -9,6 +9,9 @@ target_link_libraries(test_static bcc-static)
 
 add_test(NAME c_test_static COMMAND ${TEST_WRAPPER} c_test_static sudo ${CMAKE_CURRENT_BINARY_DIR}/test_static)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-result")
+
 if(ENABLE_USDT)
 add_executable(test_libbcc
 	test_libbcc.cc


### PR DESCRIPTION
Fixed some compiler warnings of unused return value and type comparison with llvm-7.0.0.
It's fixed by adding -Wno-unused-result in corresponding CMakeLists.txt and static cast for type comparison.

```
/home/lecopzer/workspace/bcc/src/cc/libbpf.c:456:3: warning: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Wunused-result]
   fgets(fmt, sizeof(fmt), f); // pos
   ^~~~~~~~~~~~~~~~~~~~~~~~~~
...
/home/lecopzer/workspace/bcc/src/cc/common.cc:60:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (res >= sizeof(exe_path))
       ~~~~^~~~~~~~~~
...
```

See the comment of the commits in detail.