### PR TITLE
introduce map.lookup_or_try_init()

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -45,7 +45,7 @@ This guide is incomplete. If something feels missing, check the bcc and kernel s
         - [10. BPF_DEVMAP](#10-bpf_devmap)
         - [11. BPF_CPUMAP](#11-bpf_cpumap)
         - [12. map.lookup()](#12-maplookup)
-        - [13. map.lookup_or_init()](#13-maplookup_or_init)
+        - [13. map.lookup_or_try_init()](#13-maplookup_or_try_init)
         - [14. map.delete()](#14-mapdelete)
         - [15. map.update()](#15-mapupdate)
         - [16. map.insert()](#16-mapinsert)
@@ -537,7 +537,7 @@ Syntax: ```BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries)```
 
 Creates a map named ```_name```. Most of the time this will be used via higher-level macros, like BPF_HASH, BPF_HIST, etc.
 
-Methods (covered later): map.lookup(), map.lookup_or_init(), map.delete(), map.update(), map.insert(), map.increment().
+Methods (covered later): map.lookup(), map.lookup_or_try_init(), map.delete(), map.update(), map.insert(), map.increment().
 
 Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=BPF_TABLE+path%3Aexamples&type=Code),
@@ -570,7 +570,7 @@ BPF_HASH(start, struct request *);
 
 This creates a hash named ```start``` where the key is a ```struct request *```, and the value defaults to u64. This hash is used by the disksnoop.py example for saving timestamps for each I/O request, where the key is the pointer to struct request, and the value is the timestamp.
 
-Methods (covered later): map.lookup(), map.lookup_or_init(), map.delete(), map.update(), map.insert(), map.increment().
+Methods (covered later): map.lookup(), map.lookup_or_try_init(), map.delete(), map.update(), map.insert(), map.increment().
 
 Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=BPF_HASH+path%3Aexamples&type=Code),
@@ -705,7 +705,7 @@ BPF_LPM_TRIE(trie, struct key_v6);
 
 This creates an LPM trie map named `trie` where the key is a `struct key_v6`, and the value defaults to u64.
 
-Methods (covered later): map.lookup(), map.lookup_or_init(), map.delete(), map.update(), map.insert(), map.increment().
+Methods (covered later): map.lookup(), map.lookup_or_try_init(), map.delete(), map.update(), map.insert(), map.increment().
 
 Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=BPF_LPM_TRIE+path%3Aexamples&type=Code),
@@ -766,15 +766,18 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=lookup+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=lookup+path%3Atools&type=Code)
 
-### 13. map.lookup_or_init()
+### 13. map.lookup_or_try_init()
 
-Syntax: ```*val map.lookup_or_init(&key, &zero)```
+Syntax: ```*val map.lookup_or_try_init(&key, &zero)```
 
 Lookup the key in the map, and return a pointer to its value if it exists, else initialize the key's value to the second argument. This is often used to initialize values to zero. If the key cannot be inserted (e.g. the map is full) then NULL is returned.
 
 Examples in situ:
-[search /examples](https://github.com/iovisor/bcc/search?q=lookup_or_init+path%3Aexamples&type=Code),
-[search /tools](https://github.com/iovisor/bcc/search?q=lookup_or_init+path%3Atools&type=Code)
+[search /examples](https://github.com/iovisor/bcc/search?q=lookup_or_try_init+path%3Aexamples&type=Code),
+[search /tools](https://github.com/iovisor/bcc/search?q=lookup_or_try_init+path%3Atools&type=Code)
+
+Note: The old map.lookup_or_init() may cause return from the function, so lookup_or_try_init() is recommended as it
+does not have this side effect.
 
 ### 14. map.delete()
 

--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -558,7 +558,7 @@ int count(struct pt_regs *ctx) {
 
     bpf_probe_read(&key.c, sizeof(key.c), (void *)PT_REGS_PARM1(ctx));
     // could also use `counts.increment(key)`
-    val = counts.lookup_or_init(&key, &zero);
+    val = counts.lookup_or_try_init(&key, &zero);
     if (val) {
       (*val)++;
     }
@@ -679,7 +679,7 @@ int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
     key.prev_pid = prev->pid;
 
     // could also use `stats.increment(key);`
-    val = stats.lookup_or_init(&key, &zero);
+    val = stats.lookup_or_try_init(&key, &zero);
     if (val) {
       (*val)++;
     }

--- a/examples/cpp/LLCStat.cc
+++ b/examples/cpp/LLCStat.cc
@@ -42,7 +42,7 @@ int on_cache_miss(struct bpf_perf_event_data *ctx) {
     get_key(&key);
 
     u64 zero = 0, *val;
-    val = miss_count.lookup_or_init(&key, &zero);
+    val = miss_count.lookup_or_try_init(&key, &zero);
     if (val) {
         (*val) += ctx->sample_period;
     }
@@ -55,7 +55,7 @@ int on_cache_ref(struct bpf_perf_event_data *ctx) {
     get_key(&key);
 
     u64 zero = 0, *val;
-    val = ref_count.lookup_or_init(&key, &zero);
+    val = ref_count.lookup_or_try_init(&key, &zero);
     if (val) {
         (*val) += ctx->sample_period;
     }

--- a/examples/cpp/TCPSendStack.cc
+++ b/examples/cpp/TCPSendStack.cc
@@ -38,7 +38,7 @@ int on_tcp_send(struct pt_regs *ctx) {
   key.user_stack = stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
 
   u64 zero = 0, *val;
-  val = counts.lookup_or_init(&key, &zero);
+  val = counts.lookup_or_try_init(&key, &zero);
   if (val) {
     (*val)++;
   }

--- a/examples/cpp/UseExternalMap.cc
+++ b/examples/cpp/UseExternalMap.cc
@@ -55,7 +55,7 @@ int on_sched_switch(struct tracepoint__sched__sched_switch *args) {
   key.next_pid = args->next_pid;
   __builtin_memcpy(&key.prev_comm, args->prev_comm, 16);
   __builtin_memcpy(&key.next_comm, args->next_comm, 16);
-  val = counts.lookup_or_init(&key, &zero);
+  val = counts.lookup_or_try_init(&key, &zero);
   if (val) {
     (*val)++;
   }

--- a/examples/lua/offcputime.lua
+++ b/examples/lua/offcputime.lua
@@ -64,7 +64,7 @@ int oncpu(struct pt_regs *ctx, struct task_struct *prev) {
     bpf_get_current_comm(&key.name, sizeof(key.name));
     key.stack_id = stack_traces.get_stackid(ctx, stack_flags);
 
-    val = counts.lookup_or_init(&key, &zero);
+    val = counts.lookup_or_try_init(&key, &zero);
     if (val) {
         (*val) += delta;
     }

--- a/examples/lua/task_switch.lua
+++ b/examples/lua/task_switch.lua
@@ -32,7 +32,7 @@ int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
   key.curr_pid = bpf_get_current_pid_tgid();
   key.prev_pid = prev->pid;
 
-  val = stats.lookup_or_init(&key, &zero);
+  val = stats.lookup_or_try_init(&key, &zero);
   if (val) {
     (*val)++;
   }

--- a/examples/networking/distributed_bridge/tunnel.c
+++ b/examples/networking/distributed_bridge/tunnel.c
@@ -36,7 +36,7 @@ int handle_ingress(struct __sk_buff *skb) {
   if (ifindex) {
     //bpf_trace_printk("ingress tunnel_id=%d ifindex=%d\n", tkey.tunnel_id, *ifindex);
     struct vni_key vk = {ethernet->src, *ifindex, 0};
-    struct host *src_host = mac2host.lookup_or_init(&vk,
+    struct host *src_host = mac2host.lookup_or_try_init(&vk,
         &(struct host){tkey.tunnel_id, tkey.remote_ipv4, 0, 0});
     if (src_host) {
       lock_xadd(&src_host->rx_pkts, 1);

--- a/examples/networking/http_filter/http-parse-complete.c
+++ b/examples/networking/http_filter/http-parse-complete.c
@@ -141,7 +141,7 @@ int http_filter(struct __sk_buff *skb) {
 	//keep the packet and send it to userspace retruning -1
 	HTTP_MATCH:
 	//if not already present, insert into map <Key, Leaf>
-	sessions.lookup_or_init(&key,&zero);
+	sessions.lookup_or_try_init(&key,&zero);
 
 	//send packet to userspace returning -1
 	KEEP:

--- a/examples/networking/tunnel_monitor/monitor.c
+++ b/examples/networking/tunnel_monitor/monitor.c
@@ -125,7 +125,7 @@ finish:
   if (key.outer_dip < key.outer_sip)
     swap_ipkey(&key);
   struct counters zleaf = {0};
-  struct counters *leaf = stats.lookup_or_init(&key, &zleaf);
+  struct counters *leaf = stats.lookup_or_try_init(&key, &zleaf);
   if (leaf) {
     if (is_ingress) {
       lock_xadd(&leaf->rx_pkts, 1);

--- a/examples/networking/vlan_learning/vlan_learning.c
+++ b/examples/networking/vlan_learning/vlan_learning.c
@@ -32,7 +32,7 @@ int handle_phys2virt(struct __sk_buff *skb) {
       // auto-program reverse direction table
       int out_ifindex = leaf->out_ifindex;
       struct ifindex_leaf_t zleaf = {0};
-      struct ifindex_leaf_t *out_leaf = egress.lookup_or_init(&out_ifindex, &zleaf);
+      struct ifindex_leaf_t *out_leaf = egress.lookup_or_try_init(&out_ifindex, &zleaf);
       if (out_leaf) {
 	// to capture potential configuration changes
 	out_leaf->out_ifindex = skb->ifindex;

--- a/examples/tracing/mallocstacks.py
+++ b/examples/tracing/mallocstacks.py
@@ -46,7 +46,7 @@ int alloc_enter(struct pt_regs *ctx, size_t size) {
 
     // could also use `calls.increment(key, size);`
     u64 zero = 0, *val;
-    val = calls.lookup_or_init(&key, &zero);
+    val = calls.lookup_or_try_init(&key, &zero);
     if (val) {
       (*val) += size;
     }

--- a/examples/tracing/strlen_count.py
+++ b/examples/tracing/strlen_count.py
@@ -33,7 +33,7 @@ int count(struct pt_regs *ctx) {
 
     bpf_probe_read(&key.c, sizeof(key.c), (void *)PT_REGS_PARM1(ctx));
     // could also use `counts.increment(key)`
-    val = counts.lookup_or_init(&key, &zero);
+    val = counts.lookup_or_try_init(&key, &zero);
     if (val) {
       (*val)++;
     }

--- a/examples/tracing/task_switch.c
+++ b/examples/tracing/task_switch.c
@@ -15,7 +15,7 @@ int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
     key.prev_pid = prev->pid;
 
     // could also use `stats.increment(key);`
-    val = stats.lookup_or_init(&key, &zero);
+    val = stats.lookup_or_try_init(&key, &zero);
     if (val) {
         (*val)++;
     }

--- a/examples/usdt_sample/scripts/lat_avg.py
+++ b/examples/usdt_sample/scripts/lat_avg.py
@@ -78,7 +78,7 @@ int trace_operation_end(struct pt_regs* ctx)
     start_hash.delete(&operation_id);
 
     struct hash_leaf_t zero = {};
-    struct hash_leaf_t* hash_leaf = lat_hash.lookup_or_init(&hash_key, &zero);
+    struct hash_leaf_t* hash_leaf = lat_hash.lookup_or_try_init(&hash_key, &zero);
     if (0 == hash_leaf) {
         return 0;
     }

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -78,6 +78,7 @@ struct _name##_table_t { \
   _leaf_type leaf; \
   _leaf_type * (*lookup) (_key_type *); \
   _leaf_type * (*lookup_or_init) (_key_type *, _leaf_type *); \
+  _leaf_type * (*lookup_or_try_init) (_key_type *, _leaf_type *); \
   int (*update) (_key_type *, _leaf_type *); \
   int (*insert) (_key_type *, _leaf_type *); \
   int (*delete) (_key_type *); \

--- a/tests/cc/test_bpf_table.cc
+++ b/tests/cc/test_bpf_table.cc
@@ -181,7 +181,7 @@ TEST_CASE("test bpf stack table", "[bpf_stack_table]") {
     int on_sys_getuid(void *ctx) {
       int stack_id = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
       int zero = 0, *val;
-      val = id.lookup_or_init(&zero, &stack_id);
+      val = id.lookup_or_try_init(&zero, &stack_id);
       if (val) {
         (*val) = stack_id;
       }
@@ -234,7 +234,7 @@ TEST_CASE("test bpf stack_id table", "[bpf_stack_table]") {
     int on_sys_getuid(void *ctx) {
       int stack_id = stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
       int zero = 0, *val;
-      val = id.lookup_or_init(&zero, &stack_id);
+      val = id.lookup_or_try_init(&zero, &stack_id);
       if (val) {
         (*val) = stack_id;
       }

--- a/tests/lua/test_clang.lua
+++ b/tests/lua/test_clang.lua
@@ -243,7 +243,7 @@ int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
   key.curr_pid = bpf_get_current_pid_tgid();
   key.prev_pid = prev->pid;
 
-  val = stats.lookup_or_init(&key, &zero);
+  val = stats.lookup_or_try_init(&key, &zero);
   if (val) {
     (*val)++;
   }

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -396,7 +396,7 @@ int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
   key.curr_pid = bpf_get_current_pid_tgid();
   key.prev_pid = prev->pid;
 
-  val = stats.lookup_or_init(&key, &zero);
+  val = stats.lookup_or_try_init(&key, &zero);
   if (val) {
     (*val)++;
   }

--- a/tests/python/test_license.py
+++ b/tests/python/test_license.py
@@ -42,7 +42,7 @@ int license_program(struct pt_regs *ctx) {
     key.uid = uid & 0xFFFFFFFF;
     bpf_get_current_comm(&(key.comm), 16);
 
-    val = counts.lookup_or_init(&key, &zero);  // update counter
+    val = counts.lookup_or_try_init(&key, &zero);  // update counter
     if (val) {
         (*val)++;
     }

--- a/tests/python/test_lru.py
+++ b/tests/python/test_lru.py
@@ -26,7 +26,7 @@ class TestLru(unittest.TestCase):
         int hello_world(void *ctx) {
             u32 key=0;
             u32 value = 0, *val;
-            val = stats.lookup_or_init(&key, &value);
+            val = stats.lookup_or_try_init(&key, &value);
             if (val) {
                 *val += 1;
             }

--- a/tests/python/test_percpu.py
+++ b/tests/python/test_percpu.py
@@ -29,7 +29,7 @@ class TestPercpu(unittest.TestCase):
         int hello_world(void *ctx) {
             u32 key=0;
             u64 value = 0, *val;
-            val = stats.lookup_or_init(&key, &value);
+            val = stats.lookup_or_try_init(&key, &value);
             if (val) {
                 *val += 1;
             }
@@ -61,7 +61,7 @@ class TestPercpu(unittest.TestCase):
         int hello_world(void *ctx) {
             u32 key=0;
             u32 value = 0, *val;
-            val = stats.lookup_or_init(&key, &value);
+            val = stats.lookup_or_try_init(&key, &value);
             if (val) {
                 *val += 1;
             }
@@ -97,7 +97,7 @@ class TestPercpu(unittest.TestCase):
         int hello_world(void *ctx) {
             u32 key=0;
             counter value = {0,0}, *val;
-            val = stats.lookup_or_init(&key, &value);
+            val = stats.lookup_or_try_init(&key, &value);
             if (val) {
                 val->c1 += 1;
                 val->c2 += 1;

--- a/tests/python/test_stat1.c
+++ b/tests/python/test_stat1.c
@@ -47,7 +47,7 @@ int on_packet(struct __sk_buff *skb) {
       tx = 1;
     }
     struct IPLeaf zleaf = {0};
-    struct IPLeaf *leaf = stats.lookup_or_init(&key, &zleaf);
+    struct IPLeaf *leaf = stats.lookup_or_try_init(&key, &zleaf);
     if (leaf) {
       lock_xadd(&leaf->rx_pkts, rx);
       lock_xadd(&leaf->tx_pkts, tx);

--- a/tests/python/test_trace2.c
+++ b/tests/python/test_trace2.c
@@ -8,7 +8,7 @@ BPF_HASH(stats, struct Ptr, struct Counters, 1024);
 int count_sched(struct pt_regs *ctx) {
   struct Ptr key = {.ptr = PT_REGS_PARM1(ctx)};
   struct Counters zleaf = {0};
-  struct Counters *val = stats.lookup_or_init(&key, &zleaf);
+  struct Counters *val = stats.lookup_or_try_init(&key, &zleaf);
   if (val) {
     val->stat1++;
   }

--- a/tests/python/test_trace2.py
+++ b/tests/python/test_trace2.py
@@ -19,7 +19,7 @@ int count_sched(struct pt_regs *ctx) {
   struct Counters zleaf;
 
   memset(&zleaf, 0, sizeof(zleaf));
-  struct Counters *val = stats.lookup_or_init(&key, &zleaf);
+  struct Counters *val = stats.lookup_or_try_init(&key, &zleaf);
   if (val) {
     val->stat1++;
   }

--- a/tests/python/test_trace3.c
+++ b/tests/python/test_trace3.c
@@ -47,7 +47,7 @@ int probe_blk_update_request(struct pt_regs *ctx) {
     index = SLOTS - 1;
 
   u64 zero = 0;
-  u64 *val = latency.lookup_or_init(&index, &zero);
+  u64 *val = latency.lookup_or_try_init(&index, &zero);
   if (val) {
     lock_xadd(val, 1);
   }

--- a/tests/python/test_trace4.py
+++ b/tests/python/test_trace4.py
@@ -14,14 +14,14 @@ class TestKprobeRgx(TestCase):
         typedef struct { u64 val; } Val;
         BPF_HASH(stats, Key, Val, 3);
         int hello(void *ctx) {
-          Val *val = stats.lookup_or_init(&(Key){1}, &(Val){0});
+          Val *val = stats.lookup_or_try_init(&(Key){1}, &(Val){0});
           if (val) {
             val->val++;
           }
           return 0;
         }
         int goodbye(void *ctx) {
-          Val *val = stats.lookup_or_init(&(Key){2}, &(Val){0});
+          Val *val = stats.lookup_or_try_init(&(Key){2}, &(Val){0});
           if (val) {
             val->val++;
           }

--- a/tests/python/test_trace_maxactive.py
+++ b/tests/python/test_trace_maxactive.py
@@ -15,16 +15,12 @@ class TestKprobeMaxactive(TestCase):
         BPF_HASH(stats, Key, Val, 3);
         int hello(void *ctx) {
           Val *val = stats.lookup_or_init(&(Key){1}, &(Val){0});
-          if (val) {
-            val->val++;
-          }
+          val->val++;
           return 0;
         }
         int goodbye(void *ctx) {
           Val *val = stats.lookup_or_init(&(Key){2}, &(Val){0});
-          if (val) {
-            val->val++;
-          }
+          val->val++;
           return 0;
         }
         """)

--- a/tests/python/test_tracepoint.py
+++ b/tests/python/test_tracepoint.py
@@ -29,9 +29,7 @@ class TestTracepoint(unittest.TestCase):
             u64 val = 0;
             u32 pid = args->next_pid;
             u64 *existing = switches.lookup_or_init(&pid, &val);
-            if (existing) {
-                (*existing)++;
-            }
+            (*existing)++;
             return 0;
         }
         """
@@ -55,10 +53,8 @@ class TestTracepointDataLoc(unittest.TestCase):
             char fn[64];
             u32 pid = args->pid;
             struct value_t *existing = execs.lookup_or_init(&pid, &val);
-            if (existing) {
-                TP_DATA_LOC_READ_CONST(fn, filename, 64);
-                __builtin_memcpy(existing->filename, fn, 64);
-            }
+            TP_DATA_LOC_READ_CONST(fn, filename, 64);
+            __builtin_memcpy(existing->filename, fn, 64);
             return 0;
         }
         """

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -148,11 +148,11 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
     whop = whobyreq.lookup(&req);
     if (whop == 0) {
         // missed pid who, save stats as pid 0
-        valp = counts.lookup_or_init(&info, &zero);
+        valp = counts.lookup_or_try_init(&info, &zero);
     } else {
         info.pid = whop->pid;
         __builtin_memcpy(&info.name, whop->name, sizeof(info.name));
-        valp = counts.lookup_or_init(&info, &zero);
+        valp = counts.lookup_or_try_init(&info, &zero);
     }
 
     if (valp) {

--- a/tools/deadlock.c
+++ b/tools/deadlock.c
@@ -75,7 +75,7 @@ int trace_mutex_acquire(struct pt_regs *ctx, void *mutex_addr) {
 
   struct thread_to_held_mutex_leaf_t empty_leaf = {};
   struct thread_to_held_mutex_leaf_t *leaf =
-      thread_to_held_mutexes.lookup_or_init(&pid, &empty_leaf);
+      thread_to_held_mutexes.lookup_or_try_init(&pid, &empty_leaf);
   if (!leaf) {
     bpf_trace_printk(
         "could not add thread_to_held_mutex key, thread: %d, mutex: %p\n", pid,
@@ -195,7 +195,7 @@ int trace_clone(struct pt_regs *ctx, unsigned long flags, void *child_stack,
                        sizeof(thread_created_leaf.comm));
 
   struct thread_created_leaf_t *insert_result =
-      thread_to_parent.lookup_or_init(&child_pid, &thread_created_leaf);
+      thread_to_parent.lookup_or_try_init(&child_pid, &thread_created_leaf);
   if (!insert_result) {
     bpf_trace_printk(
         "could not add thread_created_key, child: %d, parent: %d\n", child_pid,

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -118,7 +118,7 @@ static int do_entry(struct pt_regs *ctx, struct file *file,
     }
 
     struct val_t *valp, zero = {};
-    valp = counts.lookup_or_init(&info, &zero);
+    valp = counts.lookup_or_try_init(&info, &zero);
     if (valp) {
         if (is_read) {
             valp->reads++;

--- a/tools/lib/ucalls.py
+++ b/tools/lib/ucalls.py
@@ -163,7 +163,7 @@ int trace_entry(struct pt_regs *ctx) {
     bpf_probe_read(&data.method.method, sizeof(data.method.method),
                    (void *)method);
 #ifndef LATENCY
-    valp = counts.lookup_or_init(&data.method, &val);
+    valp = counts.lookup_or_try_init(&data.method, &val);
     if (valp) {
         ++(*valp);
     }
@@ -190,7 +190,7 @@ int trace_return(struct pt_regs *ctx) {
     if (!entry_timestamp) {
         return 0;   // missed the entry event
     }
-    info = times.lookup_or_init(&data.method, &zero);
+    info = times.lookup_or_try_init(&data.method, &zero);
     if (info) {
         info->num_calls += 1;
         info->total_ns += bpf_ktime_get_ns() - *entry_timestamp;
@@ -213,7 +213,7 @@ TRACEPOINT_PROBE(raw_syscalls, sys_enter) {
     sysentry.update(&pid, &data);
 #endif
 #ifndef LATENCY
-    valp = syscounts.lookup_or_init(&id, &val);
+    valp = syscounts.lookup_or_try_init(&id, &val);
     if (valp) {
         ++(*valp);
     }
@@ -232,7 +232,7 @@ TRACEPOINT_PROBE(raw_syscalls, sys_exit) {
         return 0;   // missed the entry event
     }
     id = e->id;
-    info = systimes.lookup_or_init(&id, &zero);
+    info = systimes.lookup_or_try_init(&id, &zero);
     if (info) {
         info->num_calls += 1;
         info->total_ns += bpf_ktime_get_ns() - e->timestamp;

--- a/tools/lib/uflow.py
+++ b/tools/lib/uflow.py
@@ -88,7 +88,7 @@ int NAME(struct pt_regs *ctx) {
     FILTER_METHOD
 
     data.pid = bpf_get_current_pid_tgid();
-    depth = entry.lookup_or_init(&data.pid, &zero);
+    depth = entry.lookup_or_try_init(&data.pid, &zero);
     if (!depth) {
         depth = &zero;
     }

--- a/tools/lib/uobjnew.py
+++ b/tools/lib/uobjnew.py
@@ -79,7 +79,7 @@ int alloc_entry(struct pt_regs *ctx, size_t size) {
     struct key_t key = {};
     struct val_t *valp, zero = {};
     key.size = size;
-    valp = allocs.lookup_or_init(&key, &zero);
+    valp = allocs.lookup_or_try_init(&key, &zero);
     if (valp) {
         valp->total_size += size;
         valp->num_allocs += 1;
@@ -99,7 +99,7 @@ int alloc_entry(struct pt_regs *ctx) {
     bpf_usdt_readarg(2, ctx, &classptr);
     bpf_usdt_readarg(4, ctx, &size);
     bpf_probe_read(&key.name, sizeof(key.name), (void *)classptr);
-    valp = allocs.lookup_or_init(&key, &zero);
+    valp = allocs.lookup_or_try_init(&key, &zero);
     if (valp) {
         valp->total_size += size;
         valp->num_allocs += 1;
@@ -118,7 +118,7 @@ int THETHING_alloc_entry(struct pt_regs *ctx) {
     struct val_t *valp, zero = {};
     u64 size = 0;
     bpf_usdt_readarg(1, ctx, &size);
-    valp = allocs.lookup_or_init(&key, &zero);
+    valp = allocs.lookup_or_try_init(&key, &zero);
     if (valp) {
         valp->total_size += size;
         valp->num_allocs += 1;
@@ -133,7 +133,7 @@ int object_alloc_entry(struct pt_regs *ctx) {
     u64 classptr = 0;
     bpf_usdt_readarg(1, ctx, &classptr);
     bpf_probe_read(&key.name, sizeof(key.name), (void *)classptr);
-    valp = allocs.lookup_or_init(&key, &zero);
+    valp = allocs.lookup_or_try_init(&key, &zero);
     if (valp) {
         valp->num_allocs += 1;  // We don't know the size, unfortunately
     }
@@ -153,7 +153,7 @@ elif language == "tcl":
 int alloc_entry(struct pt_regs *ctx) {
     struct key_t key = { .name = "<ALL>" };
     struct val_t *valp, zero = {};
-    valp = allocs.lookup_or_init(&key, &zero);
+    valp = allocs.lookup_or_try_init(&key, &zero);
     if (valp) {
         valp->num_allocs += 1;
     }

--- a/tools/lib/ustat.py
+++ b/tools/lib/ustat.py
@@ -93,7 +93,7 @@ BPF_HASH(%s_%s_counts, u32, u64);   // pid to event count
 int %s_%s(void *ctx) {
     u64 *valp, zero = 0;
     u32 tgid = bpf_get_current_pid_tgid() >> 32;
-    valp = %s_%s_counts.lookup_or_init(&tgid, &zero);
+    valp = %s_%s_counts.lookup_or_try_init(&tgid, &zero);
     if (valp) {
         ++(*valp);
     }

--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -91,7 +91,7 @@ int kprobe__kmem_cache_alloc(struct pt_regs *ctx, struct kmem_cache *cachep)
     bpf_probe_read(&info.name, sizeof(info.name), name);
 
     struct val_t *valp, zero = {};
-    valp = counts.lookup_or_init(&info, &zero);
+    valp = counts.lookup_or_try_init(&info, &zero);
     if (valp) {
         valp->count++;
         valp->size += cachep->size;

--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -132,14 +132,14 @@ TRACEPOINT_PROBE(raw_syscalls, sys_exit) {
     if (!start_ns)
         return 0;
 
-    val = data.lookup_or_init(&key, &zero);
+    val = data.lookup_or_try_init(&key, &zero);
     if (val) {
         val->count++;
         val->total_ns += bpf_ktime_get_ns() - *start_ns;
     }
 #else
     u64 *val, zero = 0;
-    val = data.lookup_or_init(&key, &zero);
+    val = data.lookup_or_try_init(&key, &zero);
     if (val) {
         ++(*val);
     }


### PR DESCRIPTION
Previously, map.lookup_or_init() may cause unexpected
return from the function when lookup finds no element and
init failed e.g. due to unlikely racy update or
sometimes hash table full.
This has caught surprise from many users. So, the commit
  https://github.com/iovisor/bcc/commit/ba64f031f2435aad5a85f8f37dbbe2a982cbbe6b
attempts to remove the early return in map.lookup_or_init().
But then since NULL pointer could be returned,
user will need to change their bpf program to check return value,
otherwise, verifier will reject the program.

As described in the above, such an API behavior change may cause
verifier failure and reject previously loadable bpf programs.
bcc should try to maintain API stability, esp. to avoid subtle
API behavior change.

This patch propose to restore the behavior of map.lookup_or_init()
and introduce a new one map.lookup_or_try_init(), which will
avoid unexpected return. The name is suggested by Alexei
to reflect that init may fail. map.lookup_or_try_init() will be formally
documented and used in bcc. A warning will be generated if
map.lookup_or_init() is used. Documentation will make it clear
that map.lookup_or_try_init() is preferred over map.lookup_or_init().

```
-bash-4.4$ sudo ./syscount.py
/virtual/main.c:71:11: warning: lookup_or_init() may return from the function, use loopup_or_try_init() instead.
    val = data.lookup_or_init(&key, &zero);
          ^
1 warning generated.
Tracing syscalls, printing top 10... Ctrl+C to quit.
...
```

All uses in examples and tools are converted to use
lookup_or_try_init(). Most tests are converted to use
lookup_or_try_init() too except test_trace_maxactive.py
and test_tracepoint.py to test lookup_or_init()
functionality.