### PR TITLE
debian changelog for v0.12.0 tag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+bcc (0.12.0-1) unstable; urgency=low
+
+  * Support for kernel up to 5.4
+  * klockstat tool to track kernel mutex lock statistics
+  * cmake option CMAKE_USE_LIBBPF_PACKAGE to build a bcc shared library
+    linking with distro libbpf_static.a
+  * new map.lookup_or_try_init() API to remove hidden return in
+    map.lookup_or_init()
+  * BPF_ARRAY_OF_MAPS and BPF_HASH_OF_MAPS support
+  * support symbol offset for uprobe in both C++ and python API,
+    kprobe already has the support
+  * bug fixes for trace.py, tcpretrans.py, runqslower.py, etc.
+
+ -- Yonghong Song <ys114321@gmail.com>  Tue, 10 Dec 2019 17:00:00 +0000
+
 bcc (0.11.0-1) unstable; urgency=low
 
   * Support for kernel up to 5.3


### PR DESCRIPTION
the main changes from v0.11.0 to v0.12.0 tag:
  * Support for kernel up to 5.4
  * klockstat tool to track kernel mutex lock statistics
  * cmake option CMAKE_USE_LIBBPF_PACKAGE to build a bcc shared library
    linking with distro libbpf_static.a
  * new map.lookup_or_try_init() API to remove hidden return in
    map.lookup_or_init()
  * BPF_ARRAY_OF_MAPS and BPF_HASH_OF_MAPS support
  * support symbol offset for uprobe in both C++ and python API,
    kprobe already has the support
  * bug fixes for trace.py, tcpretrans.py, runqslower.py, etc.

Signed-off-by: Yonghong Song <yhs@fb.com>