### PR TITLE
Don't prepend /proc/PID/root to user-supplied USDT binary paths starting with /proc already

### DIFF
--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -279,7 +279,7 @@ std::string Context::resolve_bin_path(const std::string &bin_path) {
     ::free(which_so);
   }
 
-  if (!result.empty() && pid_ && *pid_ != -1) {
+  if (!result.empty() && pid_ && *pid_ != -1 && result.find("/proc") != 0) {
     result = tfm::format("/proc/%d/root%s", *pid_, result);
   }
 


### PR DESCRIPTION
If I have a tracepoint that I know is in my binary and not in some shared lib, I might do:

```cpp
std::vector<USDT> USDTs;
USDTs.emplace_back(
  "/proc/42/exe",
  42,
  "my_provider",
  "my_sdt_name",
  "on_usdt_event");
```

Unfortunately this has been broken since my big change / refactor in #2324 . Why? Because that change attempts to prefix `/proc/PID/root` to everything, and if the process is in a container w/ a different pid namespace than root, `/proc/42/root/proc/42/exe` is unlikely to mean anything and almost certainly won't mean the same thing as `/proc/42/exe`.

Let's not prefix `/proc/PID/root` to procfs paths. Then the above case will be unbroken.
