### PR TITLE
snapcraft: remove python path wrapper hack

### DIFF
--- a/snapcraft/bcc-wrapper
+++ b/snapcraft/bcc-wrapper
@@ -7,7 +7,7 @@
 cmd="$1"
 if [ `id -u` = 0 ] ; then
 	shift
-	stdbuf -oL $SNAP/usr/bin/python2.7 "$SNAP/usr/share/bcc/tools/$cmd" $@
+	stdbuf -oL $SNAP/usr/share/bcc/tools/$cmd $@
 else
 	echo "Need to run $cmd as root (use sudo $@)"
 	exit 1

--- a/snapcraft/snapcraft.yaml
+++ b/snapcraft/snapcraft.yaml
@@ -31,6 +31,9 @@ base: core18
 parts:
     bcc:
         plugin: cmake
+        override-pull: |
+            snapcraftctl pull
+            find . -type f -exec sed -i 's|^#\!/usr/bin/python|#\!/usr/bin/env python|' {} \;
         configflags:
             - '-DCMAKE_INSTALL_PREFIX=/usr'
         source: ..


### PR DESCRIPTION
The python wrapper hack was not working for non-python scripts.
Fix this by patching the python executable path in the python scripts
once the source is fetched.

Signed-off-by: Colin Ian King <colin.king@canonical.com>