### PR TITLE
Unify shebangs under `#!/usr/bin/python`

### DIFF
--- a/SPECS/bcc.spec
+++ b/SPECS/bcc.spec
@@ -88,6 +88,10 @@ popd
 %install
 pushd build
 make install/strip DESTDIR=%{buildroot}
+# mangle shebangs
+find %{buildroot}/usr/share/bcc/{tools,examples} -type f -exec \
+    sed -i -e '1 s|^#!/usr/bin/python$|#!'%{__python}'|' \
+           -e '1 s|^#!/usr/bin/env python$|#!'%{__python}'|' {} \;
 
 %package -n libbcc
 Summary: Shared Library for BPF Compiler Collection (BCC)

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/networking/distributed_bridge/main.py
+++ b/examples/networking/distributed_bridge/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/networking/distributed_bridge/tunnel.py
+++ b/examples/networking/distributed_bridge/tunnel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/networking/distributed_bridge/tunnel_mesh.py
+++ b/examples/networking/distributed_bridge/tunnel_mesh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/networking/dns_matching/dns_matching.py
+++ b/examples/networking/dns_matching/dns_matching.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from __future__ import print_function
 from bcc import BPF

--- a/examples/networking/http_filter/http-parse-complete.py
+++ b/examples/networking/http_filter/http-parse-complete.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 #Bertrone Matteo - Polytechnic of Turin
 #November 2015

--- a/examples/networking/http_filter/http-parse-simple.py
+++ b/examples/networking/http_filter/http-parse-simple.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 #Bertrone Matteo - Polytechnic of Turin
 #November 2015

--- a/examples/networking/neighbor_sharing/tc_neighbor_sharing.py
+++ b/examples/networking/neighbor_sharing/tc_neighbor_sharing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/networking/simple_tc.py
+++ b/examples/networking/simple_tc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/networking/tc_perf_event.py
+++ b/examples/networking/tc_perf_event.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # tc_perf_event.py  Output skb and meta data through perf event
 #

--- a/examples/networking/tunnel_monitor/main.py
+++ b/examples/networking/tunnel_monitor/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/networking/tunnel_monitor/monitor.py
+++ b/examples/networking/tunnel_monitor/monitor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/networking/vlan_filter/data-plane-tracing.py
+++ b/examples/networking/vlan_filter/data-plane-tracing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from __future__ import print_function
 from bcc import BPF
 

--- a/examples/networking/vlan_learning/vlan_learning.py
+++ b/examples/networking/vlan_learning/vlan_learning.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/networking/xdp/xdp_drop_count.py
+++ b/examples/networking/xdp/xdp_drop_count.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # xdp_drop_count.py Drop incoming packets on XDP layer and count for which
 #                   protocol type

--- a/examples/networking/xdp/xdp_macswap_count.py
+++ b/examples/networking/xdp/xdp_macswap_count.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # xdp_macswap_count.py Swap Source and Destination MAC addresses on
 #                      incoming packets and transmit packets back on

--- a/examples/networking/xdp/xdp_redirect_cpu.py
+++ b/examples/networking/xdp/xdp_redirect_cpu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # xdp_redirect_cpu.py Redirect the incoming packet to the specific CPU
 #

--- a/examples/networking/xdp/xdp_redirect_map.py
+++ b/examples/networking/xdp/xdp_redirect_map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # xdp_redirect_map.py Redirect the incoming packet to another interface
 #                     with the helper: bpf_redirect_map()

--- a/examples/tracing/bitehist.py
+++ b/examples/tracing/bitehist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # bitehist.py	Block I/O size histogram.
 #		For Linux, uses BCC, eBPF. Embedded C.

--- a/examples/tracing/disksnoop.py
+++ b/examples/tracing/disksnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # disksnoop.py	Trace block device I/O: basic version of iosnoop.
 #		For Linux, uses BCC, eBPF. Embedded C.

--- a/examples/tracing/hello_fields.py
+++ b/examples/tracing/hello_fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # This is a Hello World example that formats output as fields.
 

--- a/examples/tracing/hello_perf_output.py
+++ b/examples/tracing/hello_perf_output.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # This is a Hello World example that uses BPF_PERF_OUTPUT.
 

--- a/examples/tracing/kvm_hypercall.py
+++ b/examples/tracing/kvm_hypercall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # kvm_hypercall.py
 #

