### PR TITLE
fix a compiler warning

### DIFF
--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -65,7 +65,7 @@ public:
   virtual bool resolve_addr(uint64_t addr, struct bcc_symbol *sym, bool demangle = true) override;
   virtual bool resolve_name(const char *unused, const char *name,
                             uint64_t *addr) override;
-  virtual void refresh();
+  virtual void refresh() override;
 };
 
 class ProcSyms : SymbolCache {
@@ -142,7 +142,7 @@ class ProcSyms : SymbolCache {
 
 public:
   ProcSyms(int pid, struct bcc_symbol_option *option = nullptr);
-  virtual void refresh();
+  virtual void refresh() override;
   virtual bool resolve_addr(uint64_t addr, struct bcc_symbol *sym, bool demangle = true) override;
   virtual bool resolve_name(const char *module, const char *name,
                             uint64_t *addr) override;


### PR DESCRIPTION
Fix the following compiler warning:
  In file included from /home/yhs/work/bcc/src/cc/bcc_syms.cc:34:
  /home/yhs/work/bcc/src/cc/syms.h:68:16: warning: 'refresh' overrides a member function but is not marked 'override'
        [-Winconsistent-missing-override]
    virtual void refresh();
                 ^
  /home/yhs/work/bcc/src/cc/syms.h:45:16: note: overridden virtual function is here
    virtual void refresh() = 0;
                 ^
  /home/yhs/work/bcc/src/cc/syms.h:145:16: warning: 'refresh' overrides a member function but is not marked 'override'
        [-Winconsistent-missing-override]
    virtual void refresh();
                 ^
  /home/yhs/work/bcc/src/cc/syms.h:45:16: note: overridden virtual function is here
    virtual void refresh() = 0;

Signed-off-by: Yonghong Song <yhs@fb.com>