### PR TITLE
fix a bug related to syscall.py

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -27,7 +27,6 @@ basestring = (unicode if sys.version_info[0] < 3 else str)
 from .libbcc import lib, bcc_symbol, bcc_symbol_option, bcc_stacktrace_build_id, _SYM_CB_TYPE
 from .table import Table, PerfEventArray
 from .perf import Perf
-from .syscall import syscall_name
 from .utils import get_online_cpus, printb, _assert_is_bytes, ArgString
 from .version import __version__
 

--- a/src/python/bcc/syscall.py
+++ b/src/python/bcc/syscall.py
@@ -381,7 +381,10 @@ try:
     out = out.split(b'\n',1)[1]
     syscalls = dict(map(_parse_syscall, out.strip().split(b'\n')))
 except Exception as e:
-    pass
+   if platform.machine() == "x86_64":
+       pass
+   else:
+       raise Exception("ausyscall: command not found")
 
 def syscall_name(syscall_num):
     """Return the syscall name for the particular syscall number."""

--- a/tools/lib/ucalls.py
+++ b/tools/lib/ucalls.py
@@ -15,7 +15,8 @@
 from __future__ import print_function
 import argparse
 from time import sleep
-from bcc import BPF, USDT, utils, syscall_name
+from bcc import BPF, USDT, utils
+from bcc.syscall import syscall_name
 
 languages = ["java", "perl", "php", "python", "ruby", "tcl"]
 


### PR DESCRIPTION
Commit 218f7482f8ae refactored syscall number=>name
mapping into a separate file src/python/bcc/syscall.py.
The commit added a reference in python __init__.py,
and this will cause virtually all non x64 arch python
tools failure.

Commit bc0d472ec9d7 attempted to fix the issue by
removing the failure in syscall.py but this is not
the correct fix for arm64 as the syscall numbers
won't match.

Removing the syscall.py reference in __init__.py
should be enough to restore the previous
working behavior.

Fixes: bc0d472ec9d7 ("Fix BCC on arm64 by allowing missing ausyscall")
Fixes: 218f7482f8ae ("Wcohen/efficiency (#2063)")
Signed-off-by: Yonghong Song <yhs@fb.com>