### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -142,13 +142,16 @@ static inline int extract_kheaders(const std::string &dirpath,
     }
   }
 
-  snprintf(dirpath_tmp, 256, "/tmp/kheaders-%s-XXXXXX", uname_data.release);
+  snprintf(dirpath_tmp, sizeof(dirpath_tmp), "/tmp/kheaders-%s-XXXXXX", uname_data.release);
   if (mkdtemp(dirpath_tmp) == NULL) {
     ret = -1;
     goto cleanup;
   }
 
-  snprintf(tar_cmd, 256, "tar -xf %s -C %s", PROC_KHEADERS_PATH, dirpath_tmp);
+  if ((size_t)snprintf(tar_cmd, sizeof(tar_cmd), "tar -xf %s -C %s", PROC_KHEADERS_PATH, dirpath_tmp) >= sizeof(tar_cmd)) {
+    ret = -1;
+    goto cleanup;
+  }
   ret = system(tar_cmd);
   if (ret) {
     system(("rm -rf " + std::string(dirpath_tmp)).c_str());


### PR DESCRIPTION
These commits fix two compiler warnings about silent string truncations when building up pathnames using snprintf.

In the case of `bpf_attach_probe` I chose the minimal fix. However, I'm somewhat confused why `fname` and `buf` have different sizes in the first place. `create_probe_event` assumes that it generates paths of up to _PATH_MAX_ characters, but then `bpf_attach_probe` assumes that the result (including the "/id" suffix) fits into 256 characters. Maybe it might make sense to either shrink `buf`, enlarge `fname` to _PATH_MAX_ or allocate `fname` with malloc based on the runtime length of the `buf` path.