### PR TITLE
fix several printb usage with python3

### DIFF
--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -245,7 +245,7 @@ def print_event(cpu, data, size):
     if args.extended_fields:
         print("%08o " % event.flags, end="")
 
-    printb(b'%s' % event.fname.decode('utf-8', 'replace'))
+    printb(b'%s' % event.fname)
 
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event, page_cnt=64)

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -245,9 +245,10 @@ def print_ipv4_event(cpu, data, size):
             start_ts = event.ts_us
         print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
     printb(b"%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
-        event.task.decode('utf-8', 'replace'), event.ip,
-        inet_ntop(AF_INET, pack("I", event.daddr)),
-        inet_ntop(AF_INET, pack("I", event.saddr)), event.lport))
+        event.task, event.ip,
+        inet_ntop(AF_INET, pack("I", event.daddr)).encode(),
+        inet_ntop(AF_INET, pack("I", event.saddr)).encode(),
+        event.lport))
 
 def print_ipv6_event(cpu, data, size):
     event = ct.cast(data, ct.POINTER(Data_ipv6)).contents
@@ -257,8 +258,9 @@ def print_ipv6_event(cpu, data, size):
             start_ts = event.ts_us
         print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
     printb(b"%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
-        event.task.decode('utf-8', 'replace'), event.ip,
-        inet_ntop(AF_INET6, event.daddr),inet_ntop(AF_INET6, event.saddr),
+        event.task, event.ip,
+        inet_ntop(AF_INET6, event.daddr).encode(),
+        inet_ntop(AF_INET6, event.saddr).encode(),
         event.lport))
 
 # initialize BPF

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -225,9 +225,9 @@ def print_ipv4_event(cpu, data, size):
     if args.print_uid:
         print("%-6d" % event.uid, end="")
     printb(b"%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
-        event.task.decode('utf-8', 'replace'), event.ip,
-        inet_ntop(AF_INET, pack("I", event.saddr)),
-        inet_ntop(AF_INET, pack("I", event.daddr)), event.dport))
+        event.task, event.ip,
+        inet_ntop(AF_INET, pack("I", event.saddr)).encode(),
+        inet_ntop(AF_INET, pack("I", event.daddr)).encode(), event.dport))
 
 def print_ipv6_event(cpu, data, size):
     event = ct.cast(data, ct.POINTER(Data_ipv6)).contents
@@ -239,8 +239,8 @@ def print_ipv6_event(cpu, data, size):
     if args.print_uid:
         print("%-6d" % event.uid, end="")
     printb(b"%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
-        event.task.decode('utf-8', 'replace'), event.ip,
-        inet_ntop(AF_INET6, event.saddr), inet_ntop(AF_INET6, event.daddr),
+        event.task, event.ip,
+        inet_ntop(AF_INET6, event.saddr).encode(), inet_ntop(AF_INET6, event.daddr).encode(),
         event.dport))
 
 # initialize BPF


### PR DESCRIPTION
The following three tools are recently changed to use
printb in order to flush out the result.
  opensnoop.py, tcpaccept.py, tcpconnect.py

With python3, however, these tools have errors like below:
```
  TypeError: %b requires a bytes-like object, or an object that implements __bytes__, not 'str'
  Traceback (most recent call last):
    File "_ctypes/callbacks.c", line 234, in 'calling callback function'
    File "/usr/lib/python3.6/site-packages/bcc/table.py", line 572, in raw_cb_
      callback(cpu, data, size)
    File "../../tools/opensnoop.py", line 248, in print_event
      printb(b'%s' % event.fname.decode('utf-8', 'replace'))
```
This patch fixed printb related issues for these three tools
for python3. The python2 still works with the fix.

Signed-off-by: Yonghong Song <yhs@fb.com>