### PR TITLE
Fix include style for bcc_syms.h

### DIFF
--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-#include <compat/linux/bpf.h>
+#include "compat/linux/bpf.h"
 
 struct bcc_symbol {
   const char *name;


### PR DESCRIPTION
Across the repo (see `libbpf.h`, `api/BPF.h`) we always use the custom header search include, to make it easier to work with different build environments. 