### PR TITLE
implement DEBUG_BTF flag

### DIFF
--- a/src/cc/bcc_btf.h
+++ b/src/cc/bcc_btf.h
@@ -43,6 +43,7 @@ class BTFStringTable {
 
 class BTF {
  public:
+  BTF(bool debug);
   ~BTF();
   int load(uint8_t *btf_sec, uintptr_t btf_sec_size,
            uint8_t *btf_ext_sec, uintptr_t btf_ext_sec_size,
@@ -62,8 +63,10 @@ class BTF {
               uint8_t *btf_ext_sec, uintptr_t btf_ext_sec_size,
               std::map<std::string, std::string> &remapped_sources,
               uint8_t **new_btf_sec, uintptr_t *new_btf_sec_size);
+  void warning(const char *format, ...);
 
  private:
+  bool debug_;
   struct btf *btf_;
   struct btf_ext *btf_ext_;
 };

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -258,7 +258,7 @@ void BPFModule::load_btf(std::map<std::string, std::tuple<uint8_t *, uintptr_t>>
   remapped_sources["/virtual/main.c"] = mod_src_;
   remapped_sources["/virtual/include/bcc/helpers.h"] = helpers_h->second;
 
-  BTF *btf = new BTF();
+  BTF *btf = new BTF(flags_ & DEBUG_BTF);
   int ret = btf->load(btf_sec, btf_sec_size, btf_ext_sec, btf_ext_sec_size,
                        remapped_sources);
   if (ret) {

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -47,6 +47,8 @@ enum {
   DEBUG_SOURCE = 0x8,
   // Debug output register state on all instructions in addition to DEBUG_BPF.
   DEBUG_BPF_REGISTER_STATE = 0x10,
+  // Debug BTF.
+  DEBUG_BTF = 0x20,
 };
 
 class TableDesc;

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -51,8 +51,10 @@ DEBUG_BPF = 0x2
 DEBUG_PREPROCESSOR = 0x4
 # Debug output ASM instructions embedded with source.
 DEBUG_SOURCE = 0x8
-#Debug output register state on all instructions in addition to DEBUG_BPF.
+# Debug output register state on all instructions in addition to DEBUG_BPF.
 DEBUG_BPF_REGISTER_STATE = 0x10
+# Debug BTF.
+DEBUG_BTF = 0x20
 
 class SymbolCache(object):
     def __init__(self, pid):


### PR DESCRIPTION
silence BTF related warning messages by default.
The DEBUG_BTF is added to enable such warning messages.

Signed-off-by: Yonghong Song <yhs@fb.com>