### PR TITLE
syscall.py: Fixes python3 related error

### DIFF
--- a/src/python/bcc/syscall.py
+++ b/src/python/bcc/syscall.py
@@ -378,7 +378,7 @@ try:
     # SYSCALL_NUM\tSYSCALL_NAME pairs.
     out = subprocess.check_output(['ausyscall', '--dump'], stderr=subprocess.STDOUT)
     # remove the first line of expected output
-    out = out.split('\n',1)[1]
+    out = out.split(b'\n',1)[1]
     syscalls = dict(map(_parse_syscall, out.strip().split(b'\n')))
 except Exception as e:
     if platform.machine() == "x86_64":


### PR DESCRIPTION
With out the patch:
Traceback (most recent call last):
  File "/root/bcc/src/python/bcc/syscall.py", line 381, in <module>
    out = out.split('\n',1)[1]
TypeError: a bytes-like object is required, not 'str'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/bcc/tests/python/test_stat1.py", line 10, in <module>
    from bcc import BPF
  File "/root/bcc/src/python/bcc/__init__.py", line 30, in <module>
    from .syscall import syscall_name
  File "/root/bcc/src/python/bcc/syscall.py", line 387, in <module>
    raise Exception("ausyscall: command not found")
Exception: ausyscall: command not found

This is because variable 'out' is a byte object type and while split,
code is passing 'str' type.

Tested this on python3 and python2

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>