--- a/examples/tracing/mallocstacks.py
+++ b/examples/tracing/mallocstacks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # mallocstacks  Trace malloc() calls in a process and print the full
 #               stack trace for all callsites.

--- a/examples/tracing/mysqld_query.py
+++ b/examples/tracing/mysqld_query.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # mysqld_query    Trace MySQL server queries. Example of USDT tracing.
 #                 For Linux, uses BCC, BPF. Embedded C.

--- a/examples/tracing/nodejs_http_server.py
+++ b/examples/tracing/nodejs_http_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # nodejs_http_server    Basic example of node.js USDT tracing.
 #                       For Linux, uses BCC, BPF. Embedded C.

--- a/examples/tracing/stacksnoop.py
+++ b/examples/tracing/stacksnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # stacksnoop    Trace a kernel function and print all kernel stack traces.
 #               For Linux, uses BCC, eBPF, and currently x86_64 only. Inline C.

--- a/examples/tracing/strlen_count.py
+++ b/examples/tracing/strlen_count.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # strlen_count  Trace strlen() and print a frequency count of strings.
 #               For Linux, uses BCC, eBPF. Embedded C.

--- a/examples/tracing/strlen_hist.py
+++ b/examples/tracing/strlen_hist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 #
 # strlen_hist.py   Histogram of system-wide strlen return values

--- a/examples/tracing/strlen_snoop.py
+++ b/examples/tracing/strlen_snoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # strlen_snoop  Trace strlen() library function for a given PID.
 #               For Linux, uses BCC, eBPF. Embedded C.

--- a/examples/tracing/sync_timing.py
+++ b/examples/tracing/sync_timing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # sync_timing.py    Trace time between syncs.
 #                   For Linux, uses BCC, eBPF. Embedded C.

--- a/examples/tracing/task_switch.py
+++ b/examples/tracing/task_switch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/tracing/tcpv4connect.py
+++ b/examples/tracing/tcpv4connect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # tcpv4connect	Trace TCP IPv4 connect()s.
 #		For Linux, uses BCC, eBPF. Embedded C.

--- a/examples/tracing/trace_fields.py
+++ b/examples/tracing/trace_fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/tracing/trace_perf_output.py
+++ b/examples/tracing/trace_perf_output.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/examples/tracing/urandomread-explicit.py
+++ b/examples/tracing/urandomread-explicit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # urandomread-explicit  Example of instrumenting a kernel tracepoint.
 #                       For Linux, uses BCC, BPF. Embedded C.

--- a/examples/tracing/urandomread.py
+++ b/examples/tracing/urandomread.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # urandomread  Example of instrumenting a kernel tracepoint.
 #              For Linux, uses BCC, BPF. Embedded C.

--- a/examples/tracing/vfsreadlat.py
+++ b/examples/tracing/vfsreadlat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # vfsreadlat.py		VFS read latency distribution.
 #			For Linux, uses BCC, eBPF. See .c file.

--- a/examples/usdt_sample/scripts/lat_avg.py
+++ b/examples/usdt_sample/scripts/lat_avg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 import argparse
 from time import sleep, strftime
 from sys import argv

--- a/examples/usdt_sample/scripts/lat_dist.py
+++ b/examples/usdt_sample/scripts/lat_dist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 import argparse
 from time import sleep, strftime
 from sys import argv

--- a/examples/usdt_sample/scripts/latency.py
+++ b/examples/usdt_sample/scripts/latency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 import argparse
 from time import sleep
 from sys import argv

--- a/scripts/py-style-check.sh
+++ b/scripts/py-style-check.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 find tools -type f -name "*.py" | xargs pep8 -r --show-source --ignore=E123,E125,E126,E127,E128,E302 || \
     echo "pep8 run failed, please fix it" >&2
 
-NO_PROPER_SHEBANG="$(find tools examples -type f -executable -name '*.py' | xargs grep -L '#!/usr/bin/env python')"
+NO_PROPER_SHEBANG="$(find tools examples -type f -executable -name '*.py' | xargs grep -L '#!/usr/bin/python')"
 if [ -n "$NO_PROPER_SHEBANG" ]; then
     echo "bad shebangs found:"
     echo "$NO_PROPER_SHEBANG"

--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # argdist   Trace a function and display a distribution of its
 #           parameter values as a histogram or frequency count.

--- a/tools/bashreadline.py
+++ b/tools/bashreadline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # bashreadline  Print entered bash commands from all running shells.
 #               For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # biolatency    Summarize block device I/O latency as a histogram.

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # biosnoop  Trace block device I/O and print details including issuing PID.

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # biotop  block device (disk) I/O by process.

