### PR TITLE
Support for hardware offload

### DIFF
--- a/examples/networking/xdp/xdp_drop_count.py
+++ b/examples/networking/xdp/xdp_drop_count.py
@@ -16,24 +16,29 @@ flags = 0
 def usage():
     print("Usage: {0} [-S] <ifdev>".format(sys.argv[0]))
     print("       -S: use skb mode\n")
+    print("       -H: use hardware offload mode\n")
     print("e.g.: {0} eth0\n".format(sys.argv[0]))
     exit(1)
 
 if len(sys.argv) < 2 or len(sys.argv) > 3:
     usage()
 
+offload_device = None
 if len(sys.argv) == 2:
     device = sys.argv[1]
+elif len(sys.argv) == 3:
+    device = sys.argv[2]
 
+maptype = "percpu_array"
 if len(sys.argv) == 3:
     if "-S" in sys.argv:
         # XDP_FLAGS_SKB_MODE
-        flags |= 2 << 0
-
-    if "-S" == sys.argv[1]:
-        device = sys.argv[2]
-    else:
-        device = sys.argv[1]
+        flags |= (1 << 1)
+    if "-H" in sys.argv:
+        # XDP_FLAGS_HW_MODE
+        maptype = "array"
+        offload_device = device
+        flags |= (1 << 3)
 
 mode = BPF.XDP
 #mode = BPF.SCHED_CLS
