### PR TITLE
implement free_bcc_memory() API

### DIFF
--- a/examples/cpp/RandomRead.cc
+++ b/examples/cpp/RandomRead.cc
@@ -117,6 +117,12 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  // done with all initial work, free bcc memory
+  if (bpf->free_bcc_memory()) {
+    std::cerr << "Failed to free llvm/clang memory" << std::endl;
+    return 1;
+  }
+
   signal(SIGINT, signal_handler);
   std::cout << "Started tracing, hit Ctrl-C to terminate." << std::endl;
   while (true)

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -45,7 +45,7 @@ set(bcc_util_sources ns_guard.cc common.cc)
 set(bcc_sym_sources bcc_syms.cc bcc_elf.c bcc_perf_map.c bcc_proc.c)
 set(bcc_common_headers libbpf.h perf_reader.h)
 set(bcc_table_headers file_desc.h table_desc.h table_storage.h)
-set(bcc_api_headers bpf_common.h bpf_module.h bcc_exception.h bcc_syms.h)
+set(bcc_api_headers bpf_common.h bpf_module.h bcc_exception.h bcc_syms.h bcc_elf.h)
 
 if(ENABLE_CLANG_JIT)
 add_library(bcc-shared SHARED

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "bcc_exception.h"
+#include "bcc_elf.h"
 #include "bcc_syms.h"
 #include "bpf_module.h"
 #include "common.h"
@@ -705,6 +706,10 @@ StatusTuple BPF::detach_perf_event_all_cpu(open_probe_t& attr) {
   if (has_error)
     return StatusTuple(-1, err_msg);
   return StatusTuple(0);
+}
+
+int BPF::free_bcc_memory() {
+  return bcc_free_memory();
 }
 
 USDT::USDT(const std::string& binary_path, const std::string& provider,

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -176,6 +176,8 @@ class BPF {
                         int& fd);
   StatusTuple unload_func(const std::string& func_name);
 
+  int free_bcc_memory();
+
  private:
   std::string get_kprobe_event(const std::string& kernel_func,
                                bpf_probe_attach_type type);

--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -68,6 +68,7 @@ int bcc_elf_get_type(const char *path);
 int bcc_elf_is_shared_obj(const char *path);
 int bcc_elf_is_exe(const char *path);
 int bcc_elf_is_vdso(const char *name);
+int bcc_free_memory();
 
 #ifdef __cplusplus
 }

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1259,6 +1259,9 @@ class BPF(object):
         """
         self.perf_buffer_poll(timeout)
 
+    def free_bcc_memory(self):
+        return lib.bcc_free_memory()
+
     def donothing(self):
         """the do nothing exit handler"""
 

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -177,6 +177,9 @@ lib.bcc_symcache_resolve_name.argtypes = [
 lib.bcc_symcache_refresh.restype = None
 lib.bcc_symcache_refresh.argtypes = [ct.c_void_p]
 
+lib.bcc_free_memory.restype = ct.c_int
+lib.bcc_free_memory.argtypes = None
+
 lib.bcc_usdt_new_frompid.restype = ct.c_void_p
 lib.bcc_usdt_new_frompid.argtypes = [ct.c_int, ct.c_char_p]
 

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -77,3 +77,5 @@ add_test(NAME py_test_usdt3 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_test_usdt3 sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_usdt3.py)
 add_test(NAME py_test_license WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_test_license sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_license.py)
+add_test(NAME py_test_free_bcc_memory WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_test_free_bcc_memory sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_free_bcc_memory.py)

--- a/tests/python/test_free_bcc_memory.py
+++ b/tests/python/test_free_bcc_memory.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#
+# USAGE: test_usdt.py
+#
+# Copyright 2018 Facebook, Inc
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+from __future__ import print_function
+from bcc import BPF
+from unittest import main, skipUnless, TestCase
+from subprocess import Popen, PIPE
+import distutils.version
+import os
+
+def kernel_version_ge(major, minor):
+    # True if running kernel is >= X.Y
+    version = distutils.version.LooseVersion(os.uname()[2]).version
+    if version[0] > major:
+        return True
+    if version[0] < major:
+        return False
+    if minor and version[1] < minor:
+        return False
+    return True
+
+class TestFreeLLVMMemory(TestCase):
+    def getRssFile(self):
+        p = Popen(["cat", "/proc/" + str(os.getpid()) + "/status"],
+                  stdout=PIPE)
+        rss = None
+        unit = None
+        for line in p.stdout.readlines():
+            if (line.find(b'RssFile') >= 0):
+                rss  = line.split(b' ')[-2]
+                unit = line.split(b' ')[-1].rstrip()
+                break
+
+        return [rss, unit]
+
+    @skipUnless(kernel_version_ge(4,5), "requires kernel >= 4.5")
+    def testFreeLLVMMemory(self):
+        text = "int test() { return 0; }"
+        b = BPF(text=text)
+
+        # get the RssFile before freeing bcc memory
+        [rss1, unit1] = self.getRssFile()
+        self.assertTrue(rss1 != None)
+
+        # free the bcc memory
+        self.assertTrue(b.free_bcc_memory() == 0)
+
+        # get the RssFile after freeing bcc memory
+        [rss2, unit2] = self.getRssFile()
+        self.assertTrue(rss2 != None)
+
+        self.assertTrue(unit1 == unit2)
+
+        print("Before freeing llvm memory: RssFile: ", rss1, unit1)
+        print("After  freeing llvm memory: RssFile: ", rss2, unit2)
+        self.assertTrue(rss1 > rss2)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The main purpose of this API is to proactively release llvm/clang
.text memory which is brought in during compilation.
bcc .text memory for some other functions, e.g., attach_tracepoint,
bpf_prog_load, etc. can also be freed after all these tasks are done.

Note that such memory is reclaimable in kernel since it has
file backup. But certain applicaiton may want to reduce this
memory immediately to satisfy constraints imposed by sysadmin, etc.

The implementation uses madvise with MADV_DONTNEED.
For the case where bcc is static linked into the binary,
we do not really know the start and the end of memory regions
used by bcc, so the implementation here bluntly returned
all .text memory back to kernel. This will incur some performance
overhead as later on executed instructions will need to bring
back to memory again.

For static linked library, instrumented RandomRead example,
without this patch, the RSS memory before load is:
```
  VmRSS:     63644 kB
  RssAnon:           23876 kB
  RssFile:           39768 kB
  RssShmem:              0 kB
```
After this patch,
```
  VmRSS:     34264 kB
  RssAnon:           23880 kB
  RssFile:           10384 kB
  RssShmem:              0 kB
```
For shared library, a python unit test, test_free_llvm_memory.py, is
added, which shows for a do-nothing bpf program, we have
```
  Before freeing llvm memory: RssFile:  43000 kB
  After  freeing llvm memory: RssFile:  11992 kB
```
The RssFile reduction on Facebook internal applications
also ranges in 30-40MB.

Signed-off-by: Yonghong Song <yhs@fb.com>