### PR TITLE
tools: fix runqslower warning

### DIFF
--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -167,7 +167,7 @@ RAW_TRACEPOINT_PROBE(sched_switch)
     long state;
 
     // ivcsw: treat like an enqueue event and store timestamp
-    bpf_probe_read(&state, sizeof(long), &prev->state);
+    bpf_probe_read(&state, sizeof(long), (const void *)&prev->state);
     if (state == TASK_RUNNING) {
         bpf_probe_read(&tgid, sizeof(prev->tgid), &prev->tgid);
         bpf_probe_read(&pid, sizeof(prev->pid), &prev->pid);


### PR DESCRIPTION
The state member of task_struct is volatile and it's use as the last
parameter of bpf_probe_read (const void *) triggers the following
clang warning (LLVM 8):

/virtual/main.c:56:42: warning: passing 'volatile long *' to parameter of type 'const void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    bpf_probe_read(&state, sizeof(long), &prev->state);
                                         ^~~~~~~~~~~~
1 warning generated.
Tracing run queue latency higher than 10000 us
TIME     COMM             PID           LAT(us)

An explicit cast fixes the warning.