### PR TITLE
fix compilation errors with latest llvm trunk

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -117,7 +117,12 @@ void SourceDebugger::dump() {
     errs() << "Debug Error: cannot get register info\n";
     return;
   }
+#if LLVM_MAJOR_VERSION >= 10
+  MCTargetOptions MCOptions;
+  std::unique_ptr<MCAsmInfo> MAI(T->createMCAsmInfo(*MRI, TripleStr, MCOptions));
+#else
   std::unique_ptr<MCAsmInfo> MAI(T->createMCAsmInfo(*MRI, TripleStr));
+#endif
   if (!MAI) {
     errs() << "Debug Error: cannot get assembly info\n";
     return;


### PR DESCRIPTION
llvm commit https://reviews.llvm.org/D66795
changed the signature of function `createMCAsmInfo()`.
```
  -  MCAsmInfo *createMCAsmInfo(const MCRegisterInfo &MRI,
  -                             StringRef TheTriple) const {
  +  MCAsmInfo *createMCAsmInfo(const MCRegisterInfo &MRI, StringRef TheTriple,
  +                             const MCTargetOptions &Options) const {
```
Did similar adjustment in bcc to ensure compilation success.

Signed-off-by: Yonghong Song <yhs@fb.com>