### PR TITLE
clang/kbuild_helper: fix arm64 cross compilation

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -46,6 +46,8 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
     arch = "x86";
   } else if (arch[0] == 'i' && !arch.compare(2, 2, "86")) {
     arch = "x86";
+  } else if (!arch.compare(0, 7, "aarch64") || !arch.compare(0, 5, "arm64")) {
+    arch = "arm64";
   } else if (!arch.compare(0, 3, "arm")) {
     arch = "arm";
   } else if (!arch.compare(0, 5, "sa110")) {
@@ -60,8 +62,6 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
     arch = "mips";
   } else if (!arch.compare(0, 2, "sh")) {
     arch = "sh";
-  } else if (!arch.compare(0, 7, "aarch64")) {
-    arch = "arm64";
   }
 
   cflags->push_back("-nostdinc");


### PR DESCRIPTION
Commit 28949f17e0 ("Translate arch into source directory when ARCH is set")
moved $ARCH processing earlier in the function so $ARCH gets processed
by the the same logic which parses the uname_machine value.

This introduced two bugs breaking ARCH=arm64 cross-compilation:

1. The arch.compare(0, 3, "arm") test matches both $ARCH=arm and $ARCH=arm64
leading to builds which always include from "arch/arm/include" instead
of "arch/arm64/include".

2. The only way arch == arm64 is if $ARCH=aarch64. uname returns aarch64
but the rest of the compiler logic expects $ARCH=arm64.

This fixes the above bugs by moving the "aarch64" test earlier than
the "arm" test and also accepting ARCH=arm64.

Fixes: 28949f17e0 ("Translate arch into source directory when ARCH is set (#2122)")
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>