### PR TITLE
Add option to build with rtti

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ include(GNUInstallDirs)
 include(CheckCXXCompilerFlag)
 include(cmake/FindCompilerFlag.cmake)
 
+option(ENABLE_RTTI "Enable compiling with real time type information" OFF)
 option(ENABLE_LLVM_SHARED "Enable linking LLVM as a shared library" OFF)
 option(ENABLE_CLANG_JIT "Enable Loading BPF through Clang Frontend" ON)
 option(ENABLE_USDT "Enable User-level Statically Defined Tracing" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+
+if (ENABLE_RTTI)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frtti")
+else()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Enables linking bcc-static in binaries compiled with rtti