### PR TITLE
Support pinned maps through BPF_TABLE_PINNED macro

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -543,6 +543,17 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=BPF_TABLE+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=BPF_TABLE+path%3Atools&type=Code)
 
+#### Pinned Maps
+
+Maps that were pinned to the BPF filesystem can be accessed through an extended syntax: ```BPF_TABLE_PINNED(_table_type, _key_type, _leaf_type, _name, _max_entries, "/sys/fs/bpf/xyz")```
+The type information is not enforced and the actual map type depends on the map that got pinned to the location.
+
+For example:
+
+```C
+BPF_TABLE_PINNED("hash", u64, u64, ids, 1024, "/sys/fs/bpf/ids");
+```
+
 ### 2. BPF_HASH
 
 Syntax: ```BPF_HASH(name [, key_type [, leaf_type [, size]]])```

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -64,6 +64,10 @@ class BPFTableBase {
     return rc;
   }
 
+  int get_fd() {
+    return desc.fd;
+  }
+
  protected:
   explicit BPFTableBase(const TableDesc& desc) : desc(desc) {}
 

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -86,6 +86,9 @@ BPF_ANNOTATE_KV_PAIR(_name, _key_type, _leaf_type)
 #define BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries) \
 BPF_F_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries, 0)
 
+#define BPF_TABLE_PINNED(_table_type, _key_type, _leaf_type, _name, _max_entries, _pinned) \
+BPF_TABLE(_table_type ":" _pinned, _key_type, _leaf_type, _name, _max_entries)
+
 // define a table same as above but allow it to be referenced by other modules
 #define BPF_TABLE_PUBLIC(_table_type, _key_type, _leaf_type, _name, _max_entries) \
 BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries); \

--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -174,8 +174,8 @@ class BFrontendAction : public clang::ASTFrontendAction {
   void DoMiscWorkAround();
   // negative fake_fd to be different from real fd in bpf_pseudo_fd.
   int get_next_fake_fd() { return next_fake_fd_--; }
-  void add_map_def(int fd, std::tuple<int, std::string, int, int, int, int> map_def) {
-    fake_fd_map_[fd] = map_def;
+  void add_map_def(int fd, std::tuple<int, std::string, int, int, int, int, unsigned int> map_def) {
+    fake_fd_map_[fd] = move(map_def);
   }
 
  private:

--- a/src/cc/table_storage.h
+++ b/src/cc/table_storage.h
@@ -27,7 +27,7 @@
 
 namespace ebpf {
 
-typedef std::map<int, std::tuple<int, std::string, int, int, int, int>> fake_fd_map_def;
+typedef std::map<int, std::tuple<int, std::string, int, int, int, int, unsigned int>> fake_fd_map_def;
 
 class TableStorageImpl;
 class TableStorageIteratorImpl;

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(test_libbcc
 	test_bpf_table.cc
 	test_hash_table.cc
 	test_perf_event.cc
+	test_pinned_table.cc
 	test_prog_table.cc
 	test_shared_table.cc
 	test_usdt_args.cc

--- a/tests/cc/test_pinned_table.cc
+++ b/tests/cc/test_pinned_table.cc
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2019 Kinvolk GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <linux/version.h>
+#include <unistd.h>
+#include <string>
+#include <sys/mount.h>
+
+#include "BPF.h"
+#include "catch.hpp"
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+TEST_CASE("test pinned table", "[pinned_table]") {
+  bool mounted = false;
+  if (system("mount | grep /sys/fs/bpf")) {
+    REQUIRE(system("mkdir -p /sys/fs/bpf") == 0);
+    REQUIRE(system("mount -o nosuid,nodev,noexec,mode=700 -t bpf bpf /sys/fs/bpf") == 0);
+    mounted = true;
+  }
+  // prepare test by pinning table to bpffs
+  {
+    const std::string BPF_PROGRAM = R"(
+      BPF_TABLE("hash", u64, u64, ids, 1024);
+    )";
+
+    ebpf::BPF bpf;
+    ebpf::StatusTuple res(0);
+    res = bpf.init(BPF_PROGRAM);
+    REQUIRE(res.code() == 0);
+
+    REQUIRE(bpf_obj_pin(bpf.get_hash_table<int, int>("ids").get_fd(), "/sys/fs/bpf/test_pinned_table") == 0);
+  }
+
+  // test table access
+  {
+    const std::string BPF_PROGRAM = R"(
+      BPF_TABLE_PINNED("hash", u64, u64, ids, 1024, "/sys/fs/bpf/test_pinned_table");
+    )";
+
+    ebpf::BPF bpf;
+    ebpf::StatusTuple res(0);
+    res = bpf.init(BPF_PROGRAM);
+    unlink("/sys/fs/bpf/test_pinned_table"); // can delete table here already
+    REQUIRE(res.code() == 0);
+
+    auto t = bpf.get_hash_table<int, int>("ids");
+    int key, value;
+
+    // write element
+    key = 0x08;
+    value = 0x43;
+    res = t.update_value(key, value);
+    REQUIRE(res.code() == 0);
+    REQUIRE(t[key] == value);
+  }
+
+  // test failure
+  {
+    const std::string BPF_PROGRAM = R"(
+      BPF_TABLE_PINNED("hash", u64, u64, ids, 1024, "/sys/fs/bpf/test_pinned_table");
+    )";
+
+    ebpf::BPF bpf;
+    ebpf::StatusTuple res(0);
+    res = bpf.init(BPF_PROGRAM);
+    REQUIRE(res.code() != 0);
+  }
+
+  if (mounted) {
+    REQUIRE(umount("/sys/fs/bpf") == 0);
+  }
+}
+#endif


### PR DESCRIPTION
Define a map to be loaded from a pinned path through
the new macro `BPF_TABLE_PINNED(..., "/sys/fs/bpf/xyz");`
instead of creating a new map.

Internally the path is appended to the section attribute
with a delimiter. The approach of adding a new pinned_path
pointer field to the table struct seemed promising but
caused more troubles than the percieved cleanless may be worth.