### PR TITLE
docs/reference_guide.md: update doc

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -258,7 +258,7 @@ Syntax: RAW_TRACEPOINT_PROBE(*event*)
 
 This is a macro that instruments the raw tracepoint defined by *event*.
 
-The argument is a pointer to struct ```bpf_raw_tracepoint_args```, which is defined in [bpf.h](https://github.com/iovisor/bcc/blob/master/src/cc/compat/linux/bpf.h).  The struct field ```args``` contains all parameters of the raw tracepoint where you can found at linux tree [include/trace/events](https://github.com/torvalds/linux/tree/master/include/trace/events)
+The argument is a pointer to struct ```bpf_raw_tracepoint_args```, which is defined in [bpf.h](https://github.com/iovisor/bcc/blob/master/src/cc/compat/linux/virtual_bpf.h).  The struct field ```args``` contains all parameters of the raw tracepoint where you can found at linux tree [include/trace/events](https://github.com/torvalds/linux/tree/master/include/trace/events)
 directory.
 
 For example:


### PR DESCRIPTION
virtual_bpf.h instead of bpf.h
src/cc/compat/linux/bpf.h -> src/cc/compat/linux/virtual_bpf.h

There is no bpf.h under compat/linux/