### PR TITLE
man: fix the field of filetop

### DIFF
--- a/man/man8/filetop.8
+++ b/man/man8/filetop.8
@@ -90,6 +90,9 @@ Total write Kbytes during interval.
 .TP
 T
 Type of file: R == regular, S == socket, O == other (pipe, etc).
+.TP
+FILE
+Filename.
 .SH OVERHEAD
 Depending on the frequency of application reads and writes, overhead can become
 significant, in the worst case slowing applications by over 50%. Hopefully for


### PR DESCRIPTION
In the man pages of filetop, the field of FILE is missing

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>