### PR TITLE
Ubuntu Eon build dependencies and version numbers

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -329,7 +329,7 @@ To build the toolchain from source, one needs:
 
 ### Install build dependencies
 ```
-# Trusty and older
+# Trusty (14.04 LTS) and older
 VER=trusty
 echo "deb http://llvm.org/apt/$VER/ llvm-toolchain-$VER-3.7 main
 deb-src http://llvm.org/apt/$VER/ llvm-toolchain-$VER-3.7 main" | \
@@ -337,9 +337,13 @@ deb-src http://llvm.org/apt/$VER/ llvm-toolchain-$VER-3.7 main" | \
 wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
 
-# For bionic
+# For Bionic (18.04 LTS)
 sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
   libllvm6.0 llvm-6.0-dev libclang-6.0-dev python zlib1g-dev libelf-dev
+
+# For Eon (19.10)
+sudo apt install -y bison build-essential cmake flex git libedit-dev \
+  libllvm7 llvm-7-dev libclang-7-dev python zlib1g-dev libelf-dev
 
 # For other versions
 sudo apt-get -y install bison build-essential cmake flex git libedit-dev \


### PR DESCRIPTION
- Add updated list of dependencies to build on Ubuntu Eon (19.10)
- Add Ubuntu version numbers for increased clarity
- Capitalize release names to match official branding