### PR TITLE
Fixes #2518 -- weird behaviour of lookup_or_init

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -767,7 +767,7 @@ Examples in situ:
 
 Syntax: ```*val map.lookup_or_init(&key, &zero)```
 
-Lookup the key in the map, and return a pointer to its value if it exists, else initialize the key's value to the second argument. This is often used to initialize values to zero.
+Lookup the key in the map, and return a pointer to its value if it exists, else initialize the key's value to the second argument. This is often used to initialize values to zero. If the key cannot be inserted (e.g. the map is full) then NULL is returned.
 
 Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=lookup_or_init+path%3Aexamples&type=Code),

--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -559,7 +559,9 @@ int count(struct pt_regs *ctx) {
     bpf_probe_read(&key.c, sizeof(key.c), (void *)PT_REGS_PARM1(ctx));
     // could also use `counts.increment(key)`
     val = counts.lookup_or_init(&key, &zero);
-    (*val)++;
+    if (val) {
+      (*val)++;
+    }
     return 0;
 };
 """)
@@ -678,7 +680,9 @@ int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
 
     // could also use `stats.increment(key);`
     val = stats.lookup_or_init(&key, &zero);
-    (*val)++;
+    if (val) {
+      (*val)++;
+    }
     return 0;
 }
 ```

--- a/examples/cpp/LLCStat.cc
+++ b/examples/cpp/LLCStat.cc
@@ -43,7 +43,9 @@ int on_cache_miss(struct bpf_perf_event_data *ctx) {
 
     u64 zero = 0, *val;
     val = miss_count.lookup_or_init(&key, &zero);
-    (*val) += ctx->sample_period;
+    if (val) {
+        (*val) += ctx->sample_period;
+    }
 
     return 0;
 }
@@ -54,7 +56,9 @@ int on_cache_ref(struct bpf_perf_event_data *ctx) {
 
     u64 zero = 0, *val;
     val = ref_count.lookup_or_init(&key, &zero);
-    (*val) += ctx->sample_period;
+    if (val) {
+        (*val) += ctx->sample_period;
+    }
 
     return 0;
 }

--- a/examples/cpp/TCPSendStack.cc
+++ b/examples/cpp/TCPSendStack.cc
@@ -39,7 +39,9 @@ int on_tcp_send(struct pt_regs *ctx) {
 
   u64 zero = 0, *val;
   val = counts.lookup_or_init(&key, &zero);
-  (*val)++;
+  if (val) {
+    (*val)++;
+  }
 
   return 0;
 }

--- a/examples/cpp/UseExternalMap.cc
+++ b/examples/cpp/UseExternalMap.cc
@@ -56,7 +56,9 @@ int on_sched_switch(struct tracepoint__sched__sched_switch *args) {
   __builtin_memcpy(&key.prev_comm, args->prev_comm, 16);
   __builtin_memcpy(&key.next_comm, args->next_comm, 16);
   val = counts.lookup_or_init(&key, &zero);
-  (*val)++;
+  if (val) {
+    (*val)++;
+  }
 
   return 0;
 }

--- a/examples/lua/offcputime.lua
+++ b/examples/lua/offcputime.lua
@@ -65,7 +65,9 @@ int oncpu(struct pt_regs *ctx, struct task_struct *prev) {
     key.stack_id = stack_traces.get_stackid(ctx, stack_flags);
 
     val = counts.lookup_or_init(&key, &zero);
-    (*val) += delta;
+    if (val) {
+        (*val) += delta;
+    }
     return 0;
 }
 ]]

--- a/examples/lua/task_switch.lua
+++ b/examples/lua/task_switch.lua
@@ -33,7 +33,9 @@ int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
   key.prev_pid = prev->pid;
 
   val = stats.lookup_or_init(&key, &zero);
-  (*val)++;
+  if (val) {
+    (*val)++;
+  }
   return 0;
 }
 ]]

--- a/examples/networking/distributed_bridge/tunnel.c
+++ b/examples/networking/distributed_bridge/tunnel.c
@@ -38,7 +38,9 @@ int handle_ingress(struct __sk_buff *skb) {
     struct vni_key vk = {ethernet->src, *ifindex, 0};
     struct host *src_host = mac2host.lookup_or_init(&vk,
         &(struct host){tkey.tunnel_id, tkey.remote_ipv4, 0, 0});
-    lock_xadd(&src_host->rx_pkts, 1);
+    if (src_host) {
+      lock_xadd(&src_host->rx_pkts, 1);
+    }
     bpf_clone_redirect(skb, *ifindex, 1/*ingress*/);
   } else {
     bpf_trace_printk("ingress invalid tunnel_id=%d\n", tkey.tunnel_id);

--- a/examples/networking/tunnel_monitor/monitor.c
+++ b/examples/networking/tunnel_monitor/monitor.c
@@ -126,12 +126,14 @@ finish:
     swap_ipkey(&key);
   struct counters zleaf = {0};
   struct counters *leaf = stats.lookup_or_init(&key, &zleaf);
-  if (is_ingress) {
-    lock_xadd(&leaf->rx_pkts, 1);
-    lock_xadd(&leaf->rx_bytes, skb->len);
-  } else {
-    lock_xadd(&leaf->tx_pkts, 1);
-    lock_xadd(&leaf->tx_bytes, skb->len);
+  if (leaf) {
+    if (is_ingress) {
+      lock_xadd(&leaf->rx_pkts, 1);
+      lock_xadd(&leaf->rx_bytes, skb->len);
+    } else {
+      lock_xadd(&leaf->tx_pkts, 1);
+      lock_xadd(&leaf->tx_bytes, skb->len);
+    }
   }
   return 1;
 }

--- a/examples/networking/vlan_learning/vlan_learning.c
+++ b/examples/networking/vlan_learning/vlan_learning.c
@@ -33,10 +33,12 @@ int handle_phys2virt(struct __sk_buff *skb) {
       int out_ifindex = leaf->out_ifindex;
       struct ifindex_leaf_t zleaf = {0};
       struct ifindex_leaf_t *out_leaf = egress.lookup_or_init(&out_ifindex, &zleaf);
-      // to capture potential configuration changes
-      out_leaf->out_ifindex = skb->ifindex;
-      out_leaf->vlan_tci = skb->vlan_tci;
-      out_leaf->vlan_proto = skb->vlan_proto;
+      if (out_leaf) {
+	// to capture potential configuration changes
+	out_leaf->out_ifindex = skb->ifindex;
+	out_leaf->vlan_tci = skb->vlan_tci;
+	out_leaf->vlan_proto = skb->vlan_proto;
+      }
       // pop the vlan header and send to the destination
       bpf_skb_vlan_pop(skb);
       bpf_clone_redirect(skb, leaf->out_ifindex, 0);

--- a/examples/tracing/mallocstacks.py
+++ b/examples/tracing/mallocstacks.py
@@ -47,7 +47,9 @@ int alloc_enter(struct pt_regs *ctx, size_t size) {
     // could also use `calls.increment(key, size);`
     u64 zero = 0, *val;
     val = calls.lookup_or_init(&key, &zero);
-    (*val) += size;
+    if (val) {
+      (*val) += size;
+    }
     return 0;
 };
 """)

