### PR TITLE
Revise python tutorial lesson 16 to make sure tutorial text and code match

### DIFF
--- a/examples/tracing/task_switch.c
+++ b/examples/tracing/task_switch.c
@@ -1,0 +1,21 @@
+#include <uapi/linux/ptrace.h>
+#include <linux/sched.h>
+
+struct key_t {
+    u32 prev_pid;
+    u32 curr_pid;
+};
+
+BPF_HASH(stats, struct key_t, u64, 1024);
+int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
+    struct key_t key = {};
+    u64 zero = 0, *val;
+
+    key.curr_pid = bpf_get_current_pid_tgid();
+    key.prev_pid = prev->pid;
+
+    // could also use `stats.increment(key);`
+    val = stats.lookup_or_init(&key, &zero);
+    (*val)++;
+    return 0;
+}

--- a/examples/tracing/task_switch.py
+++ b/examples/tracing/task_switch.py
@@ -5,29 +5,7 @@
 from bcc import BPF
 from time import sleep
 
-b = BPF(text="""
-#include <uapi/linux/ptrace.h>
-#include <linux/sched.h>
-
-struct key_t {
-  u32 prev_pid;
-  u32 curr_pid;
-};
-// map_type, key_type, leaf_type, table_name, num_entry
-BPF_HASH(stats, struct key_t, u64, 1024);
-int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
-  struct key_t key = {};
-  u64 zero = 0, *val;
-
-  key.curr_pid = bpf_get_current_pid_tgid();
-  key.prev_pid = prev->pid;
-
-  // could also use `stats.increment(key);`
-  val = stats.lookup_or_init(&key, &zero);
-  (*val)++;
-  return 0;
-}
-""")
+b = BPF(src_file="task_switch.c")
 b.attach_kprobe(event="finish_task_switch", fn_name="count_sched")
 
 # generate many schedule events


### PR DESCRIPTION
PR addressing Issue #2380 

Lesson 16 spent a lot of text discussing `BPF_TABLE`, but the code doesn't use `BPF_TABLE` at all. Rather, it uses `BPF_HASH`, which users should already be quite familiar with by the end of the tutorial. As a result, I cut out the text explaining `BPF_TABLE`.

I also separated the BPF C code into a separate file, since the tutorial was already written as though that was the case (it discusses `task_switch.c` but that file did not exist).