### PR TITLE
offwaketime: properly format "[Missed User Stack]" with folded output

### DIFF
--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -342,7 +342,7 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
         if not args.kernel_stacks_only:
             line.extend(["-"] if (need_delimiter and k.w_u_stack_id > 0 and k.w_k_stack_id > 0) else [])
             if stack_id_err(k.w_u_stack_id):
-                line.extend("[Missed User Stack]")
+                line.append("[Missed User Stack]")
             else:
                 line.extend([b.sym(addr, k.w_tgid)
                     for addr in reversed(list(waker_user_stack))])


### PR DESCRIPTION
In folded output format when both kernel and user stacks are missing,
the message "[Missing User Stack]" is formatted incorrectly, for example:

chrome;entry_SYSCALL_64_after_hwframe;do_syscall_64;SyS_poll;do_sys_poll;poll_schedule_timeout;schedule_hrtimeout_range;schedule_hrtimeout_range_clock;schedule;--;[Missed Kernel Stack];[;M;i;s;s;e;d; ;U;s;e;r; ;S;t;a;c;k;];fio 4955989

This is because we're incorrectly appending the missing stack message in
the list of stack entries. Fix by appending the message as a single item.

Signed-off-by: Andrea Righi <righi.andrea@gmail.com>