### PR TITLE
build: Rename kheaders location from proc to sys

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.h
+++ b/src/cc/frontends/clang/kbuild_helper.h
@@ -21,7 +21,7 @@
 #include <errno.h>
 #include <ftw.h>
 
-#define PROC_KHEADERS_PATH "/proc/kheaders.tar.xz"
+#define PROC_KHEADERS_PATH "/sys/kernel/kheaders.tar.xz"
 
 namespace ebpf {
 

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -131,11 +131,15 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
     kpath = kdir + "/" + kernel_path_info.second;
   }
 
-  // If all attempts to obtain kheaders fail, check for /proc/kheaders.tar.xz
+  // If all attempts to obtain kheaders fail, check for kheaders.tar.xz in sysfs
   if (!is_dir(kpath)) {
     int ret = get_proc_kheaders(tmpdir);
-    if (!ret)
+    if (!ret) {
       kpath = tmpdir;
+    } else {
+      std::cout << "Unable to find kernel headers. ";
+      std::cout << "Try rebuilding kernel with CONFIG_IKHEADERS=m (module)\n";
+    }
   }
 
   if (flags_ & DEBUG_PREPROCESSOR)


### PR DESCRIPTION
In upstream kernel, the path has been renamed as the kheaders got moved
to sysfs. Let us update BCC with the new path.

Signed-off-by: Joel Fernandes (Google) <joel@joelfernandes.org>