### PR TITLE
Add option to print unix timestamp in trace tool

### DIFF
--- a/man/man8/trace.8
+++ b/man/man8/trace.8
@@ -3,7 +3,7 @@
 trace \- Trace a function and print its arguments or return value, optionally evaluating a filter. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B trace [-h] [-b BUFFER_PAGES] [-p PID] [-L TID] [-v] [-Z STRING_SIZE] [-S] [-s SYM_FILE_LIST]
-         [-M MAX_EVENTS] [-t] [-T] [-C] [-K] [-U] [-a] [-I header]
+         [-M MAX_EVENTS] [-t] [-u] [-T] [-C] [-K] [-U] [-a] [-I header]
          probe [probe ...]
 .SH DESCRIPTION
 trace probes functions you specify and displays trace messages if a particular
@@ -45,6 +45,9 @@ Print up to MAX_EVENTS trace messages and then exit.
 .TP
 \-t
 Print times relative to the beginning of the trace (offsets), in seconds.
+.TP
+\-u
+Print UNIX timestamps instead of offsets from trace beginning, requires -t.
 .TP
 \-T
 Print the time column.


### PR DESCRIPTION
Currently, the trace tool only supports accurate timestamps from trace start (through the monotonic clock within BPF directly), and local time HH:ss (through calls to Python's datetime when printing the record). I had a need to get accurate real-time timestamps which this PR implements.

I realize that this can only ever be approximate since you need to relate monotonic time to real time somehow, and I do that by querying the real time at trace start directly after the same is done for getting the monotonic time at trace start. The hope is that the error is small enough. An improvement would be to query both times within C/C++ to avoid any Python overhead between both calls, but that could be done in the future if there is need as that needs more effort.

Sample when using `--unix-timestamp`:
```
TIME              PID     TID     COMM            FUNC             -
1558631890.211117 21369   21369   ksgxswapd       sgx_ewb          139895674765314
```

Currently the new flag is an addon to the `--timestamp` flag, which may be weird. I'm happy to change that, but it required more code changes, hence I first wanted to see if this PR is accepted or not.