### PR TITLE
Translate arch into source directory when ARCH is set

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -34,35 +34,35 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
   //               -e s/ppc.*/powerpc/ -e s/mips.*/mips/ -e s/sh[234].*/sh/
   //               -e s/aarch64.*/arm64/
 
-  string arch = uname_machine;
-  const char *archenv;
-
-  if (!strncmp(uname_machine, "x86_64", 6)) {
-    arch = "x86";
-  } else if (uname_machine[0] == 'i' && !strncmp(&uname_machine[2], "86", 2)) {
-    arch = "x86";
-  } else if (!strncmp(uname_machine, "arm", 3)) {
-    arch = "arm";
-  } else if (!strncmp(uname_machine, "sa110", 5)) {
-    arch = "arm";
-  } else if (!strncmp(uname_machine, "s390x", 5)) {
-    arch = "s390";
-  } else if (!strncmp(uname_machine, "parisc64", 8)) {
-    arch = "parisc";
-  } else if (!strncmp(uname_machine, "ppc", 3)) {
-    arch = "powerpc";
-  } else if (!strncmp(uname_machine, "mips", 4)) {
-    arch = "mips";
-  } else if (!strncmp(uname_machine, "sh", 2)) {
-    arch = "sh";
-  } else if (!strncmp(uname_machine, "aarch64", 7)) {
-    arch = "arm64";
-  }
-
+  string arch;
+  const char *archenv = getenv("ARCH");
   // If ARCH env is defined, use it over uname
-  archenv = getenv("ARCH");
   if (archenv)
     arch = string(archenv);
+  else
+    arch = string(uname_machine);
+
+  if (!arch.compare(0, 6, "x86_64")) {
+    arch = "x86";
+  } else if (arch[0] == 'i' && !arch.compare(2, 2, "86")) {
+    arch = "x86";
+  } else if (!arch.compare(0, 3, "arm")) {
+    arch = "arm";
+  } else if (!arch.compare(0, 5, "sa110")) {
+    arch = "arm";
+  } else if (!arch.compare(0, 5, "s390x")) {
+    arch = "s390";
+  } else if (!arch.compare(0, 8, "parisc64")) {
+    arch = "parisc";
+  } else if (!arch.compare(0, 3, "ppc")) {
+    arch = "powerpc";
+  } else if (!arch.compare(0, 4, "mips")) {
+    arch = "mips";
+  } else if (!arch.compare(0, 2, "sh")) {
+    arch = "sh";
+  } else if (!arch.compare(0, 7, "aarch64")) {
+    arch = "arm64";
+  }
 
   cflags->push_back("-nostdinc");
   cflags->push_back("-isystem");


### PR DESCRIPTION
When ARCH is not defined, bcc get the architecture from uname. It then
modifies it to get the name of arch directory in linux source.

When ARCH is defined however, it just copy it as is, without the
translation to the arch directory. If for instance ARCH is set to
x86_64, it tries to look into the include directory
build/arch/x86_64/, which doesn't exist.

It fixes the following issue:
$ echo $ARCH
x86_64
$ /usr/share/bcc/tools/bashreadline
In file included from <built-in>:2:
In file included from /virtual/include/bcc/bpf.h:12:
In file included from /lib/modules/4.18.0-49.el8.x86_64/build/include/linux/types.h:6:
/lib/modules/4.18.0-49.el8.x86_64/build/include/uapi/linux/types.h:5:10: fatal error: 'asm/types.h' file
      not found
         ^~~~~~~~~~~~~
1 error generated.
Traceback (most recent call last):
  File "/usr/share/bcc/tools/bashreadline", line 51, in <module>
    b = BPF(text=bpf_text)
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 318, in __init__
    raise Exception("Failed to compile BPF text")
Exception: Failed to compile BPF text