### PR TITLE
search in PATH for python

### DIFF
--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 

--- a/scripts/py-style-check.sh
+++ b/scripts/py-style-check.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 find tools -type f -name "*.py" | xargs pycodestyle -r --show-source --ignore=E123,E125,E126,E127,E128,E302 || \
     echo "pycodestyle run failed, please fix it" >&2
 
-NO_PROPER_SHEBANG="$(find tools examples -type f -executable -name '*.py' | xargs grep -L '#!/usr/bin/python')"
+NO_PROPER_SHEBANG="$(find tools examples -type f -executable -name '*.py' | xargs grep -L '#!/usr/bin/env python')"
 if [ -n "$NO_PROPER_SHEBANG" ]; then
     echo "bad shebangs found:"
     echo "$NO_PROPER_SHEBANG"


### PR DESCRIPTION
This commit is improving fail safety a bit by instructing to search PATH for python in the - may unlikely - case it’s not located at /bin