### PR TITLE
Convert bytes to string for re in get_tracepoints()

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -769,7 +769,7 @@ class BPF(object):
                 evt_dir = os.path.join(cat_dir, event)
                 if os.path.isdir(evt_dir):
                     tp = ("%s:%s" % (category, event))
-                    if re.match(tp_re, tp):
+                    if re.match(tp_re.decode(), tp):
                         results.append(tp)
         return results
 


### PR DESCRIPTION
When executing funccount with python3, the following error showed.

 # python3 funccount.py -D 't:block:*'
 Traceback (most recent call last):
   File "funccount.py", line 299, in <module>
     Tool().run()
   File "funccount.py", line 261, in run
     self.probe.load()
   File "funccount.py", line 191, in load
     bpf_text += self._generate_functions(trace_count_text)
   File "funccount.py", line 143, in _generate_functions
     tracepoints = BPF.get_tracepoints(self.pattern)
   File "/usr/lib/python3.7/site-packages/bcc/__init__.py", line 772, in get_tracepoints
     if re.match(tp_re, tp):
   File "/usr/lib64/python3.7/re.py", line 173, in match
     return _compile(pattern, flags).match(string)
 TypeError: cannot use a bytes pattern on a string-like object

This commit convert 'tp_re' from bytes to string to avoid the crash.

Signed-off-by: Gary Lin <glin@suse.com>