### PR TITLE
Add PyPerf, example of profiling Python using BPF

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -41,3 +41,5 @@ if(INSTALL_CPP_EXAMPLES)
   install (TARGETS FollyRequestContextSwitch DESTINATION share/bcc/examples/cpp)
   install (TARGETS UseExternalMap DESTINATION share/bcc/examples/cpp)
 endif(INSTALL_CPP_EXAMPLES)
+
+add_subdirectory(pyperf)

--- a/examples/cpp/pyperf/CMakeLists.txt
+++ b/examples/cpp/pyperf/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) Facebook, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+include_directories(${CMAKE_SOURCE_DIR}/src/cc)
+include_directories(${CMAKE_SOURCE_DIR}/src/cc/api)
+include_directories(${CMAKE_SOURCE_DIR}/src/cc/libbpf/include/uapi)
+
+add_executable(PyPerf PyPerf.cc PyPerfUtil.cc PyPerfBPFProgram.cc PyPerfLoggingHelper.cc Py36Offsets.cc)
+target_link_libraries(PyPerf bcc-static)
+
+if(INSTALL_CPP_EXAMPLES)
+  install (TARGETS PyPerf DESTINATION share/bcc/examples/cpp)
+endif(INSTALL_CPP_EXAMPLES)

--- a/examples/cpp/pyperf/Py36Offsets.cc
+++ b/examples/cpp/pyperf/Py36Offsets.cc
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include "PyPerfType.h"
+
+namespace ebpf {
+namespace pyperf {
+
+extern const OffsetConfig kPy36OffsetConfig = {
+    .PyObject_type = 8,               // offsetof(PyObject, ob_type)
+    .PyTypeObject_name = 24,          // offsetof(PyTypeObject, tp_name)
+    .PyThreadState_frame = 24,        // offsetof(PyThreadState, frame)
+    .PyThreadState_thread = 152,      // offsetof(PyThreadState, thread_id)
+    .PyFrameObject_back = 24,         // offsetof(PyFrameObject, f_back)
+    .PyFrameObject_code = 32,         // offsetof(PyFrameObject, f_code)
+    .PyFrameObject_lineno = 124,      // offsetof(PyFrameObject, f_lineno)
+    .PyFrameObject_localsplus = 376,  // offsetof(PyFrameObject, f_localsplus)
+    .PyCodeObject_filename = 96,      // offsetof(PyCodeObject, co_filename)
+    .PyCodeObject_name = 104,         // offsetof(PyCodeObject, co_name)
+    .PyCodeObject_varnames = 64,      // offsetof(PyCodeObject, co_varnames)
+    .PyTupleObject_item = 24,         // offsetof(PyTupleObject, ob_item)
+    .String_data = 48,                // sizeof(PyASCIIObject)
+    .String_size = 16,                // offsetof(PyVarObject, ob_size)
+};
+
+}
+}  // namespace ebpf

