### PR TITLE
fix string re being used on bytes for Python 3

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -621,7 +621,7 @@ class PerfEventArray(ArrayBase):
         num_fields = lib.bpf_perf_event_fields(self.bpf.module, self._name)
         i = 0
         while i < num_fields:
-            field = lib.bpf_perf_event_field(self.bpf.module, self._name, i)
+            field = lib.bpf_perf_event_field(self.bpf.module, self._name, i).decode()
             m = re.match(r"(.*)#(.*)", field)
             field_name = m.group(1)
             field_type = m.group(2)


### PR DESCRIPTION
When using killsnoop with Python 3, I get the following errors:

```pybt
TIME      PID    COMM             SIG  TPID   RESULT
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 232, in 'calling callback function'                                                                 
  File "/usr/lib/python3.7/site-packages/bcc/table.py", line 676, in raw_cb_                                                           
    callback(cpu, data, size)
  File "/usr/share/bcc/tools/killsnoop", line 124, in print_event                                                                      
    event = b["events"].event(data)                                                                                                    
  File "/usr/lib/python3.7/site-packages/bcc/table.py", line 654, in event                                                             
    self._event_class = self._get_event_class()
  File "/usr/lib/python3.7/site-packages/bcc/table.py", line 625, in _get_event_class                                                  
    m = re.match(r"(.*)#(.*)", field)                                                                                                  
  File "/usr/lib/python3.7/re.py", line 173, in match
    return _compile(pattern, flags).match(string)                                                                                      
TypeError: cannot use a string pattern on a bytes-like object
```

This change fixes this. It works with Python 2 too.