### PR TITLE
declare bpf_obj_get_info_by_fd() in src/cc/libbpf.h

### DIFF
--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -124,6 +124,7 @@ int bpf_prog_get_tag(int fd, unsigned long long *tag);
 int bpf_prog_get_next_id(uint32_t start_id, uint32_t *next_id);
 int bpf_prog_get_fd_by_id(uint32_t id);
 int bpf_map_get_fd_by_id(uint32_t id);
+int bpf_obj_get_info_by_fd(int prog_fd, void *info, uint32_t *info_len);
 
 #define LOG_BUF_SIZE 65536
 


### PR DESCRIPTION
Function bpf_obj_get_info_by_fd() is used in
src/cc/frontends/clang/b_frontend_action.cc
to support pinned maps.

The file src/cc/frontends/clang/b_frontend_action.cc
includes src/cc/libbpf.h which does not have
a prototype for the function. This may cause
issues in certain build system. Let us put
the prototype in src/cc/libbpf.h as the bcc C
visible API functions are all defined in this file.

Signed-off-by: Yonghong Song <yhs@fb.com>