--- a/examples/cpp/pyperf/PyPerf.cc
+++ b/examples/cpp/pyperf/PyPerf.cc
@@ -1,0 +1,75 @@
+/*
+ * PyPerf Profile Python Processes with Python stack-trace.
+ *        For Linux, uses BCC, eBPF. Embedded C.
+ *
+ * Example of using BPF to profile Python Processes with Python stack-trace.
+ *
+ * USAGE: PyPerf [-d|--duration DURATION_MS] [-c|--sample-rate SAMPLE_RATE]
+ *               [-v|--verbosity LOG_VERBOSITY]
+ *
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <cinttypes>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "PyPerfLoggingHelper.h"
+#include "PyPerfUtil.h"
+
+int main(int argc, char** argv) {
+  int pos = 1;
+
+  auto parseIntArg = [&](std::vector<std::string> argNames, uint64_t& target) {
+    std::string arg(argv[pos]);
+    for (const auto& name : argNames) {
+      if (arg == name) {
+        if (pos == argc) {
+          std::fprintf(stderr, "Expect value after %s\n", arg.c_str());
+          std::exit(1);
+        }
+        pos++;
+        std::string value(argv[pos]);
+        try {
+          target = std::stoi(value);
+        } catch (const std::exception& e) {
+          std::fprintf(stderr, "Expect integer value after %s, got %s: %s\n",
+                       arg.c_str(), value.c_str(), e.what());
+          std::exit(1);
+        }
+        return true;
+      }
+    }
+    return false;
+  };
+
+  uint64_t sampleRate = 1000000;
+  uint64_t durationMs = 1000;
+  uint64_t verbosityLevel = 0;
+  while (true) {
+    if (pos >= argc) {
+      break;
+    }
+    bool found = false;
+    found = found || parseIntArg({"-c", "--sample-rate"}, sampleRate);
+    found = found || parseIntArg({"-d", "--duration"}, durationMs);
+    found = found || parseIntArg({"-v", "--verbose"}, verbosityLevel);
+    if (!found) {
+      std::fprintf(stderr, "Unexpected argument: %s\n", argv[pos]);
+      std::exit(1);
+    }
+    pos++;
+  }
+
+  ebpf::pyperf::setVerbosity(verbosityLevel);
+  ebpf::pyperf::logInfo(1, "Profiling Sample Rate: %" PRIu64 "\n", sampleRate);
+  ebpf::pyperf::logInfo(1, "Profiling Duration: %" PRIu64 "ms\n", durationMs);
+
+  ebpf::pyperf::PyPerfUtil util;
+  util.init();
+  util.profile(sampleRate, durationMs);
+
+  return 0;
+}

--- a/examples/cpp/pyperf/PyPerfBPFProgram.cc
+++ b/examples/cpp/pyperf/PyPerfBPFProgram.cc
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <string>
+
+namespace ebpf {
+namespace pyperf {
+
+extern const std::string PYPERF_BPF_PROGRAM = R"(
+#include <linux/sched.h>
+#include <uapi/linux/ptrace.h>
+
+#define PYTHON_STACK_FRAMES_PER_PROG 25
+#define PYTHON_STACK_PROG_CNT 3
+#define STACK_MAX_LEN (PYTHON_STACK_FRAMES_PER_PROG * PYTHON_STACK_PROG_CNT)
+#define CLASS_NAME_LEN 32
+#define FUNCTION_NAME_LEN 64
+#define FILE_NAME_LEN 128
+#define TASK_COMM_LEN 16
+
+enum {
+  STACK_STATUS_COMPLETE = 0,
+  STACK_STATUS_ERROR = 1,
+  STACK_STATUS_TRUNCATED = 2,
+};
+
+enum {
+  GIL_STATE_NO_INFO = 0,
+  GIL_STATE_ERROR = 1,
+  GIL_STATE_UNINITIALIZED = 2,
+  GIL_STATE_NOT_LOCKED = 3,
+  GIL_STATE_THIS_THREAD = 4,
+  GIL_STATE_GLOBAL_CURRENT_THREAD = 5,
+  GIL_STATE_OTHER_THREAD = 6,
+  GIL_STATE_NULL = 7,
+};
+
+enum {
+  THREAD_STATE_UNKNOWN = 0,
+  THREAD_STATE_MATCH = 1,
+  THREAD_STATE_MISMATCH = 2,
+  THREAD_STATE_THIS_THREAD_NULL = 3,
+  THREAD_STATE_GLOBAL_CURRENT_THREAD_NULL = 4,
+  THREAD_STATE_BOTH_NULL = 5,
+};
+
+enum {
+  PTHREAD_ID_UNKNOWN = 0,
+  PTHREAD_ID_MATCH = 1,
+  PTHREAD_ID_MISMATCH = 2,
+  PTHREAD_ID_THREAD_STATE_NULL = 3,
+  PTHREAD_ID_NULL = 4,
+  PTHREAD_ID_ERROR = 5,
+};
+
+typedef struct {
+  int64_t PyObject_type;
+  int64_t PyTypeObject_name;
+  int64_t PyThreadState_frame;
+  int64_t PyThreadState_thread;
+  int64_t PyFrameObject_back;
+  int64_t PyFrameObject_code;
+  int64_t PyFrameObject_lineno;
+  int64_t PyFrameObject_localsplus;
+  int64_t PyCodeObject_filename;
+  int64_t PyCodeObject_name;
+  int64_t PyCodeObject_varnames;
+  int64_t PyTupleObject_item;
+  int64_t String_data;
+  int64_t String_size;
+} OffsetConfig;
+
+typedef struct {
+  uintptr_t current_state_addr; // virtual address of _PyThreadState_Current
+  uintptr_t tls_key_addr; // virtual address of autoTLSkey for pthreads TLS
+  uintptr_t gil_locked_addr; // virtual address of gil_locked
+  uintptr_t gil_last_holder_addr; // virtual address of gil_last_holder
+  OffsetConfig offsets;
+} PidData;
+
+typedef struct {
+  char classname[CLASS_NAME_LEN];
+  char name[FUNCTION_NAME_LEN];
+  char file[FILE_NAME_LEN];
+  // NOTE: PyFrameObject also has line number but it is typically just the
+  // first line of that function and PyCode_Addr2Line needs to be called
+  // to get the actual line
+} Symbol;
+
+typedef struct {
+  uint32_t pid;
+  uint32_t tid;
+  char comm[TASK_COMM_LEN];
+  uint8_t thread_state_match;
+  uint8_t gil_state;
+  uint8_t pthread_id_match;
+  uint8_t stack_status;
+  // instead of storing symbol name here directly, we add it to another
+  // hashmap with Symbols and only store the ids here
+  int64_t stack_len;
+  int32_t stack[STACK_MAX_LEN];
+} Event;
+
+#define _STR_CONCAT(str1, str2) str1##str2
+#define STR_CONCAT(str1, str2) _STR_CONCAT(str1, str2)
+#define FAIL_COMPILATION_IF(condition)            \
+  typedef struct {                                \
+    char _condition_check[1 - 2 * !!(condition)]; \
+  } STR_CONCAT(compile_time_condition_check, __COUNTER__);
+// See comments in get_frame_data
+FAIL_COMPILATION_IF(sizeof(Symbol) == sizeof(struct bpf_perf_event_value))
+
+typedef struct {
+  OffsetConfig offsets;
+  uint64_t cur_cpu;
+  int64_t symbol_counter;
+  void* frame_ptr;
+  int64_t python_stack_prog_call_cnt;
+  Event event;
+} sample_state_t;
+
+BPF_PERCPU_ARRAY(state_heap, sample_state_t, 1);
+BPF_HASH(symbols, Symbol, int32_t, __SYMBOLS_SIZE__);
+BPF_HASH(pid_config, pid_t, PidData);
+BPF_PROG_ARRAY(progs, 1);
+
+BPF_PERF_OUTPUT(events);
+
+static inline __attribute__((__always_inline__)) void* get_thread_state(
+    void* tls_base,
+    PidData* pid_data) {
+  // Python sets the thread_state using pthread_setspecific with the key
+  // stored in a global variable autoTLSkey.
+  // We read the value of the key from the global variable and then read
+  // the value in the thread-local storage. This relies on pthread implementation.
+  // This is basically the same as running the following in GDB:
+  //  p *(PyThreadState*)((struct pthread*)pthread_self())->
+  //    specific_1stblock[autoTLSkey]->data
+  int key;
+  bpf_probe_read(&key, sizeof(key), (void*)pid_data->tls_key_addr);
+  // This assumes autoTLSkey < 32, which means that the TLS is stored in
+  //   pthread->specific_1stblock[autoTLSkey]
+  // 0x310 is offsetof(struct pthread, specific_1stblock),
+  // 0x10 is sizeof(pthread_key_data)
+  // 0x8 is offsetof(struct pthread_key_data, data)
+  // 'struct pthread' is not in the public API so we have to hardcode
+  // the offsets here
+  void* thread_state;
+  bpf_probe_read(
+      &thread_state,
+      sizeof(thread_state),
+      tls_base + 0x310 + key * 0x10 + 0x08);
+  return thread_state;
+}
+
+static inline __attribute__((__always_inline__)) int submit_sample(
+    struct pt_regs* ctx,
+    sample_state_t* state) {
+  events.perf_submit(ctx, &state->event, sizeof(Event));
+  return 0;
+}
+
+// this function is trivial, but we need to do map lookup in separate function,
+// because BCC doesn't allow direct map calls (including lookups) from inside
+// a macro (which we want to do in GET_STATE() macro below)
+static inline __attribute__((__always_inline__)) sample_state_t* get_state() {
+  int zero = 0;
+  return state_heap.lookup(&zero);
+}
+
+#define GET_STATE()                     \
+  sample_state_t* state = get_state();  \
+  if (!state) {                         \
+    return 0; /* should never happen */ \
+  }
+
+static inline __attribute__((__always_inline__)) int get_thread_state_match(
+    void* this_thread_state,
+    void* global_thread_state) {
+  if (this_thread_state == 0 && global_thread_state == 0) {
+    return THREAD_STATE_BOTH_NULL;
+  }
+  if (this_thread_state == 0) {
+    return THREAD_STATE_THIS_THREAD_NULL;
+  }
+  if (global_thread_state == 0) {
+    return THREAD_STATE_GLOBAL_CURRENT_THREAD_NULL;
+  }
+  if (this_thread_state == global_thread_state) {
+    return THREAD_STATE_MATCH;
+  } else {
+    return THREAD_STATE_MISMATCH;
+  }
+}
+
+static inline __attribute__((__always_inline__)) int get_gil_state(
+    void* this_thread_state,
+    void* global_thread_state,
+    PidData* pid_data) {
+  // Get information of GIL state
+  if (pid_data->gil_locked_addr == 0 || pid_data->gil_last_holder_addr == 0) {
+    return GIL_STATE_NO_INFO;
+  }
+
+  int gil_locked = 0;
+  void* gil_thread_state = 0;
+  if (bpf_probe_read(
+          &gil_locked, sizeof(gil_locked), (void*)pid_data->gil_locked_addr)) {
+    return GIL_STATE_ERROR;
+  }
+
+  switch (gil_locked) {
+    case -1:
+      return GIL_STATE_UNINITIALIZED;
+    case 0:
+      return GIL_STATE_NOT_LOCKED;
+    case 1:
+      // GIL is held by some Thread
+      bpf_probe_read(
+          &gil_thread_state,
+          sizeof(void*),
+          (void*)pid_data->gil_last_holder_addr);
+      if (gil_thread_state == this_thread_state) {
+        return GIL_STATE_THIS_THREAD;
+      } else if (gil_thread_state == global_thread_state) {
+        return GIL_STATE_GLOBAL_CURRENT_THREAD;
+      } else if (gil_thread_state == 0) {
+        return GIL_STATE_NULL;
+      } else {
+        return GIL_STATE_OTHER_THREAD;
+      }
+    default:
+      return GIL_STATE_ERROR;
+  }
+}
+
+static inline __attribute__((__always_inline__)) int
+get_pthread_id_match(void* thread_state, void* tls_base, PidData* pid_data) {
+  if (thread_state == 0) {
+    return PTHREAD_ID_THREAD_STATE_NULL;
+  }
+
+  uint64_t pthread_self, pthread_created;
+
+  bpf_probe_read(
+      &pthread_created,
+      sizeof(pthread_created),
+      thread_state + pid_data->offsets.PyThreadState_thread);
+  if (pthread_created == 0) {
+    return PTHREAD_ID_NULL;
+  }
+
+  // 0x10 = offsetof(struct pthread, header.self)
+  bpf_probe_read(&pthread_self, sizeof(pthread_self), tls_base + 0x10);
+  if (pthread_self == 0) {
+    return PTHREAD_ID_ERROR;
+  }
+
+  if (pthread_self == pthread_created) {
+    return PTHREAD_ID_MATCH;
+  } else {
+    return PTHREAD_ID_MISMATCH;
+  }
+}
+
+int on_event(struct pt_regs* ctx) {
+  uint64_t pid_tgid = bpf_get_current_pid_tgid();
+  pid_t pid = (pid_t)(pid_tgid >> 32);
+  PidData* pid_data = pid_config.lookup(&pid);
+  if (!pid_data) {
+    return 0;
+  }
+
+  GET_STATE();
+
+  state->offsets = pid_data->offsets;
+  state->cur_cpu = bpf_get_smp_processor_id();
+  state->python_stack_prog_call_cnt = 0;
+
+  Event* event = &state->event;
+  event->pid = pid;
+  event->tid = (pid_t)pid_tgid;
+  bpf_get_current_comm(&event->comm, sizeof(event->comm));
+
+  // Get pointer of global PyThreadState, which should belong to the Thread
+  // currently holds the GIL
+  void* global_current_thread = (void*)0;
+  bpf_probe_read(
+      &global_current_thread,
+      sizeof(global_current_thread),
+      (void*)pid_data->current_state_addr);
+
+  struct task_struct* task = (struct task_struct*)bpf_get_current_task();
+#if __x86_64__
+// thread_struct->fs was renamed to fsbase in
+// https://github.com/torvalds/linux/commit/296f781a4b7801ad9c1c0219f9e87b6c25e196fe
+// so depending on kernel version, we need to account for that
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0)
+  void* tls_base = (void*)task->thread.fs;
+#else
+  void* tls_base = (void*)task->thread.fsbase;
+#endif
+#elif __aarch64__
+  void* tls_base = (void*)task->thread.tp_value;
+#else
+#error "Unsupported platform"
+#endif
+
+  // Read PyThreadState of this Thread from TLS
+  void* thread_state = get_thread_state(tls_base, pid_data);
+
+  // Check for matching between TLS PyThreadState and
+  // the global _PyThreadState_Current
+  event->thread_state_match =
+      get_thread_state_match(thread_state, global_current_thread);
+
+  // Read GIL state
+  event->gil_state =
+      get_gil_state(thread_state, global_current_thread, pid_data);
+
+  // Check for matching between pthread ID created current PyThreadState and
+  // pthread of actual current pthread
+  event->pthread_id_match =
+      get_pthread_id_match(thread_state, tls_base, pid_data);
+
+  // pre-initialize event struct in case any subprogram below fails
+  event->stack_status = STACK_STATUS_COMPLETE;
+  event->stack_len = 0;
+
+  if (thread_state != 0) {
+    // Get pointer to top frame from PyThreadState
+    bpf_probe_read(
+        &state->frame_ptr,
+        sizeof(void*),
+        thread_state + pid_data->offsets.PyThreadState_frame);
+    // jump to reading first set of Python frames
+    progs.call(ctx, PYTHON_STACK_PROG_IDX);
+    // we won't ever get here
+  }
+
+  return submit_sample(ctx, state);
+}
+
+static inline __attribute__((__always_inline__)) void get_names(
+    void* cur_frame,
+    void* code_ptr,
+    OffsetConfig* offsets,
+    Symbol* symbol,
+    void* ctx) {
+  // Figure out if we want to parse class name, basically checking the name of
+  // the first argument,
+  //   ((PyTupleObject*)$frame->f_code->co_varnames)->ob_item[0]
+  // If it's 'self', we get the type and it's name, if it's cls, we just get
+  // the name. This is not perfect but there is no better way to figure this
+  // out from the code object.
+  void* args_ptr;
+  bpf_probe_read(
+      &args_ptr, sizeof(void*), code_ptr + offsets->PyCodeObject_varnames);
+  bpf_probe_read(
+      &args_ptr, sizeof(void*), args_ptr + offsets->PyTupleObject_item);
+  bpf_probe_read_str(
+      &symbol->name, sizeof(symbol->name), args_ptr + offsets->String_data);
+
+  // compare strings as ints to save instructions
+  char self_str[4] = {'s', 'e', 'l', 'f'};
+  char cls_str[4] = {'c', 'l', 's', '\0'};
+  bool first_self = *(int32_t*)symbol->name == *(int32_t*)self_str;
+  bool first_cls = *(int32_t*)symbol->name == *(int32_t*)cls_str;
+
+  // We re-use the same Symbol instance across loop iterations, which means
+  // we will have left-over data in the struct. Although this won't affect
+  // correctness of the result because we have '\0' at end of the strings read,
+  // it would affect effectiveness of the deduplication.
+  // Helper bpf_perf_prog_read_value clears the buffer on error, so here we
+  // (ab)use this behavior to clear the memory. It requires the size of Symbol
+  // to be different from struct bpf_perf_event_value, which we check at
+  // compilation time using the FAIL_COMPILATION_IF macro.
+  bpf_perf_prog_read_value(ctx, symbol, sizeof(Symbol));
+
+  // Read class name from $frame->f_localsplus[0]->ob_type->tp_name.
+  if (first_self || first_cls) {
+    void* ptr;
+    bpf_probe_read(
+        &ptr, sizeof(void*), cur_frame + offsets->PyFrameObject_localsplus);
+    if (first_self) {
+      // we are working with an instance, first we need to get type
+      bpf_probe_read(&ptr, sizeof(void*), ptr + offsets->PyObject_type);
+    }
+    bpf_probe_read(&ptr, sizeof(void*), ptr + offsets->PyTypeObject_name);
+    bpf_probe_read_str(&symbol->classname, sizeof(symbol->classname), ptr);
+  }
+
+  void* pystr_ptr;
+  // read PyCodeObject's filename into symbol
+  bpf_probe_read(
+      &pystr_ptr, sizeof(void*), code_ptr + offsets->PyCodeObject_filename);
+  bpf_probe_read_str(
+      &symbol->file, sizeof(symbol->file), pystr_ptr + offsets->String_data);
+  // read PyCodeObject's name into symbol
+  bpf_probe_read(
+      &pystr_ptr, sizeof(void*), code_ptr + offsets->PyCodeObject_name);
+  bpf_probe_read_str(
+      &symbol->name, sizeof(symbol->name), pystr_ptr + offsets->String_data);
+}
+
+// get_frame_data reads current PyFrameObject filename/name and updates
+// stack_info->frame_ptr with pointer to next PyFrameObject
+static inline __attribute__((__always_inline__)) bool get_frame_data(
+    void** frame_ptr,
+    OffsetConfig* offsets,
+    Symbol* symbol,
+    // ctx is only used to call helper to clear symbol, see documentation below
+    void* ctx) {
+  void* cur_frame = *frame_ptr;
+  if (!cur_frame) {
+    return false;
+  }
+  void* code_ptr;
+  // read PyCodeObject first, if that fails, then no point reading next frame
+  bpf_probe_read(
+      &code_ptr, sizeof(void*), cur_frame + offsets->PyFrameObject_code);
+  if (!code_ptr) {
+    return false;
+  }
+
+  get_names(cur_frame, code_ptr, offsets, symbol, ctx);
+
+  // read next PyFrameObject pointer, update in place
+  bpf_probe_read(
+      frame_ptr, sizeof(void*), cur_frame + offsets->PyFrameObject_back);
+
+  return true;
+}
+
+// To avoid duplicate ids, every CPU needs to use different ids when inserting
+// into the hashmap. NUM_CPUS is defined at PyPerf backend side and passed
+// through CFlag.
+static inline __attribute__((__always_inline__)) int64_t get_symbol_id(
+    sample_state_t* state,
+    Symbol* sym) {
+  int32_t* symbol_id_ptr = symbols.lookup(sym);
+  if (symbol_id_ptr) {
+    return *symbol_id_ptr;
+  }
+  // the symbol is new, bump the counter
+  int32_t symbol_id = state->symbol_counter * NUM_CPUS + state->cur_cpu;
+  state->symbol_counter++;
+  symbols.update(sym, &symbol_id);
+  return symbol_id;
+}
+
+int read_python_stack(struct pt_regs* ctx) {
+  GET_STATE();
+
+  state->python_stack_prog_call_cnt++;
+  Event* sample = &state->event;
+
+  Symbol sym = {};
+  bool last_res = false;
+#pragma unroll
+  for (int i = 0; i < PYTHON_STACK_FRAMES_PER_PROG; i++) {
+    last_res = get_frame_data(&state->frame_ptr, &state->offsets, &sym, ctx);
+    if (last_res) {
+      uint32_t symbol_id = get_symbol_id(state, &sym);
+      int64_t cur_len = sample->stack_len;
+      if (cur_len >= 0 && cur_len < STACK_MAX_LEN) {
+        sample->stack[cur_len] = symbol_id;
+        sample->stack_len++;
+      }
+    }
+  }
+
+  if (!state->frame_ptr) {
+    sample->stack_status = STACK_STATUS_COMPLETE;
+  } else {
+    if (!last_res) {
+      sample->stack_status = STACK_STATUS_ERROR;
+    } else {
+      sample->stack_status = STACK_STATUS_TRUNCATED;
+    }
+  }
+
+  if (sample->stack_status == STACK_STATUS_TRUNCATED &&
+      state->python_stack_prog_call_cnt < PYTHON_STACK_PROG_CNT) {
+    // read next batch of frames
+    progs.call(ctx, PYTHON_STACK_PROG_IDX);
+  }
+
+  return submit_sample(ctx, state);
+}
+)";
+
+}
+}  // namespace ebpf

