### PR TITLE
fix asm_volatile_goto issue again

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -18,7 +18,7 @@ R"********(
 #define __BPF_HELPERS_H
 
 /* Before bpf_helpers.h is included, uapi bpf.h has been
- * included, which references linux/types.h. This will bring
+ * included, which references linux/types.h. This may bring
  * in asm_volatile_goto definition if permitted based on
  * compiler setup and kernel configs.
  *
@@ -29,8 +29,8 @@ R"********(
  */
 #ifdef asm_volatile_goto
 #undef asm_volatile_goto
-#define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
 #endif
+#define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
 
 #include <uapi/linux/bpf.h>
 #include <uapi/linux/if_packet.h>


### PR DESCRIPTION
In src/cc/export/helpers.h, we tried to
define asm_volatile_goto to something else
if it is defined through uapi bpf.h.
  #ifdef asm_volatile_goto
  #undef asm_volatile_goto
  #define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
  #endif

It is possible that due to different kernel configurations,
asm_volatile_goto may not be defined after uapi bpf.h.
To prevent compilation errors, let us unconditionally
define asm_volatile_goto here.

Signed-off-by: Yonghong Song <yhs@fb.com>