### PR TITLE
fix -h output for --sort option

### DIFF
--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -40,7 +40,7 @@ parser.add_argument("-r", "--maxrows", default=20,
     help="maximum rows to print, default 20")
 parser.add_argument("-s", "--sort", default="all",
     choices=["all", "reads", "writes", "rbytes", "wbytes"],
-    help="sort column, default rbytes")
+    help="sort column, default all")
 parser.add_argument("-p", "--pid", type=int, metavar="PID", dest="tgid",
     help="trace this PID only")
 parser.add_argument("interval", nargs="?", default=1,


### PR DESCRIPTION
This fixes a regression from c2b371d56b8bbaf9c7d01b88830193ecd1ee4e12 where the author forgot to update the help output.