### PR TITLE
fix a compilation issue with latest llvm trunk (9.0)

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -183,6 +183,7 @@ void SourceDebugger::dump() {
       uint64_t Size;
       uint8_t *FuncStart = get<0>(section.second);
       uint64_t FuncSize = get<1>(section.second);
+      unsigned SectionID = get<2>(section.second);
       ArrayRef<uint8_t> Data(FuncStart, FuncSize);
       uint32_t CurrentSrcLine = 0;
       string func_name = section.first.substr(fn_prefix_.size());
@@ -201,8 +202,14 @@ void SourceDebugger::dump() {
           break;
         } else {
           DILineInfo LineInfo;
+
           LineTable->getFileLineInfoForAddress(
-              (uint64_t)FuncStart + Index, CU->getCompilationDir(),
+#if LLVM_MAJOR_VERSION >= 9
+              {(uint64_t)FuncStart + Index, SectionID},
+#else
+              (uint64_t)FuncStart + Index,
+#endif
+              CU->getCompilationDir(),
               DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath,
               LineInfo);
 

--- a/src/cc/bcc_debug.h
+++ b/src/cc/bcc_debug.h
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "bpf_module.h"
+
 namespace ebpf {
 
 class SourceDebugger {
  public:
   SourceDebugger(
       llvm::Module *mod,
-      std::map<std::string, std::tuple<uint8_t *, uintptr_t>> &sections,
+      sec_map_def &sections,
       const std::string &fn_prefix, const std::string &mod_src,
       std::map<std::string, std::string> &src_dbg_fmap)
       : mod_(mod),
@@ -52,7 +55,7 @@ class SourceDebugger {
 
  private:
   llvm::Module *mod_;
-  const std::map<std::string, std::tuple<uint8_t *, uintptr_t>> &sections_;
+  const sec_map_def &sections_;
   const std::string &fn_prefix_;
   const std::string &mod_src_;
   std::map<std::string, std::string> &src_dbg_fmap_;

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -35,6 +35,8 @@ class Type;
 
 namespace ebpf {
 
+typedef std::map<std::string, std::tuple<uint8_t *, uintptr_t, unsigned>> sec_map_def;
+
 // Options to enable different debug logging.
 enum {
   // Debug output compiled LLVM IR.
@@ -82,8 +84,8 @@ class BPFModule {
   StatusTuple sscanf(std::string fn_name, const char *str, void *val);
   StatusTuple snprintf(std::string fn_name, char *str, size_t sz,
                        const void *val);
-  void load_btf(std::map<std::string, std::tuple<uint8_t *, uintptr_t>> &sections);
-  int load_maps(std::map<std::string, std::tuple<uint8_t *, uintptr_t>> &sections);
+  void load_btf(sec_map_def &sections);
+  int load_maps(sec_map_def &sections);
 
  public:
   BPFModule(unsigned flags, TableStorage *ts = nullptr, bool rw_engine_enabled = true,
@@ -150,7 +152,7 @@ class BPFModule {
   std::unique_ptr<llvm::ExecutionEngine> rw_engine_;
   std::unique_ptr<llvm::Module> mod_;
   std::unique_ptr<FuncSource> func_src_;
-  std::map<std::string, std::tuple<uint8_t *, uintptr_t>> sections_;
+  sec_map_def sections_;
   std::vector<TableDesc *> tables_;
   std::map<std::string, size_t> table_names_;
   std::vector<std::string> function_names_;


### PR DESCRIPTION
The following llvm change in trunk (9.0)
  https://reviews.llvm.org/D58194
breaks bcc build.
```
  [ 76%] Building CXX object src/cc/CMakeFiles/bcc-static.dir/bpf_module.cc.o
  /home/yhs/work/bcc/src/cc/bcc_debug.cc: In member function ‘void ebpf::SourceDebugger::dump()’:
  /home/yhs/work/bcc/src/cc/bcc_debug.cc:207:23: error: no matching function for call to ‘llvm::DWARFDebugLine::LineTable::getFileLineInfoForAddress(uint64_t, const char*, llvm::DILineInfoSpecifier::FileLineInfoKind, llvm::DILineInfo&) const’
               LineInfo);
                       ^
  /home/yhs/work/bcc/src/cc/bcc_debug.cc:207:23: note: candidate is:
  In file included from /home/yhs/work/llvm/build/install/include/llvm/DebugInfo/DWARF/DWARFContext.h:24:0,
                   from /home/yhs/work/bcc/src/cc/bcc_debug.cc:22:
  /home/yhs/work/llvm/build/install/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h:253:10: note: bool llvm::DWARFDebugLin
  e::LineTable::getFileLineInfoForAddress(llvm::object::SectionedAddress, const char*, llvm::DILineInfoSpecifier::FileLi
  neInfoKind, llvm::DILineInfo&) const
       bool getFileLineInfoForAddress(object::SectionedAddress Address,
```
The reason is that function getFileLineInfoForAddress() signature changed.
The first argument used to be "uint64_t" and now "object::SectionedAddress" which
includes both address and section ID.

This patch fixed this issue by specializing getFileLineInfoForAddress() for LLVM 9.
There exists no variant for getFileLineInfoForAddress() working for all LLVM versions.

Signed-off-by: Yonghong Song <yhs@fb.com>