### PR TITLE
Tools: properly handle the keyboard interrupt

### DIFF
--- a/tools/bashreadline.py
+++ b/tools/bashreadline.py
@@ -61,4 +61,7 @@ def print_event(cpu, data, size):
 
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -187,4 +187,7 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/btrfsslower.py
+++ b/tools/btrfsslower.py
@@ -352,4 +352,7 @@ else:
 # read events
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -216,4 +216,7 @@ def print_event(bpf, cpu, data, size):
 callback = partial(print_event, b)
 b["events"].open_perf_buffer(callback)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/criticalstat.py
+++ b/tools/criticalstat.py
@@ -328,4 +328,7 @@ print("Finding critical section with {} disabled for > {}us".format(
     ('preempt' if preemptoff else 'IRQ'), args.duration))
 
 while 1:
-    b.perf_buffer_poll();
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -230,4 +230,7 @@ print("%-14s %-6s %8s %s" % ("TIME(s)", "PID", "MS", "QUERY"))
 
 bpf["events"].open_perf_buffer(print_event, page_cnt=64)
 while True:
-    bpf.perf_buffer_poll()
+    try:
+        bpf.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/dcsnoop.py
+++ b/tools/dcsnoop.py
@@ -162,4 +162,7 @@ print("%-11s %-6s %-16s %1s %s" % ("TIME(s)", "PID", "COMM", "T", "FILE"))
 
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -246,4 +246,7 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -356,4 +356,7 @@ else:
 # read events
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/filelife.py
+++ b/tools/filelife.py
@@ -141,4 +141,7 @@ def print_event(cpu, data, size):
 
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/fileslower.py
+++ b/tools/fileslower.py
@@ -250,4 +250,7 @@ def print_event(cpu, data, size):
 
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/funcslower.py
+++ b/tools/funcslower.py
@@ -330,4 +330,7 @@ def print_event(cpu, data, size):
 
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while True:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/gethostlatency.py
+++ b/tools/gethostlatency.py
@@ -135,4 +135,7 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/inject.py
+++ b/tools/inject.py
@@ -507,7 +507,10 @@ struct pid_struct {
 
     def _main_loop(self):
         while True:
-            self.bpf.perf_buffer_poll()
+            try:
+                self.bpf.perf_buffer_poll()
+            except KeyboardInterrupt:
+                exit()
 
     def run(self):
         self._create_probes()

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -145,4 +145,7 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/lib/uflow.py
+++ b/tools/lib/uflow.py
@@ -206,4 +206,7 @@ def print_event(cpu, data, size):
 
 bpf["calls"].open_perf_buffer(print_event)
 while 1:
-    bpf.perf_buffer_poll()
+    try:
+        bpf.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/lib/ugc.py
+++ b/tools/lib/ugc.py
@@ -244,4 +244,7 @@ def print_event(cpu, data, size):
 
 bpf["gcs"].open_perf_buffer(print_event)
 while 1:
-    bpf.perf_buffer_poll()
+    try:
+        bpf.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/lib/uthreads.py
+++ b/tools/lib/uthreads.py
@@ -128,4 +128,7 @@ def print_event(cpu, data, size):
 
 bpf["threads"].open_perf_buffer(print_event)
 while 1:
-    bpf.perf_buffer_poll()
+    try:
+        bpf.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/mdflush.py
+++ b/tools/mdflush.py
@@ -78,4 +78,7 @@ def print_event(cpu, data, size):
 # read events
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -414,7 +414,11 @@ def main():
     print('{:16} {:<7} {:<7} {:<11} {}'.format(
         'COMM', 'PID', 'TID', 'MNT_NS', 'CALL'))
     while True:
-        b.perf_buffer_poll()
+        try:
+            b.perf_buffer_poll()
+        except KeyboardInterrupt:
+            exit()
+
 
 
 if __name__ == '__main__':

--- a/tools/mysqld_qslower.py
+++ b/tools/mysqld_qslower.py
@@ -130,4 +130,7 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/nfsslower.py
+++ b/tools/nfsslower.py
@@ -325,4 +325,7 @@ else:
 
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
+    try:
         b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/oomkill.py
+++ b/tools/oomkill.py
@@ -77,4 +77,7 @@ b = BPF(text=bpf_text)
 print("Tracing OOM kills... Ctrl-C to stop.")
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -191,4 +191,7 @@ def print_event(cpu, data, size):
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 start_time = datetime.now()
 while not args.duration or datetime.now() - start_time < args.duration:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -254,4 +254,7 @@ print("%-8s %-16s %-6s %14s" % ("TIME", "COMM", "PID", "LAT(us)"))
 # read events
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/solisten.py
+++ b/tools/solisten.py
@@ -210,4 +210,7 @@ if __name__ == "__main__":
 
     # Read events
     while 1:
-        b.perf_buffer_poll()
+        try:
+            b.perf_buffer_poll()
+        except KeyboardInterrupt:
+            exit()

--- a/tools/sslsniff.py
+++ b/tools/sslsniff.py
@@ -228,4 +228,7 @@ def print_event(cpu, data, size, rw):
 b["perf_SSL_write"].open_perf_buffer(print_event_write)
 b["perf_SSL_read"].open_perf_buffer(print_event_read)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/statsnoop.py
+++ b/tools/statsnoop.py
@@ -179,4 +179,7 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/syncsnoop.py
+++ b/tools/syncsnoop.py
@@ -50,4 +50,7 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -270,4 +270,7 @@ start_ts = 0
 b["ipv4_events"].open_perf_buffer(print_ipv4_event)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -237,4 +237,7 @@ start_ts = 0
 b["ipv4_events"].open_perf_buffer(print_ipv4_event)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/tcpconnlat.py
+++ b/tools/tcpconnlat.py
@@ -264,4 +264,7 @@ print("%-6s %-12s %-2s %-16s %-16s %-5s %s" % ("PID", "COMM", "IP", "SADDR",
 b["ipv4_events"].open_perf_buffer(print_ipv4_event)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -221,4 +221,7 @@ print("%-8s %-6s %-2s %-20s > %-20s %s (%s)" % ("TIME", "PID", "IP",
 b["ipv4_events"].open_perf_buffer(print_ipv4_event)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -506,4 +506,7 @@ start_ts = 0
 b["ipv4_events"].open_perf_buffer(print_ipv4_event, page_cnt=64)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/tcpretrans.py
+++ b/tools/tcpretrans.py
@@ -303,4 +303,7 @@ else:
     b["ipv4_events"].open_perf_buffer(print_ipv4_event)
     b["ipv6_events"].open_perf_buffer(print_ipv6_event)
     while 1:
-        b.perf_buffer_poll()
+        try:
+            b.perf_buffer_poll()
+        except KeyboardInterrupt:
+            exit()

--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -386,4 +386,7 @@ start_ts = 0
 b["ipv4_events"].open_perf_buffer(print_ipv4_event, page_cnt=64)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -662,4 +662,7 @@ def inet_ntoa(addr):
 b["tcp_ipv4_event"].open_perf_buffer(print_ipv4_event)
 b["tcp_ipv6_event"].open_perf_buffer(print_ipv6_event)
 while True:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/ttysnoop.py
+++ b/tools/ttysnoop.py
@@ -121,4 +121,7 @@ def print_event(cpu, data, size):
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/xfsslower.py
+++ b/tools/xfsslower.py
@@ -303,4 +303,7 @@ else:
 # read events
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/zfsslower.py
+++ b/tools/zfsslower.py
@@ -315,4 +315,7 @@ else:
 # read events
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:
-    b.perf_buffer_poll()
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()


### PR DESCRIPTION
Many tools rely on the user to type Ctrl-C to end, but don't actually
catch the keyboard interrupt and thus show an ugly backtrace when it
happens. Let's catch the interrupt.