--- a/examples/cpp/pyperf/PyPerfLoggingHelper.cc
+++ b/examples/cpp/pyperf/PyPerfLoggingHelper.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <cstdarg>
+#include <cstdio>
+
+#include "PyPerfLoggingHelper.h"
+
+namespace ebpf {
+namespace pyperf {
+
+static uint64_t setVerbosityLevel = 0;
+
+void setVerbosity(uint64_t verbosityLevel) {
+  setVerbosityLevel = verbosityLevel;
+}
+
+void logInfo(uint64_t logLevel, const char* fmt, ...) {
+  if (logLevel > setVerbosityLevel) {
+    return;
+  }
+
+  va_list va;
+  va_start(va, fmt);
+  std::vfprintf(stderr, fmt, va);
+  va_end(va);
+}
+
+}  // namespace pyperf
+}  // namespace ebpf

--- a/examples/cpp/pyperf/PyPerfLoggingHelper.h
+++ b/examples/cpp/pyperf/PyPerfLoggingHelper.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <cstdint>
+
+namespace ebpf {
+namespace pyperf {
+
+void setVerbosity(uint64_t verbosityLevel);
+void logInfo(uint64_t logLevel, const char* fmt, ...);
+
+}  // namespace pyperf
+}  // namespace ebpf

--- a/examples/cpp/pyperf/PyPerfType.h
+++ b/examples/cpp/pyperf/PyPerfType.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <cstdint>
+
+#define PYTHON_STACK_FRAMES_PER_PROG 25
+#define PYTHON_STACK_PROG_CNT 3
+#define STACK_MAX_LEN (PYTHON_STACK_FRAMES_PER_PROG * PYTHON_STACK_PROG_CNT)
+#define CLASS_NAME_LEN 32
+#define FUNCTION_NAME_LEN 64
+#define FILE_NAME_LEN 128
+#define TASK_COMM_LEN 16
+
+namespace ebpf {
+namespace pyperf {
+
+enum {
+  STACK_STATUS_COMPLETE = 0,
+  STACK_STATUS_ERROR = 1,
+  STACK_STATUS_TRUNCATED = 2,
+};
+
+enum {
+  GIL_STATE_NO_INFO = 0,
+  GIL_STATE_ERROR = 1,
+  GIL_STATE_UNINITIALIZED = 2,
+  GIL_STATE_NOT_LOCKED = 3,
+  GIL_STATE_THIS_THREAD = 4,
+  GIL_STATE_GLOBAL_CURRENT_THREAD = 5,
+  GIL_STATE_OTHER_THREAD = 6,
+  GIL_STATE_NULL = 7,
+};
+
+enum {
+  THREAD_STATE_UNKNOWN = 0,
+  THREAD_STATE_MATCH = 1,
+  THREAD_STATE_MISMATCH = 2,
+  THREAD_STATE_THIS_THREAD_NULL = 3,
+  THREAD_STATE_GLOBAL_CURRENT_THREAD_NULL = 4,
+  THREAD_STATE_BOTH_NULL = 5,
+};
+
+enum {
+  PTHREAD_ID_UNKNOWN = 0,
+  PTHREAD_ID_MATCH = 1,
+  PTHREAD_ID_MISMATCH = 2,
+  PTHREAD_ID_THREAD_STATE_NULL = 3,
+  PTHREAD_ID_NULL = 4,
+  PTHREAD_ID_ERROR = 5,
+};
+
+typedef struct {
+  int64_t PyObject_type;
+  int64_t PyTypeObject_name;
+  int64_t PyThreadState_frame;
+  int64_t PyThreadState_thread;
+  int64_t PyFrameObject_back;
+  int64_t PyFrameObject_code;
+  int64_t PyFrameObject_lineno;
+  int64_t PyFrameObject_localsplus;
+  int64_t PyCodeObject_filename;
+  int64_t PyCodeObject_name;
+  int64_t PyCodeObject_varnames;
+  int64_t PyTupleObject_item;
+  int64_t String_data;
+  int64_t String_size;
+} OffsetConfig;
+
+typedef struct {
+  uintptr_t current_state_addr;  // virtual address of _PyThreadState_Current
+  uintptr_t tls_key_addr;     // virtual address of autoTLSkey for pthreads TLS
+  uintptr_t gil_locked_addr;  // virtual address of gil_locked
+  uintptr_t gil_last_holder_addr;  // virtual address of gil_last_holder
+  OffsetConfig offsets;
+} PidData;
+
+typedef struct {
+  char classname[CLASS_NAME_LEN];
+  char name[FUNCTION_NAME_LEN];
+  char file[FILE_NAME_LEN];
+  // NOTE: PyFrameObject also has line number but it is typically just the
+  // first line of that function and PyCode_Addr2Line needs to be called
+  // to get the actual line
+} Symbol;
+
+typedef struct {
+  uint32_t pid;
+  uint32_t tid;
+  char comm[TASK_COMM_LEN];
+  uint8_t thread_state_match;
+  uint8_t gil_state;
+  uint8_t pthread_id_match;
+  uint8_t stack_status;
+  // instead of storing symbol name here directly, we add it to another
+  // hashmap with Symbols and only store the ids here
+  int64_t stack_len;
+  int32_t stack[STACK_MAX_LEN];
+} Event;
+
+}  // namespace pyperf
+}  // namespace ebpf

