### PR TITLE
Include stddef.h for size_t in bcc_elf.h

### DIFF
--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -20,6 +20,7 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
 #include <stdint.h>
 
 struct bcc_elf_usdt {


### PR DESCRIPTION
Closes #2601.

I confirmed that now CMake's [check_symbol_exists](https://github.com/iovisor/bpftrace/blob/fc2af891503061708e455f8de0d89c96554abd4d/CMakeLists.txt#L72) worked correctly when compiling bpftrace.