### PR TITLE
Improve PyPerf sample handling and output

### DIFF
--- a/examples/cpp/pyperf/CMakeLists.txt
+++ b/examples/cpp/pyperf/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src/cc)
 include_directories(${CMAKE_SOURCE_DIR}/src/cc/api)
 include_directories(${CMAKE_SOURCE_DIR}/src/cc/libbpf/include/uapi)
 
-add_executable(PyPerf PyPerf.cc PyPerfUtil.cc PyPerfBPFProgram.cc PyPerfLoggingHelper.cc Py36Offsets.cc)
+add_executable(PyPerf PyPerf.cc PyPerfUtil.cc PyPerfBPFProgram.cc PyPerfLoggingHelper.cc PyPerfDefaultPrinter.cc Py36Offsets.cc)
 target_link_libraries(PyPerf bcc-static)
 
 if(INSTALL_CPP_EXAMPLES)

--- a/examples/cpp/pyperf/PyPerf.cc
+++ b/examples/cpp/pyperf/PyPerf.cc
@@ -21,6 +21,7 @@
 #include "PyPerfUtil.h"
 
 int main(int argc, char** argv) {
+  // Argument parsing helpers
   int pos = 1;
 
   auto parseIntArg = [&](std::vector<std::string> argNames, uint64_t& target) {
@@ -46,9 +47,29 @@ int main(int argc, char** argv) {
     return false;
   };
 
+  auto parseBoolArg = [&](std::vector<std::string> argNames, bool& target) {
+    std::string arg(argv[pos]);
+    for (const auto& name : argNames) {
+      if (arg == ("--" + name)) {
+        target = true;
+        return true;
+      }
+      if (arg == "--no-" + name) {
+        target = false;
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // Default argument values
   uint64_t sampleRate = 1000000;
   uint64_t durationMs = 1000;
   uint64_t verbosityLevel = 0;
+  bool showGILState = true;
+  bool showThreadState = true;
+  bool showPthreadIDState = false;
+
   while (true) {
     if (pos >= argc) {
       break;
@@ -57,6 +78,10 @@ int main(int argc, char** argv) {
     found = found || parseIntArg({"-c", "--sample-rate"}, sampleRate);
     found = found || parseIntArg({"-d", "--duration"}, durationMs);
     found = found || parseIntArg({"-v", "--verbose"}, verbosityLevel);
+    found = found || parseBoolArg({"show-gil-state"}, showGILState);
+    found = found || parseBoolArg({"show-thread-state"}, showThreadState);
+    found =
+        found || parseBoolArg({"show-pthread-id-state"}, showPthreadIDState);
     if (!found) {
       std::fprintf(stderr, "Unexpected argument: %s\n", argv[pos]);
       std::exit(1);
@@ -67,11 +92,16 @@ int main(int argc, char** argv) {
   ebpf::pyperf::setVerbosity(verbosityLevel);
   ebpf::pyperf::logInfo(1, "Profiling Sample Rate: %" PRIu64 "\n", sampleRate);
   ebpf::pyperf::logInfo(1, "Profiling Duration: %" PRIu64 "ms\n", durationMs);
+  ebpf::pyperf::logInfo(1, "Showing GIL state: %d\n", showGILState);
+  ebpf::pyperf::logInfo(1, "Showing Thread state: %d\n", showThreadState);
+  ebpf::pyperf::logInfo(1, "Showing Pthread ID state: %d\n",
+                        showPthreadIDState);
 
   ebpf::pyperf::PyPerfUtil util;
   util.init();
 
-  ebpf::pyperf::PyPerfDefaultPrinter printer;
+  ebpf::pyperf::PyPerfDefaultPrinter printer(showGILState, showThreadState,
+                                             showPthreadIDState);
   util.profile(sampleRate, durationMs, &printer);
 
   return 0;

--- a/examples/cpp/pyperf/PyPerf.cc
+++ b/examples/cpp/pyperf/PyPerf.cc
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+#include "PyPerfDefaultPrinter.h"
 #include "PyPerfLoggingHelper.h"
 #include "PyPerfUtil.h"
 
@@ -69,7 +70,9 @@ int main(int argc, char** argv) {
 
   ebpf::pyperf::PyPerfUtil util;
   util.init();
-  util.profile(sampleRate, durationMs);
+
+  ebpf::pyperf::PyPerfDefaultPrinter printer;
+  util.profile(sampleRate, durationMs, &printer);
 
   return 0;
 }

--- a/examples/cpp/pyperf/PyPerfDefaultPrinter.cc
+++ b/examples/cpp/pyperf/PyPerfDefaultPrinter.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <map>
+#include <string>
+
+#include "PyPerfDefaultPrinter.h"
+#include "PyPerfUtil.h"
+
+namespace ebpf {
+namespace pyperf {
+
+const static std::string kLostSymbol = "[Lost Symbol]";
+const static std::string kIncompleteStack = "[Truncated Stack]";
+const static std::string kErrorStack = "[Stack Error]";
+const static std::string kNonPythonStack = "[Non-Python Code]";
+
+void PyPerfDefaultPrinter::processSamples(
+    const std::vector<PyPerfSample>& samples, PyPerfUtil* util) {
+  auto symbols = util->getSymbolMapping();
+  uint32_t lostSymbols = 0;
+  uint32_t truncatedStack = 0;
+
+  for (auto& sample : samples) {
+    if (sample.threadStateMatch != THREAD_STATE_THIS_THREAD_NULL &&
+        sample.threadStateMatch != THREAD_STATE_BOTH_NULL) {
+      for (const auto stackId : sample.pyStackIds) {
+        auto symbIt = symbols.find(stackId);
+        if (symbIt != symbols.end()) {
+          std::printf("    %s\n", symbIt->second.c_str());
+        } else {
+          std::printf("    %s\n", kLostSymbol.c_str());
+          lostSymbols++;
+        }
+      }
+      switch (sample.stackStatus) {
+      case STACK_STATUS_TRUNCATED:
+        std::printf("    %s\n", kIncompleteStack.c_str());
+        truncatedStack++;
+        break;
+      case STACK_STATUS_ERROR:
+        std::printf("    %s\n", kErrorStack.c_str());
+        break;
+      default:
+        break;
+      }
+    } else {
+      std::printf("    %s\n", kNonPythonStack.c_str());
+    }
+
+    std::printf("PID: %d TID: %d (%s)\n", sample.pid, sample.tid,
+                sample.comm.c_str());
+    std::printf("GIL State: %d Thread State: %d PthreadID Match State: %d\n\n",
+                sample.threadStateMatch, sample.gilState,
+                sample.pthreadIDMatch);
+  }
+
+  std::printf("%d samples collected\n", util->getTotalSamples());
+  std::printf("%d samples lost\n", util->getLostSamples());
+  std::printf("%d samples with truncated stack\n", truncatedStack);
+  std::printf("%d times Python symbol lost\n", lostSymbols);
+}
+
+}  // namespace pyperf
+}  // namespace ebpf

--- a/examples/cpp/pyperf/PyPerfDefaultPrinter.h
+++ b/examples/cpp/pyperf/PyPerfDefaultPrinter.h
@@ -12,8 +12,19 @@ namespace pyperf {
 
 class PyPerfDefaultPrinter : public PyPerfSampleProcessor {
  public:
+  PyPerfDefaultPrinter(bool showGILState, bool showThreadState,
+                       bool showPthreadIDState)
+      : showGILState_(showGILState),
+        showThreadState_(showThreadState),
+        showPthreadIDState_(showPthreadIDState) {}
+
   void processSamples(const std::vector<PyPerfSample>& samples,
                       PyPerfUtil* util) override;
+
+ private:
+  bool showGILState_;
+  bool showThreadState_;
+  bool showPthreadIDState_;
 };
 
 }  // namespace pyperf

--- a/examples/cpp/pyperf/PyPerfDefaultPrinter.h
+++ b/examples/cpp/pyperf/PyPerfDefaultPrinter.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#pragma once
+
+#include "PyPerfSampleProcessor.h"
+
+namespace ebpf {
+namespace pyperf {
+
+class PyPerfDefaultPrinter : public PyPerfSampleProcessor {
+ public:
+  void processSamples(const std::vector<PyPerfSample>& samples,
+                      PyPerfUtil* util) override;
+};
+
+}  // namespace pyperf
+}  // namespace ebpf

--- a/examples/cpp/pyperf/PyPerfLoggingHelper.h
+++ b/examples/cpp/pyperf/PyPerfLoggingHelper.h
@@ -3,6 +3,8 @@
  * Licensed under the Apache License, Version 2.0 (the "License")
  */
 
+#pragma once
+
 #include <cstdint>
 
 namespace ebpf {

--- a/examples/cpp/pyperf/PyPerfSampleProcessor.h
+++ b/examples/cpp/pyperf/PyPerfSampleProcessor.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Facebook, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "PyPerfType.h"
+
+namespace ebpf {
+namespace pyperf {
+
+class PyPerfUtil;
+
+class PyPerfSampleProcessor {
+ public:
+  virtual void processSamples(const std::vector<PyPerfSample>& samples,
+                              PyPerfUtil* util) = 0;
+};
+
+}  // namespace pyperf
+}  // namespace ebpf

--- a/examples/cpp/pyperf/PyPerfType.h
+++ b/examples/cpp/pyperf/PyPerfType.h
@@ -3,7 +3,12 @@
  * Licensed under the Apache License, Version 2.0 (the "License")
  */
 
+#pragma once
+
+#include <sys/types.h>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 #define PYTHON_STACK_FRAMES_PER_PROG 25
 #define PYTHON_STACK_PROG_CNT 3
@@ -98,6 +103,27 @@ typedef struct {
   int64_t stack_len;
   int32_t stack[STACK_MAX_LEN];
 } Event;
+
+struct PyPerfSample {
+  pid_t pid;
+  pid_t tid;
+  std::string comm;
+  uint8_t threadStateMatch;
+  uint8_t gilState;
+  uint8_t pthreadIDMatch;
+  uint8_t stackStatus;
+  std::vector<int32_t> pyStackIds;
+
+  explicit PyPerfSample(const Event* raw, int rawSize)
+      : pid(raw->pid),
+        tid(raw->tid),
+        comm(raw->comm),
+        threadStateMatch(raw->thread_state_match),
+        gilState(raw->gil_state),
+        pthreadIDMatch(raw->pthread_id_match),
+        stackStatus(raw->stack_status),
+        pyStackIds(raw->stack, raw->stack + raw->stack_len) {}
+};
 
 }  // namespace pyperf
 }  // namespace ebpf


### PR DESCRIPTION
This PR mainly contains two pars:
- Add a common interface `PyPerfSampleProcessor` that can be passed to `PyPerfUtil` to handle samples from the profiling. This way, users could use customized logic to log / aggregate / output the result samples.
- Abstract current printing logic to a specific `PyPerfDefaultPrinter` that is used by the default CLI main, and add parsing for enum values.
