### PR TITLE
Use integer types for enums in JSON (Fixes #2615)

### DIFF
--- a/src/cc/json_map_decl_visitor.cc
+++ b/src/cc/json_map_decl_visitor.cc
@@ -41,7 +41,6 @@ class BMapDeclVisitor : public clang::RecursiveASTVisitor<BMapDeclVisitor> {
   bool VisitTypedefType(const clang::TypedefType *T);
   bool VisitTagType(const clang::TagType *T);
   bool VisitPointerType(const clang::PointerType *T);
-  bool VisitEnumConstantDecl(clang::EnumConstantDecl *D);
   bool VisitEnumDecl(clang::EnumDecl *D);
   bool VisitAttr(clang::Attr *A);
 
@@ -93,22 +92,8 @@ bool BMapDeclVisitor::VisitFieldDecl(FieldDecl *D) {
   return true;
 }
 
-bool BMapDeclVisitor::VisitEnumConstantDecl(EnumConstantDecl *D) {
-  result_ += "\"";
-  result_ += D->getName();
-  result_ += "\",";
-  return false;
-}
-
 bool BMapDeclVisitor::VisitEnumDecl(EnumDecl *D) {
-  result_ += "[\"";
-  result_ += D->getName();
-  result_ += "\", [";
-  for (auto it = D->enumerator_begin(); it != D->enumerator_end(); ++it) {
-    TraverseDecl(*it);
-  }
-  result_.erase(result_.end() - 1);
-  result_ += "], \"enum\"]";
+  TraverseType(D->getIntegerType());
   return false;
 }
 

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -944,6 +944,7 @@ struct a {
 BPF_HASH(drops, struct a);
         """
         b = BPF(text=text)
+        t = b['drops']
 
     def test_int128_types(self):
         text = """


### PR DESCRIPTION
The JSON generated for enums wasn't being handled, and caused
exceptions. Since the enum values aren't needed (and would've been
useless without the associated numerical values, anyway), just use the
matching integer type instead.

---

`Traverse*()` shouldn't really be called from inside `Visit*()`, but all the other methods are doing it too, so... The original enum code seems to have been a workaround for a problem caused by that, so the whole thing should probably be fixed at some point.