### PR TITLE
Do not traverse attributes during JSON generation (Fixes #2605)

### DIFF
--- a/src/cc/json_map_decl_visitor.cc
+++ b/src/cc/json_map_decl_visitor.cc
@@ -43,6 +43,7 @@ class BMapDeclVisitor : public clang::RecursiveASTVisitor<BMapDeclVisitor> {
   bool VisitPointerType(const clang::PointerType *T);
   bool VisitEnumConstantDecl(clang::EnumConstantDecl *D);
   bool VisitEnumDecl(clang::EnumDecl *D);
+  bool VisitAttr(clang::Attr *A);
 
  private:
   bool shouldSkipPadding(const RecordDecl *D);
@@ -183,6 +184,7 @@ bool BMapDeclVisitor::VisitBuiltinType(const BuiltinType *T) {
   result_ += "\"";
   return true;
 }
+bool BMapDeclVisitor::VisitAttr(clang::Attr *A) { return false; }
 
 class JsonMapTypesVisitor : public virtual MapTypesVisitor {
  public:


### PR DESCRIPTION
Previously, `__attribute__((aligned(sizeof(...))))` would cause the type inside `sizeof()` to be appended after the JSON type information for the struct in some clang versions, generating invalid JSON. Inhibit attribute traversal, since we only want to visit the fields.

I'm not that familiar with C++ nor the internals of clang and bcc, so review with extreme prejudice. :)

I've tested that this fixes the issue for me, but I'm not sure if this is the best way to fix this. Since we *only* want to look at the fields, it might be better to just inhibit *all* child traversal for `RecordDecl`, since we manually iterate the fields anyway.

I am not sure what would be the best way to do that, though, since I have no idea what's going on with clang's AST traversal: Given that `TraverseRecordDecl` already seems to try to skipping the children, it's kind of weird that the `AlignedAttr` is visited in the first place - maybe some parent class invoked by `WalkUpFromRecordDecl`, does the attribute visiting? Returning `false` from `VisitRecordDecl` also seems to fix this, but I have no idea what kind of other side effects that might have. (And if returning `false` is the right thing to do, does that mean that most of the other methods in the file should really be returning `false`, too?)

The above roughly translates to "I have no idea what's *really* happening, and the more I look at it, the weirder it seems to get".