### PR TITLE
print_log2_hist(): check and skip possible paddings

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -317,6 +317,15 @@ class TableBase(MutableMapping):
             tmp = {}
             f1 = self.Key._fields_[0][0]
             f2 = self.Key._fields_[1][0]
+
+            # The above code assumes that self.Key._fields_[1][0] holds the
+            # slot. But a padding member may have been inserted here, which
+            # breaks the assumption and leads to chaos.
+            # TODO: this is a quick fix. Fixing/working around in the BCC
+            # internal library is the right thing to do.
+            if f2 == '__pad_1' and len(self.Key._fields_) == 3:
+                f2 = self.Key._fields_[2][0]
+
             for k, v in self.items():
                 bucket = getattr(k, f1)
                 if bucket_fn:


### PR DESCRIPTION
    When a struct S is used as key to a BPF_HISTOGRAM, it is assumed that the second
    member of S holds the slot. But when S is converted to python from bpf C,
    a padding may be inserted as a second member. This breaks print_log2_hist().

        root@debian:~/bcc/tools# ./softirqs.py -d
        Tracing soft irq event time... Hit Ctrl-C to end.
        ^C
        Traceback (most recent call last):
          File "./softirqs.py", line 144, in <module>
            dist.print_log2_hist(label, "softirq", section_print_fn=vec_to_name)
          File "/usr/local/lib/python2.7/dist-packages/bcc/table.py", line 326, in print_log2_hist
            vals[slot] = v.value
        TypeError: list indices must be integers, not str

    Fix it by skipping the possible padding. Future work would be fixing/working
    around in the library where the padding is introduced.