### PR TITLE
Add map-in-map support

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -759,7 +759,33 @@ Methods (covered later): map.redirect_map().
 Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=BPF_CPUMAP+path%3Aexamples&type=Code),
 
-### 12. map.lookup()
+### 12. BPF_ARRAY_OF_MAPS
+
+Syntax: ```BPF_ARRAY_OF_MAPS(name, inner_map_name, size)```
+
+This creates an array map with a map-in-map type (BPF_MAP_TYPE_HASH_OF_MAPS) map named ```name``` with ```size``` entries. The inner map meta data is provided by map ```inner_map_name``` and can be most of array or hash maps except ```BPF_MAP_TYPE_PROG_ARRAY```, ```BPF_MAP_TYPE_CGROUP_STORAGE``` and ```BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE```.
+
+For example:
+```C
+BPF_TABLE("hash", int, int, ex1, 1024);
+BPF_TABLE("hash", int, int, ex2, 1024);
+BPF_ARRAY_OF_MAPS(maps_array, "ex1", 10);
+```
+
+### 13. BPF_HASH_OF_MAPS
+
+Syntax: ```BPF_HASH_OF_MAPS(name, inner_map_name, size)```
+
+This creates a hash map with a map-in-map type (BPF_MAP_TYPE_HASH_OF_MAPS) map named ```name``` with ```size``` entries. The inner map meta data is provided by map ```inner_map_name``` and can be most of array or hash maps except ```BPF_MAP_TYPE_PROG_ARRAY```, ```BPF_MAP_TYPE_CGROUP_STORAGE``` and ```BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE```.
+
+For example:
+```C
+BPF_ARRAY(ex1, int, 1024);
+BPF_ARRAY(ex2, int, 1024);
+BPF_HASH_OF_MAPS(maps_hash, "ex1", 10);
+```
+
+### 14. map.lookup()
 
 Syntax: ```*val map.lookup(&key)```
 
@@ -769,7 +795,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=lookup+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=lookup+path%3Atools&type=Code)
 
-### 13. map.lookup_or_try_init()
+### 15. map.lookup_or_try_init()
 
 Syntax: ```*val map.lookup_or_try_init(&key, &zero)```
 
@@ -782,7 +808,7 @@ Examples in situ:
 Note: The old map.lookup_or_init() may cause return from the function, so lookup_or_try_init() is recommended as it
 does not have this side effect.
 
-### 14. map.delete()
+### 16. map.delete()
 
 Syntax: ```map.delete(&key)```
 
@@ -792,7 +818,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=delete+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=delete+path%3Atools&type=Code)
 
-### 15. map.update()
+### 17. map.update()
 
 Syntax: ```map.update(&key, &val)```
 
@@ -802,7 +828,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=update+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=update+path%3Atools&type=Code)
 
-### 16. map.insert()
+### 18. map.insert()
 
 Syntax: ```map.insert(&key, &val)```
 
@@ -812,7 +838,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=insert+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=insert+path%3Atools&type=Code)
 
-### 17. map.increment()
+### 19. map.increment()
 
 Syntax: ```map.increment(key[, increment_amount])```
 
@@ -822,7 +848,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=increment+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=increment+path%3Atools&type=Code)
 
-### 18. map.get_stackid()
+### 20. map.get_stackid()
 
 Syntax: ```int map.get_stackid(void *ctx, u64 flags)```
 
@@ -832,7 +858,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=get_stackid+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=get_stackid+path%3Atools&type=Code)
 
-### 19. map.perf_read()
+### 21. map.perf_read()
 
 Syntax: ```u64 map.perf_read(u32 cpu)```
 
