### PR TITLE
delete allocated array properly

### DIFF
--- a/src/cc/bcc_btf.cc
+++ b/src/cc/bcc_btf.cc
@@ -179,7 +179,7 @@ int BTF::load(uint8_t *btf_sec, uintptr_t btf_sec_size,
 
   if (new_btf_sec) {
     btf = btf__new(new_btf_sec, new_btf_sec_size);
-    delete new_btf_sec;
+    delete[] new_btf_sec;
   } else {
     btf = btf__new(btf_sec, btf_sec_size);
   }


### PR DESCRIPTION
In bcc_btf.cc, new_btf_sec is allocated with something like
```
   new_btf_sec = new uint8_t[tmp_sec_size]
```
Since the allocation is an array, the deletion should be
```
   delete[] new_btf_sec
```
instead of
```
   delete new_btf_sec
```
This patch fixed the problem.

Signed-off-by: Yonghong Song <yhs@fb.com>