### PR TITLE
fix compilation error with latest llvm/clang

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -1080,6 +1080,26 @@ DiagnosticBuilder BTypeVisitor::warning(SourceLocation loc, const char (&fmt)[N]
   return C.getDiagnostics().Report(loc, diag_id);
 }
 
+int64_t BTypeVisitor::getFieldValue(VarDecl *Decl, FieldDecl *FDecl, int64_t OrigFValue) {
+  unsigned idx = FDecl->getFieldIndex();
+
+  if (auto I = dyn_cast_or_null<InitListExpr>(Decl->getInit())) {
+#if LLVM_MAJOR_VERSION >= 8
+    Expr::EvalResult res;
+    if (I->getInit(idx)->EvaluateAsInt(res, C)) {
+      return res.Val.getInt().getExtValue();
+    }
+#else
+    llvm::APSInt res;
+    if (I->getInit(idx)->EvaluateAsInt(res, C)) {
+      return res.getExtValue();
+    }
+#endif
+  }
+
+  return OrigFValue;
+}
+
 // Open table FDs when bpf tables (as denoted by section("maps*") attribute)
 // are declared.
 bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
@@ -1124,21 +1144,9 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
         table.leaf_size = sz;
         leaf_type = F->getType();
       } else if (F->getName() == "max_entries") {
-        unsigned idx = F->getFieldIndex();
-        if (auto I = dyn_cast_or_null<InitListExpr>(Decl->getInit())) {
-          llvm::APSInt res;
-          if (I->getInit(idx)->EvaluateAsInt(res, C)) {
-            table.max_entries = res.getExtValue();
-          }
-        }
+            table.max_entries = getFieldValue(Decl, F, table.max_entries);
       } else if (F->getName() == "flags") {
-        unsigned idx = F->getFieldIndex();
-        if (auto I = dyn_cast_or_null<InitListExpr>(Decl->getInit())) {
-          llvm::APSInt res;
-          if (I->getInit(idx)->EvaluateAsInt(res, C)) {
-            table.flags = res.getExtValue();
-          }
-        }
+            table.flags = getFieldValue(Decl, F, table.flags);
       }
       ++i;
     }

--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -75,6 +75,8 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   void genParamIndirectAssign(clang::FunctionDecl *D, std::string& preamble,
                               const char **calling_conv_regs);
   void rewriteFuncParam(clang::FunctionDecl *D);
+  int64_t getFieldValue(clang::VarDecl *Decl, clang::FieldDecl *FDecl,
+                        int64_t OrigFValue);
   template <unsigned N>
   clang::DiagnosticBuilder error(clang::SourceLocation loc, const char (&fmt)[N]);
   template <unsigned N>


### PR DESCRIPTION
With latest llvm/clang, we have the following compilation errors:
```
    /home/yhs/work/bcc2/src/cc/frontends/clang/b_frontend_action.cc:
      In member function ‘bool ebpf::BTypeVisitor::VisitVarDecl(clang::VarDecl*)’:
    /home/yhs/work/bcc2/src/cc/frontends/clang/b_frontend_action.cc:1130:52:
      error: no matching function for call to ‘clang::Expr::EvaluateAsInt(llvm::APSInt&, clang::ASTContext&)’
               if (I->getInit(idx)->EvaluateAsInt(res, C)) {
                                                    ^
    /home/yhs/work/bcc2/src/cc/frontends/clang/b_frontend_action.cc:1130:52: note: candidate is:
    In file included from /home/yhs/work/llvm/build/install/include/clang/AST/Attr.h:19:0,
                 from /home/yhs/work/llvm/build/install/include/clang/AST/TypeLoc.h:18,
                 from /home/yhs/work/llvm/build/install/include/clang/AST/ASTTypeTraits.h:24,
                 from /home/yhs/work/llvm/build/install/include/clang/AST/ASTContext.h:18,
                 from /home/yhs/work/bcc2/src/cc/frontends/clang/b_frontend_action.cc:23:
    /home/yhs/work/llvm/build/install/include/clang/AST/Expr.h:604:8:
      note: bool clang::Expr::EvaluateAsInt(clang::Expr::EvalResult&, const clang::ASTContext&,
              clang::Expr::SideEffectsKind) const
       bool EvaluateAsInt(EvalResult &Result, const ASTContext &Ctx,
        ^
```
The error is introduced by the following commit:
https://reviews.llvm.org/rL348053

Basically, the clang FieldDecl method EvaluateAsInt signature got
changed and there is no compatible way in the llvm/clang
to also work in the old versions. So this patch just provided
a new implementation to get field value for llvm version 8 and later.

Signed-off-by: Yonghong Song <yhs@fb.com>