### PR TITLE
Bcc build fixes for Android

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -84,6 +84,8 @@
 
 #define min(x, y) ((x) < (y) ? (x) : (y))
 
+#define UNUSED(expr) do { (void)(expr); } while (0)
+
 struct bpf_helper {
   char *name;
   char *required_version;
@@ -1108,6 +1110,8 @@ int bpf_attach_tracepoint(int progfd, const char *tp_category,
 }
 
 int bpf_detach_tracepoint(const char *tp_category, const char *tp_name) {
+  UNUSED(tp_category);
+  UNUSED(tp_name);
   // Right now, there is nothing to do, but it's a good idea to encourage
   // callers to detach anything they attach.
   return 0;

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -981,7 +981,7 @@ int bpf_attach_uprobe(int progfd, enum bpf_probe_attach_type attach_type,
       goto error;
     }
     res = snprintf(buf, sizeof(buf), "%c:%ss/%s %s:0x%lx", attach_type==BPF_PROBE_ENTRY ? 'p' : 'r',
-                   event_type, event_alias, binary_path, offset);
+                   event_type, event_alias, binary_path, (unsigned long)offset);
     if (res < 0 || res >= sizeof(buf)) {
       fprintf(stderr, "Event alias (%s) too long for buffer\n", event_alias);
       goto error;

--- a/src/cc/perf_reader.c
+++ b/src/cc/perf_reader.c
@@ -186,7 +186,7 @@ void perf_reader_event_read(struct perf_reader *reader) {
       reader->buf = realloc(reader->buf, e->size);
       size_t len = sentinel - begin;
       memcpy(reader->buf, begin, len);
-      memcpy(reader->buf + len, base, e->size - len);
+      memcpy((void *)((unsigned long)reader->buf + len), base, e->size - len);
       ptr = reader->buf;
     }
 


### PR DESCRIPTION
In Android, certain flags are passed to build source code. These cause errors when building libbpf. These patches fix the issues.