### PR TITLE
tools: don't mix print(end="") with printb()

### DIFF
--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -216,7 +216,7 @@ def print_event(cpu, data, size):
 
         if not skip:
             if args.timestamp:
-                print("%-8.3f" % (time.time() - start_ts), end="")
+                printb(b"%-8.3f" % (time.time() - start_ts), nl="")
             ppid = event.ppid if event.ppid > 0 else get_ppid(event.pid)
             ppid = b"%d" % ppid if ppid > 0 else b"?"
             argv_text = b' '.join(argv[event.pid]).replace(b'\n', b'\\n')

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -218,17 +218,17 @@ def print_event(cpu, data, size):
 
     if args.timestamp:
         delta = event.ts - initial_ts
-        print("%-14.9f" % (float(delta) / 1000000), end="")
+        printb(b"%-14.9f" % (float(delta) / 1000000), nl="")
 
     if args.print_uid:
-        print("%-6d" % event.uid, end="")
+        printb(b"%-6d" % event.uid, nl="")
 
-    print("%-6d %-16s %4d %3d " %
-          (event.id & 0xffffffff if args.tid else event.id >> 32,
-           event.comm.decode('utf-8', 'replace'), fd_s, err), end="")
+    printb(b"%-6d %-16s %4d %3d " %
+           (event.id & 0xffffffff if args.tid else event.id >> 32,
+            event.comm, fd_s, err), nl="")
 
     if args.extended_fields:
-        print("%08o " % event.flags, end="")
+        printb(b"%08o " % event.flags, nl="")
 
     printb(b'%s' % event.fname)
 

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -196,11 +196,11 @@ def print_ipv4_event(cpu, data, size):
     event = b["ipv4_events"].event(data)
     global start_ts
     if args.time:
-        print("%-9s" % strftime("%H:%M:%S"), end="")
+        printb(b"%-9s" % strftime("%H:%M:%S").encode('ascii'), nl="")
     if args.timestamp:
         if start_ts == 0:
             start_ts = event.ts_us
-        print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
+        printb(b"%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), nl="")
     printb(b"%-7d %-12.12s %-2d %-16s %-5d %-16s %-5d" % (event.pid,
         event.task, event.ip,
         inet_ntop(AF_INET, pack("I", event.daddr)).encode(),
@@ -212,11 +212,11 @@ def print_ipv6_event(cpu, data, size):
     event = b["ipv6_events"].event(data)
     global start_ts
     if args.time:
-        print("%-9s" % strftime("%H:%M:%S"), end="")
+        printb(b"%-9s" % strftime("%H:%M:%S").encode('ascii'), nl="")
     if args.timestamp:
         if start_ts == 0:
             start_ts = event.ts_us
-        print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
+        printb(b"%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), nl="")
     printb(b"%-7d %-12.12s %-2d %-16s %-5d %-16s %-5d" % (event.pid,
         event.task, event.ip,
         inet_ntop(AF_INET6, event.daddr).encode(),

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -197,9 +197,9 @@ def print_ipv4_event(cpu, data, size):
     if args.timestamp:
         if start_ts == 0:
             start_ts = event.ts_us
-        print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
+        printb(b"%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), nl="")
     if args.print_uid:
-        print("%-6d" % event.uid, end="")
+        printb(b"%-6d" % event.uid, nl="")
     printb(b"%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
         event.task, event.ip,
         inet_ntop(AF_INET, pack("I", event.saddr)).encode(),
@@ -211,9 +211,9 @@ def print_ipv6_event(cpu, data, size):
     if args.timestamp:
         if start_ts == 0:
             start_ts = event.ts_us
-        print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
+        printb(b"%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), nl="")
     if args.print_uid:
-        print("%-6d" % event.uid, end="")
+        printb(b"%-6d" % event.uid, nl="")
     printb(b"%-6d %-12.12s %-2d %-16s %-16s %-4d" % (event.pid,
         event.task, event.ip,
         inet_ntop(AF_INET6, event.saddr).encode(), inet_ntop(AF_INET6, event.daddr).encode(),


### PR DESCRIPTION
While mixing print(end="") with printb(), some messages may miss due to
the underlying buffer handling in python 3.

For example:

  # python3 opensnoop.py
  PID    COMM               FD ERR PATH
  /proc/18849/cmdline
  4109   tmux: server       67   0 /proc/18849/cmdline
  4109   tmux: server       67   0 /proc/18849/cmdline
  4109   tmux: server       67   0 /proc/18849/cmdline

The PID, COMM, FD, and ERR are printed with print(end=""), and those of
the first instance was eaten by printb() which outputs PATH.

The following scripts mix print(end="") and printb() for the same line:

tools/execsnoop.py
tools/opensnoop.py
tools/tcpaccept.py
tools/tcpconnect.py

Those scripts work fine with python 2 but some messages may miss while
using python 3.

This commit converts print(end="") to printb(nl="") to avoid the
inconsistent outputs.

Signed-off-by: Gary Lin <glin@suse.com>