### PR TITLE
Support BTF DataSec Properly

### DIFF
--- a/src/cc/bcc_btf.cc
+++ b/src/cc/bcc_btf.cc
@@ -119,6 +119,13 @@ void BTF::fixup_datasec(uint8_t *type_sec, uintptr_t type_sec_size,
       if (sections_.find(secname) != sections_.end()) {
         t->size = std::get<1>(sections_[secname]);
       }
+      // For section name, the kernel does not accept '/'.
+      // So change DataSec name here to please the kenerl
+      // as we do not really use DataSec yet.
+      // This change can be removed if the kernel is
+      // changed to accpet '/' in section names.
+      if (strncmp(strings + t->name_off, "maps/", 5) == 0)
+        t->name_off += 5;
       next_type += vlen * sizeof(struct btf_var_secinfo);
       break;
     default:

--- a/src/cc/bcc_btf.h
+++ b/src/cc/bcc_btf.h
@@ -23,6 +23,8 @@
 #include <map>
 #include <vector>
 
+#include "bpf_module.h"
+
 struct btf;
 struct btf_ext;
 
@@ -44,7 +46,7 @@ class BTFStringTable {
 
 class BTF {
  public:
-  BTF(bool debug);
+  BTF(bool debug, sec_map_def &sections);
   ~BTF();
   int load(uint8_t *btf_sec, uintptr_t btf_sec_size,
            uint8_t *btf_ext_sec, uintptr_t btf_ext_sec_size,
@@ -60,6 +62,7 @@ class BTF {
                    unsigned *key_tid, unsigned *value_tid);
 
  private:
+  void fixup_datasec(uint8_t *type_sec, uintptr_t type_sec_size, char *strings);
   void adjust(uint8_t *btf_sec, uintptr_t btf_sec_size,
               uint8_t *btf_ext_sec, uintptr_t btf_ext_sec_size,
               std::map<std::string, std::string> &remapped_sources,
@@ -70,6 +73,7 @@ class BTF {
   bool debug_;
   struct btf *btf_;
   struct btf_ext *btf_ext_;
+  sec_map_def &sections_;
 };
 
 } // namespace ebpf

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -258,7 +258,7 @@ void BPFModule::load_btf(sec_map_def &sections) {
   remapped_sources["/virtual/main.c"] = mod_src_;
   remapped_sources["/virtual/include/bcc/helpers.h"] = helpers_h->second;
 
-  BTF *btf = new BTF(flags_ & DEBUG_BTF);
+  BTF *btf = new BTF(flags_ & DEBUG_BTF, sections);
   int ret = btf->load(btf_sec, btf_sec_size, btf_ext_sec, btf_ext_sec_size,
                        remapped_sources);
   if (ret) {


### PR DESCRIPTION
Two commits here:
  1. Set DataSec Size properly as LLVM sets to 0 due to lack of information.
  2. For section name like `maps/...`, remove `maps/` prefix as the kernel
      does not expect '/'. This is can removed later if the kernel starts to support
      '/'.