### PR TITLE
Fixed "TypeError: cannot use a string pattern on a bytes-like object"…

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -622,7 +622,7 @@ class PerfEventArray(ArrayBase):
         i = 0
         while i < num_fields:
             field = lib.bpf_perf_event_field(self.bpf.module, self._name, i).decode()
-            m = re.match(r"(.*)#(.*)", field)
+            m = re.match(r"(.*)#(.*)", field.decode())
             field_name = m.group(1)
             field_type = m.group(2)
 


### PR DESCRIPTION
… in some utilities
