### PR TITLE
memleak: use BPF_HASH macro

### DIFF
--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -141,10 +141,10 @@ struct combined_alloc_info_t {
 };
 
 BPF_HASH(sizes, u64);
-BPF_TABLE("hash", u64, struct alloc_info_t, allocs, 1000000);
+BPF_HASH(allocs, u64, struct alloc_info_t, 1000000);
 BPF_HASH(memptrs, u64, u64);
 BPF_STACK_TRACE(stack_traces, 10240);
-BPF_TABLE("hash", u64, struct combined_alloc_info_t, combined_allocs, 10240);
+BPF_HASH(combined_allocs, u64, struct combined_alloc_info_t, 10240);
 
 static inline void update_statistics_add(u64 stack_id, u64 sz) {
         struct combined_alloc_info_t *existing_cinfo;


### PR DESCRIPTION
This pull request changes `memleak.py` to use `BPF_HASH` instead of `BPF_TABLE`. It's probably better for tools to use the appropriate bcc macros in case we ever want to change their definitions (e.g., new `map.helper` function specific to that map type).