### PR TITLE
Introduce {attach|detach}_kfunc API

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -16,6 +16,8 @@ This guide is incomplete. If something feels missing, check the bcc and kernel s
         - [6. USDT probes](#6-usdt-probes)
         - [7. Raw Tracepoints](#7-raw-tracepoints)
         - [8. system call tracepoints](#8-system-call-tracepoints)
+        - [9. kfuncs](#9-kfuncs)
+        - [10. kretfuncs](#9-kretfuncs)
     - [Data](#data)
         - [1. bpf_probe_read()](#1-bpf_probe_read)
         - [2. bpf_probe_read_str()](#2-bpf_probe_read_str)
@@ -314,6 +316,50 @@ b.attach_kprobe(event=execve_fnname, fn_name="syscall__execve")
 
 Examples in situ:
 [code](https://github.com/iovisor/bcc/blob/552658edda09298afdccc8a4b5e17311a2d8a771/tools/execsnoop.py#L101) ([output](https://github.com/iovisor/bcc/blob/552658edda09298afdccc8a4b5e17311a2d8a771/tools/execsnoop_example.txt#L8))
+
+### 9. kfuncs
+
+Syntax: KFUNC_PROBE(*function*, typeof(arg1) arg1, typeof(arg2) arge ...)
+
+This is a macro that instruments the kernel function via trampoline
+*before* the function is executed. It's defined by *function* name and
+the function arguments defined as *argX*.
+
+For example:
+```C
+KFUNC_PROBE(do_sys_open, int dfd, const char *filename, int flags, int mode)
+{
+    ...
+```
+
+This instruments the do_sys_open kernel function and make its arguments
+accessible as standard argument values.
+
+Examples in situ:
+[search /tools](https://github.com/iovisor/bcc/search?q=KFUNC_PROBE+path%3Atools&type=Code)
+
+### 10. kretfuncs
+
+Syntax: KRETFUNC_PROBE(*event*, typeof(arg1) arg1, typeof(arg2) arge ..., int ret)
+
+This is a macro that instruments the kernel function via trampoline
+*after* the function is executed. It's defined by *function* name and
+the function arguments defined as *argX*.
+
+The last argument of the probe is the return value of the instrumented function.
+
+For example:
+```C
+KFUNC_PROBE(do_sys_open, int dfd, const char *filename, int flags, int mode, int ret)
+{
+    ...
+```
+
+This instruments the do_sys_open kernel function and make its arguments
+accessible as standard argument values together with its return value.
+
+Examples in situ:
+[search /tools](https://github.com/iovisor/bcc/search?q=KRETFUNC_PROBE+path%3Atools&type=Code)
 
 
 ## Data

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -28,13 +28,15 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLLVM_MAJOR_VERSION=${CMAKE_MATCH_1}")
 
 include(static_libstdc++)
 
+if(LIBBPF_INCLUDE_DIR)
+  # Add user libbpf include and notify compilation
+  # that we are using external libbpf. It's checked
+  # in src/cc/libbpf.h and proper files are included.
+  include_directories(${LIBBPF_INCLUDE_DIR})
+  add_definitions(-DHAVE_EXTERNAL_LIBBPF)
+endif()
+
 if(LIBBPF_FOUND)
-  # We need to include the libbpf packaged source to get the
-  # headers location, becaseu they are installed under 'bpf'
-  # directory, but the libbpf code references them localy
-
-  include_directories(${LIBBPF_INCLUDE_DIR}/bpf)
-
   set(extract_dir ${CMAKE_CURRENT_BINARY_DIR}/libbpf_a_extract)
   execute_process(COMMAND sh -c "mkdir -p ${extract_dir} && cd ${extract_dir} && ${CMAKE_AR} x ${LIBBPF_STATIC_LIBRARIES}")
   file(GLOB libbpf_sources "${extract_dir}/*.o")

--- a/src/cc/bcc_btf.cc
+++ b/src/cc/bcc_btf.cc
@@ -19,8 +19,7 @@
 #include <string.h>
 #include "linux/btf.h"
 #include "libbpf.h"
-#include "libbpf/src/libbpf.h"
-#include "libbpf/src/btf.h"
+#include "bcc_libbpf_inc.h"
 #include <vector>
 
 #define BCC_MAX_ERRNO       4095

--- a/src/cc/bcc_libbpf_inc.h
+++ b/src/cc/bcc_libbpf_inc.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef HAVE_EXTERNAL_LIBBPF
+# include <bpf/bpf.h>
+# include <bpf/btf.h>
+# include <bpf/libbpf.h>
+#else
+# include "libbpf/src/bpf.h"
+# include "libbpf/src/btf.h"
+# include "libbpf/src/libbpf.h"
+#endif

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -45,7 +45,7 @@
 #include "exported_files.h"
 #include "libbpf.h"
 #include "bcc_btf.h"
-#include "libbpf/src/bpf.h"
+#include "bcc_libbpf_inc.h"
 
 namespace ebpf {
 

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -907,7 +907,10 @@ int BPFModule::bcc_func_load(int prog_type, const char *name,
   attr.name = name;
   attr.insns = insns;
   attr.license = license;
-  attr.kern_version = kern_version;
+  if (attr.prog_type != BPF_PROG_TYPE_TRACING &&
+      attr.prog_type != BPF_PROG_TYPE_EXT) {
+    attr.kern_version = kern_version;
+  }
   attr.log_level = log_level;
   if (dev_name)
     attr.prog_ifindex = if_nametoindex(dev_name);

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -34,7 +34,7 @@
 #include "loader.h"
 #include "table_storage.h"
 #include "arch_helper.h"
-#include "libbpf/src/bpf.h"
+#include "bcc_libbpf_inc.h"
 
 #include "libbpf.h"
 

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -671,7 +671,8 @@ int bcc_prog_load(enum bpf_prog_type prog_type, const char *name,
   attr.name = name;
   attr.insns = insns;
   attr.license = license;
-  attr.kern_version = kern_version;
+  if (prog_type != BPF_PROG_TYPE_TRACING && prog_type != BPF_PROG_TYPE_EXT)
+    attr.kern_version = kern_version;
   attr.log_level = log_level;
   return bcc_prog_load_xattr(&attr, prog_len, log_buf, log_buf_size, true);
 }

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -52,8 +52,7 @@
 // TODO: Remove this when CentOS 6 support is not needed anymore
 #include "setns.h"
 
-#include "libbpf/src/bpf.h"
-#include "libbpf/src/libbpf.h"
+#include "bcc_libbpf_inc.h"
 
 // TODO: remove these defines when linux-libc-dev exports them properly
 

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -1160,6 +1160,11 @@ int bpf_attach_raw_tracepoint(int progfd, const char *tp_name)
   return ret;
 }
 
+bool bpf_has_kernel_btf(void)
+{
+  return libbpf_find_vmlinux_btf_id("bpf_prog_put", 0);
+}
+
 int bpf_detach_kfunc(int prog_fd, char *func)
 {
   UNUSED(prog_fd);

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -98,6 +98,8 @@ int bpf_detach_kfunc(int prog_fd, char *func);
 
 int bpf_attach_kfunc(int prog_fd);
 
+bool bpf_has_kernel_btf(void);
+
 void * bpf_open_perf_buffer(perf_reader_raw_cb raw_cb,
                             perf_reader_lost_cb lost_cb, void *cb_cookie,
                             int pid, int cpu, int page_cnt);

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -94,6 +94,10 @@ int bpf_detach_tracepoint(const char *tp_category, const char *tp_name);
 
 int bpf_attach_raw_tracepoint(int progfd, const char *tp_name);
 
+int bpf_detach_kfunc(int prog_fd, char *func);
+
+int bpf_attach_kfunc(int prog_fd);
+
 void * bpf_open_perf_buffer(perf_reader_raw_cb raw_cb,
                             perf_reader_lost_cb lost_cb, void *cb_cookie,
                             int pid, int cpu, int page_cnt);

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -882,6 +882,15 @@ class BPF(object):
             name = prefix + name
         return name
 
+    @staticmethod
+    def support_kfunc():
+        if not lib.bpf_has_kernel_btf():
+            return False;
+        # kernel symbol "bpf_trampoline_link_prog" indicates kfunc support
+        if BPF.ksymname("bpf_trampoline_link_prog") != -1:
+            return True
+        return False
+
     def detach_kfunc(self, fn_name=b""):
         fn_name = _assert_is_bytes(fn_name)
         fn_name = BPF.add_prefix(b"kfunc__", fn_name)

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -49,7 +49,7 @@ if(LIBBPF_FOUND)
   add_executable(test_libbcc_no_libbpf ${TEST_LIBBCC_SOURCES})
   add_dependencies(test_libbcc_no_libbpf bcc-shared-no-libbpf)
 
-  target_link_libraries(test_libbcc_no_libbpf ${PROJECT_BINARY_DIR}/src/cc/libbcc-no-libbpf.so dl usdt_test_lib bpf)
+  target_link_libraries(test_libbcc_no_libbpf ${PROJECT_BINARY_DIR}/src/cc/libbcc-no-libbpf.so dl usdt_test_lib ${LIBBPF_LIBRARIES})
   set_target_properties(test_libbcc_no_libbpf PROPERTIES INSTALL_RPATH ${PROJECT_BINARY_DIR}/src/cc)
   target_compile_definitions(test_libbcc_no_libbpf PRIVATE -DLIBBCC_NAME=\"libbcc-no-libbpf.so\")
 

--- a/tools/klockstat.py
+++ b/tools/klockstat.py
@@ -124,7 +124,7 @@ static bool allow_pid(u64 id)
     return 1;
 }
 
-int mutex_lock_enter(struct pt_regs *ctx)
+static int do_mutex_lock_enter(void *ctx, int skip)
 {
     if (!is_enabled())
         return 0;
@@ -149,7 +149,7 @@ int mutex_lock_enter(struct pt_regs *ctx)
             return 0;
     }
 
-    int stackid = stack_traces.get_stackid(ctx, 0);
+    int stackid = stack_traces.get_stackid(ctx, skip);
     struct depth_id did = {
       .id    = id,
       .depth = *depth,
@@ -237,7 +237,7 @@ static void update_hl_report_total(int *stackid, u64 delta)
     }
 }
 
-int mutex_lock_return(struct pt_regs *ctx)
+static int do_mutex_lock_return(void)
 {
     if (!is_enabled())
         return 0;
@@ -285,7 +285,7 @@ int mutex_lock_return(struct pt_regs *ctx)
     return 0;
 }
 
-int mutex_unlock_enter(struct pt_regs *ctx)
+static int do_mutex_unlock_enter(void)
 {
     if (!is_enabled())
         return 0;
@@ -330,8 +330,48 @@ int mutex_unlock_enter(struct pt_regs *ctx)
     time_held.delete(&did);
     return 0;
 }
+"""
+
+program_kprobe = """
+int mutex_unlock_enter(struct pt_regs *ctx)
+{
+    return do_mutex_unlock_enter();
+}
+
+int mutex_lock_return(struct pt_regs *ctx)
+{
+    return do_mutex_lock_return();
+}
+
+int mutex_lock_enter(struct pt_regs *ctx)
+{
+    return do_mutex_lock_enter(ctx, 0);
+}
+"""
+
+program_kfunc = """
+KFUNC_PROBE(mutex_unlock, void *lock)
+{
+    do_mutex_unlock_enter();
+}
+
+KRETFUNC_PROBE(mutex_lock, void *lock, int ret)
+{
+    do_mutex_lock_return();
+}
+
+KFUNC_PROBE(mutex_lock, void *lock)
+{
+    do_mutex_lock_enter(ctx, 3);
+}
 
 """
+
+is_support_kfunc = BPF.support_kfunc()
+if is_support_kfunc:
+    program += program_kfunc
+else:
+    program += program_kprobe
 
 def sort_list(maxs, totals, counts):
     if (not args.sort):
@@ -387,9 +427,10 @@ program = program.replace('STACK_STORAGE_SIZE', str(args.stack_storage_size))
 
 b = BPF(text=program)
 
-b.attach_kprobe(event="mutex_unlock", fn_name="mutex_unlock_enter")
-b.attach_kretprobe(event="mutex_lock", fn_name="mutex_lock_return")
-b.attach_kprobe(event="mutex_lock", fn_name="mutex_lock_enter")
+if not is_support_kfunc:
+    b.attach_kprobe(event="mutex_unlock",  fn_name="mutex_unlock_enter")
+    b.attach_kretprobe(event="mutex_lock", fn_name="mutex_lock_return")
+    b.attach_kprobe(event="mutex_lock",    fn_name="mutex_lock_enter")
 
 enabled = b.get_table("enabled");
 


### PR DESCRIPTION
Kernel added new probe called trampoline allowing to probe
almost any kernel function when BTF info is available in
the system.
    
Adding the interface under 'kfunc' name, which allows to
probe function entry and 'kretfunc' name, which allows to
trace function return.
    
 The main benefit is really low overhead which is really low
 for trampolines (please see commit for klockstat.py
 with perf comparison).
    
 Another benefit is the ability of kretfunc probe to access
 function arguments, so some tools might need only one program
 instead of entry/exit ones (please see commit for
 opensnoop.py changes).
