### PR TITLE
dbslower: fix a python3 bytes/string issue int the -x option

### DIFF
--- a/man/man8/dbslower.8
+++ b/man/man8/dbslower.8
@@ -2,7 +2,7 @@
 .SH NAME
 dbslower \- Trace MySQL/PostgreSQL server queries slower than a threshold.
 .SH SYNOPSIS
-.B dbslower [-v] [-p PID [PID ...]] [-m THRESHOLD] {mysql,postgres}
+.B dbslower [-v] [-p PID [PID ...]] [-x PATH] [-m THRESHOLD] {mysql,postgres}
 .SH DESCRIPTION
 This traces queries served by a MySQL or PostgreSQL server, and prints
 those that exceed a latency (query time) threshold. By default a threshold of
@@ -11,6 +11,8 @@ those that exceed a latency (query time) threshold. By default a threshold of
 This uses User Statically-Defined Tracing (USDT) probes, a feature added to
 MySQL and PostgreSQL for DTrace support, but which may not be enabled on a
 given installation. See requirements.
+Alternativly, MySQL queries can be traced without the USDT support using the
+-x option.
 
 Since this uses BPF, only the root user can use this tool.
 .SH REQUIREMENTS
@@ -24,6 +26,10 @@ Print usage message.
 \-p PID
 Trace this PID. If no PID is specified, the tool will attempt to automatically
 detect the MySQL or PostgreSQL processes running on the system.
+.TP
+\-x PATH
+Path to MySQL binary. This option allow to MySQL queries even when USDT probes
+aren't enabled on the MySQL server.
 .TP
 \-m THRESHOLD
 Minimum query latency (duration) to trace, in milliseconds. Default is 1 ms.

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -69,7 +69,7 @@ if args.path and not args.pids:
 
         (mysql_func_name, addr) = symbols[0]
 
-        if mysql_func_name.find("COM_DATA") >= 0:
+        if mysql_func_name.find(b'COM_DATA') >= 0:
             mode = "MYSQL57"
         else:
             mode = "MYSQL56"

--- a/tools/dbslower_example.txt
+++ b/tools/dbslower_example.txt
@@ -67,7 +67,7 @@ before the actual queries start coming in.
 
 USAGE:
 # dbslower -h
-usage: dbslower.py [-h] [-v] [-p [PIDS [PIDS ...]]] [-m THRESHOLD]
+usage: dbslower.py [-h] [-v] [-p [PIDS [PIDS ...]]] [-x PATH] [-m THRESHOLD]
                    {mysql,postgres}
 
 positional arguments:
@@ -78,6 +78,7 @@ optional arguments:
   -v, --verbose         print the BPF program
   -p [PID [PID ...]], --pid [PID [PID ...]]
                         the pid(s) to trace
+  -x PATH, --exe PATH   path to binary
   -m THRESHOLD, --threshold THRESHOLD
                         trace queries slower than this threshold (ms)
 
@@ -86,3 +87,4 @@ examples:
     dbslower postgres -p 188 322 # trace specific PostgreSQL processes
     dbslower mysql -p 480 -m 30  # trace MySQL queries slower than 30ms
     dbslower mysql -p 480 -v     # trace MySQL queries and print the BPF program
+    dbslower mysql -x $(which mysqld)  # trace MySQL queries with uprobes


### PR DESCRIPTION
In python3, the find method requires a bytes-like object. It fixes the
following error:

$ dbslower mysql -x $(which mysqld)
Traceback (most recent call last):
  File "/usr/share/bcc/tools/dbslower", line 72, in <module>
    if mysql_func_name.find("COM_DATA") >= 0:
TypeError: a bytes-like object is required, not 'str'

Also the -x option is currently undocumented in the man page and the
example file. So let's ix that too.