### PR TITLE
do not expose bcc_elf.h as uapi header

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -51,7 +51,7 @@ set(bcc_util_sources ns_guard.cc common.cc)
 set(bcc_sym_sources bcc_syms.cc bcc_elf.c bcc_perf_map.c bcc_proc.c)
 set(bcc_common_headers libbpf.h perf_reader.h)
 set(bcc_table_headers file_desc.h table_desc.h table_storage.h)
-set(bcc_api_headers bpf_common.h bpf_module.h bcc_exception.h bcc_syms.h bcc_elf.h)
+set(bcc_api_headers bpf_common.h bpf_module.h bcc_exception.h bcc_syms.h)
 
 if(ENABLE_CLANG_JIT)
 add_library(bcc-shared SHARED


### PR DESCRIPTION
Commit 51480d0597cc ("implement free_bcc_memory() API")
exposed bcc_elf.h as a uapi header. The original
implementation does not provide a BPFModule level
api so this header can be used to call free_bcc_memory()
for applications using BPFModule level API.

Later Commit 4c5509fc1664 ("Add free_bcc_memory to BPFModule")
added such an interface in BPFModule, so exposing this
header becomes unnecessary.

So removing bcc_elf.h from uapi headers.

Signed-off-by: Yonghong Song <yhs@fb.com>