### PR TITLE
Add stdout flushing to some tools

### DIFF
--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -15,7 +15,7 @@
 # 28-Dec-2018   Tim Douglas     Print flags argument, enable filtering
 
 from __future__ import print_function
-from bcc import ArgString, BPF
+from bcc import ArgString, BPF, printb
 import argparse
 import ctypes as ct
 from datetime import datetime, timedelta
@@ -222,7 +222,7 @@ def print_event(cpu, data, size):
     if args.extended_fields:
         print("%08o " % event.flags, end="")
 
-    print(event.fname.decode('utf-8', 'replace'))
+    printb(b'%s' % event.fname.decode('utf-8', 'replace'))
 
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event, page_cnt=64)

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -15,7 +15,8 @@
 # 28-Dec-2018   Tim Douglas     Print flags argument, enable filtering
 
 from __future__ import print_function
-from bcc import ArgString, BPF, printb
+from bcc import ArgString, BPF
+from bcc.utils import printb
 import argparse
 import ctypes as ct
 from datetime import datetime, timedelta

--- a/tools/solisten.py
+++ b/tools/solisten.py
@@ -23,6 +23,7 @@ from struct import pack
 import argparse
 from bcc import BPF
 import ctypes as ct
+from bcc.utils import printb
 
 # Arguments
 examples = """Examples:
@@ -165,12 +166,12 @@ def event_printer(show_netns):
 
         # Display
         if show_netns:
-            print("%-6d %-12.12s %-12s %-6s %-8s %-5s %-39s" % (
+            printb(b"%-6d %-12.12s %-12s %-6s %-8s %-5s %-39s" % (
                 pid, event.task, event.netns, protocol, event.backlog,
                 event.lport, address,
             ))
         else:
-            print("%-6d %-12.12s %-6s %-8s %-5s %-39s" % (
+            printb(b"%-6d %-12.12s %-6s %-8s %-5s %-39s" % (
                 pid, event.task, protocol, event.backlog,
                 event.lport, address,
             ))

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -21,6 +21,7 @@ from socket import inet_ntop, AF_INET, AF_INET6
 from struct import pack
 import argparse
 import ctypes as ct
+from bcc.utils import printb
 
 # arguments
 examples = """examples:
@@ -238,7 +239,7 @@ def print_ipv4_event(cpu, data, size):
         if start_ts == 0:
             start_ts = event.ts_us
         print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
-    print("%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
+    printb(b"%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
         event.task.decode('utf-8', 'replace'), event.ip,
         inet_ntop(AF_INET, pack("I", event.daddr)),
         inet_ntop(AF_INET, pack("I", event.saddr)), event.lport))
@@ -250,7 +251,7 @@ def print_ipv6_event(cpu, data, size):
         if start_ts == 0:
             start_ts = event.ts_us
         print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
-    print("%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
+    printb(b"%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
         event.task.decode('utf-8', 'replace'), event.ip,
         inet_ntop(AF_INET6, event.daddr),inet_ntop(AF_INET6, event.saddr),
         event.lport))

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -19,6 +19,7 @@
 
 from __future__ import print_function
 from bcc import BPF
+from bcc.utils import printb
 import argparse
 from socket import inet_ntop, ntohs, AF_INET, AF_INET6
 from struct import pack
@@ -201,7 +202,7 @@ def print_ipv4_event(cpu, data, size):
         if start_ts == 0:
             start_ts = event.ts_us
         print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
-    print("%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
+    printb(b"%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
         event.task.decode('utf-8', 'replace'), event.ip,
         inet_ntop(AF_INET, pack("I", event.saddr)),
         inet_ntop(AF_INET, pack("I", event.daddr)), event.dport))
@@ -213,7 +214,7 @@ def print_ipv6_event(cpu, data, size):
         if start_ts == 0:
             start_ts = event.ts_us
         print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
-    print("%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
+    printb(b"%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
         event.task.decode('utf-8', 'replace'), event.ip,
         inet_ntop(AF_INET6, event.saddr), inet_ntop(AF_INET6, event.daddr),
         event.dport))


### PR DESCRIPTION
I use next tools in one of my projects:
- opensnoop
- solisten
- tcpaccept
- tcpconnect
But i dont get output without flushing output.
Saw in execsnoop tool that bcc.utils.printb is used for flushing. Replaced standart python print function with this one.