### PR TITLE
rename libbpf.{a,so} to libbcc_bpf.{a,so}

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -30,10 +30,10 @@ include(static_libstdc++)
 
 file(GLOB libbpf_sources "libbpf/src/*.c")
 add_library(bpf-static STATIC libbpf.c perf_reader.c ${libbpf_sources})
-set_target_properties(bpf-static PROPERTIES OUTPUT_NAME bpf)
+set_target_properties(bpf-static PROPERTIES OUTPUT_NAME bcc_bpf)
 add_library(bpf-shared SHARED libbpf.c perf_reader.c ${libbpf_sources})
 set_target_properties(bpf-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
-set_target_properties(bpf-shared PROPERTIES OUTPUT_NAME bpf)
+set_target_properties(bpf-shared PROPERTIES OUTPUT_NAME bcc_bpf)
 
 set(bcc_common_sources bcc_common.cc bpf_module.cc bcc_btf.cc exported_files.cc)
 if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 6 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 6)


### PR DESCRIPTION
This is based on discussion in netdev regarding to libbpf repo
packaging:
  https://lore.kernel.org/bpf/20190325202009.GA14511@krava/T/#t

The libbpf repo https://github.com/libbpf/libbpf contains
the linux:tools/lib/bpf codes plus some other uapi and auxiliary
headers. It is natural for libbpf repo to generate a
libbpf.{a,so} installable as a package.

To avoid conflicts, let us rename bcc libbpf.{a,so}
to libbcc_bpf.{a,so}.

Signed-off-by: Yonghong Song <yhs@fb.com>