### PR TITLE
Support loading elf notes from memfd backed map

### DIFF
--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/mman.h>
 #include <ctype.h>
+#include <dirent.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <math.h>
@@ -26,6 +24,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "bcc_perf_map.h"
@@ -82,6 +83,40 @@ int bcc_mapping_is_file_backed(const char *mapname) {
     STARTS_WITH(mapname, "[vsyscall]"));
 }
 
+/*
+Finds a file descriptor for a given inode if it's a memory-backed fd.
+*/
+static char *_procutils_memfd_path(int pid, uint64_t inum) {
+  char path_buffer[PATH_MAX + 1];
+  char *path = NULL;
+  char *dirstr;
+  DIR *dirstream;
+  struct stat sb;
+  struct dirent *dent;
+
+  snprintf(path_buffer, (PATH_MAX + 1), "/proc/%d/fd", pid);
+  dirstr = malloc(sizeof(char) * (strlen(path_buffer) + 1));
+  strcpy(dirstr, path_buffer);
+  dirstream = opendir(dirstr);
+
+  while (path == NULL && dirstream != NULL &&
+         (dent = readdir(dirstream)) != NULL) {
+    snprintf(path_buffer, (PATH_MAX + 1), "%s/%s", dirstr, dent->d_name);
+    if (stat(path_buffer, &sb) == -1)
+      continue;
+
+    if (sb.st_ino == inum) {
+      char *pid_fd_path = malloc(sizeof(char) * (strlen(path_buffer) + 1));
+      strcpy(pid_fd_path, path_buffer);
+      path = pid_fd_path;
+    }
+  }
+  closedir(dirstream);
+  free(dirstr);
+
+  return path;
+}
+
 int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
                               void *payload) {
   char procmap_filename[128];
@@ -111,6 +146,15 @@ int bcc_procutils_each_module(int pid, bcc_procutils_modulecb callback,
       name++;
     if (!bcc_mapping_is_file_backed(name))
       continue;
+
+    if (strstr(name, "/memfd:")) {
+      char *memfd_name = _procutils_memfd_path(pid, inode);
+      if (memfd_name != NULL) {
+        strcpy(buf, memfd_name);
+        free(memfd_name);
+        name = buf;
+      }
+    }
 
     if (callback(name, begin, end, (uint64_t)offset, true, payload) < 0)
       break;

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -86,7 +86,7 @@ int bcc_mapping_is_file_backed(const char *mapname) {
 /*
 Finds a file descriptor for a given inode if it's a memory-backed fd.
 */
-static char *_procutils_memfd_path(int pid, uint64_t inum) {
+static char *_procutils_memfd_path(const int pid, const uint64_t inum) {
   char path_buffer[PATH_MAX + 1];
   char *path = NULL;
   char *dirstr;

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -95,18 +95,20 @@ static char *_procutils_memfd_path(const int pid, const uint64_t inum) {
   struct dirent *dent;
 
   snprintf(path_buffer, (PATH_MAX + 1), "/proc/%d/fd", pid);
-  dirstr = malloc(sizeof(char) * (strlen(path_buffer) + 1));
+  dirstr = malloc(strlen(path_buffer) + 1);
   strcpy(dirstr, path_buffer);
   dirstream = opendir(dirstr);
 
-  while (path == NULL && dirstream != NULL &&
-         (dent = readdir(dirstream)) != NULL) {
+  if (dirstream == NULL)
+    return NULL;
+
+  while (path == NULL && (dent = readdir(dirstream)) != NULL) {
     snprintf(path_buffer, (PATH_MAX + 1), "%s/%s", dirstr, dent->d_name);
     if (stat(path_buffer, &sb) == -1)
       continue;
 
     if (sb.st_ino == inum) {
-      char *pid_fd_path = malloc(sizeof(char) * (strlen(path_buffer) + 1));
+      char *pid_fd_path = malloc(strlen(path_buffer) + 1);
       strcpy(pid_fd_path, path_buffer);
       path = pid_fd_path;
     }


### PR DESCRIPTION
This allows for elf notes to be read from a memfd_backed "file".

If the inode number of a file descriptor matches exactly the inode number in the memory map, we know that it is a memory backed file descriptor (this can also be verified against `name` in this context, using `strstr(name, '/memfd')`, but this is less performant than comparing the inode number).

For such file descriptors, we can return a path that is relative to the pid and use that, as `/memfd:NAME` is not a file that can be checked later on. In such cases, we will return a path like `/proc/PID/fd/FDNUM`, where FDNUM corresponds to the file descriptor with that matches the inode number.

The practical application for this is that probes that are dynamically created via a library such as libstapsdt can be scoped to the lifetime of the process. This ensures that no `.so` files which were dlopen'd to load probes into the execution context will be dangling. It also has the benefit of not ever needing to touch even a temporary filesystem, as the file descriptor will always point to memory.

This allows for applications like bpftrace to have a behavior more similar to dtrace, where the elf notes can be mapped in with valloc and made accessible to dtrace.

Eg, tplist output for probes discovered this way:

```
/proc/4732/fd/7 provider:name
```

I have an example of a use-case for this up on https://github.com/sthima/libstapsdt/pull/24