### PR TITLE
Add free_bcc_memory to BPFModule

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -35,6 +35,7 @@
 
 #include "common.h"
 #include "bcc_debug.h"
+#include "bcc_elf.h"
 #include "frontends/b/loader.h"
 #include "frontends/clang/loader.h"
 #include "frontends/clang/b_frontend_action.h"
@@ -139,6 +140,10 @@ BPFModule::~BPFModule() {
   func_src_.reset();
 
   ts_->DeletePrefix(Path({id_}));
+}
+
+int BPFModule::free_bcc_memory() {
+  return bcc_free_memory();
 }
 
 // load an entire c file as a module

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -83,6 +83,7 @@ class BPFModule {
   BPFModule(unsigned flags, TableStorage *ts = nullptr, bool rw_engine_enabled = true,
             const std::string &maps_ns = "");
   ~BPFModule();
+  int free_bcc_memory();
   int load_b(const std::string &filename, const std::string &proto_filename);
   int load_c(const std::string &filename, const char *cflags[], int ncflags);
   int load_string(const std::string &text, const char *cflags[], int ncflags);


### PR DESCRIPTION
Some users uses `BPFModule` directly instead of C++ / Python API, and they would like to have similar interface of free BCC `.text` memory