### PR TITLE
Expose kprobe's maxactive parameter in bcc

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -987,7 +987,7 @@ Examples in situ:
 
 ### 2. attach_kretprobe()
 
-Syntax: ```BPF.attach_kretprobe(event="event", fn_name="name")```
+Syntax: ```BPF.attach_kretprobe(event="event", fn_name="name" [, maxactive=int])```
 
 Instruments the return of the kernel function ```event()``` using kernel dynamic tracing of the function return, and attaches our C defined function ```name()``` to be called when the kernel function returns.
 
@@ -1000,6 +1000,8 @@ b.attach_kretprobe(event="vfs_read", fn_name="do_return")
 This will instrument the kernel ```vfs_read()``` function, which will then run our BPF defined ```do_return()``` function each time it is called.
 
 You can call attach_kretprobe() more than once, and attach your BPF function to multiple kernel function returns.
+
+When a kretprobe is installed on a kernel function, there is a limit on how many parallel calls it can catch. You can change that limit with ```maxactive```. See the kprobes documentation for its default value.
 
 See the previous kretprobes section for how to instrument the return value from BPF.
 

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -167,7 +167,8 @@ StatusTuple BPF::detach_all() {
 StatusTuple BPF::attach_kprobe(const std::string& kernel_func,
                                const std::string& probe_func,
                                uint64_t kernel_func_offset,
-                               bpf_probe_attach_type attach_type) {
+                               bpf_probe_attach_type attach_type,
+                               int maxactive) {
   std::string probe_event = get_kprobe_event(kernel_func, attach_type);
   if (kprobes_.find(probe_event) != kprobes_.end())
     return StatusTuple(-1, "kprobe %s already attached", probe_event.c_str());
@@ -176,7 +177,8 @@ StatusTuple BPF::attach_kprobe(const std::string& kernel_func,
   TRY2(load_func(probe_func, BPF_PROG_TYPE_KPROBE, probe_fd));
 
   int res_fd = bpf_attach_kprobe(probe_fd, attach_type, probe_event.c_str(),
-                                 kernel_func.c_str(), kernel_func_offset);
+                                 kernel_func.c_str(), kernel_func_offset,
+                                 maxactive);
 
   if (res_fd < 0) {
     TRY2(unload_func(probe_func));

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -64,7 +64,8 @@ class BPF {
   StatusTuple attach_kprobe(const std::string& kernel_func,
                             const std::string& probe_func,
                             uint64_t kernel_func_offset = 0,
-                            bpf_probe_attach_type = BPF_PROBE_ENTRY);
+                            bpf_probe_attach_type = BPF_PROBE_ENTRY,
+                            int maxactive = 0);
   StatusTuple detach_kprobe(
       const std::string& kernel_func,
       bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY);

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -79,7 +79,8 @@ typedef void (*perf_reader_raw_cb)(void *cb_cookie, void *raw, int raw_size);
 typedef void (*perf_reader_lost_cb)(void *cb_cookie, uint64_t lost);
 
 int bpf_attach_kprobe(int progfd, enum bpf_probe_attach_type attach_type,
-                      const char *ev_name, const char *fn_name, uint64_t fn_offset);
+                      const char *ev_name, const char *fn_name, uint64_t fn_offset,
+                      int maxactive);
 int bpf_detach_kprobe(const char *ev_name);
 
 int bpf_attach_uprobe(int progfd, enum bpf_probe_attach_type attach_type,

--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -213,8 +213,9 @@ function Bpf:attach_kprobe(args)
   local ev_name = string.format("%s_%s", ptype, event:gsub("[%+%.]", "_"))
   local offset = args.fn_offset or 0
   local retprobe = args.retprobe and 1 or 0
+  local maxactive = args.maxactive or 0
 
-  local res = libbcc.bpf_attach_kprobe(fn.fd, retprobe, ev_name, event, offset)
+  local res = libbcc.bpf_attach_kprobe(fn.fd, retprobe, ev_name, event, offset, maxactive)
 
   assert(res >= 0, "failed to attach BPF to kprobe")
   self:probe_store("kprobe", ev_name, res)

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -43,7 +43,7 @@ typedef void (*perf_reader_raw_cb)(void *cb_cookie, void *raw, int raw_size);
 typedef void (*perf_reader_lost_cb)(void *cb_cookie, uint64_t lost);
 
 int bpf_attach_kprobe(int progfd, int attach_type, const char *ev_name,
-                      const char *fn_name, uint64_t fn_offset);
+                      const char *fn_name, uint64_t fn_offset, int maxactive);
 
 int bpf_detach_kprobe(const char *ev_name);
 

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -629,14 +629,14 @@ class BPF(object):
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
         ev_name = b"p_" + event.replace(b"+", b"_").replace(b".", b"_")
-        fd = lib.bpf_attach_kprobe(fn.fd, 0, ev_name, event, event_off)
+        fd = lib.bpf_attach_kprobe(fn.fd, 0, ev_name, event, event_off, 0)
         if fd < 0:
             raise Exception("Failed to attach BPF program %s to kprobe %s" %
                             (fn_name, event))
         self._add_kprobe_fd(ev_name, fd)
         return self
 
-    def attach_kretprobe(self, event=b"", fn_name=b"", event_re=b""):
+    def attach_kretprobe(self, event=b"", fn_name=b"", event_re=b"", maxactive=0):
         event = _assert_is_bytes(event)
         fn_name = _assert_is_bytes(fn_name)
         event_re = _assert_is_bytes(event_re)
@@ -645,7 +645,8 @@ class BPF(object):
         if event_re:
             for line in BPF.get_kprobe_functions(event_re):
                 try:
-                    self.attach_kretprobe(event=line, fn_name=fn_name)
+                    self.attach_kretprobe(event=line, fn_name=fn_name,
+                                          maxactive=maxactive)
                 except:
                     pass
             return
@@ -653,7 +654,7 @@ class BPF(object):
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
         ev_name = b"r_" + event.replace(b"+", b"_").replace(b".", b"_")
-        fd = lib.bpf_attach_kprobe(fn.fd, 1, ev_name, event, 0)
+        fd = lib.bpf_attach_kprobe(fn.fd, 1, ev_name, event, 0, maxactive)
         if fd < 0:
             raise Exception("Failed to attach BPF program %s to kretprobe %s" %
                             (fn_name, event))

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -93,7 +93,7 @@ _RAW_CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_void_p, ct.c_int)
 _LOST_CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_ulonglong)
 lib.bpf_attach_kprobe.restype = ct.c_int
 lib.bpf_attach_kprobe.argtypes = [ct.c_int, ct.c_int, ct.c_char_p, ct.c_char_p,
-        ct.c_ulonglong]
+        ct.c_ulonglong, ct.c_int]
 lib.bpf_detach_kprobe.restype = ct.c_int
 lib.bpf_detach_kprobe.argtypes = [ct.c_char_p]
 lib.bpf_attach_uprobe.restype = ct.c_int

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -37,6 +37,8 @@ add_test(NAME py_test_trace3_c WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_trace3_c sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_trace3.py test_trace3.c)
 add_test(NAME py_test_trace4 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_trace4 sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_trace4.py)
