### PR TITLE
support sockmap/sockhash/cgroup_local_storage maps

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -609,6 +609,29 @@ StatusTuple BPF::unload_func(const std::string& func_name) {
   return StatusTuple(0);
 }
 
+StatusTuple BPF::attach_func(int prog_fd, int attachable_fd,
+                             enum bpf_attach_type attach_type,
+                             uint64_t flags) {
+  int res = bpf_module_->bcc_func_attach(prog_fd, attachable_fd, attach_type, flags);
+  if (res != 0)
+    return StatusTuple(-1, "Can't attach for prog_fd %d, attachable_fd %d, "
+                           "attach_type %d, flags %ld: error %d",
+                       prog_fd, attachable_fd, attach_type, flags, res);
+
+  return StatusTuple(0);
+}
+
+StatusTuple BPF::detach_func(int prog_fd, int attachable_fd,
+                             enum bpf_attach_type attach_type) {
+  int res = bpf_module_->bcc_func_detach(prog_fd, attachable_fd, attach_type);
+  if (res != 0)
+    return StatusTuple(-1, "Can't detach for prog_fd %d, attachable_fd %d, "
+                           "attach_type %d: error %d",
+                       prog_fd, attachable_fd, attach_type, res);
+
+  return StatusTuple(0);
+}
+
 std::string BPF::get_syscall_fnname(const std::string& name) {
   if (syscall_prefix_ == nullptr) {
     KSyms ksym;
@@ -706,6 +729,20 @@ BPFMapInMapTable BPF::get_map_in_map_table(const std::string& name) {
   if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
     return BPFMapInMapTable(it->second);
   return BPFMapInMapTable({});
+}
+
+BPFSockmapTable BPF::get_sockmap_table(const std::string& name) {
+  TableStorage::iterator it;
+  if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+    return BPFSockmapTable(it->second);
+  return BPFSockmapTable({});
+}
+
+BPFSockhashTable BPF::get_sockhash_table(const std::string& name) {
+  TableStorage::iterator it;
+  if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+    return BPFSockhashTable(it->second);
+  return BPFSockhashTable({});
 }
 
 bool BPF::add_module(std::string module)

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -154,6 +154,22 @@ class BPF {
     return BPFSkStorageTable<ValueType>({});
   }
 
+  template <class ValueType>
+  BPFCgStorageTable<ValueType> get_cg_storage_table(const std::string& name) {
+    TableStorage::iterator it;
+    if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+      return BPFCgStorageTable<ValueType>(it->second);
+    return BPFCgStorageTable<ValueType>({});
+  }
+
+  template <class ValueType>
+  BPFPercpuCgStorageTable<ValueType> get_percpu_cg_storage_table(const std::string& name) {
+    TableStorage::iterator it;
+    if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+      return BPFPercpuCgStorageTable<ValueType>(it->second);
+    return BPFPercpuCgStorageTable<ValueType>({});
+  }
+
   void* get_bsymcache(void) {
     if (bsymcache_ == NULL) {
       bsymcache_ = bcc_buildsymcache_new();
@@ -168,6 +184,10 @@ class BPF {
   BPFDevmapTable get_devmap_table(const std::string& name);
 
   BPFXskmapTable get_xskmap_table(const std::string& name);
+
+  BPFSockmapTable get_sockmap_table(const std::string& name);
+
+  BPFSockhashTable get_sockhash_table(const std::string& name);
 
   BPFStackTable get_stack_table(const std::string& name,
                                 bool use_debug_file = true,
@@ -209,6 +229,12 @@ class BPF {
   StatusTuple load_func(const std::string& func_name, enum bpf_prog_type type,
                         int& fd);
   StatusTuple unload_func(const std::string& func_name);
+
+  StatusTuple attach_func(int prog_fd, int attachable_fd,
+                          enum bpf_attach_type attach_type,
+                          uint64_t flags);
+  StatusTuple detach_func(int prog_fd, int attachable_fd,
+                          enum bpf_attach_type attach_type);
 
   int free_bcc_memory();
 

--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -702,4 +702,44 @@ StatusTuple BPFMapInMapTable::remove_value(const int& index) {
     return StatusTuple(0);
 }
 
+BPFSockmapTable::BPFSockmapTable(const TableDesc& desc)
+    : BPFTableBase<int, int>(desc) {
+    if(desc.type != BPF_MAP_TYPE_SOCKMAP)
+      throw std::invalid_argument("Table '" + desc.name +
+                                  "' is not a sockmap table");
+}
+
+StatusTuple BPFSockmapTable::update_value(const int& index,
+                                         const int& value) {
+    if (!this->update(const_cast<int*>(&index), const_cast<int*>(&value)))
+      return StatusTuple(-1, "Error updating value: %s", std::strerror(errno));
+    return StatusTuple(0);
+}
+
+StatusTuple BPFSockmapTable::remove_value(const int& index) {
+    if (!this->remove(const_cast<int*>(&index)))
+      return StatusTuple(-1, "Error removing value: %s", std::strerror(errno));
+    return StatusTuple(0);
+}
+
+BPFSockhashTable::BPFSockhashTable(const TableDesc& desc)
+    : BPFTableBase<int, int>(desc) {
+    if(desc.type != BPF_MAP_TYPE_SOCKHASH)
+      throw std::invalid_argument("Table '" + desc.name +
+                                  "' is not a sockhash table");
+}
+
+StatusTuple BPFSockhashTable::update_value(const int& key,
+                                         const int& value) {
+    if (!this->update(const_cast<int*>(&key), const_cast<int*>(&value)))
+      return StatusTuple(-1, "Error updating value: %s", std::strerror(errno));
+    return StatusTuple(0);
+}
+
+StatusTuple BPFSockhashTable::remove_value(const int& key) {
+    if (!this->remove(const_cast<int*>(&key)))
+      return StatusTuple(-1, "Error removing value: %s", std::strerror(errno));
+    return StatusTuple(0);
+}
+
 }  // namespace ebpf

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -940,4 +940,16 @@ int BPFModule::bcc_func_load(int prog_type, const char *name,
   return ret;
 }
 
+int BPFModule::bcc_func_attach(int prog_fd, int attachable_fd,
+                               int attach_type, unsigned int flags) {
+  return bpf_prog_attach(prog_fd, attachable_fd,
+                         (enum bpf_attach_type)attach_type, flags);
+}
+
+int BPFModule::bcc_func_detach(int prog_fd, int attachable_fd,
+                               int attach_type) {
+  return bpf_prog_detach2(prog_fd, attachable_fd,
+                          (enum bpf_attach_type)attach_type);
+}
+
 } // namespace ebpf

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -145,6 +145,9 @@ class BPFModule {
                     const char *license, unsigned kern_version,
                     int log_level, char *log_buf, unsigned log_buf_size,
                     const char *dev_name = nullptr);
+  int bcc_func_attach(int prog_fd, int attachable_fd,
+                      int attach_type, unsigned int flags);
+  int bcc_func_detach(int prog_fd, int attachable_fd, int attach_type);
   size_t perf_event_fields(const char *) const;
   const char * perf_event_field(const char *, size_t i) const;
 

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_LIBBCC_SOURCES
 	test_c_api.cc
 	test_array_table.cc
 	test_bpf_table.cc
+	test_cg_storage.cc
 	test_hash_table.cc
 	test_map_in_map.cc
 	test_perf_event.cc
@@ -27,6 +28,7 @@ set(TEST_LIBBCC_SOURCES
 	test_prog_table.cc
 	test_shared_table.cc
 	test_sk_storage.cc
+	test_sock_table.cc
 	test_usdt_args.cc
 	test_usdt_probes.cc
 	utils.cc)

--- a/tests/cc/test_cg_storage.cc
+++ b/tests/cc/test_cg_storage.cc
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <linux/version.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <string>
+#include <vector>
+
+#include "BPF.h"
+#include "catch.hpp"
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+
+TEST_CASE("test cgroup storage", "[cgroup_storage]") {
+  {
+    const std::string BPF_PROGRAM = R"(
+BPF_CGROUP_STORAGE(cg_storage1, int);
+BPF_CGROUP_STORAGE(cg_storage2, int);
+int test(struct bpf_sock_ops *skops)
+{
+  struct bpf_cgroup_storage_key key = {0};
+  u32 val = 0;
+
+  cg_storage2.lookup(&key);
+  cg_storage2.update(&key, &val);
+  cg_storage2.get_local_storage(0);
+
+  return 0;
+}
+    )";
+
+    // make sure program is loaded successfully
+    ebpf::BPF bpf;
+    ebpf::StatusTuple res(0);
+    res = bpf.init(BPF_PROGRAM);
+    REQUIRE(res.code() == 0);
+
+    auto cg_storage = bpf.get_cg_storage_table<int>("cg_storage1");
+    struct bpf_cgroup_storage_key key = {0};
+    int val;
+
+    // all the following lookup/update will fail since
+    // cgroup local storage only created during prog attachment time.
+    res = cg_storage.get_value(key, val);
+    REQUIRE(res.code() != 0);
+
+    res = cg_storage.update_value(key, val);
+    REQUIRE(res.code() != 0);
+  }
+}
+
+TEST_CASE("test percpu cgroup storage", "[percpu_cgroup_storage]") {
+  {
+    const std::string BPF_PROGRAM = R"(
+BPF_PERCPU_CGROUP_STORAGE(cg_storage1, long long);
+BPF_PERCPU_CGROUP_STORAGE(cg_storage2, long long);
+int test(struct bpf_sock_ops *skops)
+{
+  struct bpf_cgroup_storage_key key = {0};
+  long long val = 0;
+
+  cg_storage2.lookup(&key);
+  cg_storage2.update(&key, &val);
+  cg_storage2.get_local_storage(0);
+
+  return 0;
+}
+    )";
+
+    // make sure program is loaded successfully
+    ebpf::BPF bpf;
+    ebpf::StatusTuple res(0);
+    res = bpf.init(BPF_PROGRAM);
+    REQUIRE(res.code() == 0);
+
+    auto cg_storage = bpf.get_percpu_cg_storage_table<long long>("cg_storage1");
+    struct bpf_cgroup_storage_key key = {0};
+    std::vector<long long> val(ebpf::BPFTable::get_possible_cpu_count());
+
+    // all the following lookup/update will fail since
+    // cgroup local storage only created during prog attachment time.
+    res = cg_storage.get_value(key, val);
+    REQUIRE(res.code() != 0);
+
+    res = cg_storage.update_value(key, val);
+    REQUIRE(res.code() != 0);
+  }
+}
+
+#endif

--- a/tests/cc/test_sock_table.cc
+++ b/tests/cc/test_sock_table.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <linux/version.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <string>
+
+#include "BPF.h"
+#include "catch.hpp"
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
+
+TEST_CASE("test sock map", "[sockmap]") {
+  {
+    const std::string BPF_PROGRAM = R"(
+BPF_SOCKMAP(sk_map1, 10);
+BPF_SOCKMAP(sk_map2, 10);
+int test(struct bpf_sock_ops *skops)
+{
+  u32 key = 0, val = 0;
+
+  sk_map2.update(&key, &val);
+  sk_map2.delete(&key);
+  sk_map2.sock_map_update(skops, &key, 0);
+
+  return 0;
+}
+    )";
+
+    // make sure program is loaded successfully
+    ebpf::BPF bpf;
+    ebpf::StatusTuple res(0);
+    res = bpf.init(BPF_PROGRAM);
+    REQUIRE(res.code() == 0);
+
+    // create a udp socket so we can do some map operations.
+    int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    REQUIRE(sockfd >= 0);
+
+    auto sk_map = bpf.get_sockmap_table("sk_map1");
+    int key = 0, val = sockfd;
+
+    res = sk_map.remove_value(key);
+    REQUIRE(res.code() != 0);
+
+    // the socket must be TCP established socket.
+    res = sk_map.update_value(key, val);
+    REQUIRE(res.code() != 0);
+  }
+}
+
+TEST_CASE("test sock hash", "[sockhash]") {
+  {
+    const std::string BPF_PROGRAM = R"(
+BPF_SOCKHASH(sk_hash1, 10);
+BPF_SOCKHASH(sk_hash2, 10);
+int test(struct bpf_sock_ops *skops)
+{
+  u32 key = 0, val = 0;
+
+  sk_hash2.update(&key, &val);
+  sk_hash2.delete(&key);
+  sk_hash2.sock_hash_update(skops, &key, 0);
+
+  return 0;
+}
+    )";
+
+    // make sure program is loaded successfully
+    ebpf::BPF bpf;
+    ebpf::StatusTuple res(0);
+    res = bpf.init(BPF_PROGRAM);
+    REQUIRE(res.code() == 0);
+
+    // create a udp socket so we can do some map operations.
+    int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    REQUIRE(sockfd >= 0);
+
+    auto sk_hash = bpf.get_sockhash_table("sk_hash1");
+    int key = 0, val = sockfd;
+
+    res = sk_hash.remove_value(key);
+    REQUIRE(res.code() != 0);
+
+    // the socket must be TCP established socket.
+    res = sk_hash.update_value(key, val);
+    REQUIRE(res.code() != 0);
+  }
+}
+
+#endif


### PR DESCRIPTION
This patch supports sockmap, sockhash and cgroup_local_storage
maps. Two C++ APIs, attach_func and detach_func are also
added to allow to attach program to cgroups. So this makes
using C++ APIs for cgroup based networking applications
easier to integrate with bpf programs.

The unit testing is rough as it needs some work to set up
cgroups and establish TCP connections to really test the
result of map operations. But still all supported map
operations in kernel and in C++ APIs are tested syntacically.

Signed-off-by: Yonghong Song <yhs@fb.com>