### PR TITLE
Add cli argument to limit run time

### DIFF
--- a/man/man8/btrfsslower.8
+++ b/man/man8/btrfsslower.8
@@ -2,7 +2,7 @@
 .SH NAME
 btrfsslower \- Trace slow btrfs file operations, with per-event details.
 .SH SYNOPSIS
-.B btrfsslower [\-h] [\-j] [\-p PID] [min_ms]
+.B btrfsslower [\-h] [\-j] [\-p PID] [min_ms] [\-d DURATION]
 .SH DESCRIPTION
 This tool traces common btrfs file operations: reads, writes, opens, and
 syncs. It measures the time spent in these operations, and prints details
@@ -25,6 +25,9 @@ Trace this PID only.
 .TP
 min_ms
 Minimum I/O latency (duration) to trace, in milliseconds. Default is 10 ms.
+.TP
+\-d DURATION
+Total duration of trace in seconds.
 .SH EXAMPLES
 .TP
 Trace synchronous file reads and writes slower than 10 ms:
@@ -46,6 +49,10 @@ Trace all file reads and writes (warning: the output will be verbose):
 Trace slower than 1 ms, for PID 181 only:
 #
 .B btrfsslower \-p 181 1
+.TP
+Trace for 10 seconds only:
+#
+.B btrfsslower \-d 10
 .SH FIELDS
 .TP
 TIME(s)

--- a/tools/btrfsslower_example.txt
+++ b/tools/btrfsslower_example.txt
@@ -137,6 +137,7 @@ optional arguments:
   -h, --help         show this help message and exit
   -j, --csv          just print fields: comma-separated values
   -p PID, --pid PID  trace this PID only
+  -d DURATION        trace for DURATION seconds only
 
 examples:
     ./btrfsslower             # trace operations slower than 10 ms (default)
@@ -144,3 +145,5 @@ examples:
     ./btrfsslower -j 1        # ... 1 ms, parsable output (csv)
     ./btrfsslower 0           # trace all operations (warning: verbose)
     ./btrfsslower -p 185      # trace PID 185 only
+    ./btrfsslower -d 10       # trace for 10 seconds only
+

--- a/tools/btrfsslower_example.txt
+++ b/tools/btrfsslower_example.txt
@@ -126,7 +126,7 @@ patterns.
 USAGE message:
 
 # ./btrfsslower -h
-usage: btrfsslower [-h] [-j] [-p PID] [min_ms]
+usage: btrfsslower [-h] [-j] [-p PID] [min_ms] [-d DURATION]
 
 Trace common btrfs file operations slower than a threshold
 
@@ -137,7 +137,8 @@ optional arguments:
   -h, --help         show this help message and exit
   -j, --csv          just print fields: comma-separated values
   -p PID, --pid PID  trace this PID only
-  -d DURATION        trace for DURATION seconds only
+  -d DURATION, --duration DURATION
+                     total duration of trace in seconds
 
 examples:
     ./btrfsslower             # trace operations slower than 10 ms (default)


### PR DESCRIPTION
If a user is granted sudo access only to btrfsslower.py and not kill or timeout, then user is unable to easily limit the runtime of btrfsslower.py. The optional cli argument stops execution of program after specified number of seconds passes.