### PR TITLE
avoid overflowing btf stringtable during btf line adjustment

### DIFF
--- a/src/cc/bcc_btf.h
+++ b/src/cc/bcc_btf.h
@@ -31,14 +31,15 @@ namespace ebpf {
 class BTFStringTable {
  private:
   uint32_t Size;
+  uint32_t OrigTblLen;
   std::map<uint32_t, uint32_t> OffsetToIdMap;
   std::vector<std::string> Table;
 
  public:
-  BTFStringTable(): Size(0) {}
+  BTFStringTable(uint32_t TblLen): Size(0), OrigTblLen(TblLen) {}
   uint32_t getSize() { return Size; }
   std::vector<std::string> &getTable() { return Table; }
-  uint32_t addString(std::string Str);
+  int32_t addString(std::string Str);
 };
 
 class BTF {


### PR DESCRIPTION
For remapped files (the main bpf program file and helpers.h),
the llvm compiler does not have the source so bcc did the
adjustment/patching after the compilation for lines in .btf.ext
line_info.

If a particular line in the main file or helpers.h is referenced
in the line_info table, the line itself will be added to
string table. If too many lines are added into the string table,
the string table may become too big (>= 64KB), and libbpf/kernel
will reject it.

In my instance with a Facebook internal bpf program, after all
referenced lines are added, the string table is 67KB.

This patch added checking during string table adjustment
to avoid overflow against the kernel limit.

Signed-off-by: Yonghong Song <yhs@fb.com>