### PR TITLE
Fix possible memory leak in error path when elf notes are backed by a memfd path

### DIFF
--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -99,8 +99,10 @@ static char *_procutils_memfd_path(const int pid, const uint64_t inum) {
   strcpy(dirstr, path_buffer);
   dirstream = opendir(dirstr);
 
-  if (dirstream == NULL)
+  if (dirstream == NULL) {
+    free(dirstr);
     return NULL;
+  }
 
   while (path == NULL && (dent = readdir(dirstream)) != NULL) {
     snprintf(path_buffer, (PATH_MAX + 1), "%s/%s", dirstr, dent->d_name);


### PR DESCRIPTION
As @palmtenor points out, https://github.com/iovisor/bcc/pull/2314#discussion_r276495408, the original PR misses freeing the memory that it allocates for a string on the error path (where the directory listing fails) resulting in a potential memory leak.

I had considered just using a separate buffer for the directory string, but decided to malloc it so I could reuse the buffer for building the full path while still retaining access to the string. If there's a reason to prefer that approach I can modify this PR according, which would eliminate the need to bother with freeing this string buffer as it would be stack-allocated instead.