### PR TITLE
Fix time going backwards on biolatency and biotop

### DIFF
--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -89,6 +89,11 @@ int trace_req_done(struct pt_regs *ctx, struct request *req)
         return 0;   // missed issue
     }
     delta = bpf_ktime_get_ns() - *tsp;
+    // check if time isn't going backwards
+    if ((s64)delta < 0) {
+        start.delete(&req);
+        return 0;
+    }
     FACTOR
 
     // store as histogram

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -163,7 +163,7 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
 
     if (valp) {
         // save stats
-        valp->us += delta * 1000;
+        valp->us += delta / 1000;
         valp->bytes += req->__data_len;
         valp->io++;
     }


### PR DESCRIPTION
Sometimes the time collected in the request completion is older than the one collected in the request start. This results in enormous numbers in the measured latency. The wrong latency makes histograms from biolatency occupies a lot of screen lines and the shows very high (and impossible) numbers on biotop.

This fix adds a check if signed delta is a negative number, in this case, the time of request completion is older than the request start and the offensor request is discarded.

This is the biolatency output before this change:

```
Tracing block device I/O... Hit Ctrl-C to end.
^C
               usecs                         : count     distribution
                   0 -> 1                    : 0        |                    |
                   2 -> 3                    : 0        |                    |
                   4 -> 7                    : 0        |                    |
                   8 -> 15                   : 0        |                    |
                  16 -> 31                   : 25       |                    |
                  32 -> 63                   : 32       |                    |
                  64 -> 127                  : 254      |                    |
                 128 -> 255                  : 2164     |*                   |
                 256 -> 511                  : 5421     |***                 |
                 512 -> 1023                 : 29795    |********************|
                1024 -> 2047                 : 17042    |***********         |
                2048 -> 4095                 : 6400     |****                |
                4096 -> 8191                 : 4935     |***                 |
                8192 -> 16383                : 588      |                    |
               16384 -> 32767                : 54       |                    |
               32768 -> 65535                : 14       |                    |
               65536 -> 131071               : 4        |                    |
              131072 -> 262143               : 4        |                    |
              262144 -> 524287               : 0        |                    |
              524288 -> 1048575              : 0        |                    |
             1048576 -> 2097151              : 0        |                    |
             2097152 -> 4194303              : 0        |                    |
             4194304 -> 8388607              : 0        |                    |
             8388608 -> 16777215             : 0        |                    |
            16777216 -> 33554431             : 0        |                    |
            33554432 -> 67108863             : 0        |                    |
            67108864 -> 134217727            : 0        |                    |
           134217728 -> 268435455            : 0        |                    |
           268435456 -> 536870911            : 0        |                    |
           536870912 -> 1073741823           : 0        |                    |
          1073741824 -> 2147483647           : 0        |                    |
          2147483648 -> 4294967295           : 0        |                    |
          4294967296 -> 8589934591           : 0        |                    |
          8589934592 -> 17179869183          : 0        |                    |
         17179869184 -> 34359738367          : 0        |                    |
         34359738368 -> 68719476735          : 0        |                    |
         68719476736 -> 137438953471         : 0        |                    |
        137438953472 -> 274877906943         : 0        |                    |
        274877906944 -> 549755813887         : 0        |                    |
        549755813888 -> 1099511627775        : 0        |                    |
       1099511627776 -> 2199023255551        : 0        |                    |
       2199023255552 -> 4398046511103        : 0        |                    |
       4398046511104 -> 8796093022207        : 0        |                    |
       8796093022208 -> 17592186044415       : 0        |                    |
      17592186044416 -> 35184372088831       : 0        |                    |
      35184372088832 -> 70368744177663       : 0        |                    |
      70368744177664 -> 140737488355327      : 0        |                    |
     140737488355328 -> 281474976710655      : 0        |                    |
     281474976710656 -> 562949953421311      : 0        |                    |
     562949953421312 -> 1125899906842623     : 0        |                    |
    1125899906842624 -> 2251799813685247     : 0        |                    |
    2251799813685248 -> 4503599627370495     : 0        |                    |
    4503599627370496 -> 9007199254740991     : 0        |                    |
    9007199254740992 -> 18014398509481983    : 0        |                    |
   18014398509481984 -> 36028797018963967    : 17       |                    |
```

And this one is after the bug is fixed:

```
Tracing block device I/O... Hit Ctrl-C to end.
^C
     usecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 163      |                                        |
        32 -> 63         : 339      |                                        |
        64 -> 127        : 258      |                                        |
       128 -> 255        : 2259     |**                                      |
       256 -> 511        : 5677     |******                                  |
       512 -> 1023       : 32662    |****************************************|
      1024 -> 2047       : 20252    |************************                |
      2048 -> 4095       : 12544    |***************                         |
      4096 -> 8191       : 11006    |*************                           |
      8192 -> 16383      : 1230     |*                                       |
     16384 -> 32767      : 201      |                                        |
     32768 -> 65535      : 544      |                                        |
     65536 -> 131071     : 746      |                                        |
    131072 -> 262143     : 881      |*                                       |
    262144 -> 524287     : 309      |                                        |
```

Thanks!