### PR TITLE
Fix a file descriptor leak when module is deleted

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1355,6 +1355,8 @@ class BPF(object):
         if self.tracefile:
             self.tracefile.close()
             self.tracefile = None
+        for name, fn in list(self.funcs.items()):
+            os.close(fn.fd)
         if self.module:
             lib.bpf_module_destroy(self.module)
             self.module = None


### PR DESCRIPTION
Fix issue #989

When module is cleaned up, let us also close all bpf program
file descriptors to avoid fd leaking.

Signed-off-by: Yonghong Song <yhs@fb.com>