### PR TITLE
fix llvm compilation error

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -201,8 +201,13 @@ void SourceDebugger::dump() {
       string src_dbg_str;
       llvm::raw_string_ostream os(src_dbg_str);
       for (uint64_t Index = 0; Index < FuncSize; Index += Size) {
+#if LLVM_MAJOR_VERSION >= 10
+        S = DisAsm->getInstruction(Inst, Size, Data.slice(Index), Index,
+                                   nulls());
+#else
         S = DisAsm->getInstruction(Inst, Size, Data.slice(Index), Index,
                                    nulls(), nulls());
+#endif
         if (S != MCDisassembler::Success) {
           os << "Debug Error: disassembler failed: " << std::to_string(S)
              << '\n';


### PR DESCRIPTION
The following changes from llvm 10
  https://github.com/llvm/llvm-project/commit/6fdd6a7b3f696972edc244488f59532d05136a27#diff-37c83c70858df19cb097e36b13b7c112
changed MCDisassembler::getInstruction() signature.
Do the corresponding change in bcc_debug.cc to fix the issue.

Signed-off-by: Yonghong Song <yhs@fb.com>