### PR TITLE
Fix the output of example scripts with python3 and handle KeyboardInterrupt

### DIFF
--- a/examples/tracing/disksnoop.py
+++ b/examples/tracing/disksnoop.py
@@ -12,6 +12,7 @@
 
 from __future__ import print_function
 from bcc import BPF
+from bcc.utils import printb
 
 REQ_WRITE = 1		# from include/linux/blk_types.h
 
@@ -56,13 +57,13 @@ while 1:
 		(bytes_s, bflags_s, us_s) = msg.split()
 
 		if int(bflags_s, 16) & REQ_WRITE:
-			type_s = "W"
+			type_s = b"W"
 		elif bytes_s == "0":	# see blk_fill_rwbs() for logic
-			type_s = "M"
+			type_s = b"M"
 		else:
-			type_s = "R"
+			type_s = b"R"
 		ms = float(int(us_s, 10)) / 1000
 
-		print("%-18.9f %-2s %-7s %8.2f" % (ts, type_s, bytes_s, ms))
+		printb(b"%-18.9f %-2s %-7s %8.2f" % (ts, type_s, bytes_s, ms))
 	except KeyboardInterrupt:
 		exit()

--- a/examples/tracing/hello_fields.py
+++ b/examples/tracing/hello_fields.py
@@ -26,4 +26,6 @@ while 1:
         (task, pid, cpu, flags, ts, msg) = b.trace_fields()
     except ValueError:
         continue
+    except KeyboardInterrupt:
+        exit()
     printb(b"%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))

--- a/examples/tracing/hello_fields.py
+++ b/examples/tracing/hello_fields.py
@@ -3,6 +3,7 @@
 # This is a Hello World example that formats output as fields.
 
 from bcc import BPF
+from bcc.utils import printb
 
 # define BPF program
 prog = """
@@ -25,4 +26,4 @@ while 1:
         (task, pid, cpu, flags, ts, msg) = b.trace_fields()
     except ValueError:
         continue
-    print("%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))
+    printb(b"%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))

--- a/examples/tracing/hello_perf_output.py
+++ b/examples/tracing/hello_perf_output.py
@@ -3,6 +3,7 @@
 # This is a Hello World example that uses BPF_PERF_OUTPUT.
 
 from bcc import BPF
+from bcc.utils import printb
 
 # define BPF program
 prog = """
@@ -44,8 +45,8 @@ def print_event(cpu, data, size):
     if start == 0:
             start = event.ts
     time_s = (float(event.ts - start)) / 1000000000
-    print("%-18.9f %-16s %-6d %s" % (time_s, event.comm, event.pid,
-        "Hello, perf_output!"))
+    printb(b"%-18.9f %-16s %-6d %s" % (time_s, event.comm, event.pid,
+        b"Hello, perf_output!"))
 
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)

--- a/examples/tracing/mallocstacks.py
+++ b/examples/tracing/mallocstacks.py
@@ -12,6 +12,7 @@
 
 from __future__ import print_function
 from bcc import BPF
+from bcc.utils import printb
 from time import sleep
 import sys
 
@@ -56,4 +57,4 @@ stack_traces = b.get_table("stack_traces")
 for k, v in reversed(sorted(calls.items(), key=lambda c: c[1].value)):
     print("%d bytes allocated at:" % v.value)
     for addr in stack_traces.walk(k.value):
-        print("\t%s" % b.sym(addr, pid, show_offset=True))
+        printb(b"\t%s" % b.sym(addr, pid, show_offset=True))

--- a/examples/tracing/mysqld_query.py
+++ b/examples/tracing/mysqld_query.py
@@ -59,4 +59,6 @@ while 1:
     except ValueError:
         print("value error")
         continue
