### PR TITLE
filetop: Avoid missing important entries

### DIFF
--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -38,8 +38,8 @@ parser.add_argument("-C", "--noclear", action="store_true",
     help="don't clear the screen")
 parser.add_argument("-r", "--maxrows", default=20,
     help="maximum rows to print, default 20")
-parser.add_argument("-s", "--sort", default="rbytes",
-    choices=["reads", "writes", "rbytes", "wbytes"],
+parser.add_argument("-s", "--sort", default="all",
+    choices=["all", "reads", "writes", "rbytes", "wbytes"],
     help="sort column, default rbytes")
 parser.add_argument("-p", "--pid", type=int, metavar="PID", dest="tgid",
     help="trace this PID only")
@@ -166,6 +166,12 @@ DNAME_INLINE_LEN = 32  # linux/dcache.h
 
 print('Tracing... Output every %d secs. Hit Ctrl-C to end' % interval)
 
+def sort_fn(counts):
+    if args.sort == "all":
+        return (counts[1].rbytes + counts[1].wbytes + counts[1].reads + counts[1].writes)
+    else:
+        return getattr(counts[1], args.sort)
+
 # output
 exiting = 0
 while 1:
@@ -188,8 +194,7 @@ while 1:
     counts = b.get_table("counts")
     line = 0
     for k, v in reversed(sorted(counts.items(),
-                                key=lambda counts:
-                                  getattr(counts[1], args.sort))):
+                                key=sort_fn)):
         name = k.name.decode('utf-8', 'replace')
         if k.name_len > DNAME_INLINE_LEN:
             name = name[:-3] + "..."


### PR DESCRIPTION
While testing, it is noticed that sometimes filetop can miss
certain heavy-weight activity. This is because it sorts by only a single
column. So for example, if writes are flooding, then it will be way down
in the filetop list and not displayed at all for the default maxrows of
20 and default sort of rbytes. It is better instead to sort by all
columns, by default. This will help catch them.

Test:
Start a bash and do: while true; do echo "asdfasdf" >> testfile; done
Run filetop. Without patch no activity is displayed due to other small
reads on the system. With the path they are.

Fixes issue: https://github.com/iovisor/bcc/issues/2252

Signed-off-by: Joel Fernandes (Google) <joel@joelfernandes.org>