### PR TITLE
Remove dependency on LLVM native target

### DIFF
--- a/cmake/clang_libs.cmake
+++ b/cmake/clang_libs.cmake
@@ -1,8 +1,8 @@
 if(ENABLE_LLVM_SHARED)
 set(llvm_libs "LLVM")
 else()
-set(llvm_raw_libs bitwriter bpfcodegen debuginfodwarf irreader linker
-  mcjit objcarcopts option passes nativecodegen lto)
+set(llvm_raw_libs bitwriter bpfcodegen executionengine debuginfodwarf irreader linker
+  interpreter mcjit objcarcopts option passes lto)
 list(FIND LLVM_AVAILABLE_LIBS "LLVMCoverage" _llvm_coverage)
 if (${_llvm_coverage} GREATER -1)
   list(APPEND llvm_raw_libs coverage)

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -108,8 +108,6 @@ BPFModule::BPFModule(unsigned flags, TableStorage *ts, bool rw_engine_enabled,
       id_(std::to_string((uintptr_t)this)),
       maps_ns_(maps_ns),
       ts_(ts) {
-  InitializeNativeTarget();
-  InitializeNativeTargetAsmPrinter();
   LLVMInitializeBPFTarget();
   LLVMInitializeBPFTargetMC();
   LLVMInitializeBPFTargetInfo();


### PR DESCRIPTION
Not needed for BCC to work. It somehow brought in the interpreter and
executionengine which is needed. Those features are added instead.