### PR TITLE
Resolve global object symbols

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -630,7 +630,7 @@ int bcc_elf_foreach_load_section(const char *path,
   for (i = 0; i < nhdrs; i++) {
     if (!gelf_getphdr(e, (int)i, &header))
       continue;
-    if (header.p_type != PT_LOAD || !(header.p_flags & PF_X))
+    if (header.p_type != PT_LOAD)
       continue;
     res = callback(header.p_vaddr, header.p_memsz, header.p_offset, payload);
     if (res < 0) {


### PR DESCRIPTION
I am trying to resolve a symbol for a global variable in a Go program. Something like this:

```go
package main

var counter int64

func main() {}
```

I want to look up where `main.counter` is. When I dump the symbol table using readelf it is there:

```
$ readelf -s /tmp/counter | grep main.counter
   156: 00000000005ec228     8 OBJECT  GLOBAL DEFAULT   11 main.counter
```

When I call into `bcc_resolve_symname` it finds the symbol but it gets caught up calling into `bcc_elf_foreach_load_section`. When it calls into the callback `_find_load` this is the state:

```
addr->target_addr: 6210088
v_addr: 4194304
mem_sz: 763136
file_offset: 0
```

This condition evaluates to:

```
addr->target_addr >= v_addr && addr->target_addr < (v_addr + mem_sz)
6210088 >= 4194304 && 6210088 < (4194304 + 763136)
6210088 >= 4194304 && 6210088 < 4957440
true && false
false
```

Which means `binary_addr` does not get set.

You can see the `addr->target_addr` is the value I want (6210088 == 0x5ec228). I made this one line change to set the `binary_addr` to the `target_addr` if it was not set by `bcc_elf_foreach_load_section`. This fixed the issue for me. To be frank, I have very little understanding of ELF so I am not confident that this change is correct. I am opening this as a PR since I have a working change but I mainly want to start a conversation about this since I'm out of my depth a bit.