### PR TITLE
better error meessage for error "unknown opcode"

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -344,6 +344,14 @@ static void bpf_print_hints(int ret, char *log)
       "you'll need to be explicit.\n\n");
   }
 
+  // referencing global/static variables or read only data
+  if (strstr(log, "unknown opcode") != NULL) {
+    fprintf(stderr, "HINT: The 'unknown opcode' can happen if you reference"
+      "a global or static variable, or data in read only section. For example,"
+      "'char *p = \"hello\"' will result in p referencing a read only section,"
+      " and 'char p[] = \"hello\"' will have \"hello\" stored on the stack.\n\n");
+  }
+
   // helper function not found in kernel
   char *helper_str = strstr(log, "invalid func ");
   if (helper_str != NULL) {


### PR DESCRIPTION
fix issue #226

The unknown opcode typically happens if the bpf
program has an external reference which does not
get resolved. Note bcc does not even preform
relocations for maps as map_id is directly
used in bpf problem through bpf_pseudo_fd()
intrinsic.

Instead of the error:
  bpf: Failed to load program: Invalid argument
  unknown opcode 00

A little explanation is added like the below:
  HINT: The 'unknown opcode' can happen if you referencea global
  or static variable, or data in read only section.
  For example,'char *p = "hello"' will result in p referencing a
  read only section,and 'char p[] = "hello"' will have "hello"
  stored on the stack.

Signed-off-by: Yonghong Song <yhs@fb.com>