### PR TITLE
Fix Erroneous "gethostlatency" Comments

### DIFF
--- a/tools/gethostlatency.py
+++ b/tools/gethostlatency.py
@@ -21,7 +21,7 @@ from time import strftime
 import argparse
 
 examples = """examples:
-    ./gethostlatency           # trace all TCP accept()s
+    ./gethostlatency           # time getaddrinfo/gethostbyname[2] calls
     ./gethostlatency -p 181    # only trace PID 181
 """
 parser = argparse.ArgumentParser(

--- a/tools/gethostlatency_example.txt
+++ b/tools/gethostlatency_example.txt
@@ -33,5 +33,5 @@ optional arguments:
   -p PID, --pid PID  trace this PID only
 
 examples:
-    ./gethostlatency           # trace all TCP accept()s
+    ./gethostlatency           # time getaddrinfo/gethostbyname[2] calls
     ./gethostlatency -p 181    # only trace PID 181


### PR DESCRIPTION
Was taking a look around earlier and noticed there was a copied comment from tcpaccept.py in gethostlatency.py. Figured would PR a fixed comment.