### PR TITLE
Fix #2098

### DIFF
--- a/examples/tracing/stack_buildid_example.py
+++ b/examples/tracing/stack_buildid_example.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+#
+# An example usage of stack_build_id
+# Most of the code here is borrowed from tools/profile.py
+#
+# Steps for using this code
+# 1) Start ping program in one terminal eg invocation: ping google.com -i0.001
+# 2) Change the path of libc specified in b.add_module() below
+# 3) Invoke the script as 'python stack_buildid_example.py'
+# 4) o/p of the tool is as shown below
+#  python example/tracing/stack_buildid_example.py
+#    sendto
+#    -                ping (5232)
+#        2
+#
+# REQUIRES: Linux 4.17+ (BPF_BUILD_ID support)
+# Licensed under the Apache License, Version 2.0 (the "License")
+# 03-Jan-2019  Vijay Nag
+
+from __future__ import print_function
+from bcc import BPF, PerfType, PerfSWConfig
+from sys import stderr
+from time import sleep
+import argparse
+import signal
+import os
+import subprocess
+import errno
+import multiprocessing
+import ctypes as ct
+
+def Get_libc_path():
+  # A small helper function that returns full path
+  # of libc in the system
+  cmd = 'cat /proc/self/maps | grep libc | awk \'{print $6}\' | uniq'
+  output = subprocess.check_output(cmd, shell=True)
+  if not isinstance(output, str):
+    output = output.decode()
+  return output.split('\n')[0]
+
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <uapi/linux/bpf_perf_event.h>
+#include <linux/sched.h>
+
+struct key_t {
+    u32 pid;
+    int user_stack_id;
+    char name[TASK_COMM_LEN];
+};
+BPF_HASH(counts, struct key_t);
+BPF_STACK_TRACE_BUILDID(stack_traces, 128);
+
+int do_perf_event(struct bpf_perf_event_data *ctx) {
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+
+    // create map key
+    struct key_t key = {.pid = pid};
+    bpf_get_current_comm(&key.name, sizeof(key.name));
+
+    key.user_stack_id = stack_traces.get_stackid(&ctx->regs, BPF_F_USER_STACK);
+
+    if (key.user_stack_id >= 0) {
+      counts.increment(key);
+    }
+    return 0;
+}
+"""
+
+b = BPF(text=bpf_text)
+b.attach_perf_event(ev_type=PerfType.SOFTWARE,
+    ev_config=PerfSWConfig.CPU_CLOCK, fn_name="do_perf_event",
+    sample_period=0, sample_freq=49, cpu=0)
+
+# Add the list of libraries/executables to the build sym cache for sym resolution
+# Change the libc path if it is different on a different machine.
+# libc.so and ping are added here so that any symbols pertaining to
+# libc or ping are resolved. More executables/libraries can be added here.
+b.add_module(Get_libc_path())
+b.add_module("/usr/sbin/sshd")
+b.add_module("/bin/ping")
+counts = b.get_table("counts")
+stack_traces = b.get_table("stack_traces")
+duration = 2
+
+def signal_handler(signal, frame):
+  print()
+
+try:
+    sleep(duration)
+except KeyboardInterrupt:
+    # as cleanup can take some time, trap Ctrl-C:
+    signal.signal(signal.SIGINT, signal_ignore)
+
+user_stack=[]
+for k,v in sorted(counts.items(), key=lambda counts: counts[1].value):
+  user_stack = [] if k.user_stack_id < 0 else \
+      stack_traces.walk(k.user_stack_id)
+
+  user_stack=list(user_stack)
+  for addr in user_stack:
+    print("    %s" % b.sym(addr, k.pid).decode('utf-8', 'replace'))
+  print("    %-16s %s (%d)" % ("-", k.name.decode('utf-8', 'replace'), k.pid))
+  print("        %d\n" % v.value)
+

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -49,6 +49,7 @@ class BPF {
   explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr,
                bool rw_engine_enabled = bpf_module_rw_engine_enabled(), const std::string &maps_ns = "")
       : flag_(flag),
+        bsymcache_(NULL),
       bpf_module_(new BPFModule(flag, ts, rw_engine_enabled, maps_ns)) {}
   StatusTuple init(const std::string& bpf_program,
                    const std::vector<std::string>& cflags = {},
@@ -137,6 +138,13 @@ class BPF {
     return BPFPercpuHashTable<KeyType, ValueType>({});
   }
 
+  void* get_bsymcache(void) {
+    if (bsymcache_ == NULL) {
+      bsymcache_ = bcc_buildsymcache_new();
+    }
+    return bsymcache_;
+  }
+
   BPFProgTable get_prog_table(const std::string& name);
 
   BPFCgroupArray get_cgroup_array(const std::string& name);
@@ -146,6 +154,12 @@ class BPF {
   BPFStackTable get_stack_table(const std::string& name,
                                 bool use_debug_file = true,
                                 bool check_debug_file_crc = true);
+
+  BPFStackBuildIdTable get_stackbuildid_table(const std::string &name,
+                                              bool use_debug_file = true,
+                                              bool check_debug_file_crc = true);
+
+  bool add_module(std::string module);
 
   StatusTuple open_perf_event(const std::string& name, uint32_t type,
                               uint64_t config);
@@ -224,6 +238,8 @@ class BPF {
                                   uint64_t& offset_res);
 
   int flag_;
+
+  void *bsymcache_;
 
   std::unique_ptr<std::string> syscall_prefix_;
 

--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -316,6 +316,69 @@ std::vector<std::string> BPFStackTable::get_stack_symbol(int stack_id,
   return res;
 }
 
+BPFStackBuildIdTable::BPFStackBuildIdTable(const TableDesc& desc, bool use_debug_file,
+                                           bool check_debug_file_crc,
+                                           void *bsymcache)
+    : BPFTableBase<int, stacktrace_buildid_t>(desc),
+      bsymcache_(bsymcache) {
+  if (desc.type != BPF_MAP_TYPE_STACK_TRACE)
+    throw std::invalid_argument("Table '" + desc.name +
+                                "' is not a stack table");
+
+  symbol_option_ = {.use_debug_file = use_debug_file,
+                    .check_debug_file_crc = check_debug_file_crc,
+                    .use_symbol_type = (1 << STT_FUNC) | (1 << STT_GNU_IFUNC)};
+}
+
+void BPFStackBuildIdTable::clear_table_non_atomic() {
+  for (int i = 0; size_t(i) < capacity(); i++) {
+    remove(&i);
+  }
+}
+
+std::vector<bpf_stack_build_id> BPFStackBuildIdTable::get_stack_addr(int stack_id) {
+  std::vector<bpf_stack_build_id> res;
+  struct stacktrace_buildid_t stack;
+  if (stack_id < 0)
+    return res;
+  if (!lookup(&stack_id, &stack))
+    return res;
+  for (int i = 0; (i < BPF_MAX_STACK_DEPTH) && \
+       (stack.trace[i].status == BPF_STACK_BUILD_ID_VALID);
+       i++) {
+        /* End of stack marker is BCC_STACK_BUILD_ID_EMPTY or
+         * BCC_STACK_BUILD_IP(fallback) mechanism.
+         * We do not support fallback mechanism
+         */
+    res.push_back(stack.trace[i]);
+  }
+  return res;
+}
+
+std::vector<std::string> BPFStackBuildIdTable::get_stack_symbol(int stack_id)
+{
+  auto addresses = get_stack_addr(stack_id);
+  std::vector<std::string> res;
+  if (addresses.empty())
+    return res;
+  res.reserve(addresses.size());
+
+  bcc_symbol symbol;
+  struct bpf_stack_build_id trace;
+  for (auto addr : addresses) {
+    memcpy(trace.build_id, addr.build_id, sizeof(trace.build_id));
+    trace.status = addr.status;
+    trace.offset = addr.offset;
+    if (bcc_buildsymcache_resolve(bsymcache_,&trace,&symbol) != 0) {
+      res.emplace_back("[UNKNOWN]");
+    } else {
+      res.push_back(symbol.name);
+      bcc_symbol_free_demangle_name(&symbol);
+    }
+  }
+  return res;
+}
+
 BPFPerfBuffer::BPFPerfBuffer(const TableDesc& desc)
     : BPFTableBase<int, int>(desc), epfd_(-1) {
   if (desc.type != BPF_MAP_TYPE_PERF_EVENT_ARRAY)

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -315,6 +315,26 @@ class BPFStackTable : public BPFTableBase<int, stacktrace_t> {
   std::map<int, void*> pid_sym_;
 };
 
+// from src/cc/export/helpers.h
+struct stacktrace_buildid_t {
+  struct bpf_stack_build_id trace[BPF_MAX_STACK_DEPTH];
+};
+
+class BPFStackBuildIdTable : public BPFTableBase<int, stacktrace_buildid_t> {
+ public:
+  BPFStackBuildIdTable(const TableDesc& desc, bool use_debug_file,
+                       bool check_debug_file_crc, void *bsymcache);
+  ~BPFStackBuildIdTable() = default;
+
+  void clear_table_non_atomic();
+  std::vector<bpf_stack_build_id> get_stack_addr(int stack_id);
+  std::vector<std::string> get_stack_symbol(int stack_id);
+
+ private:
+  void *bsymcache_;
+  bcc_symbol_option symbol_option_;
+};
+
 class BPFPerfBuffer : public BPFTableBase<int, int> {
  public:
   BPFPerfBuffer(const TableDesc& desc);

--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -884,6 +884,20 @@ int bcc_free_memory() {
   return err;
 }
 
+int bcc_elf_get_buildid(const char *path, char *buildid)
+{
+  Elf *e;
+  int fd;
+
+  if (openelf(path, &e, &fd) < 0)
+    return -1;
+
+  if (!find_buildid(e, buildid))
+    return -1;
+
+  return 0;
+}
+
 #if 0
 #include <stdio.h>
 

--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -69,6 +69,7 @@ int bcc_elf_is_shared_obj(const char *path);
 int bcc_elf_is_exe(const char *path);
 int bcc_elf_is_vdso(const char *name);
 int bcc_free_memory();
+int bcc_elf_get_buildid(const char *path, char *buildid);
 
 #ifdef __cplusplus
 }

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -21,6 +21,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <compat/linux/bpf.h>
 
 struct bcc_symbol {
   const char *name;
@@ -67,6 +68,13 @@ void bcc_symcache_refresh(void *resolver);
 int bcc_resolve_global_addr(int pid, const char *module, const uint64_t address,
                             uint64_t *global);
 
+/*bcc APIs for build_id stackmap support*/
+void *bcc_buildsymcache_new(void);
+void bcc_free_buildsymcache(void *symcache);
+int  bcc_buildsymcache_add_module(void *resolver, const char *module_name);
+int bcc_buildsymcache_resolve(void *resolver,
+                              struct bpf_stack_build_id *trace,
+                              struct bcc_symbol *sym);
 // Call cb on every function symbol in the specified module. Uses simpler
 // SYM_CB callback mainly for easier to use in Python API.
 // Will prefer use debug file and check debug file CRC when reading the module.

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -201,8 +201,15 @@ struct bpf_stacktrace {
   u64 ip[BPF_MAX_STACK_DEPTH];
 };
 
+struct bpf_stacktrace_buildid {
+  struct bpf_stack_build_id trace[BPF_MAX_STACK_DEPTH];
+};
+
 #define BPF_STACK_TRACE(_name, _max_entries) \
   BPF_TABLE("stacktrace", int, struct bpf_stacktrace, _name, roundup_pow_of_two(_max_entries))
+
+#define BPF_STACK_TRACE_BUILDID(_name, _max_entries) \
+  BPF_F_TABLE("stacktrace", int, struct bpf_stacktrace_buildid, _name, roundup_pow_of_two(_max_entries), BPF_F_STACK_BUILD_ID)
 
 #define BPF_PROG_ARRAY(_name, _max_entries) \
   BPF_TABLE("prog", u32, u32, _name, _max_entries)

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -133,6 +133,19 @@ class bcc_symbol(ct.Structure):
             ('offset', ct.c_ulonglong),
         ]
 
+class bcc_ip_offset_union(ct.Union):
+  _fields_ = [
+          ('offset', ct.c_uint64),
+          ('ip', ct.c_uint64)
+        ]
+
+class bcc_stacktrace_build_id(ct.Structure):
+    _fields_ = [
+            ('status', ct.c_uint32),
+            ('build_id',ct.c_ubyte*20),
+            ('u',bcc_ip_offset_union)
+         ]
+
 class bcc_symbol_option(ct.Structure):
     _fields_ = [
             ('use_debug_file', ct.c_int),
@@ -160,6 +173,18 @@ lib.bcc_symcache_new.argtypes = [ct.c_int, ct.POINTER(bcc_symbol_option)]
 
 lib.bcc_free_symcache.restype = ct.c_void_p
 lib.bcc_free_symcache.argtypes = [ct.c_void_p, ct.c_int]
+
+lib.bcc_buildsymcache_new.restype = ct.c_void_p
+lib.bcc_buildsymcache_new.argtypes = None
+
+lib.bcc_free_buildsymcache.restype = None
+lib.bcc_free_buildsymcache.argtypes = [ct.c_void_p]
+
+lib.bcc_buildsymcache_add_module.restype = ct.c_int
+lib.bcc_buildsymcache_add_module.argtypes = [ct.c_void_p, ct.c_char_p]
+
+lib.bcc_buildsymcache_resolve.restype = ct.c_int
+lib.bcc_buildsymcache_resolve.argtypes = [ct.c_void_p, ct.POINTER(bcc_stacktrace_build_id), ct.POINTER(bcc_symbol)]
 
 lib.bcc_symbol_free_demangle_name.restype = ct.c_void_p
 lib.bcc_symbol_free_demangle_name.argtypes = [ct.POINTER(bcc_symbol)]

--- a/tests/python/test_stackid.py
+++ b/tests/python/test_stackid.py
@@ -6,6 +6,7 @@ import bcc
 import distutils.version
 import os
 import unittest
+import subprocess
 
 def kernel_version_ge(major, minor):
     # True if running kernel is >= X.Y
@@ -49,6 +50,44 @@ int kprobe__htab_map_lookup_elem(struct pt_regs *ctx, struct bpf_map *map, u64 *
         stack = stack_traces[stackid].ip
         self.assertEqual(b.ksym(stack[0]), b"htab_map_lookup_elem")
 
+def Get_libc_path():
+  cmd = 'cat /proc/self/maps | grep libc | awk \'{print $6}\' | uniq'
+  output = subprocess.check_output(cmd, shell=True)
+  if not isinstance(output, str):
+    output = output.decode()
+  return output.split('\n')[0]
+
+@unittest.skipUnless(kernel_version_ge(4,17), "requires kernel >= 4.17")
+class TestStackBuildid(unittest.TestCase):
+    def test_simple(self):
+        b = bcc.BPF(text="""
+#include <uapi/linux/ptrace.h>
+struct bpf_map;
+BPF_STACK_TRACE_BUILDID(stack_traces, 10240);
+BPF_HASH(stack_entries, int, int);
+BPF_HASH(stub);
+int kprobe__sys_getuid(struct pt_regs *ctx, struct bpf_map *map, u64 *k) {
+    int id = stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
+    if (id < 0)
+        return 0;
+    int key = 1;
+    stack_entries.update(&key, &id);
+    return 0;
+}
+""")
+        os.getuid()
+        stub = b["stub"]
+        stack_traces = b["stack_traces"]
+        stack_entries = b["stack_entries"]
+        b.add_module(Get_libc_path())
+        try: x = stub[stub.Key(1)]
+        except: pass
+        k = stack_entries.Key(1)
+        self.assertIn(k, stack_entries)
+        stackid = stack_entries[k]
+        self.assertIsNotNone(stackid)
+        stack = stack_traces[stackid]
+        self.assertTrue(b.sym(stack.trace[0], -1).find(b"getuid")!=-1)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added build_id support for BPF stackmap.
A separate build_id stackmap can be created with the help of new macro BPF_STACK_TRACE_BUILDID
The kernel BPF reports stacktrace in the structure bpf_stack_build_id.
Changes have been made to BPF modules to support resolving symbols mentioned in the above format.
An example tool is also available in tools/stack_buildid_example.py

Fix #2098
Added build_id support for BPF stackmap.
A separate build_id stackmap can be created with the help of new macro BPF_STACK_TRACE_BUILDID
The kernel BPF reports stacktrace in the structure bpf_stack_build_id.
Changes have been made to BPF modules to support resolving symbols mentioned in the above format.
An example tool is also available in tools/stack_buildid_example.py

Fix #2098

Moved stack_buildid_example to examples directory

Moved to examples/tracing

Fix #2099 - Added eBPF APIs and test cases related to build_id stackmap

Fix #2098, #2099 - Fixed review comments