### PR TITLE
added DNAME_INLINE_LEN to be 32 as per filetop

### DIFF
--- a/tools/fileslower.py
+++ b/tools/fileslower.py
@@ -220,7 +220,7 @@ print("%-8s %-14s %-6s %1s %-7s %7s %s" % ("TIME(s)", "COMM", "TID", "D",
     "BYTES", "LAT(ms)", "FILENAME"))
 
 start_ts = time.time()
-
+DNAME_INLINE_LEN = 32 
 def print_event(cpu, data, size):
     event = b["events"].event(data)
 


### PR DESCRIPTION
fileslower was failing on newest version of bcc/tools unsure as to why right now however filetop has explicit declaration of DNAME_INLINE_LEN , adding resolves immediate issue.