### PR TITLE
support gcc 8's cold subfunctions

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -565,7 +565,7 @@ class BPF(object):
                 elif fn.startswith(b'__perf') or fn.startswith(b'perf_'):
                     continue
                 # Exclude all gcc 8's extra .cold functions
-                elif re.match('^.*\.cold\.\d+$', fn):
+                elif re.match(b'^.*\.cold\.\d+$', fn):
                     continue
                 if (t.lower() in [b't', b'w']) and re.match(event_re, fn) \
                     and fn not in blacklist:

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -564,6 +564,9 @@ class BPF(object):
                 # non-attachable.
                 elif fn.startswith(b'__perf') or fn.startswith(b'perf_'):
                     continue
+                # Exclude all gcc 8's extra .cold functions
+                elif re.match('^.*\.cold\.\d+$', fn):
+                    continue
                 if (t.lower() in [b't', b'w']) and re.match(event_re, fn) \
                     and fn not in blacklist:
                     fns.append(fn)


### PR DESCRIPTION
GCC 8 can split functions bodies into hot and cold regions, causing
extra symbols with a ".cold.N" suffix to be emitted. Exclude these
extra symbols and only allow the parent function to be traced.

Signed-off-by: Andrea Righi <righi.andrea@gmail.com>