### PR TITLE
tools: shmsnoop, sofdsnoop handle keyboard interrupt

### DIFF
--- a/tools/shmsnoop.py
+++ b/tools/shmsnoop.py
@@ -316,4 +316,7 @@ def print_event(cpu, data, size):
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 start_time = datetime.now()
 while not args.duration or datetime.now() - start_time < args.duration:
-    b.perf_buffer_poll(timeout=1000)
+    try:
+        b.perf_buffer_poll(timeout=1000)
+    except KeyboardInterrupt:
+        exit()

--- a/tools/sofdsnoop.py
+++ b/tools/sofdsnoop.py
@@ -342,4 +342,7 @@ def print_event(cpu, data, size):
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 start_time = datetime.now()
 while not args.duration or datetime.now() - start_time < args.duration:
-    b.perf_buffer_poll(timeout=1000)
+    try:
+        b.perf_buffer_poll(timeout=1000)
+    except KeyboardInterrupt:
+        exit()


### PR DESCRIPTION
Handle keyboard interrupt to avoid backtrace printed out when user
presses Ctrl-C. Other tools have been fixed recently. Let's fix these
remaining tools.