### PR TITLE
remove inproper usage of BPF_F_REUSE_STACKID in examples

### DIFF
--- a/examples/lua/memleak.lua
+++ b/examples/lua/memleak.lua
@@ -113,7 +113,7 @@ return function(BPF, utils)
     size_filter = "if (size > %d) return 0;" % args.max_size
   end
 
-  local stack_flags = "BPF_F_REUSE_STACKID"
+  local stack_flags = "0"
   if args.pid then
     stack_flags = stack_flags .. "|BPF_F_USER_STACK"
   end

--- a/examples/lua/offcputime.lua
+++ b/examples/lua/offcputime.lua
@@ -54,7 +54,7 @@ int oncpu(struct pt_regs *ctx, struct task_struct *prev) {
     // create map key
     u64 zero = 0, *val;
     struct key_t key = {};
-    int stack_flags = BPF_F_REUSE_STACKID;
+    int stack_flags = 0;
 
     /*
     if (!(prev->flags & PF_KTHREAD))

--- a/examples/tracing/mallocstacks.py
+++ b/examples/tracing/mallocstacks.py
@@ -39,8 +39,7 @@ BPF_HASH(calls, int);
 BPF_STACK_TRACE(stack_traces, """ + stacks + """);
 
 int alloc_enter(struct pt_regs *ctx, size_t size) {
-    int key = stack_traces.get_stackid(ctx,
-        BPF_F_USER_STACK|BPF_F_REUSE_STACKID);
+    int key = stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
     if (key < 0)
         return 0;
 

--- a/examples/tracing/stacksnoop.py
+++ b/examples/tracing/stacksnoop.py
@@ -59,7 +59,7 @@ void trace_stack(struct pt_regs *ctx) {
     u32 pid = bpf_get_current_pid_tgid();
     FILTER
     struct data_t data = {};
-    data.stack_id = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID),
+    data.stack_id = stack_traces.get_stackid(ctx, 0),
     data.pid = pid;
     bpf_get_current_comm(&data.comm, sizeof(data.comm));
     events.perf_submit(ctx, &data, sizeof(data));


### PR DESCRIPTION
When the application bundles stack id with process specific
info (like pid, comm, etc.), BPF_F_REUSE_STACKID should not
be used as it may associate wrong stack with processes.

This patch corrected several such uses in examples/
directory.

Signed-off-by: Yonghong Song <yhs@fb.com>