### PR TITLE
remove unused field in tp_frontend_action.h

### DIFF
--- a/src/cc/frontends/clang/tp_frontend_action.cc
+++ b/src/cc/frontends/clang/tp_frontend_action.cc
@@ -46,7 +46,7 @@ using std::ifstream;
 using namespace clang;
 
 TracepointTypeVisitor::TracepointTypeVisitor(ASTContext &C, Rewriter &rewriter)
-    : C(C), diag_(C.getDiagnostics()), rewriter_(rewriter), out_(llvm::errs()) {
+    : diag_(C.getDiagnostics()), rewriter_(rewriter), out_(llvm::errs()) {
 }
 
 enum class field_kind_t {

--- a/src/cc/frontends/clang/tp_frontend_action.h
+++ b/src/cc/frontends/clang/tp_frontend_action.h
@@ -50,7 +50,6 @@ class TracepointTypeVisitor :
   std::string GenerateTracepointStruct(clang::SourceLocation loc,
           std::string const& category, std::string const& event);
 
-  clang::ASTContext &C;
   clang::DiagnosticsEngine &diag_;
   clang::Rewriter &rewriter_;
   llvm::raw_ostream &out_;


### PR DESCRIPTION
Compiling bcc with latest clang built from trunk, I got
the following warning:
  In file included from /home/yhs/work/bcc/src/cc/frontends/clang/tp_frontend_action.cc:32:
  /home/yhs/work/bcc/src/cc/frontends/clang/tp_frontend_action.h:53:22: warning: private field 'C' is not used
        [-Wunused-private-field]
    clang::ASTContext &C;
                       ^

This patch removed this unused field.

Signed-off-by: Yonghong Song <yhs@fb.com>