### PR TITLE
tools/klockstat.py: Do not display symbol twice for stack

### DIFF
--- a/tools/klockstat.py
+++ b/tools/klockstat.py
@@ -370,7 +370,7 @@ def display(sort, maxs, totals, counts):
 
         print("%40s %10lu %6lu %10lu %10lu" % (caller, avg, counts[k].value, maxs[k].value, totals[k].value))
 
-        for addr in stack[1:args.stacks]:
+        for addr in stack[2:args.stacks]:
             print("%40s" %  b.ksym(addr, show_offset=True))
 
 


### PR DESCRIPTION
Currently we display the caller symbol in stack,
which ends up with output below when we enable stack:

                                  Caller   Avg Hold  Count   Max hold Total hold
                  b'flush_to_ldisc+0x22'      56112      2     103914     112225
                  b'flush_to_ldisc+0x22'
               b'process_one_work+0x1b0'
                   b'worker_thread+0x50'
                         b'kthread+0xfb'

Skipping one more symbol in stack to fix that:

                                  Caller   Avg Hold  Count   Max hold Total hold
                  b'flush_to_ldisc+0x22'       1893      2       2765       3787
               b'process_one_work+0x1b0'
                   b'worker_thread+0x50'
                         b'kthread+0xfb'

Signed-off-by: Jiri Olsa <jolsa@kernel.org>