--- a/tools/bitesize.py
+++ b/tools/bitesize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # bitehist.py   Block I/O size histogram.
 #               For Linux, uses BCC, eBPF. See .c file.

--- a/tools/bpflist.py
+++ b/tools/bpflist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # bpflist   Display processes currently using BPF programs and maps,
 #           pinned BPF programs and maps, and enabled probes.

--- a/tools/btrfsdist.py
+++ b/tools/btrfsdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # btrfsdist  Summarize btrfs operation latency.

--- a/tools/btrfsslower.py
+++ b/tools/btrfsslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # btrfsslower  Trace slow btrfs operations.

--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # cachestat     Count cache kernel function calls.
 #               For Linux, uses BCC, eBPF. See .c file.

--- a/tools/cachetop.py
+++ b/tools/cachetop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # cachetop      Count cache kernel function calls per processes

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # capable   Trace security capabilitiy checks (cap_capable()).

--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # cpudist   Summarize on- and off-CPU time per task as a histogram.

--- a/tools/cpuunclaimed.py
+++ b/tools/cpuunclaimed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # cpuunclaimed   Sample CPU run queues and calculate unclaimed idle CPU.

--- a/tools/criticalstat.py
+++ b/tools/criticalstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # criticalstat  Trace long critical sections (IRQs or preemption disabled)

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # dbslower      Trace MySQL and PostgreSQL queries slower than a threshold.
 #

--- a/tools/dbstat.py
+++ b/tools/dbstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # dbstat        Display a histogram of MySQL and PostgreSQL query latencies.
 #

--- a/tools/dcsnoop.py
+++ b/tools/dcsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # dcsnoop   Trace directory entry cache (dcache) lookups.

--- a/tools/dcstat.py
+++ b/tools/dcstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # dcstat   Directory entry cache (dcache) stats.

--- a/tools/deadlock_detector.py
+++ b/tools/deadlock_detector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # deadlock_detector  Detects potential deadlocks (lock order inversions)
 #                    on a running process. For Linux, uses BCC, eBPF.

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # execsnoop Trace new processes via exec() syscalls.

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # ext4dist  Summarize ext4 operation latency.

--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # ext4slower  Trace slow ext4 operations.

--- a/tools/filelife.py
+++ b/tools/filelife.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # filelife    Trace the lifespan of short-lived files.

--- a/tools/fileslower.py
+++ b/tools/fileslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # fileslower  Trace slow synchronous file reads and writes.

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # filetop  file reads and writes by process.

--- a/tools/funccount.py
+++ b/tools/funccount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # funccount Count functions, tracepoints, and USDT probes.

--- a/tools/funclatency.py
+++ b/tools/funclatency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # funclatency   Time functions and print latency as a histogram.

--- a/tools/funcslower.py
+++ b/tools/funcslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # funcslower  Trace slow kernel or user function calls.

--- a/tools/gethostlatency.py
+++ b/tools/gethostlatency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # gethostlatency  Show latency for getaddrinfo/gethostbyname[2] calls.
 #                 For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/hardirqs.py
+++ b/tools/hardirqs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # hardirqs  Summarize hard IRQ (interrupt) event time.

--- a/tools/inject.py
+++ b/tools/inject.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # This script generates a BPF program with structure inspired by trace.py. The
 # generated program operates on PID-indexed stacks. Generally speaking,

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # killsnoop Trace signals issued by the kill() syscall.

--- a/tools/lib/ucalls.py
+++ b/tools/lib/ucalls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # ucalls  Summarize method calls in high-level languages and/or system calls.

--- a/tools/lib/uflow.py
+++ b/tools/lib/uflow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # uflow  Trace method execution flow in high-level languages.

--- a/tools/lib/ugc.py
+++ b/tools/lib/ugc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # ugc  Summarize garbage collection events in high-level languages.

--- a/tools/lib/uobjnew.py
+++ b/tools/lib/uobjnew.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # uobjnew  Summarize object allocations in high-level languages.

--- a/tools/lib/ustat.py
+++ b/tools/lib/ustat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # ustat  Activity stats from high-level languages, including exceptions,

--- a/tools/lib/uthreads.py
+++ b/tools/lib/uthreads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # uthreads  Trace thread creation/destruction events in high-level languages.

