### PR TITLE
Make number of stack traces configurable from command line in example…

### DIFF
--- a/examples/tracing/mallocstacks.py
+++ b/examples/tracing/mallocstacks.py
@@ -21,6 +21,12 @@ if len(sys.argv) < 2:
     exit()
 pid = int(sys.argv[1])
 if len(sys.argv) == 3:
+    try:
+        assert int(sys.argv[2]) > 0, ""
+    except (ValueError, AssertionError) as e:
+        print("USAGE: mallocstacks PID [NUM_STACKS=1024]")
+        print("NUM_STACKS must be a non-zero, positive integer")
+        exit()
     stacks = sys.argv[2]
 else:
     stacks = "1024"

--- a/examples/tracing/mallocstacks.py
+++ b/examples/tracing/mallocstacks.py
@@ -17,16 +17,20 @@ from time import sleep
 import sys
 
 if len(sys.argv) < 2:
-    print("USAGE: mallocstacks PID")
+    print("USAGE: mallocstacks PID [NUM_STACKS=1024]")
     exit()
 pid = int(sys.argv[1])
+if len(sys.argv) == 3:
+    stacks = sys.argv[2]
+else:
+    stacks = "1024"
 
 # load BPF program
 b = BPF(text="""
 #include <uapi/linux/ptrace.h>
 
 BPF_HASH(calls, int);
-BPF_STACK_TRACE(stack_traces, 1024);
+BPF_STACK_TRACE(stack_traces, """ + stacks + """);
 
 int alloc_enter(struct pt_regs *ctx, size_t size) {
     int key = stack_traces.get_stackid(ctx,


### PR DESCRIPTION
…s/tracing/mallocstacks.py

By default examles/tracing/mallocstacks.py captures 1024 stack traces before the script exits. This PR retains the default, but allows for the number of stack traces to be configured from the command line.

I am not sure if passing an unbounded/non-validated value to BPF_STACK_TRACE is sensible, or if the implementation of BPF_STACK_TRACE validates _max_entries