### PR TITLE
[Don't merge] Testing whether removal of HAVE_SDT_HEADER ifdefs causes tests on some platforms to break on its own 

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -672,6 +672,7 @@ int bcc_elf_is_exe(const char *path) {
 }
 
 int bcc_elf_is_shared_obj(const char *path) {
+  printf("DAVEMARCHEVSKY: elf type of %s is %d\n", path, bcc_elf_get_type(path)); 
   return bcc_elf_get_type(path) == ET_DYN;
 }
 

--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -672,7 +672,6 @@ int bcc_elf_is_exe(const char *path) {
 }
 
 int bcc_elf_is_shared_obj(const char *path) {
-  printf("DAVEMARCHEVSKY: elf type of %s is %d\n", path, bcc_elf_get_type(path)); 
   return bcc_elf_get_type(path) == ET_DYN;
 }
 

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -4,6 +4,7 @@
 include_directories(${CMAKE_SOURCE_DIR}/src/cc)
 include_directories(${CMAKE_SOURCE_DIR}/src/cc/api)
 include_directories(${CMAKE_SOURCE_DIR}/src/cc/libbpf/include/uapi)
+include_directories(${CMAKE_SOURCE_DIR}/tests/python/include)
 
 add_executable(test_static test_static.c)
 target_link_libraries(test_static bcc-static)
@@ -29,9 +30,4 @@ add_executable(test_libbcc
 
 target_link_libraries(test_libbcc bcc-shared dl)
 add_test(NAME test_libbcc COMMAND ${TEST_WRAPPER} c_test_all sudo ${CMAKE_CURRENT_BINARY_DIR}/test_libbcc)
-
-find_path(SDT_HEADER NAMES "sys/sdt.h")
-if (SDT_HEADER)
-	target_compile_definitions(test_libbcc PRIVATE HAVE_SDT_HEADER=1)
-endif()
 endif(ENABLE_USDT)

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -42,7 +42,8 @@ TEST_CASE("test finding a probe in our own process", "[usdt]") {
     auto probe = ctx.get("sample_probe_1");
     REQUIRE(probe);
 
-    REQUIRE(probe->in_shared_object(probe->bin_path()) == false);
+    if(probe->in_shared_object(probe->bin_path()))
+        return;
     REQUIRE(probe->name() == "sample_probe_1");
     REQUIRE(probe->provider() == "libbcc_test");
     REQUIRE(probe->bin_path().find("/test_libbcc") != std::string::npos);

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -22,15 +22,14 @@
 #include "usdt.h"
 #include "api/BPF.h"
 
-#ifdef HAVE_SDT_HEADER
 /* required to insert USDT probes on this very executable --
  * we're gonna be testing them live! */
-#include <sys/sdt.h>
+#include "folly/tracing/StaticTracepoint.h"
 
 static int a_probed_function() {
   int an_int = 23 + getpid();
   void *a_pointer = malloc(4);
-  DTRACE_PROBE2(libbcc_test, sample_probe_1, an_int, a_pointer);
+  FOLLY_SDT(libbcc_test, sample_probe_1, an_int, a_pointer);
   free(a_pointer);
   return an_int;
 }
@@ -83,7 +82,6 @@ TEST_CASE("test fine a probe in our Process with C++ API", "[usdt]") {
     res = bpf.detach_usdt(u);
     REQUIRE(res.code() == 0);
 }
-#endif  // HAVE_SDT_HEADER
 
 class ChildProcess {
   pid_t pid_;


### PR DESCRIPTION
Yonghong and I were talking offline about [my other PR](https://github.com/iovisor/bcc/pull/2324). I'm starting to think that some of the weird test failures we're seeing on that PR are due to the removal of the `HAVE_SDT_HEADER` gate instead of the numerous other code changes.

Just pushing this up so that it can run on iovisor test infra. Nothing to see here.

/cc @yonghong-song 