### PR TITLE
tools: fix vfscount output when no duration is specified

### DIFF
--- a/man/man8/vfscount.8
+++ b/man/man8/vfscount.8
@@ -2,7 +2,7 @@
 .SH NAME
 vfscount \- Count VFS calls ("vfs_*"). Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B vfscount
+.B vfscount [duration]
 .SH DESCRIPTION
 This counts VFS calls. This can be useful for general workload
 characterization of these operations.
@@ -14,6 +14,10 @@ Edit the script to customize which functions to trace.
 Since this uses BPF, only the root user can use this tool.
 .SH REQUIREMENTS
 CONFIG_BPF and bcc.
+.SH OPTIONS
+.TP
+duration
+duration of the trace in seconds.
 .SH EXAMPLES
 .TP
 Count some VFS calls until Ctrl-C is hit:

--- a/tools/vfscount.py
+++ b/tools/vfscount.py
@@ -54,7 +54,6 @@ try:
     sleep(interval)
 except KeyboardInterrupt:
     pass
-    exit()
 
 print("\n%-16s %-26s %8s" % ("ADDR", "FUNC", "COUNT"))
 counts = b.get_table("counts")


### PR DESCRIPTION
Since commit a2e71a9eb71a ("vfscount.py: add args time (#2344)"),
vfscount does not show any output when it is interrupted by a key
press, which is the only way out when no time limit is specified. I
assume the exit() that has been added in the keyboard interrupt
handler is there so that no output is displayed when the program has
been interrupted early when a time limit has been specified. But since
the tool still invite the user to use Ctrl-C to end the tracing in
that case, it seems more consistent to show an output in that case
too.

This patch removes the exit() and the tools always show a result at
the end. It also adds the duration argument to the synopsis and the
option section in the man page.