### PR TITLE
Use libbpf-static instead of libbpf-debugsource for CMAKE_USE_LIBBPF_PACKAGE

### DIFF
--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -3,21 +3,17 @@
 #
 #  LIBBPF_FOUND            - system has libbpf
 #  LIBBPF_INCLUDE_DIR      - the libbpf include directory
-#  LIBBPF_SOURCE_DIR       - the libbpf source directory
+#  LIBBPF_STATIC_LIBRARIES - the libbpf source directory
 #  LIBBPF_LIBRARIES        - link these to use libbpf
 
-#if (LIBBPF_LIBRARIES AND LIBBPF_INCLUDE_DIR AND LIBBPF_SOURCE_DIR)
+#if (LIBBPF_LIBRARIES AND LIBBPF_INCLUDE_DIR AND LIBBPF_STATIC_LIBRARIES)
 #  set (LibBpf_FIND_QUIETLY TRUE)
-#endif (LIBBPF_LIBRARIES AND LIBBPF_INCLUDE_DIR AND LIBBPF_SOURCE_DIR)
+#endif (LIBBPF_LIBRARIES AND LIBBPF_INCLUDE_DIR AND LIBBPF_STATIC_LIBRARIES)
 
 # You'll need following packages to be installed (Fedora names):
 # libbpf
-# libbpf-debugsource
+# libbpf-static
 # libbpf-devel
-#
-# Please note that you might need to enable updates-debuginfo repo
-# for debugsource package like:
-#   dnf install --enablerepo=updates-debuginfo libbpf-debugsource
 
 find_path (LIBBPF_INCLUDE_DIR
   NAMES
@@ -32,19 +28,16 @@ find_path (LIBBPF_INCLUDE_DIR
     /sw/include
     ENV CPATH)
 
-file(GLOB libbpf_source_path /usr/src/debug/libbpf-*)
-
-find_path (LIBBPF_SOURCE_DIR
+find_library (LIBBPF_STATIC_LIBRARIES
   NAMES
-    src/bpf.c
-    src/bpf.h
-    src/libbpf.c
-    src/libbpf.h
-
+    libbpf.a
   PATHS
-    ${libbpf_source_path}
-    ENV CPATH
-)
+    /usr/lib
+    /usr/local/lib
+    /opt/local/lib
+    /sw/lib
+    ENV LIBRARY_PATH
+    ENV LD_LIBRARY_PATH)
 
 find_library (LIBBPF_LIBRARIES
   NAMES
@@ -62,7 +55,7 @@ include (FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set LIBBPF_FOUND to TRUE if all listed variables are TRUE
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibBpf "Please install the libbpf development package"
   LIBBPF_LIBRARIES
-  LIBBPF_SOURCE_DIR
+  LIBBPF_STATIC_LIBRARIES
   LIBBPF_INCLUDE_DIR)
 
-mark_as_advanced(LIBBPF_INCLUDE_DIR LIBBPF_SOURCE_DIR LIBBPF_LIBRARIES)
+mark_as_advanced(LIBBPF_INCLUDE_DIR LIBBPF_STATIC_LIBRARIES LIBBPF_LIBRARIES)

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -35,12 +35,14 @@ if(LIBBPF_FOUND)
 
   include_directories(${LIBBPF_INCLUDE_DIR}/bpf)
 
-  file(GLOB libbpf_sources "${LIBBPF_SOURCE_DIR}/src/*.c")
-  set(libbpf_uapi ${LIBBPF_SOURCE_DIR}/include/uapi/linux)
+  set(extract_dir ${CMAKE_CURRENT_BINARY_DIR}/libbpf_a_extract)
+  execute_process(COMMAND sh -c "mkdir -p ${extract_dir} && cd ${extract_dir} && ${CMAKE_AR} x ${LIBBPF_STATIC_LIBRARIES}")
+  file(GLOB libbpf_sources "${extract_dir}/*.o")
 else()
   file(GLOB libbpf_sources "libbpf/src/*.c")
-  set(libbpf_uapi libbpf/include/uapi/linux})
 endif()
+
+set(libbpf_uapi libbpf/include/uapi/linux})
 
 add_library(bpf-static STATIC libbpf.c perf_reader.c ${libbpf_sources})
 set_target_properties(bpf-static PROPERTIES OUTPUT_NAME bcc_bpf)


### PR DESCRIPTION
@yonghong-song I thought we could use source packaged within
package build, but it's not the case.. it seems we can use libbpf-static
instead just as fine, with the uapi exception (described below)

I made sure this time and prepared [bcc fedora build](https://koji.fedoraproject.org/koji/taskinfo?taskID=39395362) with this change. Works nicely on all supported archs.

thanks,
jirka

---
Currently when building with CMAKE_USE_LIBBPF_PACKAGE we assume
that 'source' package is available to build libbcc_bpf libraries.

However It turned on that using debugsource (in Fedora) package is
not suitable or even possible, so we are switching to use the
libbpf-static package instead.

Adding libbpf-static package detection and removing source
package detection.

Using ar to extract objects from archive and linking them
with both libbcc_bpf.so and libbcc_bpf.a.

Using always uapi headers from the latest libbpf Github repo,
because there are not packaged, but they are backwards compatible,
so it's no problem to have older libbpf package with newer
uapi headers.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>