### PR TITLE
Fix compile warning

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -183,7 +183,9 @@ void SourceDebugger::dump() {
       uint64_t Size;
       uint8_t *FuncStart = get<0>(section.second);
       uint64_t FuncSize = get<1>(section.second);
+#if LLVM_MAJOR_VERSION >= 9
       unsigned SectionID = get<2>(section.second);
+#endif
       ArrayRef<uint8_t> Data(FuncStart, FuncSize);
       uint32_t CurrentSrcLine = 0;
       string func_name = section.first.substr(fn_prefix_.size());


### PR DESCRIPTION
Add corresponding ifdef macro to get ride of the follow warning.

/home/lecopzer/workspace/mybcc/src/cc/bcc_debug.cc: In member function ‘void ebpf::SourceDebugger::dump()’:
/home/lecopzer/workspace/mybcc/src/cc/bcc_debug.cc:186:16: warning: unused variable ‘SectionID’ [-Wunused-variable]
       unsigned SectionID = get<2>(section.second);
                ^~~~~~~~~