### PR TITLE
support cgroup level tracing in trace.py

### DIFF
--- a/man/man8/trace.8
+++ b/man/man8/trace.8
@@ -55,6 +55,9 @@ Print the time column.
 \-C
 Print CPU id.
 .TP
+\-c CGROUP_PATH
+Trace only functions in processes under CGROUP_PATH hierarchy.
+.TP
 \-B
 Treat argument of STRCMP helper as a binary value
 .TP

--- a/tools/trace_example.txt
+++ b/tools/trace_example.txt
@@ -324,6 +324,9 @@ trace 'u:pthread:pthread_create (arg4 != 0)'
         Trace the USDT probe pthread_create when its 4th argument is non-zero
 trace 'p::SyS_nanosleep(struct timespec *ts) "sleep for %lld ns", ts->tv_nsec'
         Trace the nanosleep syscall and print the sleep duration in ns
+trace -c /sys/fs/cgroup/system.slice/workload.service '__x64_sys_nanosleep' '__x64_sys_clone'
+        Trace nanosleep/clone syscall calls only under workload.service
+        cgroup hierarchy.
 trace -I 'linux/fs.h' \
       'p::uprobe_register(struct inode *inode) "a_ops = %llx", inode->i_mapping->a_ops'
         Trace the uprobe_register inode mapping ops, and the symbol can be found


### PR DESCRIPTION
This patch added cgroup based filtering in trace.py.

If a cgroup path is specified by the user, one cgroup
array map will be added to the program:
```
  BPF_CGROUP_ARRAY(__cgroup, 1);
```
Each probe will have a filter like below:
```
  if (__cgroup.check_current_task(0) <= 0) { return 0; }
```
to filter out any events not happening in the cgroup
hierarchy as specified by the user.

The trace.py updated the `__cgroup` map with user provided
cgroup path information before attaching bpf functions
to events for probe function(s).

An example like below:
```
  $ trace.py -v -c /sys/fs/cgroup/system.slice/workload.service \
    '__x64_sys_nanosleep' '__x64_sys_clone'
     PID     TID     COMM            FUNC
     3191578 3191583 BaseAgentEvents __x64_sys_nanosleep
     3191578 3191579 FutureTimekeepr __x64_sys_clone
     3191578 3191583 BaseAgentEvents __x64_sys_nanosleep
     3191578 3191583 BaseAgentEvents __x64_sys_nanosleep
```
since workload.service only contains one process 3191578.

Going up the hierarchy to system.slice will have more processes
and hence more results:
```
  $ trace.py -v -c /sys/fs/cgroup/system.slice \
    '__x64_sys_nanosleep' '__x64_sys_clone'
     PID     TID     COMM            FUNC
     591542  591677  dynoScribe      __x64_sys_nanosleep
     591610  591613  mcreplay2       __x64_sys_nanosleep
     553252  553252  sleeperagent    __x64_sys_nanosleep
     591610  591613  mcreplay2       __x64_sys_nanosleep
     553252  553252  sleeperagent    __x64_sys_nanosleep
```
Signed-off-by: Yonghong Song <yhs@fb.com>