--- a/examples/tracing/strlen_count.py
+++ b/examples/tracing/strlen_count.py
@@ -34,7 +34,9 @@ int count(struct pt_regs *ctx) {
     bpf_probe_read(&key.c, sizeof(key.c), (void *)PT_REGS_PARM1(ctx));
     // could also use `counts.increment(key)`
     val = counts.lookup_or_init(&key, &zero);
-    (*val)++;
+    if (val) {
+      (*val)++;
+    }
     return 0;
 };
 """)

--- a/examples/tracing/task_switch.c
+++ b/examples/tracing/task_switch.c
@@ -16,6 +16,8 @@ int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
 
     // could also use `stats.increment(key);`
     val = stats.lookup_or_init(&key, &zero);
-    (*val)++;
+    if (val) {
+        (*val)++;
+    }
     return 0;
 }

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -782,7 +782,6 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           txt += "if (!leaf) {";
           txt += " " + update + ", " + arg0 + ", " + arg1 + ", BPF_NOEXIST);";
           txt += " leaf = " + lookup + ", " + arg0 + ");";
-          txt += " if (!leaf) return 0;";
           txt += "}";
           txt += "leaf;})";
         } else if (memb_name == "increment") {

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -89,7 +89,7 @@ lib.bpf_attach_socket.restype = ct.c_int
 lib.bpf_attach_socket.argtypes = [ct.c_int, ct.c_int]
 lib.bcc_func_load.restype = ct.c_int
 lib.bcc_func_load.argtypes = [ct.c_void_p, ct.c_int, ct.c_char_p, ct.c_void_p,
-        ct.c_size_t, ct.c_char_p, ct.c_uint, ct.c_int, ct.c_char_p, ct.c_uint]
+        ct.c_size_t, ct.c_char_p, ct.c_uint, ct.c_int, ct.c_char_p, ct.c_uint, ct.c_char_p]
 _RAW_CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_void_p, ct.c_int)
 _LOST_CB_TYPE = ct.CFUNCTYPE(None, ct.py_object, ct.c_ulonglong)
 lib.bpf_attach_kprobe.restype = ct.c_int

--- a/tests/cc/test_bpf_table.cc
+++ b/tests/cc/test_bpf_table.cc
@@ -182,7 +182,9 @@ TEST_CASE("test bpf stack table", "[bpf_stack_table]") {
       int stack_id = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
       int zero = 0, *val;
       val = id.lookup_or_init(&zero, &stack_id);
-      (*val) = stack_id;
+      if (val) {
+        (*val) = stack_id;
+      }
 
       return 0;
     }
@@ -233,7 +235,9 @@ TEST_CASE("test bpf stack_id table", "[bpf_stack_table]") {
       int stack_id = stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
       int zero = 0, *val;
       val = id.lookup_or_init(&zero, &stack_id);
-      (*val) = stack_id;
+      if (val) {
+        (*val) = stack_id;
+      }
 
       return 0;
     }

--- a/tests/lua/test_clang.lua
+++ b/tests/lua/test_clang.lua
@@ -244,7 +244,9 @@ int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
   key.prev_pid = prev->pid;
 
   val = stats.lookup_or_init(&key, &zero);
-  (*val)++;
+  if (val) {
+    (*val)++;
+  }
   return 0;
 }
 ]]}

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -397,7 +397,9 @@ int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
   key.prev_pid = prev->pid;
 
   val = stats.lookup_or_init(&key, &zero);
-  (*val)++;
+  if (val) {
+    (*val)++;
+  }
   return 0;
 }
 """)

--- a/tests/python/test_license.py
+++ b/tests/python/test_license.py
@@ -43,7 +43,9 @@ int license_program(struct pt_regs *ctx) {
     bpf_get_current_comm(&(key.comm), 16);
 
     val = counts.lookup_or_init(&key, &zero);  // update counter
-    (*val)++;
+    if (val) {
+        (*val)++;
+    }
     return 0;
 }
 """

--- a/tests/python/test_lru.py
+++ b/tests/python/test_lru.py
@@ -27,7 +27,9 @@ class TestLru(unittest.TestCase):
             u32 key=0;
             u32 value = 0, *val;
             val = stats.lookup_or_init(&key, &value);
-            *val += 1;
+            if (val) {
+                *val += 1;
+            }
             return 0;
         }
         """

--- a/tests/python/test_percpu.py
+++ b/tests/python/test_percpu.py
@@ -30,7 +30,9 @@ class TestPercpu(unittest.TestCase):
             u32 key=0;
             u64 value = 0, *val;
             val = stats.lookup_or_init(&key, &value);
-            *val += 1;
+            if (val) {
+                *val += 1;
+            }
             return 0;
         }
         """
@@ -60,7 +62,9 @@ class TestPercpu(unittest.TestCase):
             u32 key=0;
             u32 value = 0, *val;
             val = stats.lookup_or_init(&key, &value);
-            *val += 1;
+            if (val) {
+                *val += 1;
+            }
             return 0;
         }
         """
@@ -94,8 +98,10 @@ class TestPercpu(unittest.TestCase):
             u32 key=0;
             counter value = {0,0}, *val;
             val = stats.lookup_or_init(&key, &value);
-            val->c1 += 1;
-            val->c2 += 1;
+            if (val) {
+                val->c1 += 1;
+                val->c2 += 1;
+            }
             return 0;
         }
         """

--- a/tests/python/test_stat1.c
+++ b/tests/python/test_stat1.c
@@ -48,8 +48,10 @@ int on_packet(struct __sk_buff *skb) {
     }
     struct IPLeaf zleaf = {0};
     struct IPLeaf *leaf = stats.lookup_or_init(&key, &zleaf);
-    lock_xadd(&leaf->rx_pkts, rx);
-    lock_xadd(&leaf->tx_pkts, tx);
+    if (leaf) {
+      lock_xadd(&leaf->rx_pkts, rx);
+      lock_xadd(&leaf->tx_pkts, tx);
+    }
   }
 
 EOP:

--- a/tests/python/test_trace2.c
+++ b/tests/python/test_trace2.c
@@ -8,6 +8,9 @@ BPF_HASH(stats, struct Ptr, struct Counters, 1024);
 int count_sched(struct pt_regs *ctx) {
   struct Ptr key = {.ptr = PT_REGS_PARM1(ctx)};
   struct Counters zleaf = {0};
-  stats.lookup_or_init(&key, &zleaf)->stat1++;
+  struct Counters *val = stats.lookup_or_init(&key, &zleaf);
+  if (val) {
+    val->stat1++;
+  }
   return 0;
 }

--- a/tests/python/test_trace2.py
+++ b/tests/python/test_trace2.py
@@ -19,7 +19,10 @@ int count_sched(struct pt_regs *ctx) {
   struct Counters zleaf;
 
   memset(&zleaf, 0, sizeof(zleaf));
-  stats.lookup_or_init(&key, &zleaf)->stat1++;
+  struct Counters *val = stats.lookup_or_init(&key, &zleaf);
+  if (val) {
+    val->stat1++;
+  }
   return 0;
 }
 """

--- a/tests/python/test_trace3.c
+++ b/tests/python/test_trace3.c
@@ -48,6 +48,8 @@ int probe_blk_update_request(struct pt_regs *ctx) {
 
   u64 zero = 0;
   u64 *val = latency.lookup_or_init(&index, &zero);
-  lock_xadd(val, 1);
+  if (val) {
+    lock_xadd(val, 1);
+  }
   return 0;
 }

--- a/tests/python/test_trace4.py
+++ b/tests/python/test_trace4.py
@@ -14,14 +14,14 @@ class TestKprobeRgx(TestCase):
         typedef struct { u64 val; } Val;
         BPF_HASH(stats, Key, Val, 3);
         int hello(void *ctx) {
-          Val val = stats.lookup_or_init(&(Key){1}, &(Val){0});
+          Val *val = stats.lookup_or_init(&(Key){1}, &(Val){0});
           if (val) {
             val->val++;
           }
           return 0;
         }
         int goodbye(void *ctx) {
-          Val val = stats.lookup_or_init(&(Key){2}, &(Val){0});
+          Val *val = stats.lookup_or_init(&(Key){2}, &(Val){0});
           if (val) {
             val->val++;
           }

--- a/tests/python/test_trace4.py
+++ b/tests/python/test_trace4.py
@@ -14,11 +14,17 @@ class TestKprobeRgx(TestCase):
         typedef struct { u64 val; } Val;
         BPF_HASH(stats, Key, Val, 3);
         int hello(void *ctx) {
-          stats.lookup_or_init(&(Key){1}, &(Val){0})->val++;
+          Val val = stats.lookup_or_init(&(Key){1}, &(Val){0});
+          if (val) {
+            val->val++;
+          }
           return 0;
         }
         int goodbye(void *ctx) {
-          stats.lookup_or_init(&(Key){2}, &(Val){0})->val++;
+          Val val = stats.lookup_or_init(&(Key){2}, &(Val){0});
+          if (val) {
+            val->val++;
+          }
           return 0;
         }
         """)

--- a/tests/python/test_trace_maxactive.py
+++ b/tests/python/test_trace_maxactive.py
@@ -14,11 +14,17 @@ class TestKprobeMaxactive(TestCase):
         typedef struct { u64 val; } Val;
         BPF_HASH(stats, Key, Val, 3);
         int hello(void *ctx) {
-          stats.lookup_or_init(&(Key){1}, &(Val){0})->val++;
+          struct Val val = stats.lookup_or_init(&(Key){1}, &(Val){0});
+          if (val) {
+            val->val++;
+          }
           return 0;
         }
         int goodbye(void *ctx) {
-          stats.lookup_or_init(&(Key){2}, &(Val){0})->val++;
+          struct Val val = stats.lookup_or_init(&(Key){2}, &(Val){0});
+          if (val) {
+            val->val++;
+          }
           return 0;
         }
         """)

--- a/tests/python/test_trace_maxactive.py
+++ b/tests/python/test_trace_maxactive.py
@@ -14,14 +14,14 @@ class TestKprobeMaxactive(TestCase):
         typedef struct { u64 val; } Val;
         BPF_HASH(stats, Key, Val, 3);
         int hello(void *ctx) {
-          struct Val val = stats.lookup_or_init(&(Key){1}, &(Val){0});
+          Val *val = stats.lookup_or_init(&(Key){1}, &(Val){0});
           if (val) {
             val->val++;
           }
           return 0;
         }
         int goodbye(void *ctx) {
-          struct Val val = stats.lookup_or_init(&(Key){2}, &(Val){0});
+          Val *val = stats.lookup_or_init(&(Key){2}, &(Val){0});
           if (val) {
             val->val++;
           }

--- a/tests/python/test_tracepoint.py
+++ b/tests/python/test_tracepoint.py
@@ -29,7 +29,9 @@ class TestTracepoint(unittest.TestCase):
             u64 val = 0;
             u32 pid = args->next_pid;
             u64 *existing = switches.lookup_or_init(&pid, &val);
-            (*existing)++;
+            if (existing) {
+                (*existing)++;
+            }
             return 0;
         }
         """
@@ -53,8 +55,10 @@ class TestTracepointDataLoc(unittest.TestCase):
             char fn[64];
             u32 pid = args->pid;
             struct value_t *existing = execs.lookup_or_init(&pid, &val);
-            TP_DATA_LOC_READ_CONST(fn, filename, 64);
-            __builtin_memcpy(existing->filename, fn, 64);
+            if (existing) {
+                TP_DATA_LOC_READ_CONST(fn, filename, 64);
+                __builtin_memcpy(existing->filename, fn, 64);
+            }
             return 0;
         }
         """

--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -8,7 +8,7 @@ name=$1; shift
 kind=$1; shift
 cmd=$1; shift
 
-PYTHONPATH=@CMAKE_BINARY_DIR@/src/python
+PYTHONPATH=@CMAKE_BINARY_DIR@/src/python/bcc-python
 LD_LIBRARY_PATH=@CMAKE_BINARY_DIR@:@CMAKE_BINARY_DIR@/src/cc
 
 ns=$name

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -155,10 +155,12 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
         valp = counts.lookup_or_init(&info, &zero);
     }
 
-    // save stats
-    valp->us += delta_us;
-    valp->bytes += req->__data_len;
-    valp->io++;
+    if (valp) {
+        // save stats
+        valp->us += delta_us;
+        valp->bytes += req->__data_len;
+        valp->io++;
+    }
 
     start.delete(&req);
     whobyreq.delete(&req);

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -119,12 +119,14 @@ static int do_entry(struct pt_regs *ctx, struct file *file,
 
     struct val_t *valp, zero = {};
     valp = counts.lookup_or_init(&info, &zero);
-    if (is_read) {
-        valp->reads++;
-        valp->rbytes += count;
-    } else {
-        valp->writes++;
-        valp->wbytes += count;
+    if (valp) {
+        if (is_read) {
+            valp->reads++;
+            valp->rbytes += count;
+        } else {
+            valp->writes++;
+            valp->wbytes += count;
+        }
     }
 
     return 0;

--- a/tools/lib/ucalls.py
+++ b/tools/lib/ucalls.py
@@ -164,7 +164,9 @@ int trace_entry(struct pt_regs *ctx) {
                    (void *)method);
 #ifndef LATENCY
     valp = counts.lookup_or_init(&data.method, &val);
-    ++(*valp);
+    if (valp) {
+        ++(*valp);
+    }
 #endif
 #ifdef LATENCY
     entry.update(&data, &timestamp);
@@ -189,8 +191,10 @@ int trace_return(struct pt_regs *ctx) {
         return 0;   // missed the entry event
     }
     info = times.lookup_or_init(&data.method, &zero);
-    info->num_calls += 1;
-    info->total_ns += bpf_ktime_get_ns() - *entry_timestamp;
+    if (info) {
+        info->num_calls += 1;
+        info->total_ns += bpf_ktime_get_ns() - *entry_timestamp;
+    }
     entry.delete(&data);
     return 0;
 }
@@ -210,7 +214,9 @@ TRACEPOINT_PROBE(raw_syscalls, sys_enter) {
 #endif
 #ifndef LATENCY
     valp = syscounts.lookup_or_init(&id, &val);
-    ++(*valp);
+    if (valp) {
+        ++(*valp);
+    }
 #endif
     return 0;
 }
@@ -227,8 +233,10 @@ TRACEPOINT_PROBE(raw_syscalls, sys_exit) {
     }
     id = e->id;
     info = systimes.lookup_or_init(&id, &zero);
-    info->num_calls += 1;
-    info->total_ns += bpf_ktime_get_ns() - e->timestamp;
+    if (info) {
+        info->num_calls += 1;
+        info->total_ns += bpf_ktime_get_ns() - e->timestamp;
+    }
     sysentry.delete(&pid);
     return 0;
 }

--- a/tools/lib/uflow.py
+++ b/tools/lib/uflow.py
@@ -89,6 +89,9 @@ int NAME(struct pt_regs *ctx) {
 
     data.pid = bpf_get_current_pid_tgid();
     depth = entry.lookup_or_init(&data.pid, &zero);
+    if (!depth) {
+        depth = &zero;
+    }
     data.depth = DEPTH;
     UPDATE
 

--- a/tools/lib/uobjnew.py
+++ b/tools/lib/uobjnew.py
@@ -80,8 +80,10 @@ int alloc_entry(struct pt_regs *ctx, size_t size) {
     struct val_t *valp, zero = {};
     key.size = size;
     valp = allocs.lookup_or_init(&key, &zero);
-    valp->total_size += size;
-    valp->num_allocs += 1;
+    if (valp) {
+        valp->total_size += size;
+        valp->num_allocs += 1;
+    }
     return 0;
 }
     """
@@ -98,8 +100,10 @@ int alloc_entry(struct pt_regs *ctx) {
     bpf_usdt_readarg(4, ctx, &size);
     bpf_probe_read(&key.name, sizeof(key.name), (void *)classptr);
     valp = allocs.lookup_or_init(&key, &zero);
-    valp->total_size += size;
-    valp->num_allocs += 1;
+    if (valp) {
+        valp->total_size += size;
+        valp->num_allocs += 1;
+    }
     return 0;
 }
     """
@@ -115,8 +119,10 @@ int THETHING_alloc_entry(struct pt_regs *ctx) {
     u64 size = 0;
     bpf_usdt_readarg(1, ctx, &size);
     valp = allocs.lookup_or_init(&key, &zero);
-    valp->total_size += size;
-    valp->num_allocs += 1;
+    if (valp) {
+        valp->total_size += size;
+        valp->num_allocs += 1;
+    }
     return 0;
 }
     """
@@ -128,7 +134,9 @@ int object_alloc_entry(struct pt_regs *ctx) {
     bpf_usdt_readarg(1, ctx, &classptr);
     bpf_probe_read(&key.name, sizeof(key.name), (void *)classptr);
     valp = allocs.lookup_or_init(&key, &zero);
-    valp->num_allocs += 1;  // We don't know the size, unfortunately
+    if (valp) {
+        valp->num_allocs += 1;  // We don't know the size, unfortunately
+    }
     return 0;
 }
     """
@@ -146,7 +154,9 @@ int alloc_entry(struct pt_regs *ctx) {
     struct key_t key = { .name = "<ALL>" };
     struct val_t *valp, zero = {};
     valp = allocs.lookup_or_init(&key, &zero);
-    valp->num_allocs += 1;
+    if (valp) {
+        valp->num_allocs += 1;
+    }
     return 0;
 }
     """

--- a/tools/lib/ustat.py
+++ b/tools/lib/ustat.py
@@ -94,7 +94,9 @@ int %s_%s(void *ctx) {
     u64 *valp, zero = 0;
     u32 tgid = bpf_get_current_pid_tgid() >> 32;
     valp = %s_%s_counts.lookup_or_init(&tgid, &zero);
-    ++(*valp);
+    if (valp) {
+        ++(*valp);
+    }
     return 0;
 }
         """

--- a/tools/old/offcputime.py
+++ b/tools/old/offcputime.py
@@ -141,7 +141,9 @@ int oncpu(struct pt_regs *ctx, struct task_struct *prev) {
 
 out:
     val = counts.lookup_or_init(&key, &zero);
-    (*val) += delta;
+    if (val) {
+        (*val) += delta;
+    }
     return 0;
 }
 """

--- a/tools/old/offwaketime.py
+++ b/tools/old/offwaketime.py
@@ -189,7 +189,9 @@ out:
     }
 
     val = counts.lookup_or_init(&key, &zero);
-    (*val) += delta;
+    if (val) {
+        (*val) += delta;
+    }
     return 0;
 }
 """

--- a/tools/old/profile.py
+++ b/tools/old/profile.py
@@ -185,7 +185,9 @@ PERF_TRACE_EVENT {
     }
 
     val = counts.lookup_or_init(&key, &zero);
-    (*val)++;
+    if (val) {
+        (*val)++;
+    }
     return 0;
 }
 """

--- a/tools/old/softirqs.py
+++ b/tools/old/softirqs.py
@@ -147,7 +147,7 @@ else:
     bpf_text = bpf_text.replace('STORE',
         ' .ip = ip, .slot = 0 /* ignore */};' +
         'u64 zero = 0, *vp = dist.lookup_or_init(&key, &zero);' +
-        '(*vp) += delta;')
+        'if (vp) { (*vp) += delta; }')
 if debug:
     print(bpf_text)
 

--- a/tools/old/stackcount.py
+++ b/tools/old/stackcount.py
@@ -118,7 +118,9 @@ int trace_count(struct pt_regs *ctx) {
 
 out:
     val = counts.lookup_or_init(&key, &zero);
-    (*val)++;
+    if (val) {
+        (*val)++;
+    }
     return 0;
 }
 """

--- a/tools/old/wakeuptime.py
+++ b/tools/old/wakeuptime.py
@@ -154,7 +154,9 @@ int waker(struct pt_regs *ctx, struct task_struct *p) {
 
 out:
     val = counts.lookup_or_init(&key, &zero);
-    (*val) += delta;
+    if (val) {
+        (*val) += delta;
+    }
     return 0;
 }
 """

--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -92,8 +92,10 @@ int kprobe__kmem_cache_alloc(struct pt_regs *ctx, struct kmem_cache *cachep)
 
     struct val_t *valp, zero = {};
     valp = counts.lookup_or_init(&info, &zero);
-    valp->count++;
-    valp->size += cachep->size;
+    if (valp) {
+        valp->count++;
+        valp->size += cachep->size;
+    }
 
     return 0;
 }

--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -133,12 +133,16 @@ TRACEPOINT_PROBE(raw_syscalls, sys_exit) {
         return 0;
 
     val = data.lookup_or_init(&key, &zero);
-    val->count++;
-    val->total_ns += bpf_ktime_get_ns() - *start_ns;
+    if (val) {
+        val->count++;
+        val->total_ns += bpf_ktime_get_ns() - *start_ns;
+    }
 #else
     u64 *val, zero = 0;
     val = data.lookup_or_init(&key, &zero);
-    ++(*val);
+    if (val) {
+        ++(*val);
+    }
 #endif
     return 0;
 }


### PR DESCRIPTION
This changes the behaviour of `map.lookup_or_init` so that it returns 0 if the entry is not found *and* it cannot be inserted (e.g. the map is full). #2518 

Documentation updated. Also, all tests and sample code updated.

During testing, found two errors in test setup -- one was a mismatch between a function prototype and the libbcc python definition, and the other was an incorrect python path in the test wrapper. 

I can't actually get all the tests to pass on my platform -- but the same set of tests fail on master, so I'm not unduly worried. I didn't understand the test failures -- but they look like a failure to setup the test environment.