### PR TITLE
fix a bug in mountsnoop.py with 4.17+ kernels

### DIFF
--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -88,10 +88,8 @@ BPF_PERF_OUTPUT(events);
 
 int syscall__mount(struct pt_regs *ctx, char __user *source,
                       char __user *target, char __user *type,
-                      unsigned long flags)
+                      unsigned long flags, char __user *data)
 {
-    /* sys_mount takes too many arguments */
-    char __user *data = (char __user *)PT_REGS_PARM5(ctx);
     struct data_t event = {};
     struct task_struct *task;
     struct nsproxy *nsproxy;


### PR DESCRIPTION
in 4.17+ kernels, syscall parameters are wrapped in the first
parammeter in pt_regs. So put the 5th parameter in the
syscall__ parameter list so it can be handled properly
by the rewriter.

Signed-off-by: Yonghong Song <yhs@fb.com>