### PR TITLE
opensnoop: supported UID options

### DIFF
--- a/man/man8/opensnoop.8
+++ b/man/man8/opensnoop.8
@@ -27,6 +27,9 @@ Print usage message.
 \-T
 Include a timestamp column.
 .TP
+\-U
+Show UID.
+.TP
 \-x
 Only print failed opens.
 .TP
@@ -35,6 +38,9 @@ Trace this process ID only (filtered in-kernel).
 .TP
 \-t TID
 Trace this thread ID only (filtered in-kernel).
+.TP
+\-u UID
+Trace this UID only (filtered in-kernel).
 .TP
 \-d DURATION
 Total duration of trace in seconds.
@@ -61,6 +67,10 @@ Trace all open() syscalls, and include timestamps:
 #
 .B opensnoop \-T
 .TP
+Show UID:
+#
+.B opensnoop \-U
+.TP
 Trace only open() syscalls that failed:
 #
 .B opensnoop \-x
@@ -68,6 +78,10 @@ Trace only open() syscalls that failed:
 Trace PID 181 only:
 #
 .B opensnoop \-p 181
+.TP
+Trace UID 1000 only:
+#
+.B opensnoop \-u 1000
 .TP
 Trace all open() syscalls from processes where its name partially matches 'ed':
 #
@@ -84,6 +98,9 @@ Only print calls for writing:
 .TP
 TIME(s)
 Time of the call, in seconds.
+.TP
+UID
+User ID
 .TP
 PID
 Process ID

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -13,6 +13,7 @@
 # 29-Apr-2016   Allan McAleavy  Updated for BPF_PERF_OUTPUT.
 # 08-Oct-2016   Dina Goldshtein Support filtering by PID and TID.
 # 28-Dec-2018   Tim Douglas     Print flags argument, enable filtering
+# 06-Jan-2019   Takuma Kume     Support filtering by UID
 
 from __future__ import print_function
 from bcc import ArgString, BPF
