### PR TITLE
add `enum` support for generating perf event data struct

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -575,6 +575,7 @@ class PerfEventArray(ArrayBase):
                        'u16'               : ct.c_ushort,
                        'int'               : ct.c_int,
                        's32'               : ct.c_int,
+                       'enum'              : ct.c_int,
                        'unsigned int'      : ct.c_uint,
                        'u32'               : ct.c_uint,
                        'long'              : ct.c_long,
@@ -598,6 +599,9 @@ class PerfEventArray(ArrayBase):
             m = re.match(r"(.*)#(.*)", field)
             field_name = m.group(1)
             field_type = m.group(2)
+
+            if re.match(r"enum .*", field_type):
+                field_type = "enum"
 
             m = array_type.match(field_type)
             try:

--- a/tools/dcsnoop.py
+++ b/tools/dcsnoop.py
@@ -23,7 +23,6 @@
 from __future__ import print_function
 from bcc import BPF
 import argparse
-import ctypes as ct
 import re
 import time
 
@@ -123,17 +122,6 @@ int kretprobe__d_lookup(struct pt_regs *ctx)
 }
 """
 
-TASK_COMM_LEN = 16  # linux/sched.h
-MAX_FILE_LEN = 64  # see inline C
-
-class Data(ct.Structure):
-    _fields_ = [
-        ("pid", ct.c_uint),
-        ("type", ct.c_int),
-        ("comm", ct.c_char * TASK_COMM_LEN),
-        ("filename", ct.c_char * MAX_FILE_LEN),
-    ]
-
 if args.ebpf:
     print(bpf_text)
     exit()
@@ -151,7 +139,7 @@ mode_s = {
 start_ts = time.time()
 
 def print_event(cpu, data, size):
-    event = ct.cast(data, ct.POINTER(Data)).contents
+    event = b["events"].event(data)
     print("%-11.6f %-6d %-16s %1s %s" % (
             time.time() - start_ts, event.pid,
             event.comm.decode('utf-8', 'replace'), mode_s[event.type],


### PR DESCRIPTION
Add enum type support so that scripts like tools/dcsnoop.py could be
simplied.