### PR TITLE
docs: remove a redundant space

### DIFF
--- a/docs/kernel-versions.md
+++ b/docs/kernel-versions.md
@@ -77,7 +77,7 @@ BPF socket reuseport | 4.19 | [`2dbb9b9e6df6`](https://github.com/torvalds/linux
 BPF flow dissector | 4.20 | [`d58e468b1112`](https://github.com/torvalds/linux/commit/d58e468b1112dcd1d5193c0a89ff9f98b5a3e8b9)
 BPF cgroup sysctl | 5.2 | [`7b146cebe30c`](https://github.com/torvalds/linux/commit/7b146cebe30cb481b0f70d85779da938da818637)
 BPF raw tracepoint writable | 5.2 | [`9df1c28bb752`](https://github.com/torvalds/linux/commit/9df1c28bb75217b244257152ab7d788bb2a386d0)
-BPF trampoline | 5.5 | [`fec56f5890d9`] (https://github.com/torvalds/linux/commit/fec56f5890d93fc2ed74166c397dc186b1c25951)
+BPF trampoline | 5.5 | [`fec56f5890d9`](https://github.com/torvalds/linux/commit/fec56f5890d93fc2ed74166c397dc186b1c25951)
 
 ## Tables (_a.k.a._ Maps)
 


### PR DESCRIPTION
I found that a redundant space caused a rendering error ([link](https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md#main-features)).

Signed-off-by: Masanori Misono <m.misono760@gmail.com>