### PR TITLE
Package static archives, closes #1938

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -142,7 +142,7 @@ if(LIBBPF_FOUND)
   install(TARGETS bcc-shared-no-libbpf LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
-install(TARGETS bcc-shared LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS bcc-shared bcc-static bcc-loader-static bpf-static LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${bcc_table_headers} DESTINATION include/bcc)
 install(FILES ${bcc_api_headers} DESTINATION include/bcc)
 install(DIRECTORY ${libbpf_uapi} DESTINATION include/bcc/compat/linux FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
This should help embed libbcc into bpftrace:

* https://github.com/iovisor/bpftrace/issues/342

As well as other tools like ebpf_exporter, so that there is no longer a requirement to have a particular version libbcc installed.

cc @dalehamel, @danobi