+    except KeyboardInterrupt:
+        exit()
     printb(b"%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))

--- a/examples/tracing/mysqld_query.py
+++ b/examples/tracing/mysqld_query.py
@@ -12,6 +12,7 @@
 
 from __future__ import print_function
 from bcc import BPF, USDT
+from bcc.utils import printb
 import sys
 
 if len(sys.argv) < 2:
@@ -58,4 +59,4 @@ while 1:
     except ValueError:
         print("value error")
         continue
-    print("%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))
+    printb(b"%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))

--- a/examples/tracing/nodejs_http_server.py
+++ b/examples/tracing/nodejs_http_server.py
@@ -52,4 +52,6 @@ while 1:
     except ValueError:
         print("value error")
         continue
+    except KeyboardInterrupt:
+        exit()
     printb(b"%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))

--- a/examples/tracing/nodejs_http_server.py
+++ b/examples/tracing/nodejs_http_server.py
@@ -10,6 +10,7 @@
 
 from __future__ import print_function
 from bcc import BPF, USDT
+from bcc.utils import printb
 import sys
 
 if len(sys.argv) < 2:
@@ -51,4 +52,4 @@ while 1:
     except ValueError:
         print("value error")
         continue
-    print("%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))
+    printb(b"%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))

--- a/examples/tracing/strlen_count.py
+++ b/examples/tracing/strlen_count.py
@@ -12,6 +12,7 @@
 
 from __future__ import print_function
 from bcc import BPF
+from bcc.utils import printb
 from time import sleep
 
 # load BPF program
@@ -52,4 +53,4 @@ except KeyboardInterrupt:
 print("%10s %s" % ("COUNT", "STRING"))
 counts = b.get_table("counts")
 for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
-    print("%10d \"%s\"" % (v.value, k.c.encode('string-escape')))
+    printb(b"%10d \"%s\"" % (v.value, k.c))

--- a/examples/tracing/sync_timing.py
+++ b/examples/tracing/sync_timing.py
@@ -45,8 +45,11 @@ print("Tracing for quick sync's... Ctrl-C to end")
 # format output
 start = 0
 while 1:
-    (task, pid, cpu, flags, ts, ms) = b.trace_fields()
-    if start == 0:
-        start = ts
-    ts = ts - start
-    printb(b"At time %.2f s: multiple syncs detected, last %s ms ago" % (ts, ms))
+    try:
+        (task, pid, cpu, flags, ts, ms) = b.trace_fields()
+        if start == 0:
+            start = ts
+        ts = ts - start
+        printb(b"At time %.2f s: multiple syncs detected, last %s ms ago" % (ts, ms))
+    except KeyboardInterrupt:
+        exit()

--- a/examples/tracing/sync_timing.py
+++ b/examples/tracing/sync_timing.py
@@ -10,6 +10,7 @@
 
 from __future__ import print_function
 from bcc import BPF
+from bcc.utils import printb
 
 # load BPF program
 b = BPF(text="""
@@ -48,4 +49,4 @@ while 1:
     if start == 0:
         start = ts
     ts = ts - start
-    print("At time %.2f s: multiple syncs detected, last %s ms ago" % (ts, ms))
+    printb(b"At time %.2f s: multiple syncs detected, last %s ms ago" % (ts, ms))

--- a/examples/tracing/tcpv4connect.py
+++ b/examples/tracing/tcpv4connect.py
@@ -94,6 +94,8 @@ while 1:
 	except ValueError:
 	    # Ignore messages from other tracers
 	    continue
+	except KeyboardInterrupt:
+	    exit()
 
 	# Ignore messages from other tracers
 	if _tag != "trace_tcp4connect":

--- a/examples/tracing/tcpv4connect.py
+++ b/examples/tracing/tcpv4connect.py
@@ -16,6 +16,7 @@
 
 from __future__ import print_function
 from bcc import BPF
+from bcc.utils import printb
 
 # define BPF program
 bpf_text = """
@@ -76,11 +77,11 @@ print("%-6s %-12s %-16s %-16s %-4s" % ("PID", "COMM", "SADDR", "DADDR",
     "DPORT"))
 
 def inet_ntoa(addr):
-	dq = ''
+	dq = b''
 	for i in range(0, 4):
-		dq = dq + str(addr & 0xff)
+		dq = dq + str(addr & 0xff).encode()
 		if (i != 3):
-			dq = dq + '.'
+			dq = dq + b'.'
 		addr = addr >> 8
 	return dq
 
@@ -89,7 +90,7 @@ while 1:
 	# Read messages from kernel pipe
 	try:
 	    (task, pid, cpu, flags, ts, msg) = b.trace_fields()
-	    (_tag, saddr_hs, daddr_hs, dport_s) = msg.split(" ")
+	    (_tag, saddr_hs, daddr_hs, dport_s) = msg.split(b" ")
 	except ValueError:
 	    # Ignore messages from other tracers
 	    continue
@@ -98,7 +99,7 @@ while 1:
 	if _tag != "trace_tcp4connect":
 	    continue
 
-	print("%-6d %-12.12s %-16s %-16s %-4s" % (pid, task,
+	printb(b"%-6d %-12.12s %-16s %-16s %-4s" % (pid, task,
 	    inet_ntoa(int(saddr_hs, 16)),
 	    inet_ntoa(int(daddr_hs, 16)),
 	    dport_s))

--- a/examples/tracing/trace_fields.py
+++ b/examples/tracing/trace_fields.py
@@ -18,4 +18,7 @@ int hello(void *ctx) {
 b = BPF(text=prog)
 b.attach_kprobe(event=b.get_syscall_fnname("clone"), fn_name="hello")
 print("PID MESSAGE")
-b.trace_print(fmt="{1} {5}")
+try:
+    b.trace_print(fmt="{1} {5}")
+except KeyboardInterrupt:
+    exit()

--- a/examples/tracing/trace_perf_output.py
+++ b/examples/tracing/trace_perf_output.py
@@ -8,6 +8,7 @@
 
 import atexit
 from bcc import BPF
+from bcc.utils import printb
 import ctypes as ct
 
 class Data(ct.Structure):
@@ -50,7 +51,7 @@ def print_counter():
     global b
     print("counter = %d vs %d" % (counter, b["counters"][ct.c_int(0)].value))
 
-print("Tracing " + event_name + ", try `dd if=/dev/zero of=/dev/null`")
+printb(b"Tracing " + event_name + b", try `dd if=/dev/zero of=/dev/null`")
 print("Tracing... Hit Ctrl-C to end.")
 while 1:
     try:

--- a/examples/tracing/urandomread-explicit.py
+++ b/examples/tracing/urandomread-explicit.py
@@ -17,6 +17,7 @@
 
 from __future__ import print_function
 from bcc import BPF
+from bcc.utils import printb
 
 # define BPF program
 bpf_text = """
@@ -49,4 +50,4 @@ while 1:
         (task, pid, cpu, flags, ts, msg) = b.trace_fields()
     except ValueError:
         continue
-    print("%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))
+    printb(b"%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))

--- a/examples/tracing/urandomread-explicit.py
+++ b/examples/tracing/urandomread-explicit.py
@@ -50,4 +50,6 @@ while 1:
         (task, pid, cpu, flags, ts, msg) = b.trace_fields()
     except ValueError:
         continue
+    except KeyboardInterrupt:
+        exit()
     printb(b"%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))

--- a/examples/tracing/urandomread.py
+++ b/examples/tracing/urandomread.py
@@ -33,4 +33,6 @@ while 1:
         (task, pid, cpu, flags, ts, msg) = b.trace_fields()
     except ValueError:
         continue
+    except KeyboardInterrupt:
+        exit()
     printb(b"%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))

--- a/examples/tracing/urandomread.py
+++ b/examples/tracing/urandomread.py
@@ -13,6 +13,7 @@
 
 from __future__ import print_function
 from bcc import BPF
+from bcc.utils import printb
 
 # load BPF program
 b = BPF(text="""
@@ -32,4 +33,4 @@ while 1:
         (task, pid, cpu, flags, ts, msg) = b.trace_fields()
     except ValueError:
         continue
-    print("%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))
+    printb(b"%-18.9f %-16s %-6d %s" % (ts, task, pid, msg))


### PR DESCRIPTION
Switch to printb to get rid of the prefix 'b' of the byte arrays.
Also handle the KeyboardInterrupt exception for some scripts to avoid the code tracing when stopping the program.