### PR TITLE
add bcc_create_map_xattr() and bcc_prog_load_xattr()

### DIFF
--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -27,6 +27,7 @@ extern "C" {
 #endif
 
 struct bpf_create_map_attr;
+struct bpf_load_program_attr;
 
 enum bpf_probe_attach_type {
 	BPF_PROBE_ENTRY,
@@ -60,9 +61,12 @@ int bpf_get_next_key(int fd, void *key, void *next_key);
  *     initial attemp was insufficient in size.
  */
 int bcc_prog_load(enum bpf_prog_type prog_type, const char *name,
-                  const struct bpf_insn *insns, int insn_len,
+                  const struct bpf_insn *insns, int prog_len,
                   const char *license, unsigned kern_version,
                   int log_level, char *log_buf, unsigned log_buf_size);
+int bcc_prog_load_xattr(struct bpf_load_program_attr *attr,
+                        int prog_len, char *log_buf,
+                        unsigned log_buf_size);
 
 int bpf_attach_socket(int sockfd, int progfd);
 

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -26,6 +26,8 @@
 extern "C" {
 #endif
 
+struct bpf_create_map_attr;
+
 enum bpf_probe_attach_type {
 	BPF_PROBE_ENTRY,
 	BPF_PROBE_RETURN
@@ -34,6 +36,7 @@ enum bpf_probe_attach_type {
 int bcc_create_map(enum bpf_map_type map_type, const char *name,
                    int key_size, int value_size, int max_entries,
                    int map_flags);
+int bcc_create_map_xattr(struct bpf_create_map_attr *attr);
 int bpf_update_elem(int fd, void *key, void *value, unsigned long long flags);
 int bpf_lookup_elem(int fd, void *key, void *value);
 int bpf_delete_elem(int fd, void *key);


### PR DESCRIPTION
Two commits in the patch set. One added bcc_create_map_xattr() and the other added bcc_prog_load_xattr(). These two functions will be useful for creating map or loading program with extra parameters which are not available in bcc_create_map()/bcc_prog_load(), e.g., btf related parameters.