### PR TITLE
man: fix required kernel version in man pages

### DIFF
--- a/man/man8/bashreadline.8
+++ b/man/man8/bashreadline.8
@@ -10,8 +10,8 @@ entered command may fail: this is just showing what was entered.
 
 This program is also a basic example of eBPF/bcc and uprobes.
 
-This makes use of a Linux 4.5 feature (bpf_perf_event_output()); 
-for kernels older than 4.5, see the version under tools/old,
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
 which uses an older mechanism
 
 Since this uses BPF, only the root user can use this tool.

--- a/man/man8/biosnoop.8
+++ b/man/man8/biosnoop.8
@@ -15,8 +15,8 @@ request, as well as a starting timestamp for calculating I/O latency.
 This works by tracing various kernel blk_*() functions using dynamic tracing,
 and will need updating to match any changes to these functions.
 
-This makes use of a Linux 4.5 feature (bpf_perf_event_output());
-for kernels older than 4.5, see the version under tools/old,
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
 which uses an older mechanism
 
 Since this uses BPF, only the root user can use this tool.

--- a/man/man8/drsnoop.8
+++ b/man/man8/drsnoop.8
@@ -11,8 +11,8 @@ esses or not.
 
 This works by tracing the direct reclaim events using kernel tracepoints. 
 
-This makes use of a Linux 4.5 feature (bpf_perf_event_output());
-for kernels older than 4.5, see the version under tools/old,
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
 which uses an older mechanism.
 
 Since this uses BPF, only the root user can use this tool.

--- a/man/man8/filelife.8
+++ b/man/man8/filelife.8
@@ -13,8 +13,8 @@ This works by tracing the kernel vfs_create() and vfs_delete() functions (and
 maybe more, see the source) using dynamic tracing, and will need updating to
 match any changes to these functions.
 
-This makes use of a Linux 4.5 feature (bpf_perf_event_output());
-for kernels older than 4.5, see the version under tools/old,
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
 which uses an older mechanism.
 
 Since this uses BPF, only the root user can use this tool.

--- a/man/man8/gethostlatency.8
+++ b/man/man8/gethostlatency.8
@@ -11,8 +11,8 @@ latency of the call (duration) in milliseconds, and the host string.
 This tool can be useful for identifying DNS latency, by identifying which
 remote host name lookups were slow, and by how much.
 
-This makes use of a Linux 4.5 feature (bpf_perf_event_output());
-for kernels older than 4.5, see the version under tools/old,
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
 which uses an older mechanism
 
 This tool currently uses dynamic tracing of user-level functions and registers,

--- a/man/man8/killsnoop.8
+++ b/man/man8/killsnoop.8
@@ -11,8 +11,8 @@ is sending signals.
 This works by tracing the kernel sys_kill() function using dynamic tracing, and
 will need updating to match any changes to this function.
 
-This makes use of a Linux 4.5 feature (bpf_perf_event_output());
-for kernels older than 4.5, see the version under tools/old,
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
 which uses an older mechanism.
 
 Since this uses BPF, only the root user can use this tool.

--- a/man/man8/mountsnoop.8
+++ b/man/man8/mountsnoop.8
@@ -11,7 +11,7 @@ useful for troubleshooting system and container setup.
 This works by tracing the kernel sys_mount() and sys_umount() functions using
 dynamic tracing, and will need updating to match any changes to this function.
 
-This makes use of a Linux 4.4 feature (bpf_perf_event_output()).
+This makes use of a Linux 4.8 feature (bpf_get_current_task()).
 
 Since this uses BPF, only the root user can use this tool.
 .SH REQUIREMENTS

--- a/man/man8/opensnoop.8
+++ b/man/man8/opensnoop.8
@@ -13,8 +13,8 @@ on startup.
 This works by tracing the kernel sys_open() function using dynamic tracing, and
 will need updating to match any changes to this function.
 
-This makes use of a Linux 4.5 feature (bpf_perf_event_output());
-for kernels older than 4.5, see the version under tools/old,
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
 which uses an older mechanism.
 
 Since this uses BPF, only the root user can use this tool.

--- a/man/man8/statsnoop.8
+++ b/man/man8/statsnoop.8
@@ -12,8 +12,8 @@ applications that are failing, especially on startup.
 This works by tracing various kernel sys_stat() functions using dynamic
 tracing, and will need updating to match any changes to these functions.
 
-This makes use of a Linux 4.5 feature (bpf_perf_event_output());
-for kernels older than 4.5, see the version under tools/old,
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
 which uses an older mechanism.
 
 Since this uses BPF, only the root user can use this tool.

--- a/man/man8/syncsnoop.8
+++ b/man/man8/syncsnoop.8
@@ -11,8 +11,8 @@ be useful to know if they are happening and how frequently.
 This works by tracing the kernel sys_sync() function using dynamic tracing, and
 will need updating to match any changes to this function.
 
-This makes use of a Linux 4.5 feature (bpf_perf_event_output());
-for kernels older than 4.5, see the version under tools/old,
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
 which uses an older mechanism.
 
 This program is also a basic example of eBPF/bcc.


### PR DESCRIPTION
Several man pages state that Linux 4.5 is required because the tool relies on the `bpf_perf_event_output` helper.  However, `bpf_perf_event_output` was introduced in Linux 4.4.

In addition, mountsnoop requires Linux 4.8 because it now uses the `bpf_get_current_task` helper.