### PR TITLE
tools/profile: add -L option to support filtering on TID

### DIFF
--- a/man/man8/profile.8
+++ b/man/man8/profile.8
@@ -2,7 +2,7 @@
 .SH NAME
 profile \- Profile CPU usage by sampling stack traces. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B profile [\-adfh] [\-p PID] [\-U | \-K] [\-F FREQUENCY | \-c COUNT]
+.B profile [\-adfh] [\-p PID | \-L TID] [\-U | \-K] [\-F FREQUENCY | \-c COUNT]
 .B [\-\-stack\-storage\-size COUNT] [duration]
 .SH DESCRIPTION
 This is a CPU profiler. It works by taking samples of stack traces at timed
@@ -28,8 +28,10 @@ for an older version that may work on Linux 4.6 - 4.8.
 Print usage message.
 .TP
 \-p PID
-Trace this process ID only (filtered in-kernel). Without this, all CPUs are
-profiled.
+Trace this process ID only (filtered in-kernel).
+.TP
+\-L TID
+Trace this thread ID only (filtered in-kernel).
 .TP
 \-F frequency
 Frequency to sample stacks.
@@ -80,9 +82,13 @@ Profile 1 in a million events for 5 seconds only:
 #
 .B profile -c 1000000 5
 .TP
-Profile PID 181 only:
+Profile process with PID 181 only:
 #
 .B profile -p 181
+.TP
+Profile thread with TID 181 only:
+#
+.B profile -L 181
 .TP
 Profile for 5 seconds and output in folded stack format (suitable as input for flame graphs), including a delimiter between kernel and user stacks:
 #

--- a/tools/profile_example.txt
+++ b/tools/profile_example.txt
@@ -707,7 +707,7 @@ Run ./profile -h to see the default.
 USAGE message:
 
 # ./profile -h
-usage: profile.py [-h] [-p PID] [-U | -K] [-F FREQUENCY | -c COUNT] [-d] [-a]
+usage: profile.py [-h] [-p PID | -L TID] [-U | -K] [-F FREQUENCY | -c COUNT] [-d] [-a]
                   [-I] [-f] [--stack-storage-size STACK_STORAGE_SIZE] [-C CPU]
                   [duration]
 
@@ -718,7 +718,8 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -p PID, --pid PID     profile this PID only
+  -p PID, --pid PID     profile process with this PID only
+  -L TID, --tid TID     profile thread with this TID only
   -U, --user-stacks-only
                         show stacks from user space only (no kernel space
                         stacks)
@@ -745,6 +746,7 @@ examples:
     ./profile -c 1000000  # profile stack traces every 1 in a million events
     ./profile 5           # profile at 49 Hertz for 5 seconds only
     ./profile -f 5        # output in folded format for flame graphs
-    ./profile -p 185      # only profile threads for PID 185
+    ./profile -p 185      # only profile process with PID 185
+    ./profile -L 185      # only profile thread with TID 185
     ./profile -U          # only show user space stacks (no kernel)
     ./profile -K          # only show kernel space stacks (no user)


### PR DESCRIPTION
tools/profile already supports "-p PID" to filter on PID (tgid in kernel).
Now add "-L TID" to profile thread with this TID only (pid in kernel).