### PR TITLE
Make inode-only matching default, reverse USDT kludge

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -777,7 +777,7 @@ USDT::USDT(const std::string& binary_path, const std::string& provider,
       provider_(provider),
       name_(name),
       probe_func_(probe_func),
-      mod_match_inode_only_(0) {}
+      mod_match_inode_only_(1) {}
 
 USDT::USDT(pid_t pid, const std::string& provider, const std::string& name,
            const std::string& probe_func)
@@ -787,7 +787,7 @@ USDT::USDT(pid_t pid, const std::string& provider, const std::string& name,
       provider_(provider),
       name_(name),
       probe_func_(probe_func),
-      mod_match_inode_only_(0) {}
+      mod_match_inode_only_(1) {}
 
 USDT::USDT(const std::string& binary_path, pid_t pid,
            const std::string& provider, const std::string& name,
@@ -798,7 +798,7 @@ USDT::USDT(const std::string& binary_path, pid_t pid,
       provider_(provider),
       name_(name),
       probe_func_(probe_func),
-      mod_match_inode_only_(0) {}
+      mod_match_inode_only_(1) {}
 
 USDT::USDT(const USDT& usdt)
     : initialized_(false),

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -305,16 +305,20 @@ class USDT {
                << usdt.probe_func_;
   }
 
-  // When the kludge flag is set to 1, we will only match on inode
+  // When the kludge flag is set to 1 (default), we will only match on inode
   // when searching for modules in /proc/PID/maps that might contain the
-  // tracepoint we're looking for. Normally match is on inode and
+  // tracepoint we're looking for.
+  // By setting this to 0, we will match on both inode and
   // (dev_major, dev_minor), which is a more accurate way to uniquely
-  // identify a file.
+  // identify a file, but may fail depending on the filesystem backing the
+  // target file (see bcc#2715)
   //
-  // This hack exists because btrfs reports different device numbers for files
-  // in /proc/PID/maps vs stat syscall. Don't use it unless you're using btrfs
+  // This hack exists because btrfs and overlayfs report different device
+  // numbers for files in /proc/PID/maps vs stat syscall. Don't use it unless
+  // you've had issues with inode collisions. Both btrfs and overlayfs are
+  // known to require inode-only resolution to accurately match a file.
   //
-  // set_probe_matching_kludge(1) must be called before USDTs are submitted to
+  // set_probe_matching_kludge(0) must be called before USDTs are submitted to
   // BPF::init()
   int set_probe_matching_kludge(uint8_t kludge);
 

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -212,7 +212,7 @@ class Probe {
 
 public:
   Probe(const char *bin_path, const char *provider, const char *name,
-        uint64_t semaphore, const optional<int> &pid, uint8_t mod_match_inode_only = 0);
+        uint64_t semaphore, const optional<int> &pid, uint8_t mod_match_inode_only = 1);
 
   size_t num_locations() const { return locations_.size(); }
   size_t num_arguments() const { return locations_.front().arguments_.size(); }
@@ -265,10 +265,10 @@ private:
   uint8_t mod_match_inode_only_;
 
 public:
-  Context(const std::string &bin_path, uint8_t mod_match_inode_only = 0);
-  Context(int pid, uint8_t mod_match_inode_only = 0);
+  Context(const std::string &bin_path, uint8_t mod_match_inode_only = 1);
+  Context(int pid, uint8_t mod_match_inode_only = 1);
   Context(int pid, const std::string &bin_path,
-          uint8_t mod_match_inode_only = 0);
+          uint8_t mod_match_inode_only = 1);
   ~Context();
 
   optional<int> pid() const { return pid_; }

--- a/tests/python/test_usdt.py
+++ b/tests/python/test_usdt.py
@@ -8,7 +8,6 @@
 from __future__ import print_function
 from bcc import BPF, USDT
 from unittest import main, TestCase
-from utils import mayFail
 from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
 import ctypes as ct
@@ -140,7 +139,6 @@ int do_trace5(struct pt_regs *ctx) {
         self.assertEqual(comp.wait(), 0)
         self.app = Popen([self.ftemp.name])
 
-    @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_attach1(self):
         # enable USDT probe from given PID and verifier generated BPF programs
         u = USDT(pid=int(self.app.pid))

--- a/tests/python/test_usdt2.py
+++ b/tests/python/test_usdt2.py
@@ -8,7 +8,6 @@
 from __future__ import print_function
 from bcc import BPF, USDT
 from unittest import main, TestCase
-from utils import mayFail
 from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
 import ctypes as ct
@@ -95,7 +94,6 @@ int do_trace3(struct pt_regs *ctx) {
         self.app2 = Popen([self.ftemp.name, "11"])
         self.app3 = Popen([self.ftemp.name, "21"])
 
-    @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_attach1(self):
         # Enable USDT probe from given PID and verifier generated BPF programs.
         u = USDT(pid=int(self.app.pid))

--- a/tests/python/test_usdt3.py
+++ b/tests/python/test_usdt3.py
@@ -8,7 +8,6 @@
 from __future__ import print_function
 from bcc import BPF, USDT
 from unittest import main, TestCase
-from utils import mayFail
 from subprocess import Popen, PIPE
 import ctypes as ct
 import inspect, os, tempfile
@@ -108,7 +107,6 @@ int do_trace(struct pt_regs *ctx) {
         self.app = Popen([m_bin], env=dict(os.environ, LD_LIBRARY_PATH=self.tmp_dir))
         os.system("../../tools/tplist.py -vvv -p " + str(self.app.pid))
 
-    @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_attach1(self):
         # enable USDT probe from given PID and verifier generated BPF programs
         u = USDT(pid=int(self.app.pid))


### PR DESCRIPTION
This PR is per the discussion in #2715.

Changing the default behavior to use inode only matching fixes these test failures on github actions, as the USDT tests now run in docker (and on overlayfs). Because of this I've been able to remove the `@mayFail` decorator from the python USDT tests, as they now pass.


