### PR TITLE
[RFC] Cross-compiling eBPF to 32bit ARM

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -420,7 +420,7 @@ Examples in situ:
 
 ### 8. bpf_log2l()
 
-Syntax: ```unsigned int bpf_log2l(unsigned long v)```
+Syntax: ```unsigned int bpf_log2l(unsigned long long v)```
 
 Returns the log-2 of the provided value. This is often used to create indexes for histograms, to construct power-of-2 histograms.
 

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -534,10 +534,12 @@ u64 bpf_ntohll(u64 val) {
   return __builtin_bswap64(val);
 }
 
+#ifdef __SIZEOF_INT128__
 static inline __attribute__((always_inline))
 unsigned __int128 bpf_ntoh128(unsigned __int128 val) {
   return (((unsigned __int128)bpf_ntohll(val) << 64) | (u64)bpf_ntohll(val >> 64));
 }
+#endif
 
 static inline __attribute__((always_inline))
 u16 bpf_htons(u16 val) {
@@ -554,10 +556,12 @@ u64 bpf_htonll(u64 val) {
   return bpf_ntohll(val);
 }
 
+#ifdef __SIZEOF_INT128__
 static inline __attribute__((always_inline))
 unsigned __int128 bpf_hton128(unsigned __int128 val) {
   return bpf_ntoh128(val);
 }
+#endif
 
 static inline __attribute__((always_inline))
 u64 load_dword(void *skb, u64 off) {
@@ -576,7 +580,9 @@ bpf_store_dword(void *skb, u64 off, u64 val) {
 }
 
 #define MASK(_n) ((_n) < 64 ? (1ull << (_n)) - 1 : ((u64)-1LL))
+#ifdef __SIZEOF_INT128__
 #define MASK128(_n) ((_n) < 128 ? ((unsigned __int128)1 << (_n)) - 1 : ((unsigned __int128)-1))
+#endif
 
 static inline __attribute__((always_inline))
 unsigned int bpf_log2(unsigned int v)
@@ -593,7 +599,7 @@ unsigned int bpf_log2(unsigned int v)
 }
 
 static inline __attribute__((always_inline))
-unsigned int bpf_log2l(unsigned long v)
+unsigned int bpf_log2l(unsigned long long v)
 {
   unsigned int hi = v >> 32;
   if (hi)

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -735,6 +735,9 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #elif defined(__TARGET_ARCH_s930x)
 #define bpf_target_s930x
 #define bpf_target_defined
+#elif defined(__TARGET_ARCH_arm)
+#define bpf_target_arm
+#define bpf_target_defined
 #elif defined(__TARGET_ARCH_arm64)
 #define bpf_target_arm64
 #define bpf_target_defined
@@ -751,6 +754,8 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #define bpf_target_x86
 #elif defined(__s390x__)
 #define bpf_target_s930x
+#elif defined(__arm__)
+#define bpf_target_arm
 #elif defined(__aarch64__)
 #define bpf_target_arm64
 #elif defined(__powerpc__)
@@ -791,6 +796,17 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #define PT_REGS_RC(ctx)		((ctx)->ax)
 #define PT_REGS_IP(ctx)		((ctx)->ip)
 #define PT_REGS_SP(ctx)		((ctx)->sp)
+#elif defined(bpf_target_arm)
+#define PT_REGS_PARM1(x) ((x)->uregs[0])
+#define PT_REGS_PARM2(x) ((x)->uregs[1])
+#define PT_REGS_PARM3(x) ((x)->uregs[2])
+#define PT_REGS_PARM4(x) ((x)->uregs[3])
+#define PT_REGS_PARM5(x) ((x)->uregs[4])
+#define PT_REGS_RET(x) ((x)->uregs[14])
+#define PT_REGS_FP(x) ((x)->uregs[11]) /* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_RC(x) ((x)->uregs[0])
+#define PT_REGS_SP(x) ((x)->uregs[13])
+#define PT_REGS_IP(x) ((x)->uregs[12])
 #elif defined(bpf_target_arm64)
 #define PT_REGS_PARM1(x)	((x)->regs[0])
 #define PT_REGS_PARM2(x)	((x)->regs[1])

--- a/src/cc/frontends/clang/arch_helper.h
+++ b/src/cc/frontends/clang/arch_helper.h
@@ -21,6 +21,7 @@ typedef enum {
   BCC_ARCH_PPC,
   BCC_ARCH_PPC_LE,
   BCC_ARCH_S390X,
+  BCC_ARCH_ARM,
   BCC_ARCH_ARM64,
   BCC_ARCH_X86
 } bcc_arch_t;
@@ -41,6 +42,8 @@ static void *run_arch_callback(arch_callback_t fn)
 #endif
 #elif defined(__s390x__)
     return fn(BCC_ARCH_S390X);
+#elif defined(__arm__)
+    return fn(BCC_ARCH_ARM);
 #elif defined(__aarch64__)
     return fn(BCC_ARCH_ARM64);
 #else
@@ -59,6 +62,8 @@ static void *run_arch_callback(arch_callback_t fn)
     return fn(BCC_ARCH_S390X);
   } else if (!strcmp(archenv, "arm64")) {
     return fn(BCC_ARCH_ARM64);
+  } else if (!strcmp(archenv, "arm")) {
+    return fn(BCC_ARCH_ARM);
   } else {
     return fn(BCC_ARCH_X86);
   }

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -49,6 +49,9 @@ const char *calling_conv_regs_ppc[] = {"gpr[3]", "gpr[4]", "gpr[5]",
 const char *calling_conv_regs_s390x[] = {"gprs[2]", "gprs[3]", "gprs[4]",
 					 "gprs[5]", "gprs[6]" };
 
+const char *calling_conv_regs_arm[] = {"uregs[0]", "uregs[1]", "uregs[2]",
+                                       "uregs[3]", "uregs[4]", "uregs[5]"};
+
 const char *calling_conv_regs_arm64[] = {"regs[0]", "regs[1]", "regs[2]",
                                        "regs[3]", "regs[4]", "regs[5]"};
 
@@ -63,6 +66,9 @@ void *get_call_conv_cb(bcc_arch_t arch)
       break;
     case BCC_ARCH_S390X:
       ret = calling_conv_regs_s390x;
+      break;
+    case BCC_ARCH_ARM:
+      ret = calling_conv_regs_arm;
       break;
     case BCC_ARCH_ARM64:
       ret = calling_conv_regs_arm64;

--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -100,6 +100,11 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
   if (archenv)
 	cflags->push_back("-D__TARGET_ARCH_" + arch);
 
+  // Linux enables cmpxchg instructions unconditionally on arm64, but on normal
+  // arm they're hidden behind an #if __LINUX_ARM_ARCH__ >= 6 test so define it
+  if (!arch.compare(0, 3, "arm") && arch.compare(0, 5, "arm64") < 0)
+	cflags->push_back("-D__LINUX_ARM_ARCH__=6");
+
   cflags->push_back("-Wno-unused-value");
   cflags->push_back("-Wno-pointer-sign");
   cflags->push_back("-fno-stack-protector");

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -241,6 +241,9 @@ void *get_clang_target_cb(bcc_arch_t arch)
     case BCC_ARCH_S390X:
       ret = "s390x-ibm-linux-gnu";
       break;
+    case BCC_ARCH_ARM:
+      ret = "armv7-unknown-linux-gnueabi";
+      break;
     case BCC_ARCH_ARM64:
       ret = "aarch64-unknown-linux-gnu";
       break;


### PR DESCRIPTION
Hi,

How I handled cross-compiling and running eBPF on 32bit ARM until now is shown in this simple [bcc-arm-cross-test](https://github.com/10ne1/bcc-arm-cross-test) example repo. Basically I wrote everything from scratch and used a static [gobpf](https://github.com/iovisor/gobpf) loader on the remote device, bypassing BCC entirely.

It works well but is cumbersome. I'd like to have the full power and convenience of BCC / bcc-tools on my embedded devices, so I rebased and fixed the bpfd build (more on this later in a separate pull request because it's a big amount of work), run it on the remote devices and cross-compiled eBPF using BCC to load/interact via bpfd.

It works really well for arm64, I can run almost all bcc-tools without installing python/llvm/etc. with just a few hundred kb size footprint :+1: The last missing piece is cross-compiling eBPF to 32bit ARM within BCC, hence this RFC.

I've converted my 32bit ARM [Makefile](https://github.com/10ne1/bcc-arm-cross-test/blob/master/Makefile) based [example code](https://github.com/10ne1/bcc-arm-cross-test/blob/master/src/open-example.c) to BCC python [here](https://github.com/10ne1/bcc-arm-cross-test/blob/master/src/open-example.py). Using the changes in this RFC, the code compiles but hits this error in [_engine->finalizeObject()](https://github.com/iovisor/bcc/blob/d1e9d2221a754806f463ee950b6cd2b1e1c2c54c/src/cc/bpf_module.cc#L422):

```
<inline asm>:1:1: error: unknown directive
.syntax unified
^
LLVM ERROR: Error parsing inline asm
```

I have very little LLVM BPF knowledge, so I only understand the shallow obvious thing: The BPF asm parser doesn't know the directive.

BCC debug dumps show the problem:
```
; ModuleID = '/virtual/main.c'
source_filename = "/virtual/main.c"
target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
target triple = "bpf-pc-linux"

module asm ".syntax unified"

%struct.pt_regs = type { [18 x i32] }
```
Interestingly, dumping the asm of my [Makefile example](https://github.com/10ne1/bcc-arm-cross-test/blob/514939c112c6bf6100787bea6a2b8dcb9e2e0a00/Makefile#L22) doesn't produce the directive (I assume it's not compiled for thumb instructions):

```
; ModuleID = 'src/open-example.c'
source_filename = "src/open-example.c"
target datalayout = "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64"
target triple = "armv7--linux-gnueabihf"

%struct.pt_regs = type { [18 x i32] }
```

First question:
I tried changing the target triple or datalayout to no effect. The BCC "bpf-pc-linux" should work for arm cross-compilation because it also works for arm64, right? So I only have to change the triplet for the `frontends/clang/loader.cc`. Any ideas about the datalayout difference?

Second question:
Can the asm difference be due to the different arguments to the clang call? My [Makefile call](https://github.com/10ne1/bcc-arm-cross-test/blob/master/Makefile) which works is pretty simple, the BCC call is more complex and I see some hard-coded armv8 stuff there (I coludn't find where they're added, I assume somewhere in libllvm/clang?)

```
clang -cc1 -triple armv7-unknown-linux-gnu -emit-llvm-bc -emit-llvm-uselists -disable-free -disable-llvm-verifier -discard-value-names -main-file-name main.c -mrelocation-model pic -pic-level 2 -pic-is-pie -mthread-model posix -mdisable-fp-elim -fmath-errno -masm-verbose -mconstructor-aliases -fuse-init-array -target-cpu generic -target-feature +soft-float -target-feature +soft-float-abi -target-feature -fp-only-sp -target-feature -d16 -target-feature -vfp2 -target-feature -vfp3 -target-feature -fp16 -target-feature -vfp4 -target-feature -fp-armv8 -target-feature -neon -target-feature -crypto -target-abi aapcs -msoft-float -mfloat-abi soft -fallow-half-arguments-and-returns -dwarf-column-info -debug-info-kind=limited -dwarf-version=4 -debugger-tuning=gdb -coverage-notes-file /home/adi/workspace/linux-arm/main.gcno -nostdsysteminc -nobuiltininc -resource-dir lib/clang/7.0.1 -isystem /virtual/lib/clang/include -include ./include/linux/kconfig.h -include /virtual/include/bcc/bpf.h -include /virtual/include/bcc/helpers.h -isystem /virtual/include -I /home/adi -D __BPF_TRACING__ -I ./arch/arm/include -I arch/arm/include/generated/uapi -I arch/arm/include/generated -I include -I ./arch/arm/include/uapi -I arch/arm/include/generated/uapi -I ./include/uapi -I include/generated/uapi -D __KERNEL__ -D __HAVE_BUILTIN_BSWAP16__ -D __HAVE_BUILTIN_BSWAP32__ -D __HAVE_BUILTIN_BSWAP64__ -D __TARGET_ARCH_arm -D __LINUX_ARM_ARCH__=6 -O2 -Wno-deprecated-declarations -Wno-gnu-variable-sized-type-not-at-end -Wno-pragma-once-outside-header -Wno-address-of-packed-member -Wno-unknown-warning-option -Wno-unused-value -Wno-pointer-sign -fdebug-compilation-dir /home/adi/workspace/linux-arm -ferror-limit 19 -fmessage-length 190 -fno-signed-char -fobjc-runtime=gcc -fdiagnostics-show-option -vectorize-loops -vectorize-slp -o main.bc -x c /virtual/main.c -faddrsig
```

Third question:
Is the LLVM BPF asm parser missing something to enable 32bit arm? I looked through the LLVM src/lib/Target/BPF commits since it was added but nothing relevant popped out AFAIK. I'm using v7.0.1 currently.

Maybe I'm missing something obvious and simple here, sorry if that's the case :) Any help or pointers are much appreciated.