### PR TITLE
Add bcc_usdt_enable_fully_specified_probe to avoid usdt provider collisions

### DIFF
--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -70,6 +70,8 @@ int bcc_usdt_get_argument(void *usdt, const char *provider_name,
                           struct bcc_usdt_argument *argument);
 
 int bcc_usdt_enable_probe(void *, const char *, const char *);
+#define BCC_USDT_HAS_FULLY_SPECIFIED_PROBE
+int bcc_usdt_enable_fully_specified_probe(void *, const char *, const char *, const char *);
 const char *bcc_usdt_genargs(void **ctx_array, int len);
 const char *bcc_usdt_get_probe_argctype(
   void *ctx, const char* probe_name, const int arg_index

--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -71,7 +71,8 @@ int bcc_usdt_get_argument(void *usdt, const char *provider_name,
 
 int bcc_usdt_enable_probe(void *, const char *, const char *);
 #define BCC_USDT_HAS_FULLY_SPECIFIED_PROBE
-int bcc_usdt_enable_fully_specified_probe(void *, const char *, const char *, const char *);
+int bcc_usdt_enable_fully_specified_probe(void *, const char *, const char *,
+                                          const char *);
 const char *bcc_usdt_genargs(void **ctx_array, int len);
 const char *bcc_usdt_get_probe_argctype(
   void *ctx, const char* probe_name, const int arg_index

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -280,7 +280,8 @@ public:
   Probe *get(int pos) { return probes_[pos].get(); }
 
   bool enable_probe(const std::string &probe_name, const std::string &fn_name);
-  bool enable_probe(const std::string &provider_name, const std::string &probe_name, const std::string &fn_name);
+  bool enable_probe(const std::string &provider_name,
+                    const std::string &probe_name, const std::string &fn_name);
 
   typedef void (*each_cb)(struct bcc_usdt *);
   void each(each_cb callback);

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -280,6 +280,7 @@ public:
   Probe *get(int pos) { return probes_[pos].get(); }
 
   bool enable_probe(const std::string &probe_name, const std::string &fn_name);
+  bool enable_probe(const std::string &provider_name, const std::string &probe_name, const std::string &fn_name);
 
   typedef void (*each_cb)(struct bcc_usdt *);
   void each(each_cb callback);

--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -295,22 +295,44 @@ Probe *Context::get(const std::string &provider_name,
 
 bool Context::enable_probe(const std::string &probe_name,
                            const std::string &fn_name) {
+  return enable_probe("", probe_name, fn_name);
+}
+
+bool Context::enable_probe(const std::string &provider_name,
+                           const std::string &probe_name,
+                           const std::string &fn_name) {
   if (pid_stat_ && pid_stat_->is_stale())
     return false;
 
-  // FIXME: we may have issues here if the context has two same probes's
-  // but different providers. For example, libc:setjmp and rtld:setjmp,
-  // libc:lll_futex_wait and rtld:lll_futex_wait.
+  unsigned int matches = 0;
   Probe *found_probe = nullptr;
   for (auto &p : probes_) {
     if (p->name_ == probe_name) {
-      if (found_probe != nullptr) {
-         fprintf(stderr, "Two same-name probes (%s) but different providers\n",
-                 probe_name.c_str());
-         return false;
+      if (found_probe == nullptr && provider_name == "")
+      {
+        found_probe = p.get();
+        matches++;
       }
-      found_probe = p.get();
+      else if (found_probe != nullptr && provider_name == "")
+      {
+        fprintf(stderr, "Found duplicate provider (%s) for underspecified probe (%s)\n",
+                p->provider().c_str(), p->name().c_str());
+        matches++;
+      } else if (provider_name != "" && p->provider() == provider_name)
+      {
+        found_probe = p.get();
+        matches++;
+      }
     }
+  }
+
+  if (matches > 1) {
+    fprintf(stderr, "Found %i duplicate providers for underpecified probe (%s)\n",
+                matches, fn_name.c_str());
+    return false;
+  } else if(matches < 1) {
+    fprintf(stderr, "No matches found for probe (%s)\n", fn_name.c_str());
+    return false;
   }
 
   if (found_probe != nullptr)
@@ -446,6 +468,14 @@ int bcc_usdt_enable_probe(void *usdt, const char *probe_name,
                           const char *fn_name) {
   USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
   return ctx->enable_probe(probe_name, fn_name) ? 0 : -1;
+}
+
+int bcc_usdt_enable_fully_specified_probe(void *usdt,
+                                          const char *provider_name,
+                                          const char *probe_name,
+                                          const char *fn_name) {
+  USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
+  return ctx->enable_probe(provider_name, probe_name, fn_name) ? 0 : -1;
 }
 
 const char *bcc_usdt_genargs(void **usdt_array, int len) {


### PR DESCRIPTION
fixes #2275

I aimed for the most minimal changeset I could in order to avoid provider collisions.

I have successfully used this code in https://github.com/iovisor/bpftrace/pull/508 to be able to probe a function that would otherwise have a collision with another provider:

As you can see, `testprobe2` is defined on both the `tracetest` and `tracetest2` providers:

```
bpftrace -l 'usdt:./tracetest'
usdt:./tracetest:tracetest:testprobe
usdt:./tracetest:tracetest:testprobe2
usdt:./tracetest:tracetest2:testprobe2
```

Using the old API (`bcc_usdt_enable_probe`):

```
bpftrace -e 'usdt::tracetest2:testprobe2 { @[probe]++ }' -p ${PID}
Attaching 1 probe...
Found duplicate provider (tracetest2) for underspecified probe (testprobe2)
Found 2 duplicate providers for underpecified probe (probe_testprobe2_1)
Error finding or enabling probe: usdt:tracetest2:testprobe2
```

And the new API (`bcc_usdt_enable_fully_specified_probe`):

```
bpftrace -e 'usdt::tracetest2:testprobe2 { @[probe]++ }' -p ${PID}
Attaching 1 probe...
^C

@[usdt:tracetest2:testprobe2]: 2
```

To maintain compatibility:

* I added a check `BCC_USDT_HAS_FULLY_SPECIFIED_PROBE`, which can be useful for tools running against a previous release of libbcc to maintain their current (degraded) functionality.
* I defined a new function to enable probes, specifying the provider: `bcc_usdt_enable_fully_specified_probe`

Things I'd like comments on, in addition to the review:
* We may want to have a deprecation strategy for the old API, or perhaps it should remain in place. If we decide to deprecate, we will need to make an issue to update bcc tools to use the new API
* A better (shorter) name for `bcc_usdt_enable_fully_specified_probe`
* Tests to add to existing suite to verify this functionality
* Thoughts on what, if anything, should hold up merging this.

