### PR TITLE
offwaketime: Fix incorrect target and waker PIDs

### DIFF
--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -350,7 +350,7 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
         print("%s %d" % (";".join(line), v.value))
     else:
         # print wakeup name then stack in reverse order
-        print("    %-16s %s %s" % ("waker:", k.waker.decode('utf-8', 'replace'), k.t_pid))
+        print("    %-16s %s %s" % ("waker:", k.waker.decode('utf-8', 'replace'), k.w_pid))
         if not args.kernel_stacks_only:
             if stack_id_err(k.w_u_stack_id):
                 print("    [Missed User Stack]")
@@ -383,7 +383,7 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
             else:
                 for addr in target_user_stack:
                     print("    %s" % b.sym(addr, k.t_tgid))
-        print("    %-16s %s %s" % ("target:", k.target.decode('utf-8', 'replace'), k.w_pid))
+        print("    %-16s %s %s" % ("target:", k.target.decode('utf-8', 'replace'), k.t_pid))
         print("        %d\n" % v.value)
 
 if missing_stacks > 0:


### PR DESCRIPTION
`offwaketime` reports target and waker PIDs inversely. This patch fixes this issue.

This issue is reported in #2487 