### PR TITLE
Remove python2-bcc from list of AUR packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -163,7 +163,7 @@ Upgrade the kernel to minimum 4.3.1-1 first; the ```CONFIG_BPF_SYSCALL=y``` conf
 
 Install these packages using any AUR helper such as [pacaur](https://aur.archlinux.org/packages/pacaur), [yaourt](https://aur.archlinux.org/packages/yaourt), [cower](https://aur.archlinux.org/packages/cower), etc.:
 ```
-bcc bcc-tools python-bcc python2-bcc
+bcc bcc-tools python-bcc
 ```
 All build and install dependencies are listed [in the PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bcc) and should install automatically.
 


### PR DESCRIPTION
This package has been removed from the repositories.