+add_test(NAME py_test_trace_maxactive WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_trace_maxactive sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_trace_maxactive.py)
 add_test(NAME py_test_probe_count WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_probe_count sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_probe_count.py)
 add_test(NAME py_test_debuginfo WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/python/test_trace_maxactive.py
+++ b/tests/python/test_trace_maxactive.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# Copyright (c) PLUMgrid, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+from bcc import BPF
+import os
+import sys
+from unittest import main, TestCase
+
+class TestKprobeMaxactive(TestCase):
+    def setUp(self):
+        self.b = BPF(text=b"""
+        typedef struct { int idx; } Key;
+        typedef struct { u64 val; } Val;
+        BPF_HASH(stats, Key, Val, 3);
+        int hello(void *ctx) {
+          stats.lookup_or_init(&(Key){1}, &(Val){0})->val++;
+          return 0;
+        }
+        int goodbye(void *ctx) {
+          stats.lookup_or_init(&(Key){2}, &(Val){0})->val++;
+          return 0;
+        }
+        """)
+        self.b.attach_kprobe(event_re=self.b.get_syscall_prefix() + b"bpf",
+                             fn_name=b"hello")
+        self.b.attach_kretprobe(event_re=self.b.get_syscall_prefix() + b"bpf",
+                                fn_name=b"goodbye", maxactive=128)
+
+    def test_send1(self):
+        k1 = self.b[b"stats"].Key(1)
+        k2 = self.b[b"stats"].Key(2)
+        self.assertTrue(self.b[b"stats"][k1].val >= 2)
+        self.assertTrue(self.b[b"stats"][k2].val == 1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
When a kretprobe is installed on a kernel function, there is a limit on how many parallel calls it can catch. You can change that limit with the `maxactive` parameter. Since [commit `696ced4` ("tracing/kprobes: expose maxactive for kretprobe in kprobe_events")](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=696ced4fb1d76802f864d8848aa4716633f83c17) in the Linux kernel, debugfs exposes that parameter.

This pull request exposes that parameter in bcc as well, through `bpf_attach_kprobe` in libbcc and `BPF.attach_kretprobe` at the Python level. If a `maxactive` value is given, we fallback to using debugfs to install the kprobe event, instead of the usual `perf_event_open`.

For kernels without `maxactive` supports in debugfs, the error resolution is not straightforward. The kernel will still install a probe, but under a different name. We therefore need to check for our expected name, delete the probe with the different name, and try to attach the probe again, without the `maxactive` value.

Fixes #1072 #1250

/cc @alban @anisse 