### PR TITLE
doc: explain how to use perf with skb programs

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -521,6 +521,8 @@ Return: 0 on success
 
 A method of a BPF_PERF_OUTPUT table, for submitting custom event data to user space. See the BPF_PERF_OUTPUT entry. (This ultimately calls bpf_perf_event_output().)
 
+The ```ctx``` parameter is provided in [kprobes](#1-kprobes) or [kretprobes](#2-kretprobes). For ```SCHED_CLS``` or ```SOCKET_FILTER``` programs, the ```struct __sk_buff *skb``` must be used instead.
+
 Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=perf_submit+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=perf_submit+path%3Atools&type=Code)


### PR DESCRIPTION
There are no examples of how to use perf_submit in skb programs. This commit explains that a skb can be used as a ctx.

Signed-off-by: Oriol Arcas <oriol@starflownetworks.com>