### PR TITLE
Fix small things from the python developer tutorial

### DIFF
--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -588,7 +588,7 @@ Things to learn:
 
 ### Lesson 15. nodejs_http_server.py
 
-This program instruments a user-defined static tracing (USDT) probe, which is the user-level version of a kernel tracepoint. Sample output:
+This program instruments a user statically-defined tracing (USDT) probe, which is the user-level version of a kernel tracepoint. Sample output:
 
 ```
 # ./nodejs_http_server.py 24728

--- a/examples/tracing/disksnoop.py
+++ b/examples/tracing/disksnoop.py
@@ -43,7 +43,8 @@ void trace_completion(struct pt_regs *ctx, struct request *req) {
 }
 """)
 
-b.attach_kprobe(event="blk_start_request", fn_name="trace_start")
+if BPF.get_kprobe_functions(b'blk_start_request'):
+        b.attach_kprobe(event="blk_start_request", fn_name="trace_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_start")
 b.attach_kprobe(event="blk_account_io_completion", fn_name="trace_completion")
 


### PR DESCRIPTION
disksnoop does not execute properly on kernels 5.0+ because `blk_start_request` no longer exists in `block/blk-core.c`. I added the check found in the biolatency tool that checks the existence of the kprobe before it attaches.

For the other commit, the text read "user-defined static tracing" which does not match the acronym USDT, so I changed it to the standard "user statically-defined tracing".