@@ -841,7 +867,7 @@ This returns the hardware performance counter as configured in [5. BPF_PERF_ARRA
 Examples in situ:
 [search /tests](https://github.com/iovisor/bcc/search?q=perf_read+path%3Atests&type=Code)
 
-### 20. map.call()
+### 22. map.call()
 
 Syntax: ```void map.call(void *ctx, int index)```
 
@@ -880,7 +906,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?l=C&q=call+path%3Aexamples&type=Code),
 [search /tests](https://github.com/iovisor/bcc/search?l=C&q=call+path%3Atests&type=Code)
 
-### 21. map.redirect_map()
+### 23. map.redirect_map()
 
 Syntax: ```int map.redirect_map(int index, int flags)```
 

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -694,6 +694,13 @@ BPFStackBuildIdTable BPF::get_stackbuildid_table(const std::string &name, bool u
   return BPFStackBuildIdTable({}, use_debug_file, check_debug_file_crc, get_bsymcache());
 }
 
+BPFMapInMapTable BPF::get_map_in_map_table(const std::string& name) {
+  TableStorage::iterator it;
+  if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+    return BPFMapInMapTable(it->second);
+  return BPFMapInMapTable({});
+}
+
 bool BPF::add_module(std::string module)
 {
   return bcc_buildsymcache_add_module(get_bsymcache(), module.c_str()) != 0 ?

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -167,6 +167,8 @@ class BPF {
                                               bool use_debug_file = true,
                                               bool check_debug_file_crc = true);
 
+  BPFMapInMapTable get_map_in_map_table(const std::string& name);
+
   bool add_module(std::string module);
 
   StatusTuple open_perf_event(const std::string& name, uint32_t type,

--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -653,4 +653,25 @@ StatusTuple BPFDevmapTable::remove_value(const int& index) {
     return StatusTuple(0);
 }
 
+BPFMapInMapTable::BPFMapInMapTable(const TableDesc& desc)
+    : BPFTableBase<int, int>(desc) {
+    if(desc.type != BPF_MAP_TYPE_ARRAY_OF_MAPS &&
+       desc.type != BPF_MAP_TYPE_HASH_OF_MAPS)
+      throw std::invalid_argument("Table '" + desc.name +
+                                  "' is not a map-in-map table");
+}
+
+StatusTuple BPFMapInMapTable::update_value(const int& index,
+                                           const int& inner_map_fd) {
+    if (!this->update(const_cast<int*>(&index), const_cast<int*>(&inner_map_fd)))
+      return StatusTuple(-1, "Error updating value: %s", std::strerror(errno));
+    return StatusTuple(0);
+}
+
+StatusTuple BPFMapInMapTable::remove_value(const int& index) {
+    if (!this->remove(const_cast<int*>(&index)))
+      return StatusTuple(-1, "Error removing value: %s", std::strerror(errno));
+    return StatusTuple(0);
+}
+
 }  // namespace ebpf

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -399,7 +399,14 @@ public:
   StatusTuple update_value(const int& index, const int& value);
   StatusTuple get_value(const int& index, int& value);
   StatusTuple remove_value(const int& index);
+};
 
+class BPFMapInMapTable : public BPFTableBase<int, int> {
+public:
+  BPFMapInMapTable(const TableDesc& desc);
+
+  StatusTuple update_value(const int& index, const int& inner_map_fd);
+  StatusTuple remove_value(const int& index);
 };
 
 }  // namespace ebpf

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -19,6 +19,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <vector>
+#include <set>
 #include <linux/bpf.h>
 #include <net/if.h>
 
@@ -271,6 +272,88 @@ void BPFModule::load_btf(sec_map_def &sections) {
   btf_ = btf;
 }
 
+int BPFModule::create_maps(std::map<std::string, std::pair<int, int>> &map_tids,
+                           std::map<int, int> &map_fds,
+                           std::map<std::string, int> &inner_map_fds,
+                           bool for_inner_map) {
+  std::set<std::string> inner_maps;
+  if (for_inner_map) {
+    for (auto map : fake_fd_map_) {
+      std::string inner_map_name = get<7>(map.second);
+      if (inner_map_name.size())
+        inner_maps.insert(inner_map_name);
+    }
+  }
+
+  for (auto map : fake_fd_map_) {
+    int fd, fake_fd, map_type, key_size, value_size, max_entries, map_flags;
+    const char *map_name;
+    unsigned int pinned_id;
+    std::string inner_map_name;
+    int inner_map_fd = 0;
+
+    fake_fd     = map.first;
+    map_type    = get<0>(map.second);
+    map_name    = get<1>(map.second).c_str();
+    key_size    = get<2>(map.second);
+    value_size  = get<3>(map.second);
+    max_entries = get<4>(map.second);
+    map_flags   = get<5>(map.second);
+    pinned_id   = get<6>(map.second);
+    inner_map_name = get<7>(map.second);
+
+    if (for_inner_map) {
+      if (inner_maps.find(map_name) == inner_maps.end())
+        continue;
+      if (inner_map_name.size()) {
+        fprintf(stderr, "inner map %s has inner map %s\n",
+                map_name, inner_map_name.c_str());
+        return -1;
+      }
+    } else {
+      if (inner_map_fds.find(map_name) != inner_map_fds.end())
+        continue;
+      if (inner_map_name.size())
+        inner_map_fd = inner_map_fds[inner_map_name];
+    }
+
+    if (pinned_id) {
+        fd = bpf_map_get_fd_by_id(pinned_id);
+    } else {
+        struct bpf_create_map_attr attr = {};
+        attr.map_type = (enum bpf_map_type)map_type;
+        attr.name = map_name;
+        attr.key_size = key_size;
+        attr.value_size = value_size;
+        attr.max_entries = max_entries;
+        attr.map_flags = map_flags;
+        attr.map_ifindex = ifindex_;
+        attr.inner_map_fd = inner_map_fd;
+
+        if (map_tids.find(map_name) != map_tids.end()) {
+          attr.btf_fd = btf_->get_fd();
+          attr.btf_key_type_id = map_tids[map_name].first;
+          attr.btf_value_type_id = map_tids[map_name].second;
+        }
+
+        fd = bcc_create_map_xattr(&attr, allow_rlimit_);
+    }
+
+    if (fd < 0) {
+      fprintf(stderr, "could not open bpf map: %s, error: %s\n",
+              map_name, strerror(errno));
+      return -1;
+    }
+
+    if (for_inner_map)
+      inner_map_fds[map_name] = fd;
+
+    map_fds[fake_fd] = fd;
+  }
+
+  return 0;
+}
+
 int BPFModule::load_maps(sec_map_def &sections) {
   // find .maps.<table_name> sections and retrieve all map key/value type id's
   std::map<std::string, std::pair<int, int>> map_tids;
@@ -316,50 +399,12 @@ int BPFModule::load_maps(sec_map_def &sections) {
   }
 
   // create maps
+  std::map<std::string, int> inner_map_fds;
   std::map<int, int> map_fds;
-  for (auto map : fake_fd_map_) {
-    int fd, fake_fd, map_type, key_size, value_size, max_entries, map_flags;
-    const char *map_name;
-    unsigned int pinned_id;
-
-    fake_fd     = map.first;
-    map_type    = get<0>(map.second);
-    map_name    = get<1>(map.second).c_str();
-    key_size    = get<2>(map.second);
-    value_size  = get<3>(map.second);
-    max_entries = get<4>(map.second);
-    map_flags   = get<5>(map.second);
-    pinned_id   = get<6>(map.second);
-
-    if (pinned_id) {
-        fd = bpf_map_get_fd_by_id(pinned_id);
-    } else {
-        struct bpf_create_map_attr attr = {};
-        attr.map_type = (enum bpf_map_type)map_type;
-        attr.name = map_name;
-        attr.key_size = key_size;
-        attr.value_size = value_size;
-        attr.max_entries = max_entries;
-        attr.map_flags = map_flags;
-        attr.map_ifindex = ifindex_;
-
-        if (map_tids.find(map_name) != map_tids.end()) {
-          attr.btf_fd = btf_->get_fd();
-          attr.btf_key_type_id = map_tids[map_name].first;
-          attr.btf_value_type_id = map_tids[map_name].second;
-        }
-
-        fd = bcc_create_map_xattr(&attr, allow_rlimit_);
-    }
-
-    if (fd < 0) {
-      fprintf(stderr, "could not open bpf map: %s, error: %s\n",
-              map_name, strerror(errno));
-      return -1;
-    }
-
-    map_fds[fake_fd] = fd;
-  }
+  if (create_maps(map_tids, map_fds, inner_map_fds, true) < 0)
+    return -1;
+  if (create_maps(map_tids, map_fds, inner_map_fds, false) < 0)
+    return -1;
 
   // update map table fd's
   for (auto it = ts_->begin(), up = ts_->end(); it != up; ++it) {

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -88,6 +88,10 @@ class BPFModule {
                        const void *val);
   void load_btf(sec_map_def &sections);
   int load_maps(sec_map_def &sections);
+  int create_maps(std::map<std::string, std::pair<int, int>> &map_tids,
+                  std::map<int, int> &map_fds,
+                  std::map<std::string, int> &inner_map_fds,
+                  bool for_inner_map);
 
  public:
   BPFModule(unsigned flags, TableStorage *ts = nullptr, bool rw_engine_enabled = true,

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -269,6 +269,12 @@ struct _name##_table_t _name = { .max_entries = (_max_entries) }
 #define BPF_CPUMAP(_name, _max_entries) \
   BPF_XDP_REDIRECT_MAP("cpumap", u32, _name, _max_entries)
 
+#define BPF_ARRAY_OF_MAPS(_name, _inner_map_name, _max_entries) \
+  BPF_TABLE("array_of_maps$" _inner_map_name, int, int, _name, _max_entries)
+
+#define BPF_HASH_OF_MAPS(_name, _inner_map_name, _max_entries) \
+  BPF_TABLE("hash_of_maps$" _inner_map_name, int, int, _name, _max_entries)
+
 // packet parsing state machine helpers
 #define cursor_advance(_cursor, _len) \
   ({ void *_tmp = _cursor; _cursor += _len; _tmp; })

--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -174,7 +174,8 @@ class BFrontendAction : public clang::ASTFrontendAction {
   void DoMiscWorkAround();
   // negative fake_fd to be different from real fd in bpf_pseudo_fd.
   int get_next_fake_fd() { return next_fake_fd_--; }
-  void add_map_def(int fd, std::tuple<int, std::string, int, int, int, int, unsigned int> map_def) {
+  void add_map_def(int fd,
+    std::tuple<int, std::string, int, int, int, int, unsigned int, std::string> map_def) {
     fake_fd_map_[fd] = move(map_def);
   }
 

--- a/src/cc/table_storage.h
+++ b/src/cc/table_storage.h
@@ -27,7 +27,8 @@
 
 namespace ebpf {
 
-typedef std::map<int, std::tuple<int, std::string, int, int, int, int, unsigned int>> fake_fd_map_def;
+typedef std::map<int, std::tuple<int, std::string, int, int, int, int, unsigned int, std::string>>
+        fake_fd_map_def;
 
 class TableStorageImpl;
 class TableStorageIteratorImpl;

--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -182,6 +182,10 @@ def Table(bpf, map_id, map_fd, keytype, leaftype, name, **kwargs):
         t = DevMap(bpf, map_id, map_fd, keytype, leaftype)
     elif ttype == BPF_MAP_TYPE_CPUMAP:
         t = CpuMap(bpf, map_id, map_fd, keytype, leaftype)
+    elif ttype == BPF_MAP_TYPE_ARRAY_OF_MAPS:
+        t = MapInMapArray(bpf, map_id, map_fd, keytype, leaftype)
+    elif ttype == BPF_MAP_TYPE_HASH_OF_MAPS:
+        t = MapInMapHash(bpf, map_id, map_fd, keytype, leaftype)
     if t == None:
         raise Exception("Unknown table type %d" % ttype)
     return t
@@ -199,6 +203,9 @@ class TableBase(MutableMapping):
         self.flags = lib.bpf_table_flags_id(self.bpf.module, self.map_id)
         self._cbs = {}
         self._name = name
+
+    def get_fd(self):
+        return self.map_fd
 
     def key_sprintf(self, key):
         buf = ct.create_string_buffer(ct.sizeof(self.Key) * 8)
@@ -897,3 +904,11 @@ class DevMap(ArrayBase):
 class CpuMap(ArrayBase):
     def __init__(self, *args, **kwargs):
         super(CpuMap, self).__init__(*args, **kwargs)
+
+class MapInMapArray(ArrayBase):
+    def __init__(self, *args, **kwargs):
+        super(MapInMapArray, self).__init__(*args, **kwargs)
+
+class MapInMapHash(HashTable):
+    def __init__(self, *args, **kwargs):
+        super(MapInMapHash, self).__init__(*args, **kwargs)

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_LIBBCC_SOURCES
 	test_array_table.cc
 	test_bpf_table.cc
 	test_hash_table.cc
+	test_map_in_map.cc
 	test_perf_event.cc
 	test_pinned_table.cc
 	test_prog_table.cc

--- a/tests/cc/test_map_in_map.cc
+++ b/tests/cc/test_map_in_map.cc
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2019 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <linux/version.h>
+#include <unistd.h>
+#include <string>
+
+#include "BPF.h"
+#include "catch.hpp"
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+typedef unsigned long long __u64;
+
+TEST_CASE("test hash of maps", "[hash_of_maps]") {
+  {
+    const std::string BPF_PROGRAM = R"(
+      BPF_ARRAY(cntl, int, 1);
+      BPF_ARRAY(ex1, int, 1024);
+      BPF_ARRAY(ex2, int, 1024);
+      BPF_ARRAY(ex3, u64, 1024);
+      BPF_HASH_OF_MAPS(maps_hash, "ex1", 10);
+
+      int syscall__getuid(void *ctx) {
+         int key = 0, data, *val, cntl_val;
+         void *inner_map;
+
+         val = cntl.lookup(&key);
+         if (!val || *val == 0)
+           return 0;
+
+         // cntl_val == 1 : lookup and update
+         cntl_val = *val;
+         inner_map = maps_hash.lookup(&key);
+         if (!inner_map)
+           return 0;
+
+         if (cntl_val == 1) {
+           val = bpf_map_lookup_elem(inner_map, &key);
+           if (val) {
+             data = 1;
+             bpf_map_update_elem(inner_map, &key, &data, 0);
+           }
+         }
+
+         return 0;
+      }
+    )";
+
+    ebpf::BPF bpf;
+    ebpf::StatusTuple res(0);
+    res = bpf.init(BPF_PROGRAM);
+    REQUIRE(res.code() == 0);
+
+    auto t = bpf.get_map_in_map_table("maps_hash");
+    auto ex1_table = bpf.get_array_table<int>("ex1");
+    auto ex2_table = bpf.get_array_table<int>("ex2");
+    auto ex3_table = bpf.get_array_table<__u64>("ex3");
+    int ex1_fd = ex1_table.get_fd();
+    int ex2_fd = ex2_table.get_fd();
+    int ex3_fd = ex3_table.get_fd();
+
+    int key = 0, value = 0;
+    res = t.update_value(key, ex1_fd);
+    REQUIRE(res.code() == 0);
+
+    // updating already-occupied slot will succeed.
+    res = t.update_value(key, ex2_fd);
+    REQUIRE(res.code() == 0);
+    res = t.update_value(key, ex1_fd);
+    REQUIRE(res.code() == 0);
+
+    // an in-compatible map
+    key = 1;
+    res = t.update_value(key, ex3_fd);
+    REQUIRE(res.code() == -1);
+
+    // hash table, any valid key should work as long
+    // as hash table is not full.
+    key = 10;
+    res = t.update_value(key, ex2_fd);
+    REQUIRE(res.code() == 0);
+    res = t.remove_value(key);
+    REQUIRE(res.code() == 0);
+
+    // test effectiveness of map-in-map
+    key = 0;
+    std::string getuid_fnname = bpf.get_syscall_fnname("getuid");
+    res = bpf.attach_kprobe(getuid_fnname, "syscall__getuid");
+    REQUIRE(res.code() == 0);
+
+    auto cntl_table = bpf.get_array_table<int>("cntl");
+    cntl_table.update_value(0, 1);
+    REQUIRE(getuid() >= 0);
+    res = ex1_table.get_value(key, value);
+    REQUIRE(res.code() == 0);
+    REQUIRE(value > 0);
+
+    res = bpf.detach_kprobe(getuid_fnname);
+    REQUIRE(res.code() == 0);
+
+    res = t.remove_value(key);
+    REQUIRE(res.code() == 0);
+  }
+}
+
+TEST_CASE("test array of maps", "[array_of_maps]") {
+  {
+    const std::string BPF_PROGRAM = R"(
+      BPF_ARRAY(cntl, int, 1);
+      BPF_TABLE("hash", int, int, ex1, 1024);
+      BPF_TABLE("hash", int, int, ex2, 1024);
+      BPF_TABLE("hash", u64, u64, ex3, 1024);
+      BPF_ARRAY_OF_MAPS(maps_array, "ex1", 10);
+
+      int syscall__getuid(void *ctx) {
+         int key = 0, data, *val, cntl_val;
+         void *inner_map;
+
+         val = cntl.lookup(&key);
+         if (!val || *val == 0)
+           return 0;
+
+         // cntl_val == 1 : lookup and update
+         // cntl_val == 2 : delete
+         cntl_val = *val;
+         inner_map = maps_array.lookup(&key);
+         if (!inner_map)
+           return 0;
+
+         if (cntl_val == 1) {
+           val = bpf_map_lookup_elem(inner_map, &key);
+           if (!val) {
+             data = 1;
+             bpf_map_update_elem(inner_map, &key, &data, 0);
+           }
+         } else if (cntl_val == 2) {
+           bpf_map_delete_elem(inner_map, &key);
+         }
+
+         return 0;
+      }
+    )";
+
+    ebpf::BPF bpf;
+    ebpf::StatusTuple res(0);
+    res = bpf.init(BPF_PROGRAM);
+    REQUIRE(res.code() == 0);
+
+    auto t = bpf.get_map_in_map_table("maps_array");
+    auto ex1_table = bpf.get_hash_table<int, int>("ex1");
+    auto ex2_table = bpf.get_hash_table<int, int>("ex2");
+    auto ex3_table = bpf.get_hash_table<__u64, __u64>("ex3");
+    int ex1_fd = ex1_table.get_fd();
+    int ex2_fd = ex2_table.get_fd();
+    int ex3_fd = ex3_table.get_fd();
+
+    int key = 0, value = 0;
+    res = t.update_value(key, ex1_fd);
+    REQUIRE(res.code() == 0);
+
+    // updating already-occupied slot will succeed.
+    res = t.update_value(key, ex2_fd);
+    REQUIRE(res.code() == 0);
+    res = t.update_value(key, ex1_fd);
+    REQUIRE(res.code() == 0);
+
+    // an in-compatible map
+    key = 1;
+    res = t.update_value(key, ex3_fd);
+    REQUIRE(res.code() == -1);
+
+    // array table, out of bound access
+    key = 10;
+    res = t.update_value(key, ex2_fd);
+    REQUIRE(res.code() == -1);
+
+    // test effectiveness of map-in-map
+    key = 0;
+    std::string getuid_fnname = bpf.get_syscall_fnname("getuid");
+    res = bpf.attach_kprobe(getuid_fnname, "syscall__getuid");
+    REQUIRE(res.code() == 0);
+
+    auto cntl_table = bpf.get_array_table<int>("cntl");
+    cntl_table.update_value(0, 1);
+
+    REQUIRE(getuid() >= 0);
+    res = ex1_table.get_value(key, value);
+    REQUIRE(res.code() == 0);
+    REQUIRE(value == 1);
+
+    cntl_table.update_value(0, 2);
+    REQUIRE(getuid() >= 0);
+    res = ex1_table.get_value(key, value);
+    REQUIRE(res.code() == -1);
+
+    res = bpf.detach_kprobe(getuid_fnname);
+    REQUIRE(res.code() == 0);
+
+    res = t.remove_value(key);
+    REQUIRE(res.code() == 0);
+  }
+}
+#endif

--- a/tests/python/test_map_in_map.py
+++ b/tests/python/test_map_in_map.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+#
+# USAGE: test_map_in_map.py
+#
+# Copyright 2019 Facebook, Inc
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+from __future__ import print_function
+from bcc import BPF
+import distutils.version
+from unittest import main, skipUnless, TestCase
+import ctypes as ct
+import os
+
+def kernel_version_ge(major, minor):
+    # True if running kernel is >= X.Y
+    version = distutils.version.LooseVersion(os.uname()[2]).version
+    if version[0] > major:
+        return True
+    if version[0] < major:
+        return False
+    if minor and version[1] < minor:
+        return False
+    return True
+
+@skipUnless(kernel_version_ge(4,11), "requires kernel >= 4.11")
+class TestUDST(TestCase):
+    def test_hash_table(self):
+        bpf_text = """
+      BPF_ARRAY(cntl, int, 1);
+      BPF_TABLE("hash", int, int, ex1, 1024);
+      BPF_TABLE("hash", int, int, ex2, 1024);
+      BPF_HASH_OF_MAPS(maps_hash, "ex1", 10);
+
+      int syscall__getuid(void *ctx) {
+         int key = 0, data, *val, cntl_val;
+         void *inner_map;
+
+         val = cntl.lookup(&key);
+         if (!val || *val == 0)
+           return 0;
+
+         cntl_val = *val;
+         inner_map = maps_hash.lookup(&cntl_val);
+         if (!inner_map)
+           return 0;
+
+         val = bpf_map_lookup_elem(inner_map, &key);
+         if (!val) {
+           data = 1;
+           bpf_map_update_elem(inner_map, &key, &data, 0);
+         } else {
+           data = 1 + *val;
+           bpf_map_update_elem(inner_map, &key, &data, 0);
+         }
+
+         return 0;
+      }
+"""
+        b = BPF(text=bpf_text)
+        cntl_map = b.get_table("cntl")
+        ex1_map = b.get_table("ex1")
+        ex2_map = b.get_table("ex2")
+        hash_maps = b.get_table("maps_hash")
+
+        hash_maps[ct.c_int(1)] = ct.c_int(ex1_map.get_fd())
+        hash_maps[ct.c_int(2)] = ct.c_int(ex2_map.get_fd())
+
+        syscall_fnname = b.get_syscall_fnname("getuid")
+        b.attach_kprobe(event=syscall_fnname, fn_name="syscall__getuid")
+
+        try:
+          ex1_map[ct.c_int(0)]
+          raise Exception("Unexpected success for ex1_map[0]")
+        except KeyError:
+          pass
+
+        cntl_map[0] = ct.c_int(1)
+        os.getuid()
+        assert(ex1_map[ct.c_int(0)] >= 1)
+
+        try:
+          ex2_map[ct.c_int(0)]
+          raise Exception("Unexpected success for ex2_map[0]")
+        except KeyError:
+          pass
+
+        cntl_map[0] = ct.c_int(2)
+        os.getuid()
+        assert(ex2_map[ct.c_int(0)] >= 1)
+
+        b.detach_kprobe(event=syscall_fnname)
+        del hash_maps[ct.c_int(1)]
+        del hash_maps[ct.c_int(2)]
+
+    def test_array_table(self):
+        bpf_text = """
+      BPF_ARRAY(cntl, int, 1);
+      BPF_ARRAY(ex1, int, 1024);
+      BPF_ARRAY(ex2, int, 1024);
+      BPF_ARRAY_OF_MAPS(maps_array, "ex1", 10);
+
+      int syscall__getuid(void *ctx) {
+         int key = 0, data, *val, cntl_val;
+         void *inner_map;
+
+         val = cntl.lookup(&key);
+         if (!val || *val == 0)
+           return 0;
+
+         cntl_val = *val;
+         inner_map = maps_array.lookup(&cntl_val);
+         if (!inner_map)
+           return 0;
+
+         val = bpf_map_lookup_elem(inner_map, &key);
+         if (val) {
+           data = 1 + *val;
+           bpf_map_update_elem(inner_map, &key, &data, 0);
+         }
+
+         return 0;
+      }
+"""
+        b = BPF(text=bpf_text)
+        cntl_map = b.get_table("cntl")
+        ex1_map = b.get_table("ex1")
+        ex2_map = b.get_table("ex2")
+        array_maps = b.get_table("maps_array")
+
+        array_maps[ct.c_int(1)] = ct.c_int(ex1_map.get_fd())
+        array_maps[ct.c_int(2)] = ct.c_int(ex2_map.get_fd())
+
+        syscall_fnname = b.get_syscall_fnname("getuid")
+        b.attach_kprobe(event=syscall_fnname, fn_name="syscall__getuid")
+
+        cntl_map[0] = ct.c_int(1)
+        os.getuid()
+        assert(ex1_map[ct.c_int(0)] >= 1)
+
+        cntl_map[0] = ct.c_int(2)
+        os.getuid()
+        assert(ex2_map[ct.c_int(0)] >= 1)
+
+        b.detach_kprobe(event=syscall_fnname)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add BPF_MAP_TYPE_HASH_OF_MAPS and BPF_MAP_TYPE_HASH_OF_MAPS
supports in bcc. Two new constructs below are introduced
to bpf program:
```
  BPF_HASH_OF_MAPS(map_name, "inner_map_name", max_entries)
  BPF_ARRAY_OF_MAPS(map_name, "inner_map_name", max_entries)
```
In the above, "inner_map_name" is for metadata purpose and there
must be a map defined in bpf program with map name "inner_map_name".

Both python and C++ APIs are added.

For python, a new Table API get_fd() is introduced to get
the fd of a map so that the fd can be used by a map-in-map
do update. The get_fd() is already exposed as API function
in C++. For C++, without get_fd(), we will need to
templatize basic functions like update_value etc, which
I feed too heavy weight. Because of C++ using get_fd()
mechanism, so I exposed similar API on python side
for parity reason.

For map-in-map, the inner map lookup/update/delete won't have
explicit map names. Considering map-in-map is not
used very frequently, I feel looking primitive
bpf_map_{lookup,update,delete}_elem() probably okay,
so I did not create any new bcc specific
constructs for this purpose.

Added both C++ and python test cases to show how to
use the above two new map type in bcc.

Signed-off-by: Yonghong Song <yhs@fb.com>