### PR TITLE
man: COMM describes the process name, not the parent process name

### DIFF
--- a/man/man8/shmsnoop.8
+++ b/man/man8/shmsnoop.8
@@ -50,7 +50,7 @@ PID
 Process ID
 .TP
 COMM
-Parent process/command name.
+Process/command name.
 .TP
 RET
 Return value of shm syscall.


### PR DESCRIPTION
```
juergen@lemmy:~ → shmtool open --size 10
```
Snoop:
```
[bcc]# shmsnoop.py  
PID    COMM                SYS              RET ARGs
37903  shmtool          SHMGET               38 key: 0x0, size: 10, shmflg: 0x780 (IPC_CREAT|IPC_EXCL|0600)
37903  shmtool          SHMCTL                0 shmid: 0x38, cmd: 2, buf: 0x7ffea25edd50
```

