### PR TITLE
Support attaching uprobe to offset

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1106,9 +1106,14 @@ Examples in situ:
 
 ### 4. attach_uprobe()
 
-Syntax: ```BPF.attach_uprobe(name="location", sym="symbol", fn_name="name")```
+Syntax: ```BPF.attach_uprobe(name="location", sym="symbol", fn_name="name" [, sym_off=int])```, ```BPF.attach_uprobe(name="location", sym_re="regex", fn_name="name")```, ```BPF.attach_uprobe(name="location", addr=int, fn_name="name")```
 
-Instruments the user-level function ```symbol()``` from either the library or binary named by ```location``` using user-level dynamic tracing of the function entry, and attach our C defined function ```name()``` to be called whenever the user-level function is called.
+
+Instruments the user-level function ```symbol()``` from either the library or binary named by ```location``` using user-level dynamic tracing of the function entry, and attach our C defined function ```name()``` to be called whenever the user-level function is called. If ```sym_off``` is given, the function is attached to the offset within the symbol.
+
+The real address ```addr``` may be supplied in place of ```sym```, in which case ```sym``` must be set to its default value. If the file is a non-PIE executable, ```addr``` must be a virtual address, otherwise it must be an offset relative to the file load address.
+
+Instead of a symbol name, a regular expression can be provided in ```sym_re```. The uprobe will then attach to symbols that match the provided regular expression.
 
 Libraries can be given in the name argument without the lib prefix, or with the full path (/usr/lib/...). Binaries can be given only with the full path (/bin/sh).
 

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -75,11 +75,13 @@ class BPF {
                             const std::string& probe_func,
                             uint64_t symbol_addr = 0,
                             bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY,
-                            pid_t pid = -1);
+                            pid_t pid = -1,
+                            uint64_t symbol_offset = 0);
   StatusTuple detach_uprobe(const std::string& binary_path,
                             const std::string& symbol, uint64_t symbol_addr = 0,
                             bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY,
-                            pid_t pid = -1);
+                            pid_t pid = -1,
+                            uint64_t symbol_offset = 0);
   StatusTuple attach_usdt(const USDT& usdt, pid_t pid = -1);
   StatusTuple detach_usdt(const USDT& usdt, pid_t pid = -1);
 
@@ -239,7 +241,8 @@ class BPF {
   StatusTuple check_binary_symbol(const std::string& binary_path,
                                   const std::string& symbol,
                                   uint64_t symbol_addr, std::string& module_res,
-                                  uint64_t& offset_res);
+                                  uint64_t& offset_res,
+                                  uint64_t symbol_offset = 0);
 
   int flag_;
 

--- a/src/lua/bcc/bpf.lua
+++ b/src/lua/bcc/bpf.lua
@@ -189,7 +189,7 @@ end
 function Bpf:attach_uprobe(args)
   Bpf.check_probe_quota(1)
 
-  local path, addr = Sym.check_path_symbol(args.name, args.sym, args.addr, args.pid)
+  local path, addr = Sym.check_path_symbol(args.name, args.sym, args.addr, args.pid, args.sym_off)
   local fn = self:load_func(args.fn_name, 'BPF_PROG_TYPE_KPROBE')
   local ptype = args.retprobe and "r" or "p"
   local ev_name = string.format("%s_%s_0x%p", ptype, path:gsub("[^%a%d]", "_"), addr)

--- a/src/lua/bcc/sym.lua
+++ b/src/lua/bcc/sym.lua
@@ -32,9 +32,10 @@ local function create_cache(pid)
   }
 end
 
-local function check_path_symbol(module, symname, addr, pid)
+local function check_path_symbol(module, symname, addr, pid, sym_off)
   local sym = SYM()
   local module_path
+  local new_addr
   if libbcc.bcc_resolve_symname(module, symname, addr or 0x0, pid or 0, nil, sym) < 0 then
     if sym[0].module == nil then
       error("could not find library '%s' in the library path" % module)
@@ -45,9 +46,10 @@ local function check_path_symbol(module, symname, addr, pid)
         symname, module_path})
     end
   end
+  new_addr = sym[0].offset + (sym_off or 0)
   module_path = ffi.string(sym[0].module)
   libbcc.bcc_procutils_free(sym[0].module)
-  return module_path, sym[0].offset
+  return module_path, new_addr
 end
 
 return { create_cache=create_cache, check_path_symbol=check_path_symbol }

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -742,7 +742,7 @@ class BPF(object):
 
 
     @classmethod
-    def _check_path_symbol(cls, module, symname, addr, pid):
+    def _check_path_symbol(cls, module, symname, addr, pid, sym_off=0):
         module = _assert_is_bytes(module)
         symname = _assert_is_bytes(symname)
         sym = bcc_symbol()
@@ -754,9 +754,10 @@ class BPF(object):
             ct.byref(sym),
         ) < 0:
             raise Exception("could not determine address of symbol %s" % symname)
+        new_addr = sym.offset + sym_off
         module_path = ct.cast(sym.module, ct.c_char_p).value
         lib.bcc_procutils_free(sym.module)
-        return module_path, sym.offset
+        return module_path, new_addr
 
     @staticmethod
     def find_library(libname):
@@ -974,13 +975,15 @@ class BPF(object):
             return b"%s_%s_0x%x_%d" % (prefix, self._probe_repl.sub(b"_", path), addr, pid)
 
     def attach_uprobe(self, name=b"", sym=b"", sym_re=b"", addr=None,
-            fn_name=b"", pid=-1):
+            fn_name=b"", pid=-1, sym_off=0):
         """attach_uprobe(name="", sym="", sym_re="", addr=None, fn_name=""
-                         pid=-1)
+                         pid=-1, sym_off=0)
 
         Run the bpf function denoted by fn_name every time the symbol sym in
         the library or binary 'name' is encountered. Optional parameters pid,
         cpu, and group_fd can be used to filter the probe.
+
+        If sym_off is given, attach uprobe to offset within the symbol.
 
         The real address addr may be supplied in place of sym, in which case sym
         must be set to its default value. If the file is a non-PIE executable,
@@ -1000,6 +1003,10 @@ class BPF(object):
                  BPF(text).attach_uprobe("/usr/bin/python", "main")
         """
 
+        assert sym_off >= 0
+        if addr is not None:
+            assert sym_off == 0, "offset with addr is not supported"
+
         name = _assert_is_bytes(name)
         sym = _assert_is_bytes(sym)
         sym_re = _assert_is_bytes(sym_re)
@@ -1013,7 +1020,7 @@ class BPF(object):
                                    fn_name=fn_name, pid=pid)
             return
 
-        (path, addr) = BPF._check_path_symbol(name, sym, addr, pid)
+        (path, addr) = BPF._check_path_symbol(name, sym, addr, pid, sym_off)
 
         self._check_probe_quota(1)
         fn = self.load_func(fn_name, BPF.KPROBE)
@@ -1067,7 +1074,7 @@ class BPF(object):
             raise Exception("Failed to detach BPF from uprobe")
         self._del_uprobe_fd(ev_name)
 
-    def detach_uprobe(self, name=b"", sym=b"", addr=None, pid=-1):
+    def detach_uprobe(self, name=b"", sym=b"", addr=None, pid=-1, sym_off=0):
         """detach_uprobe(name="", sym="", addr=None, pid=-1)
 
         Stop running a bpf function that is attached to symbol 'sym' in library
@@ -1076,7 +1083,7 @@ class BPF(object):
 
         name = _assert_is_bytes(name)
         sym = _assert_is_bytes(sym)
-        (path, addr) = BPF._check_path_symbol(name, sym, addr, pid)
+        (path, addr) = BPF._check_path_symbol(name, sym, addr, pid, sym_off)
         ev_name = self._get_uprobe_evname(b"p", path, addr, pid)
         self.detach_uprobe_event(ev_name)
 


### PR DESCRIPTION
This enables to attach uprobe to offset (similar to iovisor/bpftrace#803.)
`attach_kprobe()` already supported it with`event_off`.

This does not check an offset, e.g., whether the offset is the middle of the instruction or not. Currently `attach_kprobe()` also does not perform any check.
It is nice if we can integrate bpftrace's offset check (what above PR does) with bcc, but I think it will be separate PR.