--- a/examples/cpp/pyperf/PyPerfUtil.cc
+++ b/examples/cpp/pyperf/PyPerfUtil.cc
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <exception>
+#include <unordered_map>
+
+#include <dirent.h>
+#include <linux/elf.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "PyPerfLoggingHelper.h"
+#include "PyPerfUtil.h"
+#include "bcc_elf.h"
+#include "bcc_proc.h"
+#include "bcc_syms.h"
+
+namespace ebpf {
+namespace pyperf {
+
+extern OffsetConfig kPy36OffsetConfig;
+extern std::string PYPERF_BPF_PROGRAM;
+
+const static std::string kLostSymbol = "[Lost Symbol]";
+const static std::string kIncompleteStack = "[Truncated Stack]";
+const static std::string kErrorStack = "[Stack Error]";
+const static std::string kNonPythonStack = "[Non-Python Code]";
+const static int kPerfBufSizePages = 32;
+
+const static std::string kPidCfgTableName("pid_config");
+const static std::string kProgsTableName("progs");
+const static std::string kSamplePerfBufName("events");
+
+const static std::string kOnEventFuncName("on_event");
+
+const static std::string kPythonStackFuncName("read_python_stack");
+const static std::string kPythonStackProgIdxFlag("-DPYTHON_STACK_PROG_IDX=");
+const static int kPythonStackProgIdx = 0;
+
+const static std::string kNumCpusFlag("-DNUM_CPUS=");
+const static std::string kSymbolsHashSizeFlag("-D__SYMBOLS_SIZE__=");
+const static int kSymbolsHashSize = 16384;
+
+namespace {
+
+bool getRunningPids(std::vector<int>& output) {
+  auto dir = ::opendir("/proc/");
+  if (!dir) {
+    std::fprintf(stderr, "Open /proc failed: %d\n", errno);
+    return false;
+  }
+
+  dirent* result = nullptr;
+  do {
+    if ((result = readdir(dir))) {
+      std::string basename = result->d_name;
+      if (basename == "." || basename == "..") {
+        continue;
+      }
+
+      std::string fullpath = "/proc/" + basename;
+      struct stat st;
+      if (::stat(fullpath.c_str(), &st) != 0 || !S_ISDIR(st.st_mode)) {
+        continue;
+      }
+
+      try {
+        auto pid = std::stoi(basename);
+        output.push_back(pid);
+      } catch (const std::exception& e) {
+        continue;
+      }
+    }
+  } while (result);
+
+  if (::closedir(dir) == -1) {
+    std::fprintf(stderr, "Close /proc failed: %d\n", errno);
+    return false;
+  }
+
+  return true;
+}
+
+typedef struct {
+  int pid;
+  bool found;
+  uint64_t st;
+  uint64_t en;
+} FindPythonPathHelper;
+
+const static std::string kPy36LibName = "libpython3.6";
+
+int findPythonPathCallback(const char* name, uint64_t st, uint64_t en, uint64_t,
+                           bool, void* payload) {
+  auto helper = static_cast<FindPythonPathHelper*>(payload);
+  std::string file = name;
+  auto pos = file.rfind("/");
+  if (pos != std::string::npos) {
+    file = file.substr(pos + 1);
+  }
+  if (file.find(kPy36LibName) == 0) {
+    logInfo(1, "Found Python library %s loaded at %lx-%lx for PID %d\n", name, st, en, helper->pid);
+    helper->found = true;
+    helper->st = st;
+    helper->en = en;
+    return -1;
+  }
+  return 0;
+}
+
+bool allAddrFound(const PidData& data) {
+  return (data.current_state_addr > 0) && (data.tls_key_addr > 0) &&
+         (data.gil_locked_addr > 0) && (data.gil_last_holder_addr > 0);
+}
+
+int getAddrOfPythonBinaryCallback(const char* name, uint64_t addr, uint64_t,
+                                  void* payload) {
+  PidData& data = *static_cast<PidData*>(payload);
+
+  auto checkAndGetAddr = [&](uintptr_t& targetAddr, const char* targetName) {
+    if (targetAddr == 0 && std::strcmp(name, targetName) == 0) {
+      targetAddr = addr;
+    }
+  };
+
+  checkAndGetAddr(data.tls_key_addr, "autoTLSkey");
+  checkAndGetAddr(data.current_state_addr, "_PyThreadState_Current");
+  checkAndGetAddr(data.gil_locked_addr, "gil_locked");
+  checkAndGetAddr(data.gil_last_holder_addr, "gil_last_holder");
+
+  if (allAddrFound(data)) {
+    return -1;
+  }
+  return 0;
+}
+
+bool getAddrOfPythonBinary(const std::string& path, PidData& data) {
+  std::memset(&data, 0, sizeof(data));
+
+  struct bcc_symbol_option option = {.use_debug_file = 0,
+                                     .check_debug_file_crc = 0,
+                                     .use_symbol_type = (1 << STT_OBJECT)};
+
+  bcc_elf_foreach_sym(path.c_str(), &getAddrOfPythonBinaryCallback, &option,
+                      &data);
+
+  return allAddrFound(data);
+}
+}  // namespace
+
+void handleSampleCallback(void* cb_cookie, void* raw_data, int data_size) {
+  auto profiler = static_cast<PyPerfUtil*>(cb_cookie);
+  profiler->handleSample(raw_data, data_size);
+}
+
+void handleLostSamplesCallback(void* cb_cookie, uint64_t lost_cnt) {
+  auto profiler = static_cast<PyPerfUtil*>(cb_cookie);
+  profiler->handleLostSamples(lost_cnt);
+}
+
+PyPerfUtil::PyPerfResult PyPerfUtil::init() {
+  std::vector<std::string> cflags;
+  cflags.emplace_back(kNumCpusFlag +
+                      std::to_string(::sysconf(_SC_NPROCESSORS_ONLN)));
+  cflags.emplace_back(kSymbolsHashSizeFlag + std::to_string(kSymbolsHashSize));
+  cflags.emplace_back(kPythonStackProgIdxFlag +
+                      std::to_string(kPythonStackProgIdx));
+
+  auto initRes = bpf_.init(PYPERF_BPF_PROGRAM, cflags);
+  if (initRes.code() != 0) {
+    std::fprintf(stderr, "Failed to compiled PyPerf BPF programs: %s\n",
+                 initRes.msg().c_str());
+    return PyPerfResult::INIT_FAIL;
+  }
+
+  int progFd = -1;
+  auto loadRes =
+      bpf_.load_func(kPythonStackFuncName, BPF_PROG_TYPE_PERF_EVENT, progFd);
+  if (loadRes.code() != 0) {
+    std::fprintf(stderr, "Failed to load BPF program %s: %s\n",
+                 kPythonStackFuncName.c_str(), loadRes.msg().c_str());
+    return PyPerfResult::INIT_FAIL;
+  }
+
+  auto progTable = bpf_.get_prog_table(kProgsTableName);
+  auto updateRes = progTable.update_value(kPythonStackProgIdx, progFd);
+  if (updateRes.code() != 0) {
+    std::fprintf(stderr,
+                 "Failed to set BPF program %s FD %d to program table: %s\n",
+                 kPythonStackFuncName.c_str(), progFd, updateRes.msg().c_str());
+    return PyPerfResult::INIT_FAIL;
+  }
+
+  std::vector<int> pids;
+  if (!getRunningPids(pids)) {
+    std::fprintf(stderr, "Failed getting running Processes\n");
+    return PyPerfResult::INIT_FAIL;
+  }
+
+  // Populate config for each Python Process
+  auto pid_hash = bpf_.get_hash_table<int, PidData>(kPidCfgTableName);
+  PidData pidData;
+  for (const auto pid : pids) {
+    if (!tryTargetPid(pid, pidData)) {
+      // Not a Python Process
+      continue;
+    }
+    pid_hash.update_value(pid, pidData);
+  }
+
+  // Open perf buffer
+  auto openRes = bpf_.open_perf_buffer(
+      kSamplePerfBufName, &handleSampleCallback, &handleLostSamplesCallback,
+      this, kPerfBufSizePages);
+  if (openRes.code() != 0) {
+    std::fprintf(stderr, "Unable to open Perf Buffer: %s\n",
+                 openRes.msg().c_str());
+    return PyPerfResult::PERF_BUF_OPEN_FAIL;
+  }
+
+  initCompleted_ = true;
+  return PyPerfResult::SUCCESS;
+}
+
+void PyPerfUtil::handleSample(const void* data, int dataSize) {
+  const Event* raw = static_cast<const Event*>(data);
+  samples_.emplace_back(raw, dataSize);
+  totalSamples_++;
+}
+
+void PyPerfUtil::handleLostSamples(int lostCnt) { lostSamples_ += lostCnt; }
+
+PyPerfUtil::PyPerfResult PyPerfUtil::profile(int64_t sampleRate,
+                                             int64_t durationMs) {
+  if (!initCompleted_) {
+    std::fprintf(stderr, "PyPerfUtil::init not invoked or failed\n");
+    return PyPerfResult::NO_INIT;
+  }
+
+  // Attach to CPU cycles
+  auto attachRes =
+      bpf_.attach_perf_event(0, 0, kOnEventFuncName, sampleRate, 0);
+  if (attachRes.code() != 0) {
+    std::fprintf(stderr, "Attach to CPU cycles event failed: %s\n",
+                 attachRes.msg().c_str());
+    return PyPerfResult::EVENT_ATTACH_FAIL;
+  }
+  logInfo(2, "Attached to profiling event\n");
+
+  // Get Perf Buffer and poll in a loop for a given duration
+  auto perfBuffer = bpf_.get_perf_buffer(kSamplePerfBufName);
+  if (!perfBuffer) {
+    std::fprintf(stderr, "Failed to get Perf Buffer: %s\n",
+                 kSamplePerfBufName.c_str());
+    return PyPerfResult::PERF_BUF_OPEN_FAIL;
+  }
+  logInfo(2, "Started polling Perf Buffer\n");
+  auto start = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() <
+         start + std::chrono::milliseconds(durationMs)) {
+    perfBuffer->poll(50 /* 50ms timeout */);
+  }
+  logInfo(2, "Profiling duration finished\n");
+
+  // Detach the event
+  auto detachRes = bpf_.detach_perf_event(0, 0);
+  if (detachRes.code() != 0) {
+    std::fprintf(stderr, "Detach CPU cycles event failed: %s\n",
+                 detachRes.msg().c_str());
+    return PyPerfResult::EVENT_DETACH_FAIL;
+  }
+  logInfo(2, "Detached from profiling event\n");
+
+  // Drain remaining samples
+  logInfo(2, "Draining remaining samples\n");
+  while (perfBuffer->poll(0) > 0) {
+  }
+  logInfo(2, "Finished draining remaining samples\n");
+
+  // Get symbol names and output samples
+  auto symbolTable = bpf_.get_hash_table<Symbol, int32_t>("symbols");
+  std::unordered_map<int32_t, std::string> symbols;
+  for (auto& x : symbolTable.get_table_offline()) {
+    auto symbolName = getSymbolName(x.first);
+    logInfo(2, "Symbol ID %d is %s\n", x.second, symbolName.c_str());
+    symbols.emplace(x.second, std::move(symbolName));
+  }
+  logInfo(1, "Total %d unique Python symbols\n", symbols.size());
+
+  for (auto& sample : samples_) {
+    if (sample.threadStateMatch != THREAD_STATE_THIS_THREAD_NULL &&
+        sample.threadStateMatch != THREAD_STATE_BOTH_NULL) {
+      for (const auto stackId : sample.pyStackIds) {
+        auto symbIt = symbols.find(stackId);
+        if (symbIt != symbols.end()) {
+          std::printf("    %s\n", symbIt->second.c_str());
+        } else {
+          std::printf("    %s\n", kLostSymbol.c_str());
+          lostSymbols_++;
+        }
+      }
+      switch (sample.stackStatus) {
+      case STACK_STATUS_TRUNCATED:
+        std::printf("    %s\n", kIncompleteStack.c_str());
+        truncatedStack_++;
+        break;
+      case STACK_STATUS_ERROR:
+        std::printf("    %s\n", kErrorStack.c_str());
+        break;
+      default:
+        break;
+      }
+    } else {
+      std::printf("    %s\n", kNonPythonStack.c_str());
+    }
+
+    std::printf("PID: %d TID: %d (%s)\n", sample.pid, sample.tid,
+                sample.comm.c_str());
+    std::printf("GIL State: %d Thread State: %d PthreadID Match State: %d\n\n",
+                sample.threadStateMatch, sample.gilState,
+                sample.pthreadIDMatch);
+  }
+
+  logInfo(0, "%d samples collected\n", totalSamples_);
+  logInfo(0, "%d samples lost\n", lostSamples_);
+  logInfo(0, "%d samples with truncated stack\n", truncatedStack_);
+  logInfo(0, "%d times Python symbol lost\n", lostSymbols_);
+
+  return PyPerfResult::SUCCESS;
+}
+
+std::string PyPerfUtil::getSymbolName(Symbol& sym) const {
+  std::string nameStr = std::string(sym.name).substr(0, FUNCTION_NAME_LEN);
+  std::string classStr = std::string(sym.classname).substr(0, CLASS_NAME_LEN);
+  if (classStr.size() > 0) {
+    nameStr = classStr + "." + nameStr;
+  }
+
+  std::string file = std::string(sym.file).substr(0, FILE_NAME_LEN);
+  if (file.empty()) {
+    return nameStr;
+  }
+  if (file[0] == '/') {
+    file = file.substr(1);
+  }
+  if (file.find("./") == 0) {
+    file = file.substr(2);
+  }
+  if (file.find(".py", file.size() - 3) == (file.size() - 3)) {
+    file = file.substr(0, file.size() - 3);
+  }
+  std::replace(file.begin(), file.end(), '/', '.');
+
+  return file + "." + nameStr;
+}
+
+bool PyPerfUtil::tryTargetPid(int pid, PidData& data) {
+  FindPythonPathHelper helper{pid, false, 0, 0};
+  bcc_procutils_each_module(pid, &findPythonPathCallback, &helper);
+  if (!helper.found) {
+    logInfo(2, "PID %d does not contain Python library\n", pid);
+    return false;
+  }
+
+  char path[256];
+  int res = std::snprintf(path, sizeof(path), "/proc/%d/map_files/%lx-%lx", pid,
+                          helper.st, helper.en);
+  if (res < 0 || size_t(res) >= sizeof(path)) {
+    return false;
+  }
+
+  if (!getAddrOfPythonBinary(path, data)) {
+    std::fprintf(stderr, "Failed getting addresses in potential Python library in PID %d\n", pid);
+    return false;
+  }
+  data.offsets = kPy36OffsetConfig;
+  data.current_state_addr += helper.st;
+  logInfo(2, "PID %d has _PyThreadState_Current at %lx\n", pid, data.current_state_addr);
+  data.tls_key_addr += helper.st;
+  logInfo(2, "PID %d has autoTLSKey at %lx\n", pid, data.current_state_addr);
+  data.gil_locked_addr += helper.st;
+  logInfo(2, "PID %d has gil_locked at %lx\n", pid, data.current_state_addr);
+  data.gil_last_holder_addr += helper.st;
+  logInfo(2, "PID %d has gil_last_holder at %lx\n", pid, data.current_state_addr);
+
+  return true;
+}
+
+}  // namespace pyperf
+}  // namespace ebpf

