### PR TITLE
Lazily symbolize regular ELF binaries

### DIFF
--- a/examples/cpp/pyperf/PyPerfUtil.cc
+++ b/examples/cpp/pyperf/PyPerfUtil.cc
@@ -142,6 +142,7 @@ bool getAddrOfPythonBinary(const std::string& path, PidData& data) {
 
   struct bcc_symbol_option option = {.use_debug_file = 0,
                                      .check_debug_file_crc = 0,
+                                     .lazy_symbolize = 0,
                                      .use_symbol_type = (1 << STT_OBJECT)};
 
   bcc_elf_foreach_sym(path.c_str(), &getAddrOfPythonBinaryCallback, &option,

--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -257,6 +257,7 @@ BPFStackTable::BPFStackTable(const TableDesc& desc, bool use_debug_file,
 
   symbol_option_ = {.use_debug_file = use_debug_file,
                     .check_debug_file_crc = check_debug_file_crc,
+                    .lazy_symbolize = 0,
                     .use_symbol_type = (1 << STT_FUNC) | (1 << STT_GNU_IFUNC)};
 }
 
@@ -327,6 +328,7 @@ BPFStackBuildIdTable::BPFStackBuildIdTable(const TableDesc& desc, bool use_debug
 
   symbol_option_ = {.use_debug_file = use_debug_file,
                     .check_debug_file_crc = check_debug_file_crc,
+                    .lazy_symbolize = 0,
                     .use_symbol_type = (1 << STT_FUNC) | (1 << STT_GNU_IFUNC)};
 }
 

--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -291,7 +291,7 @@ static int list_in_scn(Elf *e, Elf_Scn *section, size_t stridx, size_t symsize,
 #endif
 
       int ret;
-      if (callback_lazy)
+      if (option->lazy_symbolize)
         ret = callback_lazy(stridx, sym.st_name, name_len, sym.st_value,
                             sym.st_size, debugfile, payload);
       else
@@ -585,14 +585,16 @@ static int foreach_sym_core(const char *path, bcc_elf_symcb callback,
 
 int bcc_elf_foreach_sym(const char *path, bcc_elf_symcb callback,
                         void *option, void *payload) {
-  return foreach_sym_core(
-      path, callback, NULL, (struct bcc_symbol_option*)option, payload, 0);
+  struct bcc_symbol_option *o = option;
+  o->lazy_symbolize = 0;
+  return foreach_sym_core(path, callback, NULL, o, payload, 0);
 }
 
 int bcc_elf_foreach_sym_lazy(const char *path, bcc_elf_symcb_lazy callback,
                         void *option, void *payload) {
-  return foreach_sym_core(path, NULL, callback,
-      (struct bcc_symbol_option*)option, payload, 0);
+  struct bcc_symbol_option *o = option;
+  o->lazy_symbolize = 1;
+  return foreach_sym_core(path, NULL, callback, o, payload, 0);
 }
 
 int bcc_elf_get_text_scn_info(const char *path, uint64_t *addr,

--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -40,7 +40,7 @@ typedef void (*bcc_elf_probecb)(const char *, const struct bcc_elf_usdt *,
 typedef int (*bcc_elf_symcb)(const char *, uint64_t, uint64_t, void *);
 // Section idx, str table idx, str length, start address, length, payload
 typedef int (*bcc_elf_symcb_lazy)(size_t, size_t, size_t, uint64_t, uint64_t,
-             void *);
+             int, void *);
 // Segment virtual address, memory size, file offset, payload
 // Callback returning a negative value indicates to stop the iteration
 typedef int (*bcc_elf_load_sectioncb)(uint64_t, uint64_t, uint64_t, void *);
@@ -78,7 +78,8 @@ int bcc_elf_is_vdso(const char *name);
 int bcc_free_memory();
 int bcc_elf_get_buildid(const char *path, char *buildid);
 int bcc_elf_symbol_str(const char *path, size_t section_idx,
-                       size_t str_table_idx, char *out, size_t len);
+                       size_t str_table_idx, char *out, size_t len,
+                       int debugfile);
 
 #ifdef __cplusplus
 }

--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -38,6 +38,9 @@ typedef void (*bcc_elf_probecb)(const char *, const struct bcc_elf_usdt *,
 // Symbol name, start address, length, payload
 // Callback returning a negative value indicates to stop the iteration
 typedef int (*bcc_elf_symcb)(const char *, uint64_t, uint64_t, void *);
+// Section idx, str table idx, str length, start address, length, payload
+typedef int (*bcc_elf_symcb_lazy)(size_t, size_t, size_t, uint64_t, uint64_t,
+             void *);
 // Segment virtual address, memory size, file offset, payload
 // Callback returning a negative value indicates to stop the iteration
 typedef int (*bcc_elf_load_sectioncb)(uint64_t, uint64_t, uint64_t, void *);
@@ -57,6 +60,10 @@ int bcc_elf_foreach_load_section(const char *path,
 // Returns -1 on error, and 0 on success or stopped by callback
 int bcc_elf_foreach_sym(const char *path, bcc_elf_symcb callback, void *option,
                         void *payload);
+// Similar to bcc_elf_foreach_sym, but pass reference to symbolized string along
+// with symbolized string length
+int bcc_elf_foreach_sym_lazy(const char *path, bcc_elf_symcb_lazy callback,
+                             void *option, void *payload);
 // Iterate over all symbols from current system's vDSO
 // Returns -1 on error, and 0 on success or stopped by callback
 int bcc_elf_foreach_vdso_sym(bcc_elf_symcb callback, void *payload);
@@ -70,6 +77,8 @@ int bcc_elf_is_exe(const char *path);
 int bcc_elf_is_vdso(const char *name);
 int bcc_free_memory();
 int bcc_elf_get_buildid(const char *path, char *buildid);
+int bcc_elf_symbol_str(const char *path, size_t section_idx,
+                       size_t str_table_idx, char *out, size_t len);
 
 #ifdef __cplusplus
 }

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -346,6 +346,8 @@ bool ProcSyms::Module::find_name(const char *symname, uint64_t *addr) {
     return 0;
   };
 
+  ProcMountNSGuard g(mount_ns_);
+
   if (type_ == ModuleType::PERF_MAP)
     bcc_perf_map_foreach_sym(name_.c_str(), cb, &payload);
   if (type_ == ModuleType::EXEC || type_ == ModuleType::SO)
@@ -398,6 +400,7 @@ bool ProcSyms::Module::find_addr(uint64_t offset, struct bcc_symbol *sym) {
     if (offset < it->start + it->size) {
       // Resolve and cache the symbol name if necessary
       if (!it->name) {
+        ProcMountNSGuard g(mount_ns_);
         std::string sym_name(it->name_idx.str_len + 1, '\0');
         if (bcc_elf_symbol_str(name_.c_str(), it->name_idx.section_idx,
               it->name_idx.str_table_idx, &sym_name[0], sym_name.size(),

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -438,6 +438,7 @@ bool BuildSyms::Module::load_sym_table()
   symbol_option_ = {
     .use_debug_file = 1,
     .check_debug_file_crc = 1,
+    .lazy_symbolize = 0,
     .use_symbol_type = (1 << STT_FUNC) | (1 << STT_GNU_IFUNC)
   };
 

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -351,12 +351,10 @@ bool ProcSyms::Module::find_name(const char *symname, uint64_t *addr) {
     return 0;
   };
 
-  ProcMountNSGuard g(mount_ns_);
-
   if (type_ == ModuleType::PERF_MAP)
-    bcc_perf_map_foreach_sym(name_.c_str(), cb, &payload);
+    bcc_perf_map_foreach_sym(path_.c_str(), cb, &payload);
   if (type_ == ModuleType::EXEC || type_ == ModuleType::SO)
-    bcc_elf_foreach_sym(name_.c_str(), cb, symbol_option_, &payload);
+    bcc_elf_foreach_sym(path_.c_str(), cb, symbol_option_, &payload);
   if (type_ == ModuleType::VDSO)
     bcc_elf_foreach_vdso_sym(cb, &payload);
 
@@ -405,9 +403,8 @@ bool ProcSyms::Module::find_addr(uint64_t offset, struct bcc_symbol *sym) {
     if (offset < it->start + it->size) {
       // Resolve and cache the symbol name if necessary
       if (!it->is_name_resolved) {
-        ProcMountNSGuard g(mount_ns_);
         std::string sym_name(it->data.name_idx.str_len + 1, '\0');
-        if (bcc_elf_symbol_str(name_.c_str(), it->data.name_idx.section_idx,
+        if (bcc_elf_symbol_str(path_.c_str(), it->data.name_idx.section_idx,
               it->data.name_idx.str_table_idx, &sym_name[0], sym_name.size(),
               it->data.name_idx.debugfile))
           break;

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -277,9 +277,10 @@ int ProcSyms::Module::_add_symbol(const char *symname, uint64_t start,
 
 int ProcSyms::Module::_add_symbol_lazy(size_t section_idx, size_t str_table_idx,
                                        size_t str_len, uint64_t start,
-                                       uint64_t size, void *p) {
+                                       uint64_t size, int debugfile, void *p) {
   Module *m = static_cast<Module *>(p);
-  m->syms_.emplace_back(section_idx, str_table_idx, str_len, start, size);
+  m->syms_.emplace_back(
+      section_idx, str_table_idx, str_len, start, size, debugfile);
   return 0;
 }
 
@@ -399,7 +400,8 @@ bool ProcSyms::Module::find_addr(uint64_t offset, struct bcc_symbol *sym) {
       if (!it->name) {
         std::string sym_name(it->name_idx.str_len + 1, '\0');
         if (bcc_elf_symbol_str(name_.c_str(), it->name_idx.section_idx,
-              it->name_idx.str_table_idx, &sym_name[0], sym_name.size()))
+              it->name_idx.str_table_idx, &sym_name[0], sym_name.size(),
+              it->name_idx.debugfile))
           break;
 
         it->name = &*(symnames_.emplace(std::move(sym_name)).first);

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -47,6 +47,8 @@ static const uint32_t BCC_SYM_ALL_TYPES = 65535;
 struct bcc_symbol_option {
   int use_debug_file;
   int check_debug_file_crc;
+  // Symbolize on-demand or symbolize everything ahead of time
+  int lazy_symbolize;
   // Bitmask flags indicating what types of ELF symbols to use
   uint32_t use_symbol_type;
 };

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -73,17 +73,19 @@ class ProcSyms : SymbolCache {
     size_t section_idx;
     size_t str_table_idx;
     size_t str_len;
+    bool debugfile;
   };
 
   struct Symbol {
     Symbol(const std::string *name, uint64_t start, uint64_t size)
         : name(name), start(start), size(size) {}
     Symbol(size_t section_idx, size_t str_table_idx, size_t str_len, uint64_t start,
-           uint64_t size)
+           uint64_t size, bool debugfile)
         : start(start), size(size) {
       name_idx.section_idx = section_idx;
       name_idx.str_table_idx = str_table_idx;
       name_idx.str_len = str_len;
+      name_idx.debugfile = debugfile;
     }
     struct NameIdx name_idx;
     const std::string *name{nullptr};
@@ -140,7 +142,7 @@ class ProcSyms : SymbolCache {
                            void *p);
     static int _add_symbol_lazy(size_t section_idx, size_t str_table_idx,
                                 size_t str_len, uint64_t start, uint64_t size,
-                                void *p);
+                                int debugfile, void *p);
   };
 
   int pid_;

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -78,17 +78,22 @@ class ProcSyms : SymbolCache {
 
   struct Symbol {
     Symbol(const std::string *name, uint64_t start, uint64_t size)
-        : name(name), start(start), size(size) {}
+        : is_name_resolved(true), start(start), size(size) {
+      data.name = name;
+    }
     Symbol(size_t section_idx, size_t str_table_idx, size_t str_len, uint64_t start,
            uint64_t size, bool debugfile)
-        : start(start), size(size) {
-      name_idx.section_idx = section_idx;
-      name_idx.str_table_idx = str_table_idx;
-      name_idx.str_len = str_len;
-      name_idx.debugfile = debugfile;
+        : is_name_resolved(false), start(start), size(size) {
+      data.name_idx.section_idx = section_idx;
+      data.name_idx.str_table_idx = str_table_idx;
+      data.name_idx.str_len = str_len;
+      data.name_idx.debugfile = debugfile;
     }
-    struct NameIdx name_idx;
-    const std::string *name{nullptr};
+    bool is_name_resolved;
+    union {
+      struct NameIdx name_idx;
+      const std::string *name{nullptr};
+    } data;
     uint64_t start;
     uint64_t size;
 

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -69,10 +69,24 @@ public:
 };
 
 class ProcSyms : SymbolCache {
+  struct NameIdx {
+    size_t section_idx;
+    size_t str_table_idx;
+    size_t str_len;
+  };
+
   struct Symbol {
     Symbol(const std::string *name, uint64_t start, uint64_t size)
         : name(name), start(start), size(size) {}
-    const std::string *name;
+    Symbol(size_t section_idx, size_t str_table_idx, size_t str_len, uint64_t start,
+           uint64_t size)
+        : start(start), size(size) {
+      name_idx.section_idx = section_idx;
+      name_idx.str_table_idx = str_table_idx;
+      name_idx.str_len = str_len;
+    }
+    struct NameIdx name_idx;
+    const std::string *name{nullptr};
     uint64_t start;
     uint64_t size;
 
@@ -124,6 +138,9 @@ class ProcSyms : SymbolCache {
 
     static int _add_symbol(const char *symname, uint64_t start, uint64_t size,
                            void *p);
+    static int _add_symbol_lazy(size_t section_idx, size_t str_table_idx,
+                                size_t str_len, uint64_t start, uint64_t size,
+                                void *p);
   };
 
   int pid_;

--- a/src/cc/usdt/usdt_args.cc
+++ b/src/cc/usdt/usdt_args.cc
@@ -39,6 +39,7 @@ bool Argument::get_global_address(uint64_t *address, const std::string &binpath,
     static struct bcc_symbol_option default_option = {
       .use_debug_file = 1,
       .check_debug_file_crc = 1,
+      .lazy_symbolize = 0,
       .use_symbol_type = BCC_SYM_ALL_TYPES
     };
     return ProcSyms(*pid, &default_option)

--- a/src/lua/bcc/libbcc.lua
+++ b/src/lua/bcc/libbcc.lua
@@ -116,6 +116,7 @@ struct bcc_symbol {
 struct bcc_symbol_option {
   int use_debug_file;
   int check_debug_file_crc;
+  int lazy_symbolize;
   uint32_t use_symbol_type;
 };
 


### PR DESCRIPTION
This patch adds a new API to bcc_elf.h, bcc_elf_foreach_sym_lazy. This
helper avoids storing symbol names in string format, as for large
binaries this data can get quite large.

Instead we store the location in the ELF binary where we can later find
the string. Later on, we can load these strings on demand and cache them
in case they're accessed again.

This patch also makes lazy resolution the default for regular ELF
binaries, where regular means not perfmap or VDSO.

This closes #2421 .