### PR TITLE
remove unused extern variables

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -799,8 +799,6 @@ static int bcc_free_memory_with_file(const char *path) {
       saddr = (unsigned long)bcc_free_memory - sym_addr + header.sh_addr;
       eaddr = saddr + header.sh_size;
 
-      extern unsigned long _start, _fini;
-
       // adjust saddr and eaddr, start addr needs to be page aligned
       saddr_n = (saddr + page_size - 1) & ~(page_size - 1);
       eaddr -= saddr_n - saddr;


### PR DESCRIPTION
On fc29, compiling bcc from source, the following
compiler warnings are seen:
```
  /home/yhs/work/bcc/src/cc/bcc_elf.c: In function ‘bcc_free_memory_with_file’:
  /home/yhs/work/bcc/src/cc/bcc_elf.c:802:36: warning: unused variable ‘_fini’ [-Wunused-variable]
       extern unsigned long _start, _fini;
                                    ^~~~~
/home/yhs/work/bcc/src/cc/bcc_elf.c:802:28: warning: unused variable ‘_start’ [-Wunused-variable]
       extern unsigned long _start, _fini;
                            ^~~~~~
```
These unused externs are accidentally introduced by
Commit 51480d0597cc ("implement free_bcc_memory() API").
This patch removed them.

Signed-off-by: Yonghong Song <yhs@fb.com>