### PR TITLE
Clarify kernel configuration flags

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,7 +32,10 @@ CONFIG_NET_CLS_BPF=m
 # [optional, for tc actions]
 CONFIG_NET_ACT_BPF=m
 CONFIG_BPF_JIT=y
+# [for Linux kernel versions 4.1 through 4.6]
 CONFIG_HAVE_BPF_JIT=y
+# [for Linux kernel versions 4.7 and later]
+CONFIG_HAVE_EBPF_JIT=y
 # [optional, for kprobes]
 CONFIG_BPF_EVENTS=y
 ```


### PR DESCRIPTION
This PR updates INSTALL.md per the discussion in #1153. One of the flags mentioned no longer exists in the kernel, and was replaced with a different flag.