### PR TITLE
do not use BPF_F_REUSE_STACKID incorrectly

### DIFF
--- a/tools/deadlock.c
+++ b/tools/deadlock.c
@@ -95,7 +95,7 @@ int trace_mutex_acquire(struct pt_regs *ctx, void *mutex_addr) {
   }
 
   u64 stack_id =
-      stack_traces.get_stackid(ctx, BPF_F_USER_STACK | BPF_F_REUSE_STACKID);
+      stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
 
   int added_mutex = 0;
   #pragma unroll
@@ -190,7 +190,7 @@ int trace_clone(struct pt_regs *ctx, unsigned long flags, void *child_stack,
   struct thread_created_leaf_t thread_created_leaf = {};
   thread_created_leaf.parent_pid = bpf_get_current_pid_tgid();
   thread_created_leaf.stack_id =
-      stack_traces.get_stackid(ctx, BPF_F_USER_STACK | BPF_F_REUSE_STACKID);
+      stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
   bpf_get_current_comm(&thread_created_leaf.comm,
                        sizeof(thread_created_leaf.comm));
 

--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -399,7 +399,7 @@ elif max_size is not None:
         size_filter = "if (size > %d) return 0;" % max_size
 bpf_source = bpf_source.replace("SIZE_FILTER", size_filter)
 
-stack_flags = "BPF_F_REUSE_STACKID"
+stack_flags = "0"
 if not kernel_trace:
         stack_flags += "|BPF_F_USER_STACK"
 bpf_source = bpf_source.replace("STACK_FLAGS", stack_flags)

--- a/tools/old/profile.py
+++ b/tools/old/profile.py
@@ -209,9 +209,9 @@ bpf_text = bpf_text.replace('STACK_STORAGE_SIZE', str(args.stack_storage_size))
 
 # handle stack args
 kernel_stack_get = "stack_traces.get_stackid(args, " \
-    "%d | BPF_F_REUSE_STACKID)" % skip
+    "%d)" % skip
 user_stack_get = \
-    "stack_traces.get_stackid(args, BPF_F_REUSE_STACKID | BPF_F_USER_STACK)"
+    "stack_traces.get_stackid(args, BPF_F_USER_STACK)"
 stack_context = ""
 if args.user_stacks_only:
     stack_context = "user"

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -110,14 +110,14 @@ class Probe(object):
         if self.user_stack:
                 stack_trace += """
                     key.user_stack_id = stack_traces.get_stackid(
-                      %s, BPF_F_REUSE_STACKID | BPF_F_USER_STACK
+                      %s, BPF_F_USER_STACK
                     );""" % (ctx_name)
         else:
                 stack_trace += "key.user_stack_id = -1;"
         if self.kernel_stack:
                 stack_trace += """
                     key.kernel_stack_id = stack_traces.get_stackid(
-                      %s, BPF_F_REUSE_STACKID
+                      %s, 0
                     );""" % (ctx_name)
         else:
                 stack_trace += "key.kernel_stack_id = -1;"

--- a/tools/stacksnoop.lua
+++ b/tools/stacksnoop.lua
@@ -32,7 +32,7 @@ void trace_stack(struct pt_regs *ctx) {
     u32 pid = bpf_get_current_pid_tgid();
     FILTER
     struct data_t data = {};
-    data.stack_id = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID),
+    data.stack_id = stack_traces.get_stackid(ctx, 0),
     data.pid = pid;
     bpf_get_current_comm(&data.comm, sizeof(data.comm));
     events.perf_submit(ctx, &data, sizeof(data));

--- a/tools/trace.py
+++ b/tools/trace.py
@@ -487,12 +487,12 @@ BPF_PERF_OUTPUT(%s);
                 if self.user_stack:
                         stack_trace += """
         __data.user_stack_id = %s.get_stackid(
-          %s, BPF_F_REUSE_STACKID | BPF_F_USER_STACK
+          %s, BPF_F_USER_STACK
         );""" % (self.stacks_name, ctx_name)
                 if self.kernel_stack:
                         stack_trace += """
         __data.kernel_stack_id = %s.get_stackid(
-          %s, BPF_F_REUSE_STACKID
+          %s, 0
         );""" % (self.stacks_name, ctx_name)
 
                 text = heading + """

--- a/tools/wakeuptime.py
+++ b/tools/wakeuptime.py
@@ -135,7 +135,7 @@ int waker(struct pt_regs *ctx, struct task_struct *p) {
 
     struct key_t key = {};
 
-    key.w_k_stack_id = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
+    key.w_k_stack_id = stack_traces.get_stackid(ctx, 0);
     bpf_probe_read(&key.target, sizeof(key.target), p->comm);
     bpf_get_current_comm(&key.waker, sizeof(key.waker));
 


### PR DESCRIPTION
Do not use BPF_F_REUSE_STACKID if the stack id is used
together with process specific info like
pid/tgid/comm. Using BPF_F_REUSE_STACKID may cause
stack id pointing to a different stack later on.

Signed-off-by: Yonghong Song <yhs@fb.com>