### PR TITLE
tcpaccept: only show TCP accept event

### DIFF
--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -161,6 +161,8 @@ TRACEPOINT_PROBE(sock, inet_sock_set_state)
 {
     if (args->protocol != IPPROTO_TCP)
         return 0;
+    if (args->oldstate != TCP_SYN_RECV || args->newstate != TCP_ESTABLISHED)
+        return 0;
     u32 pid = bpf_get_current_pid_tgid();
 
     ##FILTER_PID##


### PR DESCRIPTION
pr #1842 forgot to add filtering in the new tracepoint code so it's
incorrectly showing every sock:inet_sock_set_state event.

This patch fixes that.