### PR TITLE
ignore external maps during retrieving type id's

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -279,6 +279,18 @@ int BPFModule::load_maps(std::map<std::string, std::tuple<uint8_t *, uintptr_t>>
         unsigned key_tid = 0, value_tid = 0;
         unsigned expected_ksize = 0, expected_vsize = 0;
 
+        // skip extern maps, which won't be in fake_fd_map_ as they do not
+        // require explicit bpf_create_map.
+        bool is_extern = false;
+        for (auto &t : tables_) {
+          if (t->name == map_name) {
+            is_extern = t->is_extern;
+            break;
+          }
+        }
+        if (is_extern)
+          continue;
+
         for (auto map : fake_fd_map_) {
           std::string name;
 


### PR DESCRIPTION
When running example UseExternalMap or test test_libbcc,
the following warning showed up:
```
  -bash-4.4$ sudo ./UseExternalMap
  libbpf: map:control btf_key_type_size:4 != map_def_key_size:0
  .....
  -bash-4.4$ sudo ./test_libbcc
  libbpf: map:mysharedtable btf_key_type_size:4 != map_def_key_size:0
  .....
```
This is related to external maps. When the application
defines an external maps, the extra .maps.<map_name> section
gets generated. But the map is not in fake_fd_map_
as the external map does not require an explicit bpf_create_map
syscall. It merely duplicates fd from an existing map.

The warning showed up because the external map was not
in fake_fd_map_ and expected_ksize and expected_vsize are based
on fake_fd_map_ hence is 0, which does not match the real map.

There is really no reason to find type ids for external maps.
So just skip them and the warnings are gone as well.

Signed-off-by: Yonghong Song <yhs@fb.com>