### PR TITLE
include <linux/stddef.h> to get macro defintions for compiling on Alp…

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -22,6 +22,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <linux/stddef.h> // Not alphabetical - Get required macro definitions
 #include <linux/bpf.h>
 #include <linux/bpf_common.h>
 #include <linux/if_packet.h>

--- a/src/cc/perf_reader.c
+++ b/src/cc/perf_reader.c
@@ -25,6 +25,7 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <linux/stddef.h> // Not alphabetical - Get required macro definitions
 #include <linux/types.h>
 #include <linux/perf_event.h>
 


### PR DESCRIPTION
include <linux/stddef.h> to get macro definitions for compiling on Alpine Linux 3.10

Otherwise, macros like __always_inline and __cpu_to_be64p are undefined.

There is a related PR for `libbpf` here: https://github.com/libbpf/libbpf/pull/99

Relates to #2338