### PR TITLE
Fix tools/syscount -l

### DIFF
--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -17,7 +17,7 @@ import sys
 import signal
 from bcc import BPF
 from bcc.utils import printb
-from bcc.syscall import syscall_name
+from bcc.syscall import syscall_name, syscalls
 
 if sys.version_info.major < 3:
     izip_longest = itertools.izip_longest


### PR DESCRIPTION
In #2063, syscount's syscall mapping was moved into its own module.
Unfortunately, that broke the "print list of recognized syscalls and
exit" usage of syscount. Fix it by importing the syscall mapping from
the new module.