### PR TITLE
docs/reference_guide: Update kernel macro name

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -417,7 +417,7 @@ This is used for targeted error injection.
 
 bpf_override_return will only work when the kprobed function is whitelisted to
 allow error injections. Whitelisting entails tagging a function with
-`BPF_ALLOW_ERROR_INJECTION()` in the kernel source tree; see `io_ctl_init` for
+`ALLOW_ERROR_INJECTION()` in the kernel source tree; see `io_ctl_init` for
 an example. If the kprobed function is not whitelisted, the bpf program will
 fail to attach with ` ioctl(PERF_EVENT_IOC_SET_BPF): Invalid argument`
 


### PR DESCRIPTION
540adea3809f "error-injection: Separate error-injection from kprobe",
merged in v4.16, changed the name of BPF_ALLOW_ERROR_INJECTION
to just ALLOW_ERROR_INJECTION.

Update the name to help readers grepping the kernel code.