### PR TITLE
ustat: added basic race condition protection

### DIFF
--- a/tools/lib/ustat.py
+++ b/tools/lib/ustat.py
@@ -20,8 +20,9 @@
 
 from __future__ import print_function
 import argparse
-from bcc import BPF, USDT
+from bcc import BPF, USDT, USDTException
 import os
+import sys
 from subprocess import call
 from time import sleep, strftime
 
@@ -62,7 +63,12 @@ class Probe(object):
     def _enable_probes(self):
         self.usdts = []
         for pid in self.targets:
-            usdt = USDT(pid=pid)
+            try:
+                usdt = USDT(pid=pid)
+            except USDTException:
+                # avoid race condition on pid going away.
+                print("failed to instrument %d" % pid, file=sys.stderr)
+                continue
             for event in self.events:
                 try:
                     usdt.enable_probe(event, "%s_%s" % (self.language, event))
@@ -111,6 +117,9 @@ int %s_%s(void *ctx) {
         for event, category in self.events.items():
             counts = bpf["%s_%s_counts" % (self.language, event)]
             for pid, count in counts.items():
+                if pid.value not in result:
+                    print("result was not found for %d" % pid.value, file=sys.stderr)
+                    continue
                 result[pid.value][category] = count.value
             counts.clear()
         return result


### PR DESCRIPTION
In #2102 build there were 4 test failures on Fedora.

3 of them were due to the following traceback:
```
27: Traceback (most recent call last):
27:   File "../../tools/lib/ustat.py", line 294, in <module>
27:     Tool().run()
27:   File "../../tools/lib/ustat.py", line 286, in run
27:     self._loop_iter()
27:   File "../../tools/lib/ustat.py", line 255, in _loop_iter
27:     counts.update(probe.get_counts(self.bpf))
27:   File "../../tools/lib/ustat.py", line 114, in get_counts
27:     result[pid.value][category] = count.value
27: KeyError: 20335L
```

Seems like there is a possible inconsistency between `self.targets` and `bpf[*_counts]`:
https://github.com/iovisor/bcc/blob/dccc4f28b7404b2f77f8ad8c7ad1ea741db589f2/tools/lib/ustat.py#L107-L116

Workaround it by skipping PIDs that are not in `result` dict.

Also while here, fix a race condition on the `USDT` instrumentation init and PID going away, which happens on the boxes with high process churn.