@@ -25,9 +26,11 @@ import os
 examples = """examples:
     ./opensnoop           # trace all open() syscalls
     ./opensnoop -T        # include timestamps
+    ./opensnoop -U        # include UID
     ./opensnoop -x        # only show failed opens
     ./opensnoop -p 181    # only trace PID 181
     ./opensnoop -t 123    # only trace TID 123
+    ./opensnoop -u 1000   # only trace UID 1000
     ./opensnoop -d 10     # trace for 10 seconds only
     ./opensnoop -n main   # only print process names containing "main"
     ./opensnoop -e        # show extended fields
@@ -39,12 +42,16 @@ parser = argparse.ArgumentParser(
     epilog=examples)
 parser.add_argument("-T", "--timestamp", action="store_true",
     help="include timestamp on output")
+parser.add_argument("-U", "--print-uid", action="store_true",
+    help="print UID column")
 parser.add_argument("-x", "--failed", action="store_true",
     help="only show failed opens")
 parser.add_argument("-p", "--pid",
     help="trace this PID only")
 parser.add_argument("-t", "--tid",
     help="trace this TID only")
+parser.add_argument("-u", "--uid",
+    help="trace this UID only")
 parser.add_argument("-d", "--duration",
     help="total duration of trace in seconds")
 parser.add_argument("-n", "--name",
@@ -85,6 +92,7 @@ struct val_t {
 struct data_t {
     u64 id;
     u64 ts;
+    u32 uid;
     int ret;
     char comm[TASK_COMM_LEN];
     char fname[NAME_MAX];
@@ -100,8 +108,10 @@ int trace_entry(struct pt_regs *ctx, int dfd, const char __user *filename, int f
     u64 id = bpf_get_current_pid_tgid();
     u32 pid = id >> 32; // PID is higher part
     u32 tid = id;       // Cast and get the lower part
+    u32 uid = bpf_get_current_uid_gid();
 
     PID_TID_FILTER
+    UID_FILTER
     FLAGS_FILTER
     if (bpf_get_current_comm(&val.comm, sizeof(val.comm)) == 0) {
         val.id = id;
@@ -130,6 +140,7 @@ int trace_return(struct pt_regs *ctx)
     bpf_probe_read(&data.fname, sizeof(data.fname), (void *)valp->fname);
     data.id = valp->id;
     data.ts = tsp / 1000;
+    data.uid = bpf_get_current_uid_gid();
     data.flags = valp->flags; // EXTENDED_STRUCT_MEMBER
     data.ret = PT_REGS_RC(ctx);
 
@@ -147,6 +158,11 @@ elif args.pid:
         'if (pid != %s) { return 0; }' % args.pid)
 else:
     bpf_text = bpf_text.replace('PID_TID_FILTER', '')
+if args.uid:
+    bpf_text = bpf_text.replace('UID_FILTER',
+        'if (uid != %s) { return 0; }' % args.uid)
+else:
+    bpf_text = bpf_text.replace('UID_FILTER', '')
 if args.flag_filter:
     bpf_text = bpf_text.replace('FLAGS_FILTER',
         'if (!(flags & %d)) { return 0; }' % flag_filter_mask)
@@ -172,6 +188,7 @@ class Data(ct.Structure):
     _fields_ = [
         ("id", ct.c_ulonglong),
         ("ts", ct.c_ulonglong),
+        ("uid", ct.c_uint32),
         ("ret", ct.c_int),
         ("comm", ct.c_char * TASK_COMM_LEN),
         ("fname", ct.c_char * NAME_MAX),
@@ -183,6 +200,8 @@ initial_ts = 0
 # header
 if args.timestamp:
     print("%-14s" % ("TIME(s)"), end="")
+if args.print_uid:
+    print("%-6s" % ("UID"), end="")
 print("%-6s %-16s %4s %3s " %
       ("TID" if args.tid else "PID", "COMM", "FD", "ERR"), end="")
 if args.extended_fields:
@@ -214,6 +233,9 @@ def print_event(cpu, data, size):
     if args.timestamp:
         delta = event.ts - initial_ts
         print("%-14.9f" % (float(delta) / 1000000), end="")
+
+    if args.print_uid:
+        print("%-6d" % event.uid, end="")
 
     print("%-6d %-16s %4d %3d " %
           (event.id & 0xffffffff if args.tid else event.id >> 32,

--- a/tools/opensnoop_example.txt
+++ b/tools/opensnoop_example.txt
@@ -65,6 +65,27 @@ This shows the supervise process is opening the status.new file twice every
 second.
 
 
+The -U option include UID on output:
+
+# ./opensnoop -U
+UID   PID    COMM               FD ERR PATH
+0     27063  vminfo              5   0 /var/run/utmp
+103   628    dbus-daemon        -1   2 /usr/local/share/dbus-1/system-services
+103   628    dbus-daemon        18   0 /usr/share/dbus-1/system-services
+103   628    dbus-daemon        -1   2 /lib/dbus-1/system-services
+
+
+The -u option filtering UID:
+
+# ./opensnoop -Uu 1000
+UID   PID    COMM               FD ERR PATH
+1000  30240  ls                  3   0 /etc/ld.so.cache
+1000  30240  ls                  3   0 /lib/x86_64-linux-gnu/libselinux.so.1
+1000  30240  ls                  3   0 /lib/x86_64-linux-gnu/libc.so.6
+1000  30240  ls                  3   0 /lib/x86_64-linux-gnu/libpcre.so.3
+1000  30240  ls                  3   0 /lib/x86_64-linux-gnu/libdl.so.2
+1000  30240  ls                  3   0 /lib/x86_64-linux-gnu/libpthread.so.0
+
 The -x option only prints failed opens:
 
 # ./opensnoop -x
@@ -172,9 +193,11 @@ Trace open() syscalls
 optional arguments:
   -h, --help            show this help message and exit
   -T, --timestamp       include timestamp on output
+  -U, --print-uid       include UID on output
   -x, --failed          only show failed opens
   -p PID, --pid PID     trace this PID only
   -t TID, --tid TID     trace this TID only
+  -u UID, --uid UID     trace this UID only
   -d DURATION, --duration DURATION
                         total duration of trace in seconds
   -n NAME, --name NAME  only print process names containing this name
@@ -186,9 +209,11 @@ optional arguments:
 examples:
     ./opensnoop           # trace all open() syscalls
     ./opensnoop -T        # include timestamps
+    ./opensnoop -U        # include UID
     ./opensnoop -x        # only show failed opens
     ./opensnoop -p 181    # only trace PID 181
     ./opensnoop -t 123    # only trace TID 123
+    ./opensnoop -u 1000   # only trace UID 1000
     ./opensnoop -d 10     # trace for 10 seconds only
     ./opensnoop -n main   # only print process names containing "main"
     ./opensnoop -e        # show extended fields


### PR DESCRIPTION
Hi. Nice to meet you!

UID related options supported.

I think that it is use case of a multi-tenant environment.

- The -U option include UID on output:
  ```sh
  # ./opensnoop -U
  UID   PID    COMM               FD ERR PATH
  0     27063  vminfo              5   0 /var/run/utmp
  103   628    dbus-daemon        -1   2 /usr/local/share/dbus-1/system-services
  103   628    dbus-daemon        18   0 /usr/share/dbus-1/system-services
  103   628    dbus-daemon        -1   2 /lib/dbus-1/system-services
  ```

The reason for the print extension by the `-U` option is to maintain backward compatibility.

- The -u option filtering UID:
  ```sh
  # ./opensnoop -Uu 1000
  UID   PID    COMM               FD ERR PATH
  1000  30240  ls                  3   0 /etc/ld.so.cache
  1000  30240  ls                  3   0 /lib/x86_64-linux-gnu/libselinux.so.1
  1000  30240  ls                  3   0 /lib/x86_64-linux-gnu/libc.so.6
  1000  30240  ls                  3   0 /lib/x86_64-linux-gnu/libpcre.so.3
  1000  30240  ls                  3   0 /lib/x86_64-linux-gnu/libdl.so.2
  1000  30240  ls                  3   0 /lib/x86_64-linux-gnu/libpthread.so.0
  ```
