### PR TITLE
Add libbcc-loader-static.a symbols into libbcc.a

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 add_library(bcc-loader-static STATIC ${bcc_sym_sources} ${bcc_util_sources})
 target_link_libraries(bcc-loader-static elf)
 add_library(bcc-static STATIC
-  ${bcc_common_sources} ${bcc_table_sources} ${bcc_util_sources} ${bcc_usdt_sources})
+  ${bcc_common_sources} ${bcc_table_sources} ${bcc_util_sources} ${bcc_usdt_sources} ${bcc_sym_sources} ${bcc_util_sources})
 set_target_properties(bcc-static PROPERTIES OUTPUT_NAME bcc)
 set(bcc-lua-static
   ${bcc_common_sources} ${bcc_table_sources} ${bcc_sym_sources} ${bcc_util_sources})


### PR DESCRIPTION
It's useful to have all the bcc symbols in one place when statically
linking against bcc. This patch adds all the symbols from
libbcc-loader-static into libbcc. This is in line with how
libbcc-lua-static does it as well.