### PR TITLE
Add udp_rcvbuf_errors.py to tools to help debug UDP RcvbufErrors packet drops

### DIFF
--- a/tools/udp_rcvbuf_errors.py
+++ b/tools/udp_rcvbuf_errors.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+#
+# udp_rcvbuf_errors.py	UDP RcvbufErrors analysis tool.
+#
+# Prints out information for UDP packets which were dropped
+# a result of the socket receive buffer being full.
+#
+# USAGE: udp_rcvbuf_errors
+
+# Copyright (c) 2019 Cloudflare, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+#
+# 15-Jan-2019 Thomas Lefebvre Created this.
+
+from bcc import BPF
+import ctypes as ct
+import argparse
+from time import strftime
+from socket import inet_ntop, AF_INET, AF_INET6
+from struct import pack
+
+examples = """examples:
+    ./udp_rcvbuf_errors           # trace UDP RcvbufErrors kernel drops
+"""
+parser = argparse.ArgumentParser(
+    description="Trace UDP RcvbufErrors drops by the kernel",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+args = parser.parse_args()
+debug = 0
+
+# define BPF program
+bpf_text = """
+#include <uapi/linux/udp.h>
+#include <uapi/linux/ip.h>
+#include <net/sock.h>
+
+struct ipv4_data_t {
+    u32 saddr;
+    u32 daddr;
+    u16 sport;
+    u16 dport;
+    u32 rmem_alloc;
+    u32 rcvbuf;
+};
+BPF_PERF_OUTPUT(ipv4_events);
+
+struct ipv6_data_t {
+    unsigned __int128 saddr;
+    unsigned __int128 daddr;
+    u16 sport;
+    u16 dport;
+    u32 rmem_alloc;
+    u32 rcvbuf;
+};
+BPF_PERF_OUTPUT(ipv6_events);
+
+static struct udphdr *skb_to_udphdr(const struct sk_buff *skb)
+{
+    // unstable API. verify logic in udp_hdr() -> skb_transport_header().
+    return (struct udphdr *)(skb->head + skb->transport_header);
+}
+
+static inline struct iphdr *skb_to_iphdr(const struct sk_buff *skb)
+{
+    // unstable API. verify logic in ip_hdr() -> skb_network_header().
+    return (struct iphdr *)(skb->head + skb->network_header);
+}
+
+int kprobe__udp_queue_rcv_skb(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
+    if (sk->sk_rmem_alloc.counter <= sk->sk_rcvbuf)
+    {
+        return 0;
+    }
+    u16 family = sk->__sk_common.skc_family;
+    u16 sport = 0, dport = 0;
+    struct iphdr *ip = skb_to_iphdr(skb);
+    struct udphdr *udp = skb_to_udphdr(skb);
+    sport = udp->source;
+    dport = udp->dest;
+    sport = ntohs(sport);
+    dport = ntohs(dport);
+
+    if (family == AF_INET) {
+        struct ipv4_data_t data4 = {};
+        data4.saddr = ip->saddr;
+        data4.daddr = ip->daddr;
+        data4.dport = dport;
+        data4.sport = sport;
+        data4.rmem_alloc = sk->sk_rmem_alloc.counter;
+        data4.rcvbuf = sk->sk_rcvbuf;
+        ipv4_events.perf_submit(ctx, &data4, sizeof(data4));
+    } else if (family == AF_INET6) {
+        struct ipv6_data_t data6 = {};
+        bpf_probe_read(&data6.saddr, sizeof(data6.saddr),
+            sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+        bpf_probe_read(&data6.daddr, sizeof(data6.daddr),
+            sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+        data6.dport = dport;
+        data6.sport = sport;
+        data6.rmem_alloc = sk->sk_rmem_alloc.counter;
+        data6.rcvbuf = sk->sk_rcvbuf;
+        ipv6_events.perf_submit(ctx, &data6, sizeof(data6));
+    }
+    return 0;
+}
+"""
+
+
+class Data_ipv4(ct.Structure):
+    _fields_ = [
+        ("saddr", ct.c_uint),
+        ("daddr", ct.c_uint),
+        ("sport", ct.c_ushort),
+        ("dport", ct.c_ushort),
+        ("rmem_alloc", ct.c_uint),
+        ("rcvbuf", ct.c_uint),
+    ]
+
+
+class Data_ipv6(ct.Structure):
+    _fields_ = [
+        ("saddr", (ct.c_ulonglong * 2)),
+        ("daddr", (ct.c_ulonglong * 2)),
+        ("sport", ct.c_ushort),
+        ("dport", ct.c_ushort),
+        ("rmem_alloc", ct.c_uint),
+        ("rcvbuf", ct.c_uint),
+    ]
+
+
+def print_ipv4_event(cpu, data, size):
+    event = ct.cast(data, ct.POINTER(Data_ipv4)).contents
+    print("%-8s %-30s > %-30s %-13s %-9s" % (
+        strftime("%H:%M:%S"),
+        "%s:%d" % (inet_ntop(AF_INET, pack('I', event.saddr)), event.sport),
+        "%s:%s" % (inet_ntop(AF_INET, pack('I', event.daddr)), event.dport),
+        event.rmem_alloc,
+        event.rcvbuf,
+       ))
+
+
+def print_ipv6_event(cpu, data, size):
+    event = ct.cast(data, ct.POINTER(Data_ipv6)).contents
+    print("%-8s %-30s > %-30s %-13s %-9s" % (
+        strftime("%H:%M:%S"),
+        "%s:%d" % (inet_ntop(AF_INET6, pack('I', event.saddr)), event.sport),
+        "%s:%s" % (inet_ntop(AF_INET6, pack('I', event.daddr)), event.dport),
+        event.rmem_alloc,
+        event.rcvbuf,
+       ))
+
+
+b = BPF(text=bpf_text)
+print("%-8s %-30s > %-30s %-13s %-9s" % (
+    "TIME", "SADDR:SPORT", "DADDR:DPORT", "SK_RMEM_ALLOC", "SK_RCVBUF"
+))
+
+b["ipv4_events"].open_perf_buffer(print_ipv4_event)
+b["ipv6_events"].open_perf_buffer(print_ipv6_event)
+
+while 1:
+    b.perf_buffer_poll()

--- a/tools/udp_rcvbuf_errors_example.txt
+++ b/tools/udp_rcvbuf_errors_example.txt
@@ -1,0 +1,37 @@
+Demonstrations of udp_rcvbuf_errors, the Linux eBPF/bcc version.
+
+
+udp_rcvbuf_errors prints information about UDP packets that were dropped by the
+kernel due to the receive buffer being full. For example:
+
+# udp_rcvbuf_errors                                              
+TIME     SADDR:SPORT                    > DADDR:DPORT                    SK_RMEM_ALLOC SK_RCVBUF
+00:11:20 170.79.86.205:28239            > 1.1.1.1:53                     524672        524287
+00:11:20 131.161.192.243:63942          > 1.1.1.1:53                     524672        524287
+00:11:20 170.79.84.148:6239             > 1.1.1.1:53                     524672        524287
+00:11:20 189.126.63.85:64188            > 1.1.1.1:53                     524672        524287
+00:11:20 177.47.85.250:49627            > 1.1.1.1:53                     524672        524287
+
+The last two columns show:
+  SK_RMEM_ALLOC: the size of the buffer the kernel is trying to allocate when
+                 receiving the packet
+  SK_RCVBUF:     the size of the receive buffer
+
+In this example the kernel tries to allocate 385 bytes more than the size of the
+buffer, which leads to those five packets to be dropped.
+
+This is useful for debugging high rates of UDP drops due to RcvbufErrors, which
+can cause the remote end to do timer-based retransmits, hurting performance.
+
+USAGE message:
+
+# ./udp_rcvbuf_errors.py -h
+usage: udp_rcvbuf_errors.py [-h]
+
+Trace UDP RcvbufErrors drops by the kernel
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+examples:
+    ./udp_rcvbuf_errors           # trace UDP RcvbufErrors drops


### PR DESCRIPTION
`udp_rcvbuf_errors` prints information about UDP packets that were dropped by the
kernel due to the receive buffer being full.
This is useful for debugging high rates of UDP drops due to RcvbufErrors and finding which socket is responsible for them in real time.