### PR TITLE
capable: Hide TID and INSETID columns by default

### DIFF
--- a/man/man8/capable.8
+++ b/man/man8/capable.8
@@ -25,6 +25,9 @@ Include kernel stack traces to the output.
 .TP
 \-U
 Include user-space stack traces to the output.
+.TP
+\-x
+Show extra fields in TID and INSETID columns.
 .SH EXAMPLES
 .TP
 Trace all capability checks system-wide:

--- a/tools/capable_example.txt
+++ b/tools/capable_example.txt
@@ -5,37 +5,42 @@ capable traces calls to the kernel cap_capable() function, which does security
 capability checks, and prints details for each call. For example:
 
 # ./capable.py 
-TIME      UID    PID    COMM             CAP  NAME                 AUDIT  INSETID
-22:11:23  114    2676   snmpd            12   CAP_NET_ADMIN        1      N/A
-22:11:23  0      6990   run              24   CAP_SYS_RESOURCE     1      N/A
-22:11:23  0      7003   chmod            3    CAP_FOWNER           1      N/A
-22:11:23  0      7003   chmod            4    CAP_FSETID           1      N/A
-22:11:23  0      7005   chmod            4    CAP_FSETID           1      N/A
-22:11:23  0      7005   chmod            4    CAP_FSETID           1      N/A
-22:11:23  0      7006   chown            4    CAP_FSETID           1      N/A
-22:11:23  0      7006   chown            4    CAP_FSETID           1      N/A
-22:11:23  0      6990   setuidgid        6    CAP_SETGID           1      N/A
-22:11:23  0      6990   setuidgid        6    CAP_SETGID           1      N/A
-22:11:23  0      6990   setuidgid        7    CAP_SETUID           1      N/A
-22:11:24  0      7013   run              24   CAP_SYS_RESOURCE     1      N/A
-22:11:24  0      7026   chmod            3    CAP_FOWNER           1      N/A
-22:11:24  0      7026   chmod            4    CAP_FSETID           1      N/A
-22:11:24  0      7028   chmod            4    CAP_FSETID           1      N/A
-22:11:24  0      7028   chmod            4    CAP_FSETID           1      N/A
-22:11:24  0      7029   chown            4    CAP_FSETID           1      N/A
-22:11:24  0      7029   chown            4    CAP_FSETID           1      N/A
-22:11:24  0      7013   setuidgid        6    CAP_SETGID           1      N/A
-22:11:24  0      7013   setuidgid        6    CAP_SETGID           1      N/A
-22:11:24  0      7013   setuidgid        7    CAP_SETUID           1      N/A
-22:11:25  0      7036   run              24   CAP_SYS_RESOURCE     1      N/A
-22:11:25  0      7049   chmod            3    CAP_FOWNER           1      N/A
-22:11:25  0      7049   chmod            4    CAP_FSETID           1      N/A
-22:11:25  0      7051   chmod            4    CAP_FSETID           1      N/A
-22:11:25  0      7051   chmod            4    CAP_FSETID           1      N/A
+TIME      UID    PID    COMM             CAP  NAME                 AUDIT
+22:11:23  114    2676   snmpd            12   CAP_NET_ADMIN        1
+22:11:23  0      6990   run              24   CAP_SYS_RESOURCE     1
+22:11:23  0      7003   chmod            3    CAP_FOWNER           1
+22:11:23  0      7003   chmod            4    CAP_FSETID           1
+22:11:23  0      7005   chmod            4    CAP_FSETID           1
+22:11:23  0      7005   chmod            4    CAP_FSETID           1
+22:11:23  0      7006   chown            4    CAP_FSETID           1
+22:11:23  0      7006   chown            4    CAP_FSETID           1
+22:11:23  0      6990   setuidgid        6    CAP_SETGID           1
+22:11:23  0      6990   setuidgid        6    CAP_SETGID           1
+22:11:23  0      6990   setuidgid        7    CAP_SETUID           1
+22:11:24  0      7013   run              24   CAP_SYS_RESOURCE     1
+22:11:24  0      7026   chmod            3    CAP_FOWNER           1
+22:11:24  0      7026   chmod            4    CAP_FSETID           1
+22:11:24  0      7028   chmod            4    CAP_FSETID           1
+22:11:24  0      7028   chmod            4    CAP_FSETID           1
+22:11:24  0      7029   chown            4    CAP_FSETID           1
+22:11:24  0      7029   chown            4    CAP_FSETID           1
+22:11:24  0      7013   setuidgid        6    CAP_SETGID           1
+22:11:24  0      7013   setuidgid        6    CAP_SETGID           1
+22:11:24  0      7013   setuidgid        7    CAP_SETUID           1
+22:11:25  0      7036   run              24   CAP_SYS_RESOURCE     1
+22:11:25  0      7049   chmod            3    CAP_FOWNER           1
+22:11:25  0      7049   chmod            4    CAP_FSETID           1
+22:11:25  0      7051   chmod            4    CAP_FSETID           1
+22:11:25  0      7051   chmod            4    CAP_FSETID           1
 
-A recent kernel version >= 5.1 also reports the INSETID bit to cap_capable():
+Checks where AUDIT is 0 are ignored by default, which can be changed
+with -v but is more verbose.
 
-# ./capable.py
+We can show the TID and INSETID columns with -x.
+Since only a recent kernel version >= 5.1 reports the INSETID bit to cap_capable(),
+the fallback value "N/A" will be displayed on older kernels.
+
+# ./capable.py -x
 TIME      UID    PID    TID    COMM             CAP  NAME                 AUDIT  INSETID
 08:22:36  0      12869  12869  chown            0    CAP_CHOWN            1      0
 08:22:36  0      12869  12869  chown            0    CAP_CHOWN            1      0


### PR DESCRIPTION
The TID and the INSETID bit are the less interesting
fields and keeping them out allows to reduce the line
length below 80 characters.

Closes https://github.com/iovisor/bcc/issues/2392

I have updated the example description since I anyway found out that one had the TID column and the other not.