### PR TITLE
sync to latest libbpf repo

### DIFF
--- a/docs/kernel-versions.md
+++ b/docs/kernel-versions.md
@@ -183,6 +183,7 @@ Helper | Kernel version | License | Commit |
 `BPF_FUNC_get_stack()` | 4.18 | GPL | [`de2ff05f48af`](https://git.kernel.org/cgit/linux/kernel/git/davem/net-next.git/commit/?id=de2ff05f48afcde816ff4edb217417f62f624ab5)
 `BPF_FUNC_get_stackid()` | 4.6 | GPL | [`d5a3b1f69186`](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=d5a3b1f691865be576c2bffa708549b8cdccda19)
 `BPF_FUNC_getsockopt()` | 4.15 |  | [`cd86d1fd2102`](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=cd86d1fd21025fdd6daf23d1288da405e7ad0ec6)
+`BPF_FUNC_jiffies64()` | 5.5 |  | [`5576b991e9c1`](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=5576b991e9c1a11d2cc21c4b94fc75ec27603896)
 `BPF_FUNC_ktime_get_ns()` | 4.1 | GPL | [`d9847d310ab4`](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=d9847d310ab4003725e6ed1822682e24bd406908)
 `BPF_FUNC_l3_csum_replace()` | 4.1 |  | [`91bc4822c3d6`](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=91bc4822c3d61b9bb7ef66d3b77948a4f9177954)
 `BPF_FUNC_l4_csum_replace()` | 4.1 |  | [`91bc4822c3d6`](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=91bc4822c3d61b9bb7ef66d3b77948a4f9177954)

--- a/introspection/bps.c
+++ b/introspection/bps.c
@@ -44,6 +44,7 @@ static const char * const prog_type_strings[] = {
   [BPF_PROG_TYPE_CGROUP_SOCKOPT] = "cgroup_sockopt",
   [BPF_PROG_TYPE_TRACING] = "tracing",
   [BPF_PROG_TYPE_STRUCT_OPS] = "struct_ops",
+  [BPF_PROG_TYPE_EXT] = "ext",
 };
 
 static const char * const map_type_strings[] = {

--- a/src/cc/compat/linux/virtual_bpf.h
+++ b/src/cc/compat/linux/virtual_bpf.h
@@ -181,6 +181,7 @@ enum bpf_prog_type {
 	BPF_PROG_TYPE_CGROUP_SOCKOPT,
 	BPF_PROG_TYPE_TRACING,
 	BPF_PROG_TYPE_STRUCT_OPS,
+	BPF_PROG_TYPE_EXT,
 };
 
 enum bpf_attach_type {
@@ -2886,6 +2887,12 @@ union bpf_attr {
  *		**-EPERM** if no permission to send the *sig*.
  *
  *		**-EAGAIN** if bpf program can try again.
+ *
+ * u64 bpf_jiffies64(void)
+ *	Description
+ *		Obtain the 64bit jiffies
+ *	Return
+ *		The 64 bit jiffies
  */
 #define __BPF_FUNC_MAPPER(FN)		\
 	FN(unspec),			\
@@ -3005,7 +3012,8 @@ union bpf_attr {
 	FN(probe_read_user_str),	\
 	FN(probe_read_kernel_str),	\
 	FN(tcp_send_ack),		\
-	FN(send_signal_thread),
+	FN(send_signal_thread),		\
+	FN(jiffies64),
 
 /* integer value in 'imm' field of BPF_CALL instruction selects which helper
  * function eBPF program intends to call

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -215,6 +215,7 @@ static struct bpf_helper helpers[] = {
   {"probe_read_kernel_str", "5.5"},
   {"tcp_send_ack", "5.5"},
   {"send_signal_thread", "5.5"},
+  {"jiffies64", "5.5"},
 };
 
 static uint64_t ptr_to_u64(void *ptr)


### PR DESCRIPTION
Sync to latest libbpf repo. New helper bpf_jiffies64
and new program type BPF_PROG_TYPE_EXT is added.

Signed-off-by: Yonghong Song <yhs@fb.com>