### PR TITLE
fix b.support_raw_tracepoint for 5.0 kernel

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -858,7 +858,8 @@ class BPF(object):
     @staticmethod
     def support_raw_tracepoint():
         # kernel symbol "bpf_find_raw_tracepoint" indicates raw_tracepint support
-        if BPF.ksymname("bpf_find_raw_tracepoint") != -1:
+        if BPF.ksymname("bpf_find_raw_tracepoint") != -1 or \
+           BPF.ksymname("bpf_get_raw_tracepoint") != -1:
             return True
         return False
 


### PR DESCRIPTION
Fix issue #2240.

In 5.0, the following commit
```
  commit a38d1107f937ca95dcf820161ef44ea683d6a0b1
  Author: Matt Mullins <mmullins@fb.com>
  Date:   Wed Dec 12 16:42:37 2018 -0800

      bpf: support raw tracepoints in modules
```
renamed the function bpf_find_raw_tracepoint() to
bpf_get_raw_tracepoint(). The bcc relies on checking
bpf_find_raw_tracepoint() in /proc/kallsyms to detect
whether raw_tracepoint is supported in kernel or not.

We do not have better mechanism to detect raw_tracepoint
support without additional syscalls. So tentatively,
let us just check bpf_get_raw_tracepoint() ksym as well
for raw_tracepoint support.

Signed-off-by: Yonghong Song <yhs@fb.com>