### PR TITLE
Rename bpf_common.h to bcc_common.h

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(bpf-shared SHARED libbpf.c perf_reader.c ${libbpf_sources})
 set_target_properties(bpf-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
 set_target_properties(bpf-shared PROPERTIES OUTPUT_NAME bpf)
 
-set(bcc_common_sources bpf_common.cc bpf_module.cc bcc_btf.cc exported_files.cc)
+set(bcc_common_sources bcc_common.cc bpf_module.cc bcc_btf.cc exported_files.cc)
 if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 6 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 6)
   set(bcc_common_sources ${bcc_common_sources} bcc_debug.cc)
 endif()
@@ -51,7 +51,7 @@ set(bcc_util_sources ns_guard.cc common.cc)
 set(bcc_sym_sources bcc_syms.cc bcc_elf.c bcc_perf_map.c bcc_proc.c)
 set(bcc_common_headers libbpf.h perf_reader.h)
 set(bcc_table_headers file_desc.h table_desc.h table_storage.h)
-set(bcc_api_headers bpf_common.h bpf_module.h bcc_exception.h bcc_syms.h)
+set(bcc_api_headers bcc_common.h bpf_module.h bcc_exception.h bcc_syms.h)
 
 if(ENABLE_CLANG_JIT)
 add_library(bcc-shared SHARED

--- a/src/cc/bcc_common.cc
+++ b/src/cc/bcc_common.cc
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "bpf_common.h"
+#include "bcc_common.h"
 #include "bpf_module.h"
 
 extern "C" {

--- a/src/cc/bcc_common.h
+++ b/src/cc/bcc_common.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef BPF_COMMON_H
-#define BPF_COMMON_H
+#ifndef BCC_COMMON_H
+#define BCC_COMMON_H
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -16,7 +16,7 @@ import ctypes as ct
 
 lib = ct.CDLL("libbcc.so.0", use_errno=True)
 
-# keep in sync with bpf_common.h
+# keep in sync with bcc_common.h
 lib.bpf_module_create_b.restype = ct.c_void_p
 lib.bpf_module_create_b.argtypes = [ct.c_char_p, ct.c_char_p, ct.c_uint]
 lib.bpf_module_create_c.restype = ct.c_void_p

--- a/tests/cc/test_static.c
+++ b/tests/cc/test_static.c
@@ -1,4 +1,4 @@
-#include "bpf_common.h"
+#include "bcc_common.h"
 
 int main(int argc, char **argv) {
   void *mod = bpf_module_create_c_from_string("BPF_TABLE(\"array\", int, int, stats, 10);\n", 4, NULL, 0, true);


### PR DESCRIPTION
This avoids potential conflict with Kernel UAPI's `bpf_common.h` in certain build environment, especially considering `libbpf` now includes and installs that UAPI header file.