### PR TITLE
fix libbpf_uapi path typo

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
   file(GLOB libbpf_sources "libbpf/src/*.c")
 endif()
 
-set(libbpf_uapi libbpf/include/uapi/linux})
+set(libbpf_uapi libbpf/include/uapi/linux/)
 
 add_library(bpf-static STATIC libbpf.c perf_reader.c ${libbpf_sources})
 set_target_properties(bpf-static PROPERTIES OUTPUT_NAME bcc_bpf)


### PR DESCRIPTION
A typo occured in libbpf_uapi path from src/cc/CMakeLists.txt which
made compat linux uapi headers failed to copy.

fixes #2674 

Signed-off-by: Caspar Zhang <caspar@linux.alibaba.com>