### PR TITLE
tools: fix printb usage in solisten

### DIFF
--- a/tools/solisten.py
+++ b/tools/solisten.py
@@ -151,14 +151,14 @@ def event_printer(show_netns):
 
         # Display
         if show_netns:
-            printb(b"%-6d %-12.12s %-12s %-6s %-8s %-5s %-39s" % (
-                pid, event.task, event.netns, protocol, event.backlog,
-                event.lport, address,
+            printb(b"%-6d %-12.12s %-12d %-6s %-8d %-5d %-39s" % (
+                pid, event.task, event.netns, protocol.encode(), event.backlog,
+                event.lport, address.encode(),
             ))
         else:
-            printb(b"%-6d %-12.12s %-6s %-8s %-5s %-39s" % (
-                pid, event.task, protocol, event.backlog,
-                event.lport, address,
+            printb(b"%-6d %-12.12s %-6s %-8d %-5d %-39s" % (
+                pid, event.task, protocol.encode(), event.backlog,
+                event.lport, address.encode(),
             ))
 
     return print_event


### PR DESCRIPTION
Since its conversion to printb, solisten has suffers from yet another python2/3 bytes/str issue:

Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 234, in 'calling callback function'
  File "/usr/lib/python3.6/site-packages/bcc/table.py", line 581, in raw_cb_
    callback(cpu, data, size)
  File "/usr/share/bcc/tools/solisten", line 176, in print_event
    event.lport, address,
TypeError: %b requires a bytes-like object, or an object that implements __bytes__, not 'str'

This patch fix the issue on python3. The tools still works on python2.