### PR TITLE
enable debug output for test_usdt3.py

### DIFF
--- a/tests/python/test_usdt3.py
+++ b/tests/python/test_usdt3.py
@@ -105,7 +105,7 @@ int do_trace(struct pt_regs *ctx) {
 
         # Run the application
         self.app = Popen([m_bin], env=dict(os.environ, LD_LIBRARY_PATH=self.tmp_dir))
-        # os.system("tplist.py -vvv -p " + str(self.app.pid))
+        os.system("../../tools/tplist.py -vvv -p " + str(self.app.pid))
 
     def test_attach1(self):
         # enable USDT probe from given PID and verifier generated BPF programs


### PR DESCRIPTION
test_usdt3.py has been flaky for a while.
When the test failed, it looks like it did not catch
a single event.

The patch enabled debug output to print out all
the trace points before attachments so we will have
more context in case of failure. Also this debug
output seems significantly reduced flakiness
and in my fc28 I cannot reproduce the test failure
with it.

Signed-off-by: Yonghong Song <yhs@fb.com>