### PR TITLE
stackcount: add -c option for CPU only events

### DIFF
--- a/man/man8/stackcount.8
+++ b/man/man8/stackcount.8
@@ -2,8 +2,8 @@
 .SH NAME
 stackcount \- Count function calls and their stack traces. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B stackcount [\-h] [\-p PID] [\-i INTERVAL] [\-D DURATION] [\-T] [\-r] [\-s]
-              [\-P] [\-K] [\-U] [\-v] [\-d] [\-f] pattern
+.B stackcount [\-h] [\-p PID] [\-c CPU] [\-i INTERVAL] [\-D DURATION] [\-T] [\-r]
+              [\-s] [\-P] [\-K] [\-U] [\-v] [\-d] [\-f] pattern
 .SH DESCRIPTION
 stackcount traces functions and frequency counts them with their entire
 stack trace, kernel stack and user stack, summarized in-kernel for efficiency.
@@ -54,6 +54,9 @@ Folded output format.
 \-p PID
 Trace this process ID only (filtered in-kernel).
 .TP
+\-c CPU
+Trace this CPU only (filtered in-kernel).
+.TP
 .TP
 pattern
 A function name, or a search pattern. Can include wildcards ("*"). If the
@@ -103,6 +106,10 @@ Output every 5 seconds, with timestamps:
 Only count stacks when PID 185 is on-CPU:
 #
 .B stackcount \-p 185 ip_output
+.TP
+Only count stacks for CPU 1:
+#
+.B stackcount \-c 1 put_prev_entity
 .TP
 Count user stacks for dynamic heap allocations with malloc in PID 185:
 #

--- a/tools/stackcount_example.txt
+++ b/tools/stackcount_example.txt
@@ -843,8 +843,8 @@ This folded output can be piped directly into flamegraph.pl (the Perl version).
 USAGE message:
 
 # ./stackcount -h
-usage: stackcount [-h] [-p PID] [-i INTERVAL] [-D DURATION] [-T] [-r] [-s]
-                  [-P] [-K] [-U] [-v] [-d] [-f] [--debug]
+usage: stackcount [-h] [-p PID] [-c CPU] [-i INTERVAL] [-D DURATION] [-T] [-r]
+                  [-s] [-P] [-K] [-U] [-v] [-d] [-f] [--debug]
                   pattern
 
 Count events and their stack traces
@@ -855,6 +855,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -p PID, --pid PID     trace this PID only
+  -c CPU, --cpu CPU     trace this CPU only
   -i INTERVAL, --interval INTERVAL
                         summary interval, seconds
   -D DURATION, --duration DURATION
@@ -886,5 +887,6 @@ examples:
     ./stackcount -p 185 c:malloc    # count stacks for malloc in PID 185
     ./stackcount t:sched:sched_fork # count stacks for sched_fork tracepoint
     ./stackcount -p 185 u:node:*    # count stacks for all USDT probes in node
+    ./stackcount -c 1 put_prev_entity   # count put_prev_entity stacks for CPU 1 only
     ./stackcount -K t:sched:sched_switch   # kernel stacks only
     ./stackcount -U t:sched:sched_switch   # user stacks only


### PR DESCRIPTION
Add the -c option to trace events happened only the requested CPU.
Update command line, man and example.

Signed-off-by: Dima Stepanov <dimastep@yandex-team.ru>
Signed-off-by: Yury Kotov <yury-kotov@yandex-team.ru>