### PR TITLE
sanitize BTF_KIND_FUNC

### DIFF
--- a/src/cc/bcc_btf.h
+++ b/src/cc/bcc_btf.h
@@ -62,7 +62,7 @@ class BTF {
                    unsigned *key_tid, unsigned *value_tid);
 
  private:
-  void fixup_datasec(uint8_t *type_sec, uintptr_t type_sec_size, char *strings);
+  void fixup_btf(uint8_t *type_sec, uintptr_t type_sec_size, char *strings);
   void adjust(uint8_t *btf_sec, uintptr_t btf_sec_size,
               uint8_t *btf_ext_sec, uintptr_t btf_ext_sec_size,
               std::map<std::string, std::string> &remapped_sources,


### PR DESCRIPTION
The llvm patch https://reviews.llvm.org/D71638 extends
BTF_KIND_FUNC to include scope of the function,
static, global and extern, with btf_type->info vlen
encoding since vlen is always 0 before the extension.

This patch did the sanitization so that the
bcc with latest llvm can still work on older kernels.

Signed-off-by: Yonghong Song <yhs@fb.com>