### PR TITLE
Remove kretprobe__ prefix from program names

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -539,6 +539,8 @@ int bcc_prog_load_xattr(struct bpf_load_program_attr *attr, int prog_len,
   if (name_len) {
     if (strncmp(attr->name, "kprobe__", 8) == 0)
       name_offset = 8;
+    else if (strncmp(attr->name, "kretprobe__", 11) == 0)
+      name_offset = 11;
     else if (strncmp(attr->name, "tracepoint__", 12) == 0)
       name_offset = 12;
     else if (strncmp(attr->name, "raw_tracepoint__", 16) == 0)


### PR DESCRIPTION
Such prefixes are currently removed for kprobes, tracepoints, and raw tracepoints, but not for kretprobes.  This pull request removes it for kretprobe as well, for consistency.

One consequence of this change is that a bcc tool or script with both `kprobe__some_func` and `kretprobe__some_func` will now load both BPF programs under the same name, i.e., `some_func`. I don't know if that's an issue (?)