### PR TITLE
klockstat: fix caller filter

### DIFF
--- a/man/man8/klockstat.8
+++ b/man/man8/klockstat.8
@@ -61,7 +61,7 @@ Print usage message.
 print summary at this interval (seconds)
 .TP
 \-c CALLER
-print locks taken by given caller
+print locks taken by given caller filter (e.g., pipe_)
 .TP
 \-S FIELDS
 sort data on specific columns defined by FIELDS string (by default the data is sorted by Max columns)

--- a/tools/klockstat.py
+++ b/tools/klockstat.py
@@ -363,7 +363,7 @@ def display(sort, maxs, totals, counts):
             stack  = list(stack_traces.walk(k.value))
             caller = b.ksym(stack[1], show_offset=True)
 
-            if (args.caller and caller.find(args.caller)):
+            if (args.caller and caller.find(args.caller.encode())):
                 continue
 
         avg = totals[k].value / counts[k].value


### PR DESCRIPTION
- args.caller needs to be bytes not string
- also filter calls with missing stack info
- clarify man page a bit