### PR TITLE
opensnoop: print flags, enable filtering

### DIFF
--- a/man/man8/opensnoop.8
+++ b/man/man8/opensnoop.8
@@ -41,6 +41,12 @@ Total duration of trace in seconds.
 .TP
 \-n name
 Only print processes where its name partially matches 'name'
+.TP
+\-e
+Show extended fields.
+.TP
+\-f FLAG
+Filter on open() flags, e.g., O_WRONLY.
 .SH EXAMPLES
 .TP
 Trace all open() syscalls:
@@ -66,6 +72,14 @@ Trace PID 181 only:
 Trace all open() syscalls from processes where its name partially matches 'ed':
 #
 .B opensnoop \-n ed
+.TP
+Show extended fields:
+#
+.B opensnoop \-e
+.TP
+Only print calls for writing:
+#
+.B opensnoop \-f O_WRONLY \-f O_RDWR
 .SH FIELDS
 .TP
 TIME(s)

--- a/man/man8/opensnoop.8
+++ b/man/man8/opensnoop.8
@@ -100,6 +100,9 @@ File descriptor (if success), or -1 (if failed)
 ERR
 Error number (see the system's errno.h)
 .TP
+FLAGS
+Flags passed to open(2), in octal
+.TP
 PATH
 Open path
 .SH OVERHEAD

--- a/tools/opensnoop_example.txt
+++ b/tools/opensnoop_example.txt
@@ -135,7 +135,7 @@ to the '-n' option.
 The -e option prints out extra columns; for example, the following output
 contains the flags passed to open(2), in octal:
 
-# ./opensnoop.py -e
+# ./opensnoop -e
 PID    COMM               FD ERR FLAGS    PATH
 28512  sshd               10   0 00101101 /proc/self/oom_score_adj
 28512  sshd                3   0 02100000 /etc/ld.so.cache
@@ -150,7 +150,7 @@ PID    COMM               FD ERR FLAGS    PATH
 
 The -f option filters based on flags to the open(2) call, for example:
 
-$ sudo ./opensnoop.py -e -f O_WRONLY -f O_RDWR
+# ./opensnoop -e -f O_WRONLY -f O_RDWR
 PID    COMM               FD ERR FLAGS    PATH
 28084  clear_console       3   0 00100002 /dev/tty
 28084  clear_console      -1  13 00100002 /dev/tty0
@@ -164,8 +164,8 @@ PID    COMM               FD ERR FLAGS    PATH
 USAGE message:
 
 # ./opensnoop -h
-usage: opensnoop.py [-h] [-T] [-x] [-p PID] [-t TID] [-d DURATION] [-n NAME]
-                    [-e] [-f FLAG_FILTER]
+usage: opensnoop [-h] [-T] [-x] [-p PID] [-t TID] [-d DURATION] [-n NAME]
+                 [-e] [-f FLAG_FILTER]
 
 Trace open() syscalls
 

--- a/tools/opensnoop_example.txt
+++ b/tools/opensnoop_example.txt
@@ -132,10 +132,40 @@ This caught the 'sed' command because it partially matches 'ed' that's passed
 to the '-n' option.
 
 
+The -e option prints out extra columns; for example, the following output
+contains the flags passed to open(2), in octal:
+
+# ./opensnoop.py -e
+PID    COMM               FD ERR FLAGS    PATH
+28512  sshd               10   0 00101101 /proc/self/oom_score_adj
+28512  sshd                3   0 02100000 /etc/ld.so.cache
+28512  sshd                3   0 02100000 /lib/x86_64-linux-gnu/libwrap.so.0
+28512  sshd                3   0 02100000 /lib/x86_64-linux-gnu/libaudit.so.1
+28512  sshd                3   0 02100000 /lib/x86_64-linux-gnu/libpam.so.0
+28512  sshd                3   0 02100000 /lib/x86_64-linux-gnu/libselinux.so.1
+28512  sshd                3   0 02100000 /lib/x86_64-linux-gnu/libsystemd.so.0
+28512  sshd                3   0 02100000 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.2
+28512  sshd                3   0 02100000 /lib/x86_64-linux-gnu/libutil.so.1
+
+
+The -f option filters based on flags to the open(2) call, for example:
+
+$ sudo ./opensnoop.py -e -f O_WRONLY -f O_RDWR
+PID    COMM               FD ERR FLAGS    PATH
+28084  clear_console       3   0 00100002 /dev/tty
+28084  clear_console      -1  13 00100002 /dev/tty0
+28084  clear_console      -1  13 00100001 /dev/tty0
+28084  clear_console      -1  13 00100002 /dev/console
+28084  clear_console      -1  13 00100001 /dev/console
+28051  sshd                8   0 02100002 /var/run/utmp
+28051  sshd                7   0 00100001 /var/log/wtmp
+
+
 USAGE message:
 
 # ./opensnoop -h
-usage: opensnoop [-h] [-T] [-x] [-p PID] [-t TID] [-d DURATION] [-n NAME]
+usage: opensnoop.py [-h] [-T] [-x] [-p PID] [-t TID] [-d DURATION] [-n NAME]
+                    [-e] [-f FLAG_FILTER]
 
 Trace open() syscalls
 
@@ -148,6 +178,10 @@ optional arguments:
   -d DURATION, --duration DURATION
                         total duration of trace in seconds
   -n NAME, --name NAME  only print process names containing this name
+  -e, --extended_fields
+                        show extended fields
+  -f FLAG_FILTER, --flag_filter FLAG_FILTER
+                        filter on flags argument (e.g., O_WRONLY)
 
 examples:
     ./opensnoop           # trace all open() syscalls
@@ -157,3 +191,5 @@ examples:
     ./opensnoop -t 123    # only trace TID 123
     ./opensnoop -d 10     # trace for 10 seconds only
     ./opensnoop -n main   # only print process names containing "main"
+    ./opensnoop -e        # show extended fields
+    ./opensnoop -f O_WRONLY -f O_RDWR  # only print calls for writing


### PR DESCRIPTION
This PR adds printing of the `flags` argument to `open(2)` and allows for filtering, e.g., to only print out files for writing.

```
$ sudo ./opensnoop.py -f O_WRONLY -f O_RDWR
PID    COMM               FD ERR FLAGS    PATH
15286  postgres            3   0 00101101 /var/run/postgresql/9.6-main.pg_stat_tmp/global.tmp
15286  postgres            6   0 00101101 /var/run/postgresql/9.6-main.pg_stat_tmp/db_0.tmp
23562  postgres           11   0 00100001 /proc/self/oom_score_adj
23562  postgres            3   0 00100002 base/16385/2601
...
```

Thanks!