### PR TITLE
set proper layout for the module before finalizing the object

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -618,6 +618,11 @@ int BPFModule::finalize() {
       *sections_p;
 
   mod->setTargetTriple("bpf-pc-linux");
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  mod->setDataLayout("e-m:e-p:64:64-i64:64-n32:64-S128");
+#else
+  mod->setDataLayout("E-m:e-p:64:64-i64:64-n32:64-S128");
+#endif
   sections_p = rw_engine_enabled_ ? &sections_ : &tmp_sections;
 
   string err;


### PR DESCRIPTION
Otherwise, if llvm is built with assertion on,
we will hit the following error for a simple trace.py script like
```
  -bash-4.4$ sudo ./trace.py 'SyS_nanosleep'
  python: /home/yhs/work/llvm/lib/ExecutionEngine/MCJIT/MCJIT.cpp:204:
          virtual void llvm::MCJIT::generateCodeForModule(llvm::Module*):
          Assertion `M->getDataLayout() == getDataLayout() && "DataLayout Mismatch"'
          failed.
  Aborted (core dumped)
  -bash-4.4$
```
Signed-off-by: Yonghong Song <yhs@fb.com>