### PR TITLE
fix a bug in networking/simulation.py

### DIFF
--- a/examples/networking/simulation.py
+++ b/examples/networking/simulation.py
@@ -65,7 +65,17 @@ class Simulation(object):
                 raise
 
         if out_ifc: out_ifc.up().commit()
-        ns_ipdb.interfaces.lo.up().commit()
+
+        # this is a workaround for fc31 and possible other disto's.
+        # when interface 'lo' is already up, do another 'up().commit()'
+        # has issues in fc31.
+        # the workaround may become permanent if we upgrade pyroute2
+        # in all machines.
+        if 'state' in ns_ipdb.interfaces.lo.keys():
+            if ns_ipdb.interfaces.lo['state'] != 'up':
+                ns_ipdb.interfaces.lo.up().commit()
+        else:
+            ns_ipdb.interfaces.lo.up().commit()
         ns_ipdb.initdb()
         in_ifc = ns_ipdb.interfaces[in_ifname]
         with in_ifc as v:


### PR DESCRIPTION
test test_brb.py failed on fc31 with the following error messages:
```
  Traceback (most recent call last):
    File "./test_brb.py", line 162, in test_brb
      disable_ipv6=True)
    File "/home/yhs/work/bcc/tests/python/simulation.py", line 94, in _create_ns
      disable_ipv6)
    File "/home/yhs/work/bcc/tests/python/simulation.py", line 68, in _ns_add_ifc
      ns_ipdb.interfaces.lo.up().commit()
    File "/usr/local/lib/python3.7/site-packages/pyroute2/ipdb/interfaces.py", line 1078, in commit
      raise error
    File "/usr/local/lib/python3.7/site-packages/pyroute2/ipdb/interfaces.py", line 859, in commit
    transaction.wait_all_targets()
    File "/usr/local/lib/python3.7/site-packages/pyroute2/ipdb/transactional.py", line 507, in wait_all_targets
      raise CommitException('target %s is not set' % key)
  pyroute2.ipdb.exceptions.CommitException: target state is not set
```
The reason is in networking/simulation.py, if the interface 'lo'
inside the namespace is already up and it is tried to commit
to 'up' state again, the pyroute2 library will cause an exception.

The fix is to avoid to 'up' interface 'lo' again if the interface
is already in 'up' state.

Signed-off-by: Yonghong Song <yhs@fb.com>