### PR TITLE
tools: prepare block tools for the removing of legacy I/O path

### DIFF
--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -116,7 +116,8 @@ b = BPF(text=bpf_text)
 if args.queued:
     b.attach_kprobe(event="blk_account_io_start", fn_name="trace_req_start")
 else:
-    b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
+    if BPF.get_kprobe_functions(b'blk_start_request'):
+        b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
     b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_account_io_completion",
     fn_name="trace_req_completion")

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -122,7 +122,8 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
 }
 """, debug=0)
 b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
-b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
+if BPF.get_kprobe_functions(b'blk_start_request'):
+    b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_account_io_completion",
     fn_name="trace_req_completion")

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -173,7 +173,8 @@ if args.ebpf:
 
 b = BPF(text=bpf_text)
 b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
-b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
+if BPF.get_kprobe_functions(b'blk_start_request'):
+    b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_account_io_completion",
     fn_name="trace_req_completion")


### PR DESCRIPTION
Recent -next kernels don't have blk_start_request() function
anymore. It has been removed in a recent cleanup. bio* tools should be
able to handle the lack of this probe.