### PR TITLE
update usage of MCInstPrinter printInst() for llvm10

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -225,7 +225,11 @@ void SourceDebugger::dump() {
                       CurrentSrcLine, os);
           os << format("%4" PRIu64 ":", Index >> 3) << '\t';
           dumpBytes(Data.slice(Index, Size), os);
+#if LLVM_MAJOR_VERSION >= 10
+          IP->printInst(&Inst, 0, "", *STI, os);
+#else
           IP->printInst(&Inst, os, "", *STI);
+#endif
           os << '\n';
         }
       }


### PR DESCRIPTION
Upstream patch
  https://reviews.llvm.org/D72172
changed function signature for MCInstPrinter method printInst().
Make adjustment in bcc as well.

Signed-off-by: Yonghong Song <yhs@fb.com>