--- a/tools/llcstat.py
+++ b/tools/llcstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # llcstat.py Summarize cache references and cache misses by PID.
 #            Cache reference and cache miss are corresponding events defined in

--- a/tools/mdflush.py
+++ b/tools/mdflush.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # mdflush  Trace md flush events.

--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # memleak   Trace and display outstanding allocations to detect
 #           memory leaks in user-mode processes and the kernel.

--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # mountsnoop Trace mount() and umount syscalls.
 #            For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/mysqld_qslower.py
+++ b/tools/mysqld_qslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # mysqld_qslower    MySQL server queries slower than a threshold.
 #                   For Linux, uses BCC, BPF. Embedded C.

--- a/tools/nfsdist.py
+++ b/tools/nfsdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # nfsdist   Summarize NFS operation latency

--- a/tools/nfsslower.py
+++ b/tools/nfsslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # nfsslower     Trace slow NFS operations

--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # offcputime    Summarize off-CPU time by stack trace
 #               For Linux, uses BCC, eBPF.

--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # offwaketime   Summarize blocked time by kernel off-CPU stack + waker stack
 #               For Linux, uses BCC, eBPF.

--- a/tools/old/bashreadline.py
+++ b/tools/old/bashreadline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # bashreadline  Print entered bash commands from all running shells.
 #               For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/old/biosnoop.py
+++ b/tools/old/biosnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # biosnoop  Trace block device I/O and print details including issuing PID.

--- a/tools/old/filelife.py
+++ b/tools/old/filelife.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # filelife    Trace the lifespan of short-lived files.

--- a/tools/old/gethostlatency.py
+++ b/tools/old/gethostlatency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # gethostlatency  Show latency for getaddrinfo/gethostbyname[2] calls.
 #                 For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/old/killsnoop.py
+++ b/tools/old/killsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # killsnoop Trace signals issued by the kill() syscall.

--- a/tools/old/memleak.py
+++ b/tools/old/memleak.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # memleak   Trace and display outstanding allocations to detect
 #           memory leaks in user-mode processes and the kernel.

--- a/tools/old/offcputime.py
+++ b/tools/old/offcputime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # offcputime    Summarize off-CPU time by kernel stack trace
 #               For Linux, uses BCC, eBPF.

--- a/tools/old/offwaketime.py
+++ b/tools/old/offwaketime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # offwaketime   Summarize blocked time by kernel off-CPU stack + waker stack
 #               For Linux, uses BCC, eBPF.

--- a/tools/old/oomkill.py
+++ b/tools/old/oomkill.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # oomkill   Trace oom_kill_process(). For Linux, uses BCC, eBPF.
 #

--- a/tools/old/opensnoop.py
+++ b/tools/old/opensnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # opensnoop Trace open() syscalls.

--- a/tools/old/profile.py
+++ b/tools/old/profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # profile  Profile CPU usage by sampling stack traces at a timed interval.

--- a/tools/old/softirqs.py
+++ b/tools/old/softirqs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # softirqs  Summarize soft IRQ (interrupt) event time.

--- a/tools/old/stackcount.py
+++ b/tools/old/stackcount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # stackcount    Count kernel function calls and their stack traces.
 #               For Linux, uses BCC, eBPF.

--- a/tools/old/stacksnoop.py
+++ b/tools/old/stacksnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # stacksnoop    Trace a kernel function and print all kernel stack traces.
 #               For Linux, uses BCC, eBPF, and currently x86_64 only. Inline C.

--- a/tools/old/statsnoop.py
+++ b/tools/old/statsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # statsnoop Trace stat() syscalls.

--- a/tools/old/syncsnoop.py
+++ b/tools/old/syncsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # syncsnoop Trace sync() syscall.

--- a/tools/old/tcpaccept.py
+++ b/tools/old/tcpaccept.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpaccept Trace TCP accept()s.

--- a/tools/old/tcpconnect.py
+++ b/tools/old/tcpconnect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpconnect    Trace TCP connect()s.

--- a/tools/old/wakeuptime.py
+++ b/tools/old/wakeuptime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # wakeuptime    Summarize sleep to wakeup time by waker kernel stack
 #               For Linux, uses BCC, eBPF.

--- a/tools/oomkill.py
+++ b/tools/oomkill.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # oomkill   Trace oom_kill_process(). For Linux, uses BCC, eBPF.
 #

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # opensnoop Trace open() syscalls.

