### PR TITLE
FAQ: Add Q&A about kernel lockdown

### DIFF
--- a/FAQ.txt
+++ b/FAQ.txt
@@ -21,6 +21,15 @@ Q: hello_world.py still fails with:
    Exception: Failed to load BPF program hello
 A: sudo
 
+Q: hello_world.py fails with
+   bpf: Failed to load program: Operation not permitted
+   despite running as root, and strace shows each `bpf()` system call failing with an EPERM.
+A: The so-called Kernel lockdown might be the root cause. Try disabling it with the so-called
+   sysrq mechanism:
+       echo 1 > /proc/sys/kernel/sysrq
+       echo x > /proc/sysrq-trigger
+   Also see https://github.com/iovisor/bcc/issues/2525
+
 Q: How do I fulfill the Linux kernel version requirement?
 A: You need to obtain a recent version of the Linux source code
    (please look at the README for the exact version), enable the


### PR DESCRIPTION
The problem described in https://github.com/iovisor/bcc/issues/2525, where `bfp()` system calls failed with EPERM, was solved by lifting the kernel lockdown. Thanks to @deg00 for telling us. This adds a corresponding FAQ entry.