### PR TITLE
remove the warning for map.lookup_or_init()

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -784,8 +784,6 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           txt += " " + update + ", " + arg0 + ", " + arg1 + ", BPF_NOEXIST);";
           txt += " leaf = " + lookup + ", " + arg0 + ");";
           if (memb_name == "lookup_or_init") {
-            warning(GET_BEGINLOC(Call), "lookup_or_init() may cause return from the function, "
-                                        "use lookup_or_try_init() instead.");
             txt += " if (!leaf) return 0;";
           }
           txt += "}";


### PR DESCRIPTION
Commit 82f4302a651a ("introduce map.lookup_or_try_init()")
introduced new API map.lookup_or_try_init(). A compile time
warning is introduced if old map.lookup_or_init() is used
to discourage the usage.

The API is still supported and documentation already
recommends using the new one. So let us drop the
warning.

Signed-off-by: Yonghong Song <yhs@fb.com>