### PR TITLE
Add allow_partial_usdt_init param so partial init of USDT vector is possible

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -245,6 +245,8 @@ int do_trace(struct pt_regs *ctx) {
 
 This reads the sixth USDT argument, and then pulls it in as a string to ```path```.
 
+When initializing USDTs via the third argument of ```BPF::init``` in the C API, if any USDT fails to ```init```, entire ```BPF::init``` will fail. If you're OK with some USDTs failing to ```init```, use ```BPF::init_usdt``` before calling ```BPF::init```.
+
 Examples in situ:
 [code](https://github.com/iovisor/bcc/commit/4f88a9401357d7b75e917abd994aa6ea97dda4d3#diff-04a7cad583be5646080970344c48c1f4R24),
 [search /examples](https://github.com/iovisor/bcc/search?q=bpf_usdt_readarg+path%3Aexamples&type=Code),

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -58,6 +58,8 @@ class BPF {
                    const std::vector<std::string>& cflags = {},
                    const std::vector<USDT>& usdt = {});
 
+  StatusTuple init_usdt(const USDT& usdt);
+
   ~BPF();
   StatusTuple detach_all();
 
@@ -244,6 +246,8 @@ class BPF {
                                   uint64_t& offset_res,
                                   uint64_t symbol_offset = 0);
 
+  void init_fail_reset();
+
   int flag_;
 
   void *bsymcache_;
@@ -255,6 +259,7 @@ class BPF {
   std::map<std::string, int> funcs_;
 
   std::vector<USDT> usdt_;
+  std::string all_bpf_program_;
 
   std::map<std::string, open_probe_t> kprobes_;
   std::map<std::string, open_probe_t> uprobes_;


### PR DESCRIPTION
Looking for early feedback here before I write tests / flesh this out more.

Consider this scenario: I'm hoping to attach USDTs to many short-lived processes, let's say 30. I want to gather data from USDT handlers on these processes for 5 seconds. It's guaranteed that at least one of the processes that was alive when I constructed the vector of USDTs to pass into `BPF::init` will not be alive by the time the 5 seconds are up. I'm OK with this and would still like to gather as much data as possible.

If the process dies after `USDT::init()` is successful but before `attach_usdt` is called, we're already OK because we can handle each `StatusTuple` independently outside of `bcc`. Similarly, if process dies between `attach_usdt` and `detach_usdt` calls, we're fine for same reason.

But if it dies between construction of `USDT` object and `USDT::init()` being called by `BPF::init()`, we currently consider failure to init any `USDT` critical enough to stop the whole `BPF::init()`. 

This PR adds a `allow_partial_usdt_init` param to `BPF::init` to let users of `bcc` signal that they're OK with `USDT::init()` failures. `USDT::initialized()` getter is added so `bcc` user can check which `USDT`s succeeded / failed.

One downside of this initial pass is that the info in `StatusTuple`s for `USDT::init` is lost. So if we have some `USDT::init` failures when `allow_partial_usdt_init` is `true` it'll be hard to get visibility into them. 

/cc @yonghong-song 