### PR TITLE
man: fix a reference to runqlat in runqslower man page

### DIFF
--- a/man/man8/runqslower.8
+++ b/man/man8/runqslower.8
@@ -1,6 +1,6 @@
 .TH runqslower 8  "2016-02-07" "USER COMMANDS"
 .SH NAME
-runqlat \- Trace long process scheduling delays.
+runqslower \- Trace long process scheduling delays.
 .SH SYNOPSIS
 .B runqslower [\-p PID] [min_us]
 .SH DESCRIPTION


### PR DESCRIPTION
The runqslower man page obviously derived from the man page of
runqlat. It seems that a reference to runqlat in the NAME section has
been overlooked.