### PR TITLE
INSTALL.md: add install instructions for Fedora 30+

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -105,6 +105,17 @@ sudo apt-get install bcc-tools libbcc-examples linux-headers-$(uname -r)
 
 ## Fedora - Binary
 
+### Fedora 30 and newer
+
+As of Fedora 30, bcc binaries are available in the standard repository.
+You can install them via
+
+```bash
+sudo dnf install bcc
+```
+
+### Fedora 29 and older
+
 Ensure that you are running a 4.2+ kernel with `uname -r`. If not, install a 4.2+ kernel from
 http://alt.fedoraproject.org/pub/alt/rawhide-kernel-nodebug, for example:
 


### PR DESCRIPTION
Wow! Fedora 30 has bcc binaries in its standard repo. Having this documented in INSTALL.md would have saved me some hassle, so here I am adding it for others... :-)