### PR TITLE
support gcc 8's cold subfunctions

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -576,7 +576,7 @@ class BPF(object):
                 elif fn.startswith(b'__perf') or fn.startswith(b'perf_'):
                     continue
                 # Exclude all gcc 8's extra .cold functions
-                elif re.match(b'^.*\.cold\.\d+$', fn):
+                elif re.match(b'^.*\.cold(\.\d+)?$', fn):
                     continue
                 if (t.lower() in [b't', b'w']) and re.match(event_re, fn) \
                     and fn not in blacklist:


### PR DESCRIPTION
GCC 8 can split functions bodies into hot and cold regions, causing extra symbols with a ".cold" or ".cold.N" suffix to be emitted. Extra symbols with suffix ".cold.N" were already excluded. This PR excludes also symbols with the suffix ".cold".