--- a/examples/cpp/pyperf/PyPerfUtil.h
+++ b/examples/cpp/pyperf/PyPerfUtil.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <linux/perf_event.h>
+#include <sys/types.h>
+
+#include "BPF.h"
+#include "PyPerfType.h"
+
+namespace ebpf {
+namespace pyperf {
+
+class PyPerfUtil {
+ public:
+  enum class PyPerfResult : int {
+    SUCCESS = 0,
+    INIT_FAIL,
+    PERF_BUF_OPEN_FAIL,
+    NO_INIT,
+    EVENT_ATTACH_FAIL,
+    EVENT_DETACH_FAIL
+  };
+
+  struct Sample {
+    pid_t pid;
+    pid_t tid;
+    std::string comm;
+    uint8_t threadStateMatch;
+    uint8_t gilState;
+    uint8_t pthreadIDMatch;
+    uint8_t stackStatus;
+    std::vector<int32_t> pyStackIds;
+
+    explicit Sample(const Event* raw, int rawSize)
+        : pid(raw->pid),
+          tid(raw->tid),
+          comm(raw->comm),
+          threadStateMatch(raw->thread_state_match),
+          gilState(raw->gil_state),
+          pthreadIDMatch(raw->pthread_id_match),
+          stackStatus(raw->stack_status),
+          pyStackIds(raw->stack, raw->stack + raw->stack_len) {}
+  };
+
+  // init must be invoked exactly once before invoking profile
+  PyPerfResult init();
+
+  PyPerfResult profile(int64_t sampleRate, int64_t durationMs);
+
+ private:
+  uint32_t lostSymbols_ = 0, totalSamples_ = 0, lostSamples_ = 0, truncatedStack_ = 0;
+
+  ebpf::BPF bpf_{0, nullptr, false, "", true};
+  std::vector<Sample> samples_;
+  bool initCompleted_{false};
+
+  void handleSample(const void* data, int dataSize);
+  void handleLostSamples(int lostCnt);
+  friend void handleLostSamplesCallback(void*, uint64_t);
+  friend void handleSampleCallback(void*, void*, int);
+
+  std::string getSymbolName(Symbol& sym) const;
+
+  bool tryTargetPid(int pid, PidData& data);
+};
+}  // namespace pyperf
+}  // namespace ebpf


