### PR TITLE
Revert "Remove duplicate code from xdp_drop_count.py (#2049)"

### DIFF
--- a/examples/networking/xdp/xdp_drop_count.py
+++ b/examples/networking/xdp/xdp_drop_count.py
@@ -103,7 +103,16 @@ int xdp_prog1(struct CTXTYPE *ctx) {
         nh_off += sizeof(struct vlan_hdr);
         if (data + nh_off > data_end)
             return rc;
-        h_proto = vhdr->h_vlan_encapsulated_proto;
+            h_proto = vhdr->h_vlan_encapsulated_proto;
+    }
+    if (h_proto == htons(ETH_P_8021Q) || h_proto == htons(ETH_P_8021AD)) {
+        struct vlan_hdr *vhdr;
+
+        vhdr = data + nh_off;
+        nh_off += sizeof(struct vlan_hdr);
+        if (data + nh_off > data_end)
+            return rc;
+            h_proto = vhdr->h_vlan_encapsulated_proto;
     }
 
     if (h_proto == htons(ETH_P_IP))


### PR DESCRIPTION
This reverts commit 5b76047f528b56072b541c406103f07589d6efe2.

The code is actually not duplicated. It is used to process
double vlan's. See comments in:
  https://github.com/iovisor/bcc/pull/1493