### PR TITLE
tools/execsnoop: add -T option

### DIFF
--- a/man/man8/execsnoop.8
+++ b/man/man8/execsnoop.8
@@ -2,7 +2,8 @@
 .SH NAME
 execsnoop \- Trace new processes via exec() syscalls. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B execsnoop [\-h] [\-t] [\-x] [\-n NAME] [\-l LINE]
+.B execsnoop [\-h] [\-T] [\-t] [\-x] [\-q] [\-n NAME] [\-l LINE]
+.B           [\-\-max-args MAX_ARGS]
 .SH DESCRIPTION
 execsnoop traces new processes, showing the filename executed and argument
 list.
@@ -23,6 +24,9 @@ CONFIG_BPF and bcc.
 .TP
 \-h
 Print usage message.
+.TP
+\-T
+Include a time column (HH:MM:SS).
 .TP
 \-t
 Include a timestamp column.
@@ -69,6 +73,9 @@ Only trace exec()s where argument's line contains "testpkg":
 .B execsnoop \-l testpkg
 .SH FIELDS
 .TP
+TIME
+Time of exec() return, in HH:MM:SS format.
+.TP
 TIME(s)
 Time of exec() return, in seconds.
 .TP
@@ -77,6 +84,9 @@ Parent process/command name.
 .TP
 PID
 Process ID
+.TP
+PPID
+Parent process ID
 .TP
 RET
 Return value of exec(). 0 == successs. Failures are only shown when using the

--- a/tools/execsnoop_example.txt
+++ b/tools/execsnoop_example.txt
@@ -17,7 +17,7 @@ groff            15902    0 /usr/bin/troff -mtty-char -mandoc -rLL=169n -rLT=169
 groff            15903    0 /usr/bin/grotty
 
 The output shows the parent process/command name (PCOMM), the PID, the return
-value of the exec() (RET), and the filename with arguments (ARGS). 
+value of the exec() (RET), and the filename with arguments (ARGS).
 
 This works by traces the execve() system call (commonly used exec() variant),
 and shows details of the arguments and return value. This catches new processes
@@ -51,13 +51,14 @@ failures (trying to execute a /usr/local/bin/setuidgid, which I just noticed
 doesn't exist).
 
 
-A -t option can be used to include a timestamp column, and a -n option to match
-on a name. Regular expressions are allowed. 
+A -T option can be used to include a time column, a -t option to include a
+timestamp column, and a -n option to match on a name. Regular expressions
+are allowed.
 For example, matching commands containing "mount":
 
-# ./execsnoop -tn mount
-TIME(s) PCOMM            PID    RET ARGS
-2.849   mount            18049    0 /bin/mount -p
+# ./execsnoop -Ttn mount
+TIME     TIME(s) PCOMM            PID    PPID  RET ARGS
+14:08:23 2.849   mount            18049  1045    0 /bin/mount -p
 
 The -l option can be used to only show command where one of the arguments
 matches specified line. The limitation is that we are looking only into first 20
@@ -79,14 +80,16 @@ rpm              3345452 4146419   0 /bin/rpm -qa testpkg
 USAGE message:
 
 # ./execsnoop -h
-usage: execsnoop [-h] [-t] [-x] [-n NAME] [-l LINE] [--max-args MAX_ARGS]
+usage: execsnoop [-h] [-T] [-t] [-x] [-q] [-n NAME] [-l LINE] [--max-args MAX_ARGS]
 
 Trace exec() syscalls
 
 optional arguments:
   -h, --help            show this help message and exit
+  -T, --time            include time column on output (HH:MM:SS)
   -t, --timestamp       include timestamp on output
   -x, --fails           include failed exec()s
+  -q, --quote           Add quotemarks (") around arguments
   -n NAME, --name NAME  only print commands matching this name (regex), any
                         arg
   -l LINE, --line LINE  only print commands where arg contains this line
@@ -97,6 +100,8 @@ optional arguments:
 examples:
     ./execsnoop           # trace all exec() syscalls
     ./execsnoop -x        # include failed exec()s
+    ./execsnoop -T        # include time (HH:MM:SS)
     ./execsnoop -t        # include timestamps
+    ./execsnoop -q        # add "quotemarks" around arguments
     ./execsnoop -n main   # only print command lines containing "main"
     ./execsnoop -l tpkg   # only print command where arguments contains "tpkg"


### PR DESCRIPTION
Add a -T option to include a time column on output (HH:MM:SS) and update manpage
and example file accordingly.