--- a/tools/pidpersec.py
+++ b/tools/pidpersec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # pidpersec Count new processes (via fork).

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # profile  Profile CPU usage by sampling stack traces at a timed interval.

--- a/tools/runqlat.py
+++ b/tools/runqlat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # runqlat   Run queue (scheduler) latency as a histogram.

--- a/tools/runqlen.py
+++ b/tools/runqlen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # runqlen    Summarize scheduler run queue length as a histogram.

--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # runqslower    Trace long process scheduling delays.

--- a/tools/shmsnoop.py
+++ b/tools/shmsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # shmsnoop Trace shm*() syscalls.

--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # slabratetop  Summarize kmem_cache_alloc() calls.

--- a/tools/sofdsnoop.py
+++ b/tools/sofdsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # sofdsnoop traces file descriptors passed via socket

--- a/tools/softirqs.py
+++ b/tools/softirqs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # softirqs  Summarize soft IRQ (interrupt) event time.

--- a/tools/solisten.py
+++ b/tools/solisten.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # solisten      Trace TCP listen events
 #               For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/sslsniff.py
+++ b/tools/sslsniff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # sslsniff  Captures data on read/recv or write/send functions of OpenSSL,
 #           GnuTLS and NSS

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # stackcount    Count events and their stack traces.
 #               For Linux, uses BCC, eBPF.

--- a/tools/statsnoop.py
+++ b/tools/statsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # statsnoop Trace stat() syscalls.

--- a/tools/syncsnoop.py
+++ b/tools/syncsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # syncsnoop Trace sync() syscall.

--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # syscount   Summarize syscall counts and latencies.
 #

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpaccept Trace TCP accept()s.

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpconnect    Trace TCP connect()s.

--- a/tools/tcpconnlat.py
+++ b/tools/tcpconnlat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpconnlat    Trace TCP active connection latency (connect).

--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpdrop   Trace TCP kernel-dropped packets/segments.

--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcplife   Trace the lifespan of TCP sessions and summarize.

--- a/tools/tcpretrans.py
+++ b/tools/tcpretrans.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpretrans    Trace or count TCP retransmits and TLPs.

--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 # @lint-avoid-python-3-compatibility-imports
 #

--- a/tools/tcpsubnet.py
+++ b/tools/tcpsubnet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpsubnet   Summarize TCP bytes sent to different subnets.

--- a/tools/tcptop.py
+++ b/tools/tcptop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcptop    Summarize TCP send/recv throughput by host.

--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # tcpv4tracer   Trace TCP connections.
 #               For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/tplist.py
+++ b/tools/tplist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # tplist    Display kernel tracepoints or USDT probes and their formats.
 #

--- a/tools/trace.py
+++ b/tools/trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # trace         Trace a function and print a trace message based on its
 #               parameters, with an optional filter.

--- a/tools/ttysnoop.py
+++ b/tools/ttysnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # ttysnoop   Watch live output from a tty or pts device.

--- a/tools/vfscount.py
+++ b/tools/vfscount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # vfscount  Count VFS calls ("vfs_*").

--- a/tools/vfsstat.py
+++ b/tools/vfsstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # vfsstat   Count some VFS calls.

--- a/tools/wakeuptime.py
+++ b/tools/wakeuptime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # wakeuptime    Summarize sleep to wakeup time by waker kernel stack
 #               For Linux, uses BCC, eBPF.

--- a/tools/xfsdist.py
+++ b/tools/xfsdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # xfsdist  Summarize XFS operation latency.

--- a/tools/xfsslower.py
+++ b/tools/xfsslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # xfsslower  Trace slow XFS operations.

--- a/tools/zfsdist.py
+++ b/tools/zfsdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # zfsdist  Summarize ZFS operation latency.

--- a/tools/zfsslower.py
+++ b/tools/zfsslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # @lint-avoid-python-3-compatibility-imports
 #
 # zfsslower  Trace slow ZFS operations.


### PR DESCRIPTION
This is a partial rollback of #2102.

Previously we've consolidate shebangs on `#!/usr/bin/env python`, which brought some unintended consequences in #2145 like lack of observability, since all proctitles are all `python` now.

Now all shebangs are unified as `#!/usr/bin/python` and it's up to package maintainers to mangle shebangs:
* SPEC is doing it's own explicit shebang rewrite with `sed`.
  * newer Fedora has `pathfix.py`.
* `dh_python2`/`dh_python3` also fixes shebangs by default.

Fixes: #2145 