### PR TITLE
add forward declaration of bpf_insn in bpf_module.h

### DIFF
--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -33,6 +33,8 @@ class Module;
 class Type;
 }
 
+struct bpf_insn;
+
 namespace ebpf {
 
 typedef std::map<std::string, std::tuple<uint8_t *, uintptr_t, unsigned>> sec_map_def;


### PR DESCRIPTION
struct bpf_insn is used (as a pointee) in bpf_module.h,
but no definition or forward declaration can be found
by just looking at this file.

definition is not needed as it is used as a pointee.
providing a forward declaration here.

Signed-off-by: Yonghong Song <yhs@fb.com>