### PR TITLE
Make TRY2 macro work outside of ebpf namespace

### DIFF
--- a/src/cc/bcc_exception.h
+++ b/src/cc/bcc_exception.h
@@ -49,12 +49,12 @@ private:
   std::string msg_;
 };
 
-#define TRY2(CMD)              \
-  do {                         \
-    StatusTuple __stp = (CMD); \
-    if (__stp.code() != 0) {   \
-      return __stp;            \
-    }                          \
+#define TRY2(CMD)                    \
+  do {                               \
+    ebpf::StatusTuple __stp = (CMD); \
+    if (__stp.code() != 0) {         \
+      return __stp;                  \
+    }                                \
   } while (0)
 
 }  // namespace ebpf


### PR DESCRIPTION
The `TRY2` macro is very useful for wrapping methods that return a StatusTuple, and is defined in the same header as StatusTuple (and is therefore visible when including `BPH.h`). However, the macro is written in such a way that it only works from within the `ebpf` namespace, which limits its usefulness in other projects. This makes it so I can use the `TRY2` macro in my own project.