### PR TITLE
Fix BCC on arm64 by allowing missing ausyscall

### DIFF
--- a/src/python/bcc/syscall.py
+++ b/src/python/bcc/syscall.py
@@ -381,10 +381,7 @@ try:
     out = out.split(b'\n',1)[1]
     syscalls = dict(map(_parse_syscall, out.strip().split(b'\n')))
 except Exception as e:
-    if platform.machine() == "x86_64":
-        pass
-    else:
-        raise Exception("ausyscall: command not found")
+    pass
 
 def syscall_name(syscall_num):
     """Return the syscall name for the particular syscall number."""


### PR DESCRIPTION
ausyscall is not available on ARM64 systems I am testing. The system is
running debian buster. All BCC tools fail as a result. Let us not fail
if ausyscall is missing.

Signed-off-by: Joel Fernandes <joelaf@google.com>