### PR TITLE
Turn on lazy symbolize by default

### DIFF
--- a/examples/cpp/pyperf/PyPerfUtil.cc
+++ b/examples/cpp/pyperf/PyPerfUtil.cc
@@ -142,7 +142,7 @@ bool getAddrOfPythonBinary(const std::string& path, PidData& data) {
 
   struct bcc_symbol_option option = {.use_debug_file = 0,
                                      .check_debug_file_crc = 0,
-                                     .lazy_symbolize = 0,
+                                     .lazy_symbolize = 1,
                                      .use_symbol_type = (1 << STT_OBJECT)};
 
   bcc_elf_foreach_sym(path.c_str(), &getAddrOfPythonBinaryCallback, &option,

--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -257,7 +257,7 @@ BPFStackTable::BPFStackTable(const TableDesc& desc, bool use_debug_file,
 
   symbol_option_ = {.use_debug_file = use_debug_file,
                     .check_debug_file_crc = check_debug_file_crc,
-                    .lazy_symbolize = 0,
+                    .lazy_symbolize = 1,
                     .use_symbol_type = (1 << STT_FUNC) | (1 << STT_GNU_IFUNC)};
 }
 
@@ -328,7 +328,7 @@ BPFStackBuildIdTable::BPFStackBuildIdTable(const TableDesc& desc, bool use_debug
 
   symbol_option_ = {.use_debug_file = use_debug_file,
                     .check_debug_file_crc = check_debug_file_crc,
-                    .lazy_symbolize = 0,
+                    .lazy_symbolize = 1,
                     .use_symbol_type = (1 << STT_FUNC) | (1 << STT_GNU_IFUNC)};
 }
 

--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -110,7 +110,7 @@ ProcSyms::ProcSyms(int pid, struct bcc_symbol_option *option)
     symbol_option_ = {
       .use_debug_file = 1,
       .check_debug_file_crc = 1,
-      .lazy_symbolize = 0,
+      .lazy_symbolize = 1,
       .use_symbol_type = (1 << STT_FUNC) | (1 << STT_GNU_IFUNC)
     };
   load_modules();
@@ -435,7 +435,7 @@ bool BuildSyms::Module::load_sym_table()
   symbol_option_ = {
     .use_debug_file = 1,
     .check_debug_file_crc = 1,
-    .lazy_symbolize = 0,
+    .lazy_symbolize = 1,
     .use_symbol_type = (1 << STT_FUNC) | (1 << STT_GNU_IFUNC)
   };
 
@@ -671,7 +671,7 @@ int bcc_foreach_function_symbol(const char *module, SYM_CB cb) {
   static struct bcc_symbol_option default_option = {
     .use_debug_file = 1,
     .check_debug_file_crc = 1,
-    .lazy_symbolize = 0,
+    .lazy_symbolize = 1,
     .use_symbol_type = (1 << STT_FUNC) | (1 << STT_GNU_IFUNC)
   };
 
@@ -710,7 +710,7 @@ int bcc_resolve_symname(const char *module, const char *symname,
   static struct bcc_symbol_option default_option = {
     .use_debug_file = 1,
     .check_debug_file_crc = 1,
-    .lazy_symbolize = 0,
+    .lazy_symbolize = 1,
 #if defined(__powerpc64__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     .use_symbol_type = BCC_SYM_ALL_TYPES | (1 << STT_PPC64LE_SYM_LEP),
 #else

--- a/src/cc/usdt/usdt_args.cc
+++ b/src/cc/usdt/usdt_args.cc
@@ -39,7 +39,7 @@ bool Argument::get_global_address(uint64_t *address, const std::string &binpath,
     static struct bcc_symbol_option default_option = {
       .use_debug_file = 1,
       .check_debug_file_crc = 1,
-      .lazy_symbolize = 0,
+      .lazy_symbolize = 1,
       .use_symbol_type = BCC_SYM_ALL_TYPES
     };
     return ProcSyms(*pid, &default_option)


### PR DESCRIPTION
This turns on lazy symbolization by default. Symbol names will be
resolved the first time they're requested and then cached for future
access. This can reduce bcc memory usage by quite a bit in certain
workloads.