### PR TITLE
fix various compilation warnings

### DIFF
--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -32,6 +32,7 @@ struct bcc_symbol {
 };
 
 typedef int (*SYM_CB)(const char *symname, uint64_t addr);
+struct mod_info;
 
 #ifndef STT_GNU_IFUNC
 #define STT_GNU_IFUNC 10

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -216,7 +216,7 @@ static uint64_t ptr_to_u64(void *ptr)
 
 int bcc_create_map_xattr(struct bpf_create_map_attr *attr, bool allow_rlimit)
 {
-  size_t name_len = attr->name ? strlen(attr->name) : 0;
+  unsigned name_len = attr->name ? strlen(attr->name) : 0;
   char map_name[BPF_OBJ_NAME_LEN] = {};
 
   memcpy(map_name, attr->name, min(name_len, BPF_OBJ_NAME_LEN - 1));
@@ -499,7 +499,7 @@ int bpf_prog_get_tag(int fd, unsigned long long *ptag)
 int bcc_prog_load_xattr(struct bpf_load_program_attr *attr, int prog_len,
                         char *log_buf, unsigned log_buf_size, bool allow_rlimit)
 {
-  size_t name_len = attr->name ? strlen(attr->name) : 0;
+  unsigned name_len = attr->name ? strlen(attr->name) : 0;
   char *tmp_log_buf = NULL, *attr_log_buf = NULL;
   unsigned tmp_log_buf_size = 0, attr_log_buf_size = 0;
   int ret = 0, name_offset = 0;

--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -483,7 +483,6 @@ const char *bcc_usdt_genargs(void **usdt_array, int len) {
     for (size_t j = 0; j < ctx->num_probes(); j++) {
       USDT::Probe *p = ctx->get(j);
       if (p->enabled()) {
-        auto pid = ctx->pid();
         std::string key = ctx->cmd_bin_path() + "*" + p->provider() + "*" + p->name();
         if (generated_probes.find(key) != generated_probes.end())
           continue;


### PR DESCRIPTION
The following compilation warnings are fix:
...
/home/yhs/work/bcc/src/cc/libbpf.c:548:12: warning: comparison of distinct pointer types ('typeof (name_len - name_offset) *' (aka 'unsigned long *')
      and 'typeof (16U - 1) *' (aka 'unsigned int *')) [-Wcompare-distinct-pointer-types]
           min(name_len - name_offset, BPF_OBJ_NAME_LEN - 1));
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/yhs/work/bcc/src/cc/libbpf/include/linux/kernel.h:28:17: note: expanded from macro 'min'
        (void) (&_min1 == &_min2);
...
/home/yhs/work/bcc/src/cc/bcc_syms.h:71:34: warning: declaration of 'struct mod_info' will not be visible outside of this function [-Wvisibility]
int _bcc_syms_find_module(struct mod_info *info, int enter_ns, void *p);
...
/home/yhs/work/bcc/src/cc/usdt/usdt.cc:486:14: warning: unused variable 'pid' [-Wunused-variable]
        auto pid = ctx->pid();
             ^
...

Signed-off-by: Yonghong Song <yhs@fb.com>