### PR TITLE
loader: Add support for reading kernel headers from /proc

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.h
+++ b/src/cc/frontends/clang/kbuild_helper.h
@@ -21,6 +21,8 @@
 #include <errno.h>
 #include <ftw.h>
 
+#define PROC_KHEADERS_PATH "/proc/kheaders.tar.xz"
+
 namespace ebpf {
 
 struct FileDeleter {
@@ -101,4 +103,5 @@ class KBuildHelper {
   bool has_source_dir_;
 };
 
+int get_proc_kheaders(std::string &dir);
 }  // namespace ebpf

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -120,6 +120,7 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
   const char *version_override = ::getenv("BCC_LINUX_VERSION_CODE");
   bool has_kpath_source = false;
   string vmacro;
+  std::string tmpdir;
 
   if (kpath_env) {
     kpath = string(kpath_env);
@@ -128,6 +129,13 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
     auto kernel_path_info = get_kernel_path_info(kdir);
     has_kpath_source = kernel_path_info.first;
     kpath = kdir + "/" + kernel_path_info.second;
+  }
+
+  // If all attempts to obtain kheaders fail, check for /proc/kheaders.tar.xz
+  if (!is_dir(kpath)) {
+    int ret = get_proc_kheaders(tmpdir);
+    if (!ret)
+      kpath = tmpdir;
   }
 
   if (flags_ & DEBUG_PREPROCESSOR)


### PR DESCRIPTION
BCC right now relies on the filesystem to have kernel headers however
this is quite a hindrance to embedded and Android systems, and even
distros that may not have the kernel headers for the running kernel.
This patch makes use of the new /proc/kheaders.tar.xz archive that is
proposed upstream: https://lore.kernel.org/patchwork/patch/1059427/

The approach involves creating a temporary directory containing the
headers and compiling from there. It is used as a last resort if headers
could not be found by other means.

Testing shows this adds around 400ms to start up time of BCC, however
the cost is 0 if the headers already exists in /lib. For
Android/embedded systems, the cost of 400ms is acceptable considering
otherwise the tools just remain broken. A clang virtual filesystem
approach was suggested on LKML, however such an approach does not add
benefit since most of the time goes in tarball extraction and
decompression which would have to be done in either way.

Signed-off-by: Joel Fernandes (Google) <joel@joelfernandes.org>