### PR TITLE
support symbol resolution of short-lived process. 

### DIFF
--- a/man/man8/trace.8
+++ b/man/man8/trace.8
@@ -2,7 +2,7 @@
 .SH NAME
 trace \- Trace a function and print its arguments or return value, optionally evaluating a filter. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B trace [-h] [-b BUFFER_PAGES] [-p PID] [-L TID] [-v] [-Z STRING_SIZE] [-S]
+.B trace [-h] [-b BUFFER_PAGES] [-p PID] [-L TID] [-v] [-Z STRING_SIZE] [-S] [-s SYM_FILE_LIST]
          [-M MAX_EVENTS] [-t] [-T] [-C] [-K] [-U] [-a] [-I header]
          probe [probe ...]
 .SH DESCRIPTION
@@ -28,8 +28,12 @@ Trace only functions in the thread TID.
 Display the generated BPF program, for debugging purposes.
 .TP
 \-z STRING_SIZE
-When collecting string arguments (of type char*), collect up to STRING_SIZE 
+When collecting string arguments (of type char*), collect up to STRING_SIZE
 characters. Longer strings will be truncated.
+.TP
+\-s SYM_FILE_LIST
+When collecting stack trace in build id format, use the coma separated list for
+symbol resolution.
 .TP
 \-S
 If set, trace messages from trace's own process. By default, this is off to
@@ -177,6 +181,10 @@ Trace the pthread_create USDT probe from the pthread library and print the addre
 Trace the nanosleep system call and print the sleep duration in nanoseconds:
 #
 .B trace 'p::SyS_nanosleep(struct timespec *ts) "sleep for %lld ns", ts->tv_nsec'
+.TP
+Trace the inet_pton system call using build id mechanism and print the stack
+#
+.B trace -s /lib/x86_64-linux-gnu/libc.so.6,/bin/ping 'p:c:inet_pton' -U
 .SH SOURCE
 This is from bcc.
 .IP

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -655,7 +655,6 @@ BPFStackTable BPF::get_stack_table(const std::string& name, bool use_debug_file,
 BPFStackBuildIdTable BPF::get_stackbuildid_table(const std::string &name, bool use_debug_file,
                                                  bool check_debug_file_crc) {
   TableStorage::iterator it;
-
   if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
     return BPFStackBuildIdTable(it->second, use_debug_file, check_debug_file_crc, get_bsymcache());
   return BPFStackBuildIdTable({}, use_debug_file, check_debug_file_crc, get_bsymcache());

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -655,6 +655,7 @@ BPFStackTable BPF::get_stack_table(const std::string& name, bool use_debug_file,
 BPFStackBuildIdTable BPF::get_stackbuildid_table(const std::string &name, bool use_debug_file,
                                                  bool check_debug_file_crc) {
   TableStorage::iterator it;
+
   if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
     return BPFStackBuildIdTable(it->second, use_debug_file, check_debug_file_crc, get_bsymcache());
   return BPFStackBuildIdTable({}, use_debug_file, check_debug_file_crc, get_bsymcache());

--- a/tools/trace_example.txt
+++ b/tools/trace_example.txt
@@ -104,6 +104,19 @@ TIME     PID    COMM         FUNC             -
 01:23:55 0      swapper/0    block_rq_complete sectors=8
 ^C
 
+Suppose that you want to trace a system-call in a short-lived process, you can use
+the -s option to trace. The option is followed by list of libraries/executables to
+use for symbol resolution.
+# trace -s /lib/x86_64-linux-gnu/libc.so.6,/bin/ping 'p:c:inet_pton' -U
+Note: Kernel bpf will report stack map with ip/build_id
+PID     TID     COMM            FUNC
+4175    4175    ping            inet_pton
+        inet_pton+0x136340 [libc.so.6]
+        getaddrinfo+0xfb510 [libc.so.6]
+        _init+0x2a08 [ping]
+
+During the trace, 'ping -c1 google.com' was executed to obtain the above results
+
 To discover the tracepoint structure format (which you can refer to as the "args"
 pointer variable), use the tplist tool. For example:
 
@@ -268,6 +281,8 @@ optional arguments:
   -v, --verbose         print resulting BPF program code before executing
   -Z STRING_SIZE, --string-size STRING_SIZE
                         maximum size to read from strings
+  -s SYM_FILE_LIST      when collecting stack trace in build id format,
+                        use the coma separated list for symbol resolution
   -S, --include-self    do not filter trace's own pid from the trace
   -M MAX_EVENTS, --max-events MAX_EVENTS
                         number of events to print before quitting
@@ -325,4 +340,7 @@ trace -I 'net/sock.h' \\
         to 53 (DNS; 13568 in big endian order)
 trace -I 'linux/fs_struct.h' 'mntns_install "users = %d", $task->fs->users'
         Trace the number of users accessing the file system of the current task
+trace -s /lib/x86_64-linux-gnu/libc.so.6,/bin/ping 'p:c:inet_pton' -U
+        Trace inet_pton system call and use the specified libraries/executables for
+        symbol resolution.
 "


### PR DESCRIPTION
Support symbol resolution for short-lived processes (#2014)
New command line options have been added to tools/trace.py to support the new BUILD_ID stackmap. List of symbol files can be added to the script to resolve symbols from build id as reported by the kernel in the stack trace. A comma separated list of symbol files can be passed to the script as shown below. 

Eg invocation to trace inet_pton(as mentioned in #2014)
python tools/trace.py -s /lib/x86_64-linux-gnu/libc.so.6,/bin/ping  'p:c:inet_pton' -U