### PR DESCRIPTION
This is a tool attaches BPF program to CPU Perf Events for profiling. The BPF program understands CPython internal data structure and hence able to walk actual Python stack-trace, as oppose to strac-trace of the CPython runtime itself as we would normally get with Linux `perf`.

To use the tool, just run the `PyPerf` binary:
- Use `-d` / `--duration` to specify intended profiling duration, in milliseconds. Default value, if not specified, is `1000ms`.
- Use `-c` / `--sample-rate` to specify intended profiling sample rate, same as `-c` argument of Linux `perf`. Default value, if not specified, is `1e6`.

You can also use `-v` / `--verbose` to specify logging verbosity `1` or `2` for more detailed information during profiling.

The tool is a prototype at this point is by no mean mature. It currently has follow limitation:
- It only runs on CPU Cycles event.
- It only works on Python 3.6 at this point. In fact all Python version from 3.0 to 3.6 should work, I just need to verify and change the constant value. However in Python 3.7 there are some internal data structure changes that the actual parsing logic needs to be updated.
- It currently hard-codes the Python internal data structure offsets. It would be better to get a dependency of `python-devel` and get them directly from the header files.
- The output is pretty horrible. No de-duplication across same stack, and we always output the GIL state, Thread state and output them in raw integer value. I will need to work on prettifying the output and make better sense of the enum values.

Landing it in C++ example for now, once it's mature enough I will move it to `tools/`.

Feel free to try it out and let me know what do you think!