### PR TITLE
vfscount.py: add args time

### DIFF
--- a/man/man8/vfscount.8
+++ b/man/man8/vfscount.8
@@ -19,6 +19,10 @@ CONFIG_BPF and bcc.
 Count some VFS calls until Ctrl-C is hit:
 #
 .B vfscount
+.TP
+Count some VFS calls in ten seconds
+#
+.B vfscount 10
 .SH FIELDS
 .TP
 ADDR

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -208,7 +208,7 @@ def print_event(cpu, data, size):
     event = bpf["events"].event(data)
     print("%-14.6f %-6d %8.3f %s" % (
         float(event.timestamp - start) / 1000000000,
-        event.pid, float(event.delta) / 1000000, event.query))
+        event.pid, float(event.duration) / 1000000, event.query))
 
 if mode.startswith("MYSQL"):
     print("Tracing database queries for application %s slower than %d ms..." %

--- a/tools/vfscount.py
+++ b/tools/vfscount.py
@@ -14,7 +14,19 @@
 from __future__ import print_function
 from bcc import BPF
 from time import sleep
+from sys import argv
+def usage():
+    print("USAGE: %s [time]" % argv[0])
+    exit()
 
+interval = 99999999
+if len(argv) > 1:
+    try:
+        interval = int(argv[1])
+        if interval == 0:
+            raise
+    except:  # also catches -h, --help
+        usage()
 # load BPF program
 b = BPF(text="""
 #include <uapi/linux/ptrace.h>
@@ -39,9 +51,10 @@ print("Tracing... Ctrl-C to end.")
 
 # output
 try:
-    sleep(99999999)
+    sleep(interval)
 except KeyboardInterrupt:
     pass
+    exit()
 
 print("\n%-16s %-26s %8s" % ("ADDR", "FUNC", "COUNT"))
 counts = b.get_table("counts")

--- a/tools/vfscount_example.txt
+++ b/tools/vfscount_example.txt
@@ -18,7 +18,7 @@ ffffffff811ecb51 vfs_fstatat                     488
 ffffffff811ecac1 vfs_getattr                     704
 ffffffff811ec9f1 vfs_getattr_nosec               704
 ffffffff811e80a1 vfs_write                      1764
-ffffffff811e7f71 vfs_read          []             2283
+ffffffff811e7f71 vfs_read                       2283
 
 Here we are using an output in 10 seconds, and printing 10 seconds summaries
 # ./vfscount 10

--- a/tools/vfscount_example.txt
+++ b/tools/vfscount_example.txt
@@ -1,8 +1,8 @@
 Demonstrations of vfscount, the Linux eBPF/bcc version.
 
 
-This counts VFS calls, by tracing all kernel functions beginning with "vfs_":
-
+This counts VFS calls  during time, by tracing all kernel functions beginning 
+with "vfs_", By defaults, the time is 99999999s
 # ./vfscount
 Tracing... Ctrl-C to end.
 ^C
@@ -18,9 +18,38 @@ ffffffff811ecb51 vfs_fstatat                     488
 ffffffff811ecac1 vfs_getattr                     704
 ffffffff811ec9f1 vfs_getattr_nosec               704
 ffffffff811e80a1 vfs_write                      1764
-ffffffff811e7f71 vfs_read                       2283
+ffffffff811e7f71 vfs_read          []             2283
+
+Here we are using an output in 10 seconds, and printing 10 seconds summaries
+# ./vfscount 10
+Tracing... Ctrl-C to end.
+
+ADDR             FUNC                          COUNT
+ffffffffa1283671 vfs_rename                        1
+ffffffffa129f471 vfs_setxattr                      1
+ffffffffa12831c1 vfs_mkdir                         1
+ffffffffa1282a51 vfs_rmdir                        10
+ffffffffa1283f31 vfs_unlink                       28
+ffffffffa1273e61 vfs_writev                       53
+ffffffffa12ae061 vfs_statfs                       55
+ffffffffa129e971 vfs_getxattr                    138
+ffffffffa1288561 vfs_readlink                    157
+ffffffffa12d6311 vfs_lock_file                   223
+ffffffffa1274da1 vfs_write                       537
+ffffffffa12798f1 vfs_statx_fd                   2337
+ffffffffa1279971 vfs_statx                      3064
+ffffffffa1271ba1 vfs_open                       4334
+ffffffffa12798b1 vfs_getattr                    4823
+ffffffffa1279821 vfs_getattr_nosec              4823
+ffffffffa1274af1 vfs_read                       9060
+
 
 This can be useful for workload characterization, to see what types of
 operations are in use.
 
 You can edit the script to customize what kernel functions are matched.
+
+Full usage:
+
+# ./vfsstat -h
+USAGE: ./vfsstat [time]


### PR DESCRIPTION
Just like vfsstat.py. I think the args time is good for us to analysis.If we need to know the number of vfs call during a period of time, the previous implement can't tell the details. 