### PR TITLE
man: remove duplicated description of '-f' option from offcputime.8

### DIFF
--- a/man/man8/offcputime.8
+++ b/man/man8/offcputime.8
@@ -34,9 +34,6 @@ CONFIG_BPF and bcc.
 \-h
 Print usage message.
 .TP
-\-f
-Print output in folded stack format.
-.TP
 \-p PID
 Trace this process ID only (filtered in-kernel).
 .TP
@@ -59,7 +56,7 @@ Show stacks from kernel space only (no user space stacks).
 Insert delimiter between kernel/user stacks.
 .TP
 \-f
-Output folded format.
+Print output in folded stack format.
 .TP
 \-\-stack-storage-size STACK_STORAGE_SIZE
 Change the number of unique stack traces that can be stored and displayed.


### PR DESCRIPTION
In commit 66bf2e8e (offcputime: one symbol cache per process, improve
pid/tid handling, 2016-07-31) the '-f' option was documented again
probably with the intent of following the order of options in the
synopsis, but it was already documented.

Remove the fist instance and keep the new one to follow the same order
of the synopsis, but use the original description.