### PR TITLE
Add cgroup support for attach_kprobe()

### DIFF
--- a/examples/cpp/CPUDistribution.cc
+++ b/examples/cpp/CPUDistribution.cc
@@ -66,18 +66,20 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  int probe_time = 10;
+  if (argc >= 2) {
+    probe_time = atoi(argv[1]);
+  }
+
+  std::string path{argc > 2 ? argv[2] : ""};
   auto attach_res =
-      bpf.attach_kprobe("finish_task_switch", "task_switch_event");
+      bpf.attach_kprobe_cgroup("finish_task_switch", "task_switch_event", path);
   if (attach_res.code() != 0) {
     std::cerr << attach_res.msg() << std::endl;
     return 1;
   }
 
-  int probe_time = 10;
-  if (argc == 2) {
-    probe_time = atoi(argv[1]);
-  }
-  std::cout << "Probing for " << probe_time << " seconds" << std::endl;
+  std::cout << "Probing for " << probe_time << " seconds, cgroup: " << path << std::endl;
   sleep(probe_time);
 
   auto table = bpf.get_hash_table<int, uint64_t>("cpu_time");

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -64,8 +64,19 @@ class BPF {
   StatusTuple attach_kprobe(const std::string& kernel_func,
                             const std::string& probe_func,
                             uint64_t kernel_func_offset = 0,
-                            bpf_probe_attach_type = BPF_PROBE_ENTRY,
-                            int maxactive = 0);
+                            bpf_probe_attach_type type = BPF_PROBE_ENTRY,
+                            int maxactive = 0) {
+    return attach_kprobe_(kernel_func, probe_func, "", kernel_func_offset, type, maxactive);
+  }
+
+  StatusTuple attach_kprobe_cgroup(const std::string& kernel_func,
+                            const std::string& probe_func,
+                            const std::string& cgroup_name,
+                            uint64_t kernel_func_offset = 0,
+                            bpf_probe_attach_type type = BPF_PROBE_ENTRY,
+                            int maxactive = 0) {
+    return attach_kprobe_(kernel_func, probe_func, cgroup_name, kernel_func_offset, type, maxactive);
+  }
   StatusTuple detach_kprobe(
       const std::string& kernel_func,
       bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY);
@@ -197,6 +208,12 @@ class BPF {
   int free_bcc_memory();
 
  private:
+  StatusTuple attach_kprobe_(const std::string& kernel_func,
+                             const std::string& probe_func,
+                             const std::string& cgroup_name,
+                             uint64_t kernel_func_offset = 0,
+                             bpf_probe_attach_type = BPF_PROBE_ENTRY,
+                             int maxactive = 0);
   std::string get_kprobe_event(const std::string& kernel_func,
                                bpf_probe_attach_type type);
   std::string get_uprobe_event(const std::string& binary_path, uint64_t offset,

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -80,7 +80,7 @@ typedef void (*perf_reader_lost_cb)(void *cb_cookie, uint64_t lost);
 
 int bpf_attach_kprobe(int progfd, enum bpf_probe_attach_type attach_type,
                       const char *ev_name, const char *fn_name, uint64_t fn_offset,
-                      int maxactive);
+                      int maxactive, int cgroup_fd);
 int bpf_detach_kprobe(const char *ev_name);
 
 int bpf_attach_uprobe(int progfd, enum bpf_probe_attach_type attach_type,


### PR DESCRIPTION
Close issue #2510

Test cases:
1. taskset -c 1,2 stress -c 2
2. mkdir /sys/fs/cgroup/perf_event/test && echo `pidof stress` > /sys/fs/cgroup/perf_event/test/tasks
3. `./examples/cpp/CPUDistribution 10 test` should only see activities on one CPU