### PR TITLE
bcc.BPF.cleanup(): Ensure self.funcs items get deleted during cleanup

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1366,6 +1366,7 @@ class BPF(object):
             self.tracefile = None
         for name, fn in list(self.funcs.items()):
             os.close(fn.fd)
+            del self.funcs[name]
         if self.module:
             lib.bpf_module_destroy(self.module)
             self.module = None


### PR DESCRIPTION
Since commit 115b959d86
("Fix a file descriptor leak when module is deleted (#2530)"), we
observe the following exceptions during python exit:

  Error in atexit._run_exitfuncs:
  Traceback (most recent call last):
    File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
      func(*targs, **kargs)
    File "/usr/lib/python2.7/dist-packages/bcc/__init__.py", line 1366, in cleanup
      os.close(fn.fd)
  OSError: [Errno 9] Bad file descriptor

which occurs for python programs issuing a call to 'cleanup()', or using
the 'with bcc.BPF(...)' code pattern.

BPF's 'cleanup' is registered to be invoked atexit. Alas, commit
115b959d86 introduced an 'os.close(fn.fd)' call for each func loaded (to
prevent accidental FD leakage).

Problem is, that the 'self.funcs' dict entries are NOT deleted, making
subsequent calls to 'cleanup' to attempt closing the same 'fn.fd' again
and again.

It is expected from 'cleanup' to operate correctly when called
repeatedly; Therefore, it should "nullify" references to closed
resources.

Fix, by deleting the reference to each unloaded function from the
'self.func' dictionary.

Fixes: 115b959d86 ("Fix a file descriptor leak when module is deleted (#2530)")
Reported-by: Dana Rubin <drubin@metanetworks.com>
Signed-off-by: Shmulik Ladkani <shmulik.ladkani@gmail.com>