### PR TITLE
Bpflist fix

### DIFF
--- a/tools/bpflist.py
+++ b/tools/bpflist.py
@@ -76,7 +76,12 @@ for pdir in os.listdir('/proc'):
             find_bpf_fds(int(pdir))
         except OSError:
             continue
-print("%-6s %-16s %-8s %s" % ("PID", "COMM", "TYPE", "COUNT"))
-for (pid, typ), count in sorted(counts.items(), key=lambda t: t[0][0]):
+
+items = counts.items()
+max_type_len = items and max(list(map(lambda t: len(t[0][1]), items))) or 0
+print_format = "%%-6s %%-16s %%-%ss %%s" % (max_type_len + 1)
+
+print(print_format % ("PID", "COMM", "TYPE", "COUNT"))
+for (pid, typ), count in sorted(items, key=lambda t: t[0][0]):
     comm = comm_for_pid(pid)
-    print("%-6d %-16s %-8s %-4d" % (pid, comm, typ, count))
+    print(print_format % (pid, comm, typ, count))

--- a/tools/bpflist.py
+++ b/tools/bpflist.py
@@ -65,7 +65,7 @@ def find_bpf_fds(pid):
             link = os.readlink(os.path.join(root, fd))
         except OSError:
             continue
-        match = re.match('.*bpf-(\\w+)', link)
+        match = re.match('anon_inode:bpf-([\\w-]+)', link)
         if match:
             tup = (pid, match.group(1))
             counts[tup] = counts.get(tup, 0) + 1


### PR DESCRIPTION
Let bpflist to list `raw-tracepoints` and do not let to list raw files (e.g., formerly, the `vim bpf-woo` process will be listed).