### PR TITLE
Misc fixes on Python tools

### DIFF
--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -53,7 +53,7 @@ loadavg = "/proc/loadavg"
 diskstats = "/proc/diskstats"
 
 # signal handler
-def signal_ignore(signal, frame):
+def signal_ignore(signal_value, frame):
     print()
 
 # load BPF program

--- a/tools/cachetop.py
+++ b/tools/cachetop.py
@@ -40,7 +40,7 @@ FIELDS = (
     "WRITE_HIT%"
 )
 DEFAULT_FIELD = "HITS"
-
+DEFAULT_SORT_FIELD = FIELDS.index(DEFAULT_FIELD)
 
 # signal handler
 def signal_ignore(signal, frame):
@@ -61,7 +61,7 @@ def get_meminfo():
 
 def get_processes_stats(
         bpf,
-        sort_field=FIELDS.index(DEFAULT_FIELD),
+        sort_field=DEFAULT_SORT_FIELD,
         sort_reverse=False):
     '''
     Return a tuple containing:
@@ -223,7 +223,7 @@ def handle_loop(stdscr, args):
             uid = int(stat[1])
             try:
                 username = pwd.getpwuid(uid)[0]
-            except KeyError as ex:
+            except KeyError:
                 # `pwd` throws a KeyError if the user cannot be found. This can
                 # happen e.g. when the process is running in a cgroup that has
                 # different users from the host.

--- a/tools/criticalstat.py
+++ b/tools/criticalstat.py
@@ -319,7 +319,7 @@ def print_event(cpu, data, size):
             print("NO STACK FOUND DUE TO COLLISION")
         print("===================================")
         print("")
-    except:
+    except Exception:
         sys.exit(0)
 
 b["events"].open_perf_buffer(print_event, page_cnt=256)

--- a/tools/fileslower.py
+++ b/tools/fileslower.py
@@ -205,7 +205,7 @@ b.attach_kretprobe(event="__vfs_read", fn_name="trace_read_return")
 try:
     b.attach_kprobe(event="__vfs_write", fn_name="trace_write_entry")
     b.attach_kretprobe(event="__vfs_write", fn_name="trace_write_return")
-except:
+except Exception:
     # older kernels don't have __vfs_write so try vfs_write instead
     b.attach_kprobe(event="vfs_write", fn_name="trace_write_entry")
     b.attach_kretprobe(event="vfs_write", fn_name="trace_write_return")

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -60,7 +60,7 @@ debug = 0
 loadavg = "/proc/loadavg"
 
 # signal handler
-def signal_ignore(signal, frame):
+def signal_ignore(signal_value, frame):
     print()
 
 # define BPF program

--- a/tools/lib/uflow_example.txt
+++ b/tools/lib/uflow_example.txt
@@ -48,8 +48,8 @@ CPU PID    TID    TIME(us) METHOD
 3   27722  27731  3.144          <- java/lang/ThreadGroup.checkAccess
 3   27722  27731  3.144          -> java/lang/ThreadGroup.addUnstarted
 3   27722  27731  3.144          <- java/lang/ThreadGroup.addUnstarted
-3   27722  27731  3.145          -> java/lang/Thread.isDaemon     
-3   27722  27731  3.145          <- java/lang/Thread.isDaemon     
+3   27722  27731  3.145          -> java/lang/Thread.isDaemon
+3   27722  27731  3.145          <- java/lang/Thread.isDaemon
 3   27722  27731  3.145          -> java/lang/Thread.getPriority   
 3   27722  27731  3.145          <- java/lang/Thread.getPriority   
 3   27722  27731  3.145          -> java/lang/Thread.getContextClassLoader

--- a/tools/llcstat.py
+++ b/tools/llcstat.py
@@ -85,7 +85,7 @@ try:
     b.attach_perf_event(
         ev_type=PerfType.HARDWARE, ev_config=PerfHWConfig.CACHE_REFERENCES,
         fn_name="on_cache_ref", sample_period=args.sample_period)
-except:
+except Exception:
     print("Failed to attach to a hardware event. Is this a virtual machine?")
     exit()
 

--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -218,7 +218,7 @@ if min_us == 0:
 else:
     bpf_text = bpf_text.replace('FILTER_US', 'delta_us <= %s' % str(min_us))
 if args.pid:
-    bpf_text = bpf_text.replace('FILTER_PID', 'pid != %s' % pid)
+    bpf_text = bpf_text.replace('FILTER_PID', 'pid != %s' % args.pid)
 else:
     bpf_text = bpf_text.replace('FILTER_PID', '0')
 if debug or args.ebpf:


### PR DESCRIPTION
Mostly things caught by PEP Linter. Some of them are stylistic (like "don't catch bare exception"), but others are syntactically valid:
- `signal` defined both as module name and function argument
- Function default argument has function call
- Undefined local variable `pid` should be `args.pid`
- `uflow_example.txt` has non-ASCII character