### PR TITLE
tools: fix some python3 bytes vs strings issues

### DIFF
--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -225,7 +225,7 @@ def print_event(cpu, data, size):
             skip = True
         if args.quote:
             argv[event.pid] = [
-                "\"" + arg.replace("\"", "\\\"") + "\""
+                b"\"" + arg.replace(b"\"", b"\\\"") + b"\""
                 for arg in argv[event.pid]
             ]
 

--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -288,13 +288,15 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
             if stack_id_err(k.user_stack_id):
                 line.append("[Missed User Stack]")
             else:
-                line.extend([b.sym(addr, k.tgid) for addr in reversed(user_stack)])
+                line.extend([b.sym(addr, k.tgid).decode('utf-8', 'replace')
+                    for addr in reversed(user_stack)])
         if not args.user_stacks_only:
             line.extend(["-"] if (need_delimiter and k.kernel_stack_id >= 0 and k.user_stack_id >= 0) else [])
             if stack_id_err(k.kernel_stack_id):
                 line.append("[Missed Kernel Stack]")
             else:
-                line.extend([b.ksym(addr) for addr in reversed(kernel_stack)])
+                line.extend([b.ksym(addr).decode('utf-8', 'replace')
+                    for addr in reversed(kernel_stack)])
         print("%s %d" % (";".join(line), v.value))
     else:
         # print default multi-line stack output

--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -323,28 +323,28 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
             if stack_id_err(k.t_u_stack_id):
                 line.append("[Missed User Stack]")
             else:
-                line.extend([b.sym(addr, k.t_tgid)
+                line.extend([b.sym(addr, k.t_tgid).decode('utf-8', 'replace')
                     for addr in reversed(list(target_user_stack)[1:])])
         if not args.user_stacks_only:
             line.extend(["-"] if (need_delimiter and k.t_k_stack_id > 0 and k.t_u_stack_id > 0) else [])
             if stack_id_err(k.t_k_stack_id):
                 line.append("[Missed Kernel Stack]")
             else:
-                line.extend([b.ksym(addr)
+                line.extend([b.ksym(addr).decode('utf-8', 'replace')
                     for addr in reversed(list(target_kernel_stack)[1:])])
         line.append("--")
         if not args.user_stacks_only:
             if stack_id_err(k.w_k_stack_id):
                 line.append("[Missed Kernel Stack]")
             else:
-                line.extend([b.ksym(addr)
+                line.extend([b.ksym(addr).decode('utf-8', 'replace')
                     for addr in reversed(list(waker_kernel_stack))])
         if not args.kernel_stacks_only:
             line.extend(["-"] if (need_delimiter and k.w_u_stack_id > 0 and k.w_k_stack_id > 0) else [])
             if stack_id_err(k.w_u_stack_id):
                 line.append("[Missed User Stack]")
             else:
-                line.extend([b.sym(addr, k.w_tgid)
+                line.extend([b.sym(addr, k.w_tgid).decode('utf-8', 'replace')
                     for addr in reversed(list(waker_user_stack))])
         line.append(k.waker.decode('utf-8', 'replace'))
         print("%s %d" % (";".join(line), v.value))


### PR DESCRIPTION
It fixes the following errors:

$ execsnoop.py -q
PCOMM            PID    PPID   RET ARGS
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 234, in 'calling callback function'
  File "/usr/lib/python3.6/site-packages/bcc/table.py", line 572, in raw_cb_
    callback(cpu, data, size)
  File "tools/execsnoop.py", line 229, in print_event
    for arg in argv[event.pid]
  File "tools/execsnoop.py", line 229, in <listcomp>
    for arg in argv[event.pid]
TypeError: a bytes-like object is required, not 'str'

$ offcputime.py -K -f 5
Traceback (most recent call last):
  File "./tools/offcputime.py", line 298, in <module>
    print("%s %d" % (";".join(line), v.value))
TypeError: sequence item 1: expected str instance, bytes found

$ offwaketime.py -f 5
Traceback (most recent call last):
  File "./tools/offwaketime.py", line 350, in <module>
    print("%s %d" % (";".join(line), v.value))
TypeError: sequence item 1: expected str instance, bytes found