@@ -56,8 +61,7 @@ b = BPF(text = """
 #include <linux/ip.h>
 #include <linux/ipv6.h>
 
-
-BPF_TABLE("percpu_array", uint32_t, long, dropcnt, 256);
+BPF_TABLE(MAPTYPE, uint32_t, long, dropcnt, 256);
 
 static inline int parse_ipv4(void *data, u64 nh_off, void *data_end) {
     struct iphdr *iph = data + nh_off;
@@ -119,13 +123,15 @@ int xdp_prog1(struct CTXTYPE *ctx) {
 
     value = dropcnt.lookup(&index);
     if (value)
-        *value += 1;
+        __sync_fetch_and_add(value, 1);
 
     return rc;
 }
-""", cflags=["-w", "-DRETURNCODE=%s" % ret, "-DCTXTYPE=%s" % ctxtype])
+""", cflags=["-w", "-DRETURNCODE=%s" % ret, "-DCTXTYPE=%s" % ctxtype,
+			 "-DMAPTYPE=\"%s\"" % maptype],
+     device=offload_device)
 
-fn = b.load_func("xdp_prog1", mode)
+fn = b.load_func("xdp_prog1", mode, offload_device)
 
 if mode == BPF.XDP:
     b.attach_xdp(device, fn, flags)
@@ -143,7 +149,7 @@ print("Printing drops per IP protocol-number, hit CTRL+C to stop")
 while 1:
     try:
         for k in dropcnt.keys():
-            val = dropcnt.sum(k).value
+            val = dropcnt[k].value if maptype == "array" else dropcnt.sum(k).value
             i = k.value
             if val:
                 delta = val - prev[i]

--- a/src/cc/bcc_common.cc
+++ b/src/cc/bcc_common.cc
@@ -17,8 +17,9 @@
 #include "bpf_module.h"
 
 extern "C" {
-void * bpf_module_create_b(const char *filename, const char *proto_filename, unsigned flags) {
-  auto mod = new ebpf::BPFModule(flags);
+void * bpf_module_create_b(const char *filename, const char *proto_filename, unsigned flags,
+                           const char *dev_name) {
+  auto mod = new ebpf::BPFModule(flags, nullptr, true, "", true, dev_name);
   if (mod->load_b(filename, proto_filename) != 0) {
     delete mod;
     return nullptr;
@@ -27,8 +28,8 @@ void * bpf_module_create_b(const char *filename, const char *proto_filename, uns
 }
 
 void * bpf_module_create_c(const char *filename, unsigned flags, const char *cflags[],
-                           int ncflags, bool allow_rlimit) {
-  auto mod = new ebpf::BPFModule(flags, nullptr, true, "", allow_rlimit);
+                           int ncflags, bool allow_rlimit, const char *dev_name) {
+  auto mod = new ebpf::BPFModule(flags, nullptr, true, "", allow_rlimit, dev_name);
   if (mod->load_c(filename, cflags, ncflags) != 0) {
     delete mod;
     return nullptr;
@@ -37,8 +38,8 @@ void * bpf_module_create_c(const char *filename, unsigned flags, const char *cfl
 }
 
 void * bpf_module_create_c_from_string(const char *text, unsigned flags, const char *cflags[],
-                                       int ncflags, bool allow_rlimit) {
-  auto mod = new ebpf::BPFModule(flags, nullptr, true, "", allow_rlimit);
+                                       int ncflags, bool allow_rlimit, const char *dev_name) {
+  auto mod = new ebpf::BPFModule(flags, nullptr, true, "", allow_rlimit, dev_name);
   if (mod->load_string(text, cflags, ncflags) != 0) {
     delete mod;
     return nullptr;
@@ -240,12 +241,13 @@ int bpf_table_leaf_sscanf(void *program, size_t id, const char *buf, void *leaf)
 int bcc_func_load(void *program, int prog_type, const char *name,
                   const struct bpf_insn *insns, int prog_len,
                   const char *license, unsigned kern_version,
-                  int log_level, char *log_buf, unsigned log_buf_size) {
+                  int log_level, char *log_buf, unsigned log_buf_size,
+                  const char *dev_name) {
   auto mod = static_cast<ebpf::BPFModule *>(program);
   if (!mod) return -1;
   return mod->bcc_func_load(prog_type, name, insns, prog_len,
                             license, kern_version, log_level,
-                            log_buf, log_buf_size);
+                            log_buf, log_buf_size, dev_name);
 
 }
 

--- a/src/cc/bcc_common.h
+++ b/src/cc/bcc_common.h
@@ -25,11 +25,13 @@
 extern "C" {
 #endif
 
-void * bpf_module_create_b(const char *filename, const char *proto_filename, unsigned flags);
+void * bpf_module_create_b(const char *filename, const char *proto_filename, unsigned flags,
+                           const char *dev_name);
 void * bpf_module_create_c(const char *filename, unsigned flags, const char *cflags[], int ncflags,
-                           bool allow_rlimit);
+                           bool allow_rlimit, const char *dev_name);
 void * bpf_module_create_c_from_string(const char *text, unsigned flags, const char *cflags[],
-                                       int ncflags, bool allow_rlimit);
+                                       int ncflags, bool allow_rlimit,
+                                       const char *dev_name);
 void bpf_module_destroy(void *program);
 char * bpf_module_license(void *program);
 unsigned bpf_module_kern_version(void *program);
@@ -69,7 +71,8 @@ struct bpf_insn;
 int bcc_func_load(void *program, int prog_type, const char *name,
                   const struct bpf_insn *insns, int prog_len,
                   const char *license, unsigned kern_version,
-                  int log_level, char *log_buf, unsigned log_buf_size);
+                  int log_level, char *log_buf, unsigned log_buf_size,
+                  const char *dev_name);
 
 #ifdef __cplusplus
 }

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -91,7 +91,8 @@ class BPFModule {
 
  public:
   BPFModule(unsigned flags, TableStorage *ts = nullptr, bool rw_engine_enabled = true,
-            const std::string &maps_ns = "", bool allow_rlimit = true);
+            const std::string &maps_ns = "", bool allow_rlimit = true,
+            const char *dev_name = nullptr);
   ~BPFModule();
   int free_bcc_memory();
   int load_b(const std::string &filename, const std::string &proto_filename);
@@ -138,7 +139,8 @@ class BPFModule {
   int bcc_func_load(int prog_type, const char *name,
                     const struct bpf_insn *insns, int prog_len,
                     const char *license, unsigned kern_version,
-                    int log_level, char *log_buf, unsigned log_buf_size);
+                    int log_level, char *log_buf, unsigned log_buf_size,
+                    const char *dev_name = nullptr);
   size_t perf_event_fields(const char *) const;
   const char * perf_event_field(const char *, size_t i) const;
 
@@ -168,6 +170,7 @@ class BPFModule {
   std::unique_ptr<TableStorage> local_ts_;
   BTF *btf_;
   fake_fd_map_def fake_fd_map_;
+  unsigned int ifindex_;
 
   // map of events -- key: event name, value: event fields
   std::map<std::string, std::vector<std::string>> perf_events_;

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -276,7 +276,7 @@ class BPF(object):
         return None
 
     def __init__(self, src_file=b"", hdr_file=b"", text=None, debug=0,
-            cflags=[], usdt_contexts=[], allow_rlimit=True):
+            cflags=[], usdt_contexts=[], allow_rlimit=True, device=None):
         """Create a new BPF module with the given source code.
 
         Note:
@@ -319,7 +319,7 @@ class BPF(object):
 
         # files that end in ".b" are treated as B files. Everything else is a (BPF-)C file
         if src_file.endswith(b".b"):
-            self.module = lib.bpf_module_create_b(src_file, hdr_file, self.debug)
+            self.module = lib.bpf_module_create_b(src_file, hdr_file, self.debug, device)
         else:
             if src_file:
                 # Read the BPF C source file into the text variable. This ensures,
@@ -342,7 +342,7 @@ class BPF(object):
             self.module = lib.bpf_module_create_c_from_string(text,
                                                               self.debug,
                                                               cflags_array, len(cflags_array),
-                                                              allow_rlimit)
+                                                              allow_rlimit, device)
         if not self.module:
             raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
 
@@ -367,7 +367,7 @@ class BPF(object):
 
         return fns
 
-    def load_func(self, func_name, prog_type):
+    def load_func(self, func_name, prog_type, device = None):
         func_name = _assert_is_bytes(func_name)
         if func_name in self.funcs:
             return self.funcs[func_name]
@@ -383,7 +383,7 @@ class BPF(object):
                 lib.bpf_function_size(self.module, func_name),
                 lib.bpf_module_license(self.module),
                 lib.bpf_module_kern_version(self.module),
-                log_level, None, 0);
+                log_level, None, 0, device);
 
         if fd < 0:
             atexit.register(self.donothing)

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -18,13 +18,14 @@ lib = ct.CDLL("libbcc.so.0", use_errno=True)
 
 # keep in sync with bcc_common.h
 lib.bpf_module_create_b.restype = ct.c_void_p
-lib.bpf_module_create_b.argtypes = [ct.c_char_p, ct.c_char_p, ct.c_uint]
+lib.bpf_module_create_b.argtypes = [ct.c_char_p, ct.c_char_p, ct.c_uint,
+        ct.c_char_p]
 lib.bpf_module_create_c.restype = ct.c_void_p
 lib.bpf_module_create_c.argtypes = [ct.c_char_p, ct.c_uint,
-        ct.POINTER(ct.c_char_p), ct.c_int, ct.c_bool]
+        ct.POINTER(ct.c_char_p), ct.c_int, ct.c_bool, ct.c_char_p]
 lib.bpf_module_create_c_from_string.restype = ct.c_void_p
 lib.bpf_module_create_c_from_string.argtypes = [ct.c_char_p, ct.c_uint,
-        ct.POINTER(ct.c_char_p), ct.c_int, ct.c_bool]
+        ct.POINTER(ct.c_char_p), ct.c_int, ct.c_bool, ct.c_char_p]
 lib.bpf_module_destroy.restype = None
 lib.bpf_module_destroy.argtypes = [ct.c_void_p]
 lib.bpf_module_license.restype = ct.c_char_p

--- a/tests/cc/test_static.c
+++ b/tests/cc/test_static.c
@@ -1,6 +1,6 @@
 #include "bcc_common.h"
 
 int main(int argc, char **argv) {
-  void *mod = bpf_module_create_c_from_string("BPF_TABLE(\"array\", int, int, stats, 10);\n", 4, NULL, 0, true);
+  void *mod = bpf_module_create_c_from_string("BPF_TABLE(\"array\", int, int, stats, 10);\n", 4, NULL, 0, true, NULL);
   return !(mod != NULL);
 }


### PR DESCRIPTION
This pull request implements hardware offload support in bcc.

To offload maps and programs to the device, `map_ifindex` (for `bpf$BPF_MAP_CREATE`) and `prog_ifindex` (`bpf$BPF_PROG_LOAD`) need to be set to the index of the network interface at creation time. This support requires a number of changes, some **breaking to the bcc APIs**.

Changes to the Python methods `load_func` and `BPF` are backward-compatible. Changes to `bpf_module_create_b`, `bpf_module_create_c`, `bpf_module_create_c_from_string`, and `bcc_func_load`, and `BPFModule::BPFModule` are not. I'm not sure which of these we want to avoid or there's a better way; I'm opening this pull request to start the discussion.

I've also updated the `xdp_drop_count.py` example to support hardware offload with the new `-H device` option.