### PR TITLE
manpage: remove non-existent -p option from the biotop manpage

### DIFF
--- a/man/man8/biotop.8
+++ b/man/man8/biotop.8
@@ -30,9 +30,6 @@ Don't clear the screen.
 \-r MAXROWS
 Maximum number of rows to print. Default is 20.
 .TP
-\-p PID
-Trace this PID only.
-.TP
 interval
 Interval between updates, seconds.
 .TP


### PR DESCRIPTION
The biotop manpage references a -p option that the tools doesn't have,
and AFAICT, never had. It's only referenced in the manpage option, not
in the synopsis, in "biotop -h" output not biotop_example.txt.