### PR TITLE
Fix s390 kprobes support

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -182,6 +182,8 @@ class BPF(object):
         b"__x32_compat_sys_",
         b"__ia32_compat_sys_",
         b"__arm64_sys_",
+        b"__s390x_sys_",
+        b"__s390_sys_",
     ]
 
     # BPF timestamps come from the monotonic clock. To be able to filter


### PR DESCRIPTION
Ever since Linux kernel commit aa0d6e70d, kprobes on s390 could no longer
be found due to a change in symbol names.
Symptom:
  $ ./tools/execsnoop.py
  cannot attach kprobe, probe entry may not exist
  [...]

Signed-off-by: Stefan Raspl <raspl@linux.ibm.com>