### PR TITLE
2357 SEC macro redefined error

### DIFF
--- a/src/cc/compat/linux/virtual_bpf.h
+++ b/src/cc/compat/linux/virtual_bpf.h
@@ -1407,7 +1407,7 @@ union bpf_attr {
  *
  * 		::
  *
- * 			SEC("kprobe/sys_open")
+ * 			BCC_SEC("kprobe/sys_open")
  * 			void bpf_sys_open(struct pt_regs *ctx)
  * 			{
  * 			        char buf[PATHLEN]; // PATHLEN is defined to 256

--- a/src/cc/export/footer.h
+++ b/src/cc/export/footer.h
@@ -23,6 +23,6 @@ R"********(
 #define ___LICENSE(s) #s
 #define __LICENSE(s) ___LICENSE(s)
 #define _LICENSE __LICENSE(BPF_LICENSE)
-char _license[] SEC("license") = _LICENSE;
+char _license[] BCC_SEC("license") = _LICENSE;
 
 )********"

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -51,7 +51,7 @@ R"********(
  * different sections in elf_bpf file. Section names
  * are interpreted by elf_bpf loader
  */
-#define SEC(NAME) __attribute__((section(NAME), used))
+#define BCC_SEC(NAME) __attribute__((section(NAME), used))
 
 // Associate map with its key/value types
 #define BPF_ANNOTATE_KV_PAIR(name, type_key, type_val)	\
@@ -262,9 +262,9 @@ struct _name##_table_t _name = { .max_entries = (_max_entries) }
   ({ void *_tmp = _cursor; _cursor += _len; _tmp; })
 
 #ifdef LINUX_VERSION_CODE_OVERRIDE
-unsigned _version SEC("version") = LINUX_VERSION_CODE_OVERRIDE;
+unsigned _version BCC_SEC("version") = LINUX_VERSION_CODE_OVERRIDE;
 #else
-unsigned _version SEC("version") = LINUX_VERSION_CODE;
+unsigned _version BCC_SEC("version") = LINUX_VERSION_CODE;
 #endif
 
 /* helper functions called from eBPF programs written in C */
@@ -624,7 +624,7 @@ unsigned int bpf_log2l(unsigned long v)
 struct bpf_context;
 
 static inline __attribute__((always_inline))
-SEC("helpers")
+BCC_SEC("helpers")
 u64 bpf_dext_pkt(void *pkt, u64 off, u64 bofs, u64 bsz) {
   if (bofs == 0 && bsz == 8) {
     return load_byte(pkt, off);
@@ -647,7 +647,7 @@ u64 bpf_dext_pkt(void *pkt, u64 off, u64 bofs, u64 bsz) {
 }
 
 static inline __attribute__((always_inline))
-SEC("helpers")
+BCC_SEC("helpers")
 void bpf_dins_pkt(void *pkt, u64 off, u64 bofs, u64 bsz, u64 val) {
   // The load_xxx function does a bswap before returning the short/word/dword,
   // so the value in register will always be host endian. However, the bytes
@@ -690,25 +690,25 @@ void bpf_dins_pkt(void *pkt, u64 off, u64 bofs, u64 bsz, u64 val) {
 }
 
 static inline __attribute__((always_inline))
-SEC("helpers")
+BCC_SEC("helpers")
 void * bpf_map_lookup_elem_(uintptr_t map, void *key) {
   return bpf_map_lookup_elem((void *)map, key);
 }
 
 static inline __attribute__((always_inline))
-SEC("helpers")
+BCC_SEC("helpers")
 int bpf_map_update_elem_(uintptr_t map, void *key, void *value, u64 flags) {
   return bpf_map_update_elem((void *)map, key, value, flags);
 }
 
 static inline __attribute__((always_inline))
-SEC("helpers")
+BCC_SEC("helpers")
 int bpf_map_delete_elem_(uintptr_t map, void *key) {
   return bpf_map_delete_elem((void *)map, key);
 }
 
 static inline __attribute__((always_inline))
-SEC("helpers")
+BCC_SEC("helpers")
 int bpf_l3_csum_replace_(void *ctx, u64 off, u64 from, u64 to, u64 flags) {
   switch (flags & 0xf) {
     case 2:
@@ -724,7 +724,7 @@ int bpf_l3_csum_replace_(void *ctx, u64 off, u64 from, u64 to, u64 flags) {
 }
 
 static inline __attribute__((always_inline))
-SEC("helpers")
+BCC_SEC("helpers")
 int bpf_l4_csum_replace_(void *ctx, u64 off, u64 from, u64 to, u64 flags) {
   switch (flags & 0xf) {
     case 2:


### PR DESCRIPTION
I encountered the following error in a script attempting to trace zfs.

In file included from /virtual/main.c:6:
In file included from /export/home/delphix/zfs/include/sys/zio.h:35:
In file included from /export/home/delphix/zfs/include/sys/zfs_context.h:38:
In file included from /export/home/delphix/zfs/include/spl/sys/condvar.h:33:
/export/home/delphix/zfs/include/spl/sys/time.h:41:9: warning: 'SEC' macro
 redefined [-Wmacro-redefined] #define SEC 1
                                       ^
/virtual/include/bcc/helpers.h:54:9: note: previous definition is here
        ^

I added the BPF prefix bcc to avoid similar naming conflicts,