### PR TITLE
Fix process map parsing when freeing bcc memory

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -863,7 +863,7 @@ int bcc_free_memory() {
     int path_start = 0, path_end = 0;
     unsigned int devmajor, devminor;
     char perms[8];
-    if (sscanf(line, "%lx-%lx %7s %lx %u:%u %lu %n%*[^\n]%n",
+    if (sscanf(line, "%lx-%lx %7s %lx %x:%x %lu %n%*[^\n]%n",
                &addr_start, &addr_end, perms, &offset,
                &devmajor, &devminor, &inode,
                &path_start, &path_end) < 7)


### PR DESCRIPTION
This fixes the format string used to parse the major and minor device fields in `/proc/self/maps`. These fields have hexadecimal values and hence cannot be parsed as unsigned integers.

Fixes: 51480d05 ("implement free_bcc_memory() API (#2097)")