### PR TITLE
allow application to set rlimit for RLIMIT_MEMLOCK instead of bcc

### DIFF
--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -47,10 +47,13 @@ class BPF {
   static const int BPF_MAX_STACK_DEPTH = 127;
 
   explicit BPF(unsigned int flag = 0, TableStorage* ts = nullptr,
-               bool rw_engine_enabled = bpf_module_rw_engine_enabled(), const std::string &maps_ns = "")
+               bool rw_engine_enabled = bpf_module_rw_engine_enabled(),
+               const std::string &maps_ns = "",
+               bool allow_rlimit = true)
       : flag_(flag),
         bsymcache_(NULL),
-      bpf_module_(new BPFModule(flag, ts, rw_engine_enabled, maps_ns)) {}
+        bpf_module_(new BPFModule(flag, ts, rw_engine_enabled, maps_ns,
+                    allow_rlimit)) {}
   StatusTuple init(const std::string& bpf_program,
                    const std::vector<std::string>& cflags = {},
                    const std::vector<USDT>& usdt = {});

--- a/src/cc/bpf_common.cc
+++ b/src/cc/bpf_common.cc
@@ -26,8 +26,9 @@ void * bpf_module_create_b(const char *filename, const char *proto_filename, uns
   return mod;
 }
 
-void * bpf_module_create_c(const char *filename, unsigned flags, const char *cflags[], int ncflags) {
-  auto mod = new ebpf::BPFModule(flags);
+void * bpf_module_create_c(const char *filename, unsigned flags, const char *cflags[],
+                           int ncflags, bool allow_rlimit) {
+  auto mod = new ebpf::BPFModule(flags, nullptr, true, "", allow_rlimit);
   if (mod->load_c(filename, cflags, ncflags) != 0) {
     delete mod;
     return nullptr;
@@ -35,8 +36,9 @@ void * bpf_module_create_c(const char *filename, unsigned flags, const char *cfl
   return mod;
 }
 
-void * bpf_module_create_c_from_string(const char *text, unsigned flags, const char *cflags[], int ncflags) {
-  auto mod = new ebpf::BPFModule(flags);
+void * bpf_module_create_c_from_string(const char *text, unsigned flags, const char *cflags[],
+                                       int ncflags, bool allow_rlimit) {
+  auto mod = new ebpf::BPFModule(flags, nullptr, true, "", allow_rlimit);
   if (mod->load_string(text, cflags, ncflags) != 0) {
     delete mod;
     return nullptr;

--- a/src/cc/bpf_common.h
+++ b/src/cc/bpf_common.h
@@ -17,6 +17,7 @@
 #ifndef BPF_COMMON_H
 #define BPF_COMMON_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -25,8 +26,10 @@ extern "C" {
 #endif
 
 void * bpf_module_create_b(const char *filename, const char *proto_filename, unsigned flags);
-void * bpf_module_create_c(const char *filename, unsigned flags, const char *cflags[], int ncflags);
-void * bpf_module_create_c_from_string(const char *text, unsigned flags, const char *cflags[], int ncflags);
+void * bpf_module_create_c(const char *filename, unsigned flags, const char *cflags[], int ncflags,
+                           bool allow_rlimit);
+void * bpf_module_create_c_from_string(const char *text, unsigned flags, const char *cflags[],
+                                       int ncflags, bool allow_rlimit);
 void bpf_module_destroy(void *program);
 char * bpf_module_license(void *program);
 unsigned bpf_module_kern_version(void *program);

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -85,7 +85,7 @@ class BPFModule {
 
  public:
   BPFModule(unsigned flags, TableStorage *ts = nullptr, bool rw_engine_enabled = true,
-            const std::string &maps_ns = "");
+            const std::string &maps_ns = "", bool allow_rlimit = true);
   ~BPFModule();
   int free_bcc_memory();
   int load_b(const std::string &filename, const std::string &proto_filename);
@@ -138,6 +138,7 @@ class BPFModule {
   unsigned flags_;  // 0x1 for printing
   bool rw_engine_enabled_;
   bool used_b_loader_;
+  bool allow_rlimit_;
   std::string filename_;
   std::string proto_filename_;
   std::unique_ptr<llvm::LLVMContext> ctx_;

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -19,6 +19,7 @@
 #define LIBBPF_H
 
 #include "linux/bpf.h"
+#include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
 
@@ -37,7 +38,7 @@ enum bpf_probe_attach_type {
 int bcc_create_map(enum bpf_map_type map_type, const char *name,
                    int key_size, int value_size, int max_entries,
                    int map_flags);
-int bcc_create_map_xattr(struct bpf_create_map_attr *attr);
+int bcc_create_map_xattr(struct bpf_create_map_attr *attr, bool allow_rlimit);
 int bpf_update_elem(int fd, void *key, void *value, unsigned long long flags);
 int bpf_lookup_elem(int fd, void *key, void *value);
 int bpf_delete_elem(int fd, void *key);
@@ -66,7 +67,7 @@ int bcc_prog_load(enum bpf_prog_type prog_type, const char *name,
                   int log_level, char *log_buf, unsigned log_buf_size);
 int bcc_prog_load_xattr(struct bpf_load_program_attr *attr,
                         int prog_len, char *log_buf,
-                        unsigned log_buf_size);
+                        unsigned log_buf_size, bool allow_rlimit);
 
 int bpf_attach_socket(int sockfd, int progfd);
 

--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -121,7 +121,7 @@ function Bpf:initialize(args)
 
   if args.text then
     log.info("\n%s\n", args.text)
-    self.module = libbcc.bpf_module_create_c_from_string(args.text, llvm_debug, cflags_ary, #cflags)
+    self.module = libbcc.bpf_module_create_c_from_string(args.text, llvm_debug, cflags_ary, #cflags, true)
   elseif args.src_file then
     local src = _find_file(Bpf.SCRIPT_ROOT, args.src_file)
 
@@ -129,7 +129,7 @@ function Bpf:initialize(args)
       local hdr = _find_file(Bpf.SCRIPT_ROOT, args.hdr_file)
       self.module = libbcc.bpf_module_create_b(src, hdr, llvm_debug)
     else
-      self.module = libbcc.bpf_module_create_c(src, llvm_debug, cflags_ary, #cflags)
+      self.module = libbcc.bpf_module_create_c(src, llvm_debug, cflags_ary, #cflags, true)
     end
   end
 

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -59,8 +59,8 @@ int bpf_close_perf_event_fd(int fd);
 
 ffi.cdef[[
 void * bpf_module_create_b(const char *filename, const char *proto_filename, unsigned flags);
-void * bpf_module_create_c(const char *filename, unsigned flags, const char *cflags[], int ncflags);
-void * bpf_module_create_c_from_string(const char *text, unsigned flags, const char *cflags[], int ncflags);
+void * bpf_module_create_c(const char *filename, unsigned flags, const char *cflags[], int ncflags, bool allow_rlimit);
+void * bpf_module_create_c_from_string(const char *text, unsigned flags, const char *cflags[], int ncflags, bool allow_rlimit);
 void bpf_module_destroy(void *program);
 char * bpf_module_license(void *program);
 unsigned bpf_module_kern_version(void *program);

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -270,7 +270,7 @@ class BPF(object):
         return None
 
     def __init__(self, src_file=b"", hdr_file=b"", text=None, debug=0,
-            cflags=[], usdt_contexts=[]):
+            cflags=[], usdt_contexts=[], allow_rlimit=True):
         """Create a new BPF module with the given source code.
 
         Note:
@@ -318,7 +318,7 @@ class BPF(object):
 
         if text:
             self.module = lib.bpf_module_create_c_from_string(text,
-                    self.debug, cflags_array, len(cflags_array))
+                    self.debug, cflags_array, len(cflags_array), allow_rlimit)
             if not self.module:
                 raise Exception("Failed to compile BPF text")
         else:
@@ -329,7 +329,7 @@ class BPF(object):
                         self.debug)
             else:
                 self.module = lib.bpf_module_create_c(src_file, self.debug,
-                        cflags_array, len(cflags_array))
+                        cflags_array, len(cflags_array), allow_rlimit)
             if not self.module:
                 raise Exception("Failed to compile BPF module %s" % src_file)
 

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -21,10 +21,10 @@ lib.bpf_module_create_b.restype = ct.c_void_p
 lib.bpf_module_create_b.argtypes = [ct.c_char_p, ct.c_char_p, ct.c_uint]
 lib.bpf_module_create_c.restype = ct.c_void_p
 lib.bpf_module_create_c.argtypes = [ct.c_char_p, ct.c_uint,
-        ct.POINTER(ct.c_char_p), ct.c_int]
+        ct.POINTER(ct.c_char_p), ct.c_int, ct.c_bool]
 lib.bpf_module_create_c_from_string.restype = ct.c_void_p
 lib.bpf_module_create_c_from_string.argtypes = [ct.c_char_p, ct.c_uint,
-        ct.POINTER(ct.c_char_p), ct.c_int]
+        ct.POINTER(ct.c_char_p), ct.c_int, ct.c_bool]
 lib.bpf_module_destroy.restype = None
 lib.bpf_module_destroy.argtypes = [ct.c_void_p]
 lib.bpf_module_license.restype = ct.c_char_p

--- a/tests/cc/test_static.c
+++ b/tests/cc/test_static.c
@@ -1,6 +1,6 @@
 #include "bpf_common.h"
 
 int main(int argc, char **argv) {
-  void *mod = bpf_module_create_c_from_string("BPF_TABLE(\"array\", int, int, stats, 10);\n", 4, NULL, 0);
+  void *mod = bpf_module_create_c_from_string("BPF_TABLE(\"array\", int, int, stats, 10);\n", 4, NULL, 0, true);
   return !(mod != NULL);
 }

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -79,3 +79,5 @@ add_test(NAME py_test_license WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_test_license sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_license.py)
 add_test(NAME py_test_free_bcc_memory WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_test_free_bcc_memory sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_free_bcc_memory.py)
+add_test(NAME py_test_rlimit WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_test_rlimit sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_rlimit.py)

--- a/tests/python/test_rlimit.py
+++ b/tests/python/test_rlimit.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#
+# USAGE: test_usdt.py
+#
+# Copyright 2018 Facebook, Inc
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+from __future__ import print_function
+from bcc import BPF
+from unittest import main, skipUnless, TestCase
+import distutils.version
+import os, resource
+
+class TestRlimitMemlock(TestCase):
+    def testRlimitMemlock(self):
+        text = """
+BPF_HASH(unused, u64, u64, 65536);
+int test() { return 0; }
+"""
+        # save the original memlock limits
+        memlock_limit = resource.getrlimit(resource.RLIMIT_MEMLOCK)
+
+        # set a small RLIMIT_MEMLOCK limit
+        resource.setrlimit(resource.RLIMIT_MEMLOCK, (4096, 4096))
+
+        # below will fail
+        failed = 0
+        try:
+            b = BPF(text=text, allow_rlimit=False)
+        except:
+            failed = 1
+        self.assertEqual(failed, 1)
+
+        # below should succeed
+        b = BPF(text=text, allow_rlimit=True)
+
+        # reset to the original memlock limits
+        resource.setrlimit(resource.RLIMIT_MEMLOCK, memlock_limit)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Currently, if map_create and prog_load failed in bcc, bcc
will tries to raise MEMLOCK resource limit to INFINITY
and try again.

The map and program memory is charged against
user->locked_vm which is accumulated per user
and the MEMLOCK rlimit is set per task. This makes
hard to get a proper estimate what value to set, hence
INFINITY is the most popular value.

In production systems, there is a reason why INFINITY
may not be the best option.
  - Uncontrolled prog/map memories could eat much more memory before it is noticied.
  - If there is a bug in user space or kernel leaking prog/map's (not released), they will not get noticed since other bpf program/map will continue to load successfully with INFINITY MEMLOCK rlimit.

This patch provides a mechanism for python and C++ APIs to
disable bcc setrlimit.

The C++ example RandomRead is intrumented to allow/disallow setrlimit,
and the following is an execution instance:
```
  -bash-4.4$ sudo ./RandomRead -r
  could not open bpf map: cgroup, error: Operation not permitted
  Unable to initialize BPF program
  -bash-4.4$ sudo ./RandomRead -u
  Started tracing, hit Ctrl-C to terminate.
  ^CTerminating...
  -bash-4.4$
```
A python test is also added.

Signed-off-by: Yonghong Song <yhs@fb.com>