### PR TITLE
profile.py: return kernel annotations for folded stacks

### DIFF
--- a/tools/profile.py
+++ b/tools/profile.py
@@ -319,7 +319,7 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
             if stack_id_err(k.kernel_stack_id):
                 line.append("[Missed Kernel Stack]")
             else:
-                line.extend([b.ksym(addr) for addr in reversed(kernel_stack)])
+                line.extend([aksym(addr) for addr in reversed(kernel_stack)])
         print("%s %d" % (b";".join(line).decode('utf-8', 'replace'), v.value))
     else:
         # print default multi-line stack output


### PR DESCRIPTION
fixes flame graph color hues, which recognize the _[k] tag. eg:

```
./profile.py -af > out.stacks
./flamegraph.pl --color=java < out.stacks > out.svg
```

