### PR TITLE
tools: fix stacktraces formatting in memleak.py

### DIFF
--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -472,7 +472,8 @@ def print_outstanding():
                          key=lambda a: a.size)[-top_stacks:]
         for alloc in to_show:
                 print("\t%d bytes in %d allocations from stack\n\t\t%s" %
-                      (alloc.size, alloc.count, b"\n\t\t".join(alloc.stack)))
+                      (alloc.size, alloc.count,
+                       b"\n\t\t".join(alloc.stack).decode("ascii")))
 
 def print_outstanding_combined():
         stack_traces = bpf["stack_traces"]


### PR DESCRIPTION
Fix printing of stacktraces. Example:
Before this patch:

Attaching to kernel allocators, Ctrl+C to quit.
[14:11:43] Top 10 stacks with outstanding allocations:
	8 bytes in 1 allocations from stack
		b'pcpu_alloc+0x3d8 [kernel]\n\t\tpcpu_alloc+0x3d8 [kernel]\n\t\tperf_trace_event_init+0xc9 [kernel]\n\t\tperf_trace_init+0x69 [kernel]\n\t\tperf_tp_event_init+0x1b [kernel]\n\t\tperf_try_init_event+0x42 [kernel]\n\t\tperf_event_alloc+0x620 [kernel]\n\t\t__do_sys_perf_event_open+0x188 [kernel]\n\t\tdo_syscall_64+0x48 [kernel]\n\t\tentry_SYSCALL_64_after_hwframe+0x44 [kernel]'
	16 bytes in 1 allocations from stack
		b'pcpu_alloc+0x3d8 [kernel]\n\t\tpcpu_alloc+0x3d8 [kernel]\n\t\tbpf_prog_alloc+0x33 [kernel]\n\t\tbpf_prog_load+0xf5 [kernel]\n\t\tperf_event_for_each_child+0x34 [kernel]\n\t\t_perf_ioctl+0x1d7 [kernel]\n\t\t__switch_to_asm+0x34 [kernel]\n\t\t__switch_to_asm+0x40 [kernel]\n\t\t__switch_to_asm+0x34 [kernel]\n\t\t__switch_to_asm+0x40 [kernel]\n\t\t__switch_to_asm+0x34 [kernel]\n\t\t__switch_to_asm+0x40 [kernel]\n\t\t__do_sys_bpf+0x953 [kernel]\n\t\tperf_ioctl+0x40 [kernel]\n\t\tdo_vfs_ioctl+0xa5 [kernel]\n\t\tdo_syscall_64+0x48 [kernel]\n\t\tentry_SYSCALL_64_after_hwframe+0x44 [kernel]'

With this patch:

Attaching to kernel allocators, Ctrl+C to quit.
[14:13:09] Top 10 stacks with outstanding allocations:
	576 bytes in 3 allocations from stack
		kmem_cache_alloc+0x15c [kernel]
		__d_alloc+0x22 [kernel]
		kmem_cache_alloc+0x15c [kernel]
		__cpa_flush_tlb+0x0 [kernel]
		__d_alloc+0x22 [kernel]
		alloc_file_pseudo+0x65 [kernel]
		anon_inode_getfile+0x7f [kernel]
		anon_inode_getfd+0x35 [kernel]
		bpf_prog_load+0x3ef [kernel]
		_perf_ioctl+0x1d7 [kernel]
		alloc_file_pseudo+0xa7 [kernel]
		__do_sys_bpf+0x953 [kernel]
		perf_ioctl+0x40 [kernel]
		do_vfs_ioctl+0xa5 [kernel]
		do_syscall_64+0x48 [kernel]
		entry_SYSCALL_64_after_hwframe+0x44 [kernel]
	768 bytes in 4 allocations from stack
		kmem_cache_alloc+0x15c [kernel]
		__d_alloc+0x22 [kernel]
		kmem_cache_alloc+0x15c [kernel]
		__d_alloc+0x22 [kernel]
		alloc_file_pseudo+0x65 [kernel]
		ns_capable_common+0x2b [kernel]
		anon_inode_getfile+0x7f [kernel]
		__do_sys_perf_event_open+0x86f [kernel]
		do_syscall_64+0x48 [kernel]
		entry_SYSCALL_64_after_hwframe+0x44 [kernel]