### PR TITLE
workaround kernel 5.0 asm_volatile_goto issue

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -17,6 +17,21 @@ R"********(
 #ifndef __BPF_HELPERS_H
 #define __BPF_HELPERS_H
 
+/* Before bpf_helpers.h is included, uapi bpf.h has been
+ * included, which references linux/types.h. This will bring
+ * in asm_volatile_goto definition if permitted based on
+ * compiler setup and kernel configs.
+ *
+ * clang does not support "asm volatile goto" yet.
+ * So redefine asm_volatile_goto to some invalid asm code.
+ * If asm_volatile_goto is actually used by the bpf program,
+ * a compilation error will appear.
+ */
+#ifdef asm_volatile_goto
+#undef asm_volatile_goto
+#define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
+#endif
+
 #include <uapi/linux/bpf.h>
 #include <uapi/linux/if_packet.h>
 #include <linux/version.h>


### PR DESCRIPTION
Fix issue #2119.

Kernel 5.0 added more usages of `asm goto` and llvm
does not support asm goto yet. This resulted in
compilation error for virtually any bcc script.

The workaround here is to redefine asm_volatile_goto to
```
  asm volatile("invalid use of asm_volatile_goto")
```
which can pass clang.
If bpf program does not use `asm_volatile_goto`,
nothing bad will happen. The functions using
`asm_volatile_goto` will be thrown away.
If bpf program accidentally uses `asm_volatile_goto`,
a compilation error like below will be printed out:
```
  <inline asm>:1:2: error: invalid register/token name
          invalid use of asm_volatile_goto
          ^
  LLVM ERROR: Error parsing inline asm
```
Signed-off-by: Yonghong Song <yhs@fb.com>