### PR TITLE
Fix CentOS 6 support.

### DIFF
--- a/introspection/CMakeLists.txt
+++ b/introspection/CMakeLists.txt
@@ -8,6 +8,6 @@ include_directories(${CMAKE_SOURCE_DIR}/src/cc/libbpf/include/uapi)
 option(INSTALL_INTROSPECTION "Install BPF introspection tools" ON)
 
 add_executable(bps bps.c)
-target_link_libraries(bps bpf-static elf z)
+target_link_libraries(bps bpf-static elf rt z)
 
 install (TARGETS bps DESTINATION share/bcc/introspection)


### PR DESCRIPTION
CentOS 6 support was added in #1504 and inadvertently reverted in #1763 leading to builds failing due to undefined reference to `clock_gettime`.

```
Scanning dependencies of target bps
[ 22%] Building C object introspection/CMakeFiles/bps.dir/bps.c.o
[ 22%] Linking C executable bps
CMakeFiles/bps.dir/bps.c.o: In function `print_prog_info':
bps.c:(.text+0x32): undefined reference to `clock_gettime'
bps.c:(.text+0x13b): undefined reference to `clock_gettime'
collect2: error: ld returned 1 exit status
introspection/CMakeFiles/bps.dir/build.make:95: recipe for target 'introspection/bps' failed
make[2]: *** [introspection/bps] Error 1
CMakeFiles/Makefile2:651: recipe for target 'introspection/CMakeFiles/bps.dir/all' failed
make[1]: *** [introspection/CMakeFiles/bps.dir/all] Error 2
```

To re-add support for building on CentOS 6 and keep binary size down, add `librt` to the list of `target_link_libraries` to allow `clock_gettime` to be resolved.