### PR TITLE
FAQ: fix error message

### DIFF
--- a/FAQ.txt
+++ b/FAQ.txt
@@ -11,7 +11,7 @@ A: make sure to 'make install' and add the directory
    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 Q: hello_world.py fails with:
-   ImportError: No module named bpf
+   ImportError: No module named bcc
 A: checkout "sudo make install" output to find out bpf package installation site,
    add it to the PYTHONPATH env variable before running the program.
    sudo bash -c 'PYTHONPATH=/usr/lib/python2.7/site-packages python examples/hello_world.py'


### PR DESCRIPTION
Just a quick fix for a thing I noticed while reading the FAQ and trying things out...

The package is called bcc, and not bpf:

```
    from bcc import BPF
```

If that is not available then the error message thrown by the Python interpreter reads

```
    ModuleNotFoundError: No module named 'bcc'
```

and not `No module named 'bpf'`, as currently indicated by the FAQ.