### PR TITLE
Comment on duplicate code for parsing double vlans

### DIFF
--- a/examples/networking/xdp/xdp_drop_count.py
+++ b/examples/networking/xdp/xdp_drop_count.py
@@ -96,23 +96,18 @@ int xdp_prog1(struct CTXTYPE *ctx) {
 
     h_proto = eth->h_proto;
 
-    if (h_proto == htons(ETH_P_8021Q) || h_proto == htons(ETH_P_8021AD)) {
-        struct vlan_hdr *vhdr;
+    // parse double vlans
+    #pragma unroll
+    for (int i=0; i<2; i++) {
+        if (h_proto == htons(ETH_P_8021Q) || h_proto == htons(ETH_P_8021AD)) {
+            struct vlan_hdr *vhdr;
 
-        vhdr = data + nh_off;
-        nh_off += sizeof(struct vlan_hdr);
-        if (data + nh_off > data_end)
-            return rc;
-            h_proto = vhdr->h_vlan_encapsulated_proto;
-    }
-    if (h_proto == htons(ETH_P_8021Q) || h_proto == htons(ETH_P_8021AD)) {
-        struct vlan_hdr *vhdr;
-
-        vhdr = data + nh_off;
-        nh_off += sizeof(struct vlan_hdr);
-        if (data + nh_off > data_end)
-            return rc;
-            h_proto = vhdr->h_vlan_encapsulated_proto;
+            vhdr = data + nh_off;
+            nh_off += sizeof(struct vlan_hdr);
+            if (data + nh_off > data_end)
+                return rc;
+                h_proto = vhdr->h_vlan_encapsulated_proto;
+        }
     }
 
     if (h_proto == htons(ETH_P_IP))


### PR DESCRIPTION
I also changed it into a short loop, which I don't think improves (or degrades) the code, but at least makes it clear that the double parsing is intentional.

See #1493 and #2049.