### PR TITLE
add arm64 kprobe function name prefix in kernel 4.19

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -172,6 +172,7 @@ class BPF(object):
         b"__x64_sys_",
         b"__x32_compat_sys_",
         b"__ia32_compat_sys_",
+        b"__arm64_sys_",
     ]
 
     # BPF timestamps come from the monotonic clock. To be able to filter


### PR DESCRIPTION
	modified:   __init__.py