### PR TITLE
Make StatusTuple code and msg methods const

### DIFF
--- a/src/cc/bcc_exception.h
+++ b/src/cc/bcc_exception.h
@@ -40,9 +40,9 @@ public:
     msg_ += msg;
   }
 
-  int code() { return ret_; }
+  int code() const { return ret_; }
 
-  std::string msg() { return msg_; }
+  const std::string& msg() const { return msg_; }
 
 private:
   int ret_;


### PR DESCRIPTION
I ran into this while trying to write a method that takes a const StatusTuple reference, these methods should be marked const. I also fixed an unnecessary string copy in msg.