### PR TITLE
fix #1851 for Arch Linux users

### DIFF
--- a/man/man8/bashreadline.8
+++ b/man/man8/bashreadline.8
@@ -2,7 +2,7 @@
 .SH NAME
 bashreadline \- Print entered bash commands system wide. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B bashreadline
+.B bashreadline [\-h] [\-s SHARED]
 .SH DESCRIPTION
 bashreadline traces the return of the readline() function using uprobes, to
 show the bash commands that were entered interactively, system wide. The
@@ -17,6 +17,15 @@ which uses an older mechanism
 Since this uses BPF, only the root user can use this tool.
 .SH REQUIREMENTS
 CONFIG_BPF and bcc.
+.SH OPTIONS
+.TP
+\-h
+Print usage message.
+.TP
+\-s
+Specify the location of libreadline.so shared library when you failed to run the
+script directly with error: "Exception: could not determine address of symbol 
+\'readline\'". Default value is /lib/libreadline.so.
 .SH EXAMPLES
 .TP
 Trace bash commands system wide:

--- a/tools/bashreadline.py
+++ b/tools/bashreadline.py
@@ -3,7 +3,12 @@
 # bashreadline  Print entered bash commands from all running shells.
 #               For Linux, uses BCC, eBPF. Embedded C.
 #
+# USAGE: bashreadline [-s SHARED]
 # This works by tracing the readline() function using a uretprobe (uprobes).
+# When you failed to run the script directly with error:
+# `Exception: could not determine address of symbol b'readline'`,
+# you may need specify the location of libreadline.so library
+# with `-s` option.
 #
 # Copyright 2016 Netflix, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -14,6 +19,16 @@
 from __future__ import print_function
 from bcc import BPF
 from time import strftime
+import argparse
+
+parser = argparse.ArgumentParser(
+        description="Print entered bash commands from all running shells",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument("-s", "--shared",
+        help="specify the location of libreadline.so library")
+args = parser.parse_args()
+
+name = args.shared if args.shared else "/bin/bash"
 
 # load BPF program
 bpf_text = """
@@ -41,7 +56,7 @@ int printret(struct pt_regs *ctx) {
 """
 
 b = BPF(text=bpf_text)
-b.attach_uretprobe(name="/bin/bash", sym="readline", fn_name="printret")
+b.attach_uretprobe(name=name, sym="readline", fn_name="printret")
 
 # header
 print("%-9s %-6s %s" % ("TIME", "PID", "COMMAND"))

--- a/tools/bashreadline.py
+++ b/tools/bashreadline.py
@@ -24,8 +24,10 @@ import argparse
 parser = argparse.ArgumentParser(
         description="Print entered bash commands from all running shells",
         formatter_class=argparse.RawDescriptionHelpFormatter)
-parser.add_argument("-s", "--shared",
-        help="specify the location of libreadline.so library")
+parser.add_argument("-s", "--shared", nargs="?",
+        const="/lib/libreadline.so", type=str,
+        help="specify the location of libreadline.so library.\
+              Default is /lib/libreadline.so")
 args = parser.parse_args()
 
 name = args.shared if args.shared else "/bin/bash"

--- a/tools/bashreadline_example.txt
+++ b/tools/bashreadline_example.txt
@@ -14,6 +14,16 @@ TIME      PID    COMMAND
 05:29:04  3059   echo another shell
 05:29:13  21176  echo first shell again
 
+When running the script on Arch Linux, you may need to specify the location
+of libreadline.so library:
+
+# ./bashreadline -s /lib/libreadline.so
+TIME      PID    COMMAND
+11:17:34  28796  whoami
+11:17:41  28796  ps -ef
+11:17:51  28796  echo "Hello eBPF!"
+
+
 The entered command may fail. This is just showing what command lines were
 entered interactively for bash to process.
 


### PR DESCRIPTION
The fix for **Arch Linux** came from #1851.

Have tested that the script can run on `Ubuntu 18.04.2` without any modification.
Haven't tested for other distributions.