### PR TITLE
tools: rename "deadlock_detector" to "deadlock" (#2152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[dbstat](tools/dbstat.py): Summarize MySQL/PostgreSQL query latency as a histogram. [Examples](tools/dbstat_example.txt).
 - tools/[dcsnoop](tools/dcsnoop.py): Trace directory entry cache (dcache) lookups. [Examples](tools/dcsnoop_example.txt).
 - tools/[dcstat](tools/dcstat.py): Directory entry cache (dcache) stats. [Examples](tools/dcstat_example.txt).
-- tools/[deadlock_detector](tools/deadlock_detector.py): Detect potential deadlocks on a running process. [Examples](tools/deadlock_detector_example.txt).
+- tools/[deadlock](tools/deadlock.py): Detect potential deadlocks on a running process. [Examples](tools/deadlock_example.txt).
 - tools/[execsnoop](tools/execsnoop.py): Trace new processes via exec() syscalls. [Examples](tools/execsnoop_example.txt).
 - tools/[ext4dist](tools/ext4dist.py): Summarize ext4 operation latency distribution as a histogram. [Examples](tools/ext4dist_example.txt).
 - tools/[ext4slower](tools/ext4slower.py): Trace slow ext4 operations. [Examples](tools/ext4slower_example.txt).

--- a/man/man8/deadlock_detector.8
+++ b/man/man8/deadlock_detector.8
@@ -1,14 +1,14 @@
-.TH deadlock_detector 8  "2017-02-01" "USER COMMANDS"
+.TH deadlock 8  "2017-02-01" "USER COMMANDS"
 .SH NAME
-deadlock_detector \- Find potential deadlocks (lock order inversions)
+deadlock \- Find potential deadlocks (lock order inversions)
 in a running program.
 .SH SYNOPSIS
-.B deadlock_detector [\-h] [\--binary BINARY] [\--dump-graph DUMP_GRAPH]
-.B                  [\--verbose] [\--lock-symbols LOCK_SYMBOLS]
-.B                  [\--unlock-symbols UNLOCK_SYMBOLS]
-.B                  pid
+.B deadlock [\-h] [\--binary BINARY] [\--dump-graph DUMP_GRAPH]
+.B          [\--verbose] [\--lock-symbols LOCK_SYMBOLS]
+.B          [\--unlock-symbols UNLOCK_SYMBOLS]
+.B          pid
 .SH DESCRIPTION
-deadlock_detector finds potential deadlocks in a running process. The program
+deadlock finds potential deadlocks in a running process. The program
 attaches uprobes on `pthread_mutex_lock` and `pthread_mutex_unlock` by default
 to build a mutex wait directed graph, and then looks for a cycle in this graph.
 This graph has the following properties:
@@ -65,13 +65,13 @@ Pid to trace
 Find potential deadlocks in PID 181. The --binary argument is not needed for \
 statically-linked binaries.
 #
-.B deadlock_detector 181
+.B deadlock 181
 .TP
 Find potential deadlocks in PID 181. If the process was created from a \
 dynamically-linked executable, the --binary argument is required and must be \
 the path of the pthread library:
 #
-.B deadlock_detector 181 --binary /lib/x86_64-linux-gnu/libpthread.so.0
+.B deadlock 181 --binary /lib/x86_64-linux-gnu/libpthread.so.0
 .TP
 Find potential deadlocks in PID 181. If the process was created from a \
 statically-linked executable, optionally pass the location of the binary. \
@@ -80,19 +80,19 @@ contain `:` in the path cannot be attached with uprobes. As a workaround, we \
 can create a symlink to the binary, and provide the symlink name instead with \
 the `--binary` option:
 #
-.B deadlock_detector 181 --binary /usr/local/bin/lockinversion
+.B deadlock 181 --binary /usr/local/bin/lockinversion
 .TP
 Find potential deadlocks in PID 181 and dump the mutex wait graph to a file:
 #
-.B deadlock_detector 181 --dump-graph graph.json
+.B deadlock 181 --dump-graph graph.json
 .TP
 Find potential deadlocks in PID 181 and print mutex wait graph statistics:
 #
-.B deadlock_detector 181 --verbose
+.B deadlock 181 --verbose
 .TP
 Find potential deadlocks in PID 181 with custom mutexes:
 #
-.B deadlock_detector 181
+.B deadlock 181
 .B      --lock-symbols custom_mutex1_lock,custom_mutex2_lock
 .B      --unlock_symbols custom_mutex1_unlock,custom_mutex2_unlock
 .SH OUTPUT

--- a/snapcraft/snapcraft.yaml
+++ b/snapcraft/snapcraft.yaml
@@ -101,8 +101,8 @@ apps:
         command: usr/share/bcc/tools/dcsnoop
     dcstat:
         command: usr/share/bcc/tools/dcstat
-    deadlock-detector:
-        command: usr/share/bcc/tools/deadlock_detector
+    deadlock:
+        command: usr/share/bcc/tools/deadlock
     execsnoop:
         command: usr/share/bcc/tools/execsnoop
     ext4dist:

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -137,11 +137,11 @@ class SmokeTests(TestCase):
         self.run_with_duration("dcstat.py 1 1")
 
     @skipUnless(kernel_version_ge(4,6), "requires kernel >= 4.6")
-    def test_deadlock_detector(self):
+    def test_deadlock(self):
         # TODO This tool requires a massive BPF stack traces table allocation,
         # which might fail the run or even trigger the oomkiller to kill some
         # other processes. Disabling for now.
-        # self.run_with_int("deadlock_detector.py $(pgrep -n bash)", timeout=10)
+        # self.run_with_int("deadlock.py $(pgrep -n bash)", timeout=10)
         pass
 
     @skipUnless(kernel_version_ge(4,8), "requires kernel >= 4.8")

--- a/tools/deadlock.c
+++ b/tools/deadlock.c
@@ -1,6 +1,6 @@
 /*
- * deadlock_detector.c  Detects potential deadlocks in a running process.
- *                      For Linux, uses BCC, eBPF. See .py file.
+ * deadlock.c  Detects potential deadlocks in a running process.
+ *             For Linux, uses BCC, eBPF. See .py file.
  *
  * Copyright 2017 Facebook, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License")

--- a/tools/deadlock.py
+++ b/tools/deadlock.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 #
-# deadlock_detector  Detects potential deadlocks (lock order inversions)
-#                    on a running process. For Linux, uses BCC, eBPF.
+# deadlock  Detects potential deadlocks (lock order inversions)
+#           on a running process. For Linux, uses BCC, eBPF.
 #
-# USAGE: deadlock_detector.py [-h] [--binary BINARY] [--dump-graph DUMP_GRAPH]
-#                             [--verbose] [--lock-symbols LOCK_SYMBOLS]
-#                             [--unlock-symbols UNLOCK_SYMBOLS]
-#                             pid
+# USAGE: deadlock.py [-h] [--binary BINARY] [--dump-graph DUMP_GRAPH]
+#                    [--verbose] [--lock-symbols LOCK_SYMBOLS]
+#                    [--unlock-symbols UNLOCK_SYMBOLS]
+#                    pid
 #
 # This traces pthread mutex lock and unlock calls to build a directed graph
 # representing the mutex wait graph:
@@ -388,25 +388,25 @@ def strlist(s):
 
 def main():
     examples = '''Examples:
-    deadlock_detector 181        # Analyze PID 181
+    deadlock 181                 # Analyze PID 181
 
-    deadlock_detector 181 --binary /lib/x86_64-linux-gnu/libpthread.so.0
+    deadlock 181 --binary /lib/x86_64-linux-gnu/libpthread.so.0
                                  # Analyze PID 181 and locks from this binary.
                                  # If tracing a process that is running from
                                  # a dynamically-linked binary, this argument
                                  # is required and should be the path to the
                                  # pthread library.
 
-    deadlock_detector 181 --verbose
+    deadlock 181 --verbose
                                  # Analyze PID 181 and print statistics about
                                  # the mutex wait graph.
 
-    deadlock_detector 181 --lock-symbols my_mutex_lock1,my_mutex_lock2 \\
+    deadlock 181 --lock-symbols my_mutex_lock1,my_mutex_lock2 \\
         --unlock-symbols my_mutex_unlock1,my_mutex_unlock2
                                  # Analyze PID 181 and trace custom mutex
                                  # symbols instead of pthread mutexes.
 
-    deadlock_detector 181 --dump-graph graph.json
+    deadlock 181 --dump-graph graph.json
                                  # Analyze PID 181 and dump the mutex wait
                                  # graph to graph.json.
     '''
@@ -465,7 +465,7 @@ def main():
             print('%s. Is the process (pid=%d) running?' % (str(e), args.pid))
             sys.exit(1)
 
-    bpf = BPF(src_file=b'deadlock_detector.c')
+    bpf = BPF(src_file=b'deadlock.c')
 
     # Trace where threads are created
     bpf.attach_kretprobe(event=bpf.get_syscall_fnname('clone'), fn_name='trace_clone')

--- a/tools/deadlock_example.txt
+++ b/tools/deadlock_example.txt
@@ -1,4 +1,4 @@
-Demonstrations of deadlock_detector.
+Demonstrations of deadlock.
 
 This program detects potential deadlocks on a running process. The program
 attaches uprobes on `pthread_mutex_lock` and `pthread_mutex_unlock` to build
@@ -35,7 +35,7 @@ after the mutex has been created. As a result, this tool will not find
 potential deadlocks that involve only one mutex.
 
 
-# ./deadlock_detector.py 181
+# ./deadlock.py 181
 Tracing... Hit Ctrl-C to end.
 ----------------
 Potential Deadlock Detected!
@@ -239,7 +239,7 @@ uses a similar format as ThreadSanitizer
 (https://github.com/google/sanitizers/wiki/ThreadSanitizerDeadlockDetector).
 
 
-# ./deadlock_detector.py 181 --binary /usr/local/bin/lockinversion
+# ./deadlock.py 181 --binary /usr/local/bin/lockinversion
 
 Tracing... Hit Ctrl-C to end.
 ^C
@@ -253,7 +253,7 @@ cannot be attached with uprobes. As a workaround, we can create a symlink
 to the binary, and provide the symlink name instead to the `--binary` option.
 
 
-# ./deadlock_detector.py 181 --binary /lib/x86_64-linux-gnu/libpthread.so.0
+# ./deadlock.py 181 --binary /lib/x86_64-linux-gnu/libpthread.so.0
 
 Tracing... Hit Ctrl-C to end.
 ^C
@@ -263,7 +263,7 @@ this argument is required and needs to be the path to the pthread shared
 library used by the executable.
 
 
-# ./deadlock_detector.py 181 --dump-graph graph.json --verbose
+# ./deadlock.py 181 --dump-graph graph.json --verbose
 
 Tracing... Hit Ctrl-C to end.
 Mutexes: 0, Edges: 0
@@ -284,7 +284,7 @@ serialize the graph to analyze it later, you can pass the `--dump-graph FILE`
 flag, and the program will serialize the graph in json.
 
 
-# ./deadlock_detector.py 181 --lock-symbols custom_mutex1_lock,custom_mutex2_lock --unlock_symbols custom_mutex1_unlock,custom_mutex2_unlock --verbose
+# ./deadlock.py 181 --lock-symbols custom_mutex1_lock,custom_mutex2_lock --unlock_symbols custom_mutex1_unlock,custom_mutex2_unlock --verbose
 
 Tracing... Hit Ctrl-C to end.
 Mutexes: 0, Edges: 0
@@ -307,12 +307,12 @@ in false positives.
 
 USAGE message:
 
-# ./deadlock_detector.py -h
+# ./deadlock.py -h
 
-usage: deadlock_detector.py [-h] [--binary BINARY] [--dump-graph DUMP_GRAPH]
-                            [--verbose] [--lock-symbols LOCK_SYMBOLS]
-                            [--unlock-symbols UNLOCK_SYMBOLS]
-                            pid
+usage: deadlock.py [-h] [--binary BINARY] [--dump-graph DUMP_GRAPH]
+                   [--verbose] [--lock-symbols LOCK_SYMBOLS]
+                   [--unlock-symbols UNLOCK_SYMBOLS]
+                   pid
 
 Detect potential deadlocks (lock inversions) in a running binary.
 Must be run as root.
@@ -342,24 +342,24 @@ optional arguments:
                         be inlined in the binary.
 
 Examples:
-    deadlock_detector 181        # Analyze PID 181
+    deadlock 181                 # Analyze PID 181
 
-    deadlock_detector 181 --binary /lib/x86_64-linux-gnu/libpthread.so.0
+    deadlock 181 --binary /lib/x86_64-linux-gnu/libpthread.so.0
                                  # Analyze PID 181 and locks from this binary.
                                  # If tracing a process that is running from
                                  # a dynamically-linked binary, this argument
                                  # is required and should be the path to the
                                  # pthread library.
 
-    deadlock_detector 181 --verbose
+    deadlock 181 --verbose
                                  # Analyze PID 181 and print statistics about
                                  # the mutex wait graph.
 
-    deadlock_detector 181 --lock-symbols my_mutex_lock1,my_mutex_lock2 \
+    deadlock 181 --lock-symbols my_mutex_lock1,my_mutex_lock2 \
         --unlock-symbols my_mutex_unlock1,my_mutex_unlock2
                                  # Analyze PID 181 and trace custom mutex
                                  # symbols instead of pthread mutexes.
 
-    deadlock_detector 181 --dump-graph graph.json
+    deadlock 181 --dump-graph graph.json
                                  # Analyze PID 181 and dump the mutex wait
                                  # graph to graph.json.


### PR DESCRIPTION
This renames the `deadlock_detector.py` tool to `deadlock.py` to make
the name more diagram-friendly and to be consistent with the naming of the
other tools.