### PR TITLE
libbcc debian package is architecture-dependent

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>= 9), cmake,
 Homepage: https://github.com/iovisor/bcc
 
 Package: libbcc
-Architecture: all
+Architecture: any
 Provides: libbpfcc, libbpfcc-dev
 Conflicts: libbpfcc, libbpfcc-dev
 Depends: libc6, libstdc++6, libelf1


### PR DESCRIPTION
#1968 marked the `libbcc` debian package as being architecture-independent by setting the `Architecture` field to `all`. However, the `libbcc` package contains shared objects which are architecture-dependent. One of the consequences is that a corresponding `-dbgsym` package is not generated when `libbcc` is generated.

This changes the `Architecture` from `all` to `any`, which indicates the package supports all architectures, but must be built independently for each one. It also causes a `libbcc-dbgsym` package to be built with the debug info stripped from `libbcc`.

I don't have other architectures handy to test with, but I built the packages on amd64 and found that install cleanly, that some of the basic BCC tools work correctly:
```
# ls
bcc-lua_0.12.0-1-delphix-2020.02.08.11.34.22_all.deb
bcc-tools_0.12.0-1-delphix-2020.02.08.11.34.22_all.deb
libbcc-dbgsym_0.12.0-1-delphix-2020.02.08.11.34.22_amd64.ddeb
libbcc-examples_0.12.0-1-delphix-2020.02.08.11.34.22_amd64.deb
libbcc_0.12.0-1-delphix-2020.02.08.11.34.22_amd64.deb
python-bcc_0.12.0-1-delphix-2020.02.08.11.34.22_all.deb
python3-bcc_0.12.0-1-delphix-2020.02.08.11.34.22_all.deb
```
```
# sudo dpkg -i ./*deb
Selecting previously unselected package bcc-lua.
(Reading database ... 112565 files and directories currently installed.)
Preparing to unpack .../bcc-lua_0.12.0-1-delphix-2020.02.08.11.34.22_all.deb ...
Unpacking bcc-lua (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Selecting previously unselected package bcc-tools.
Preparing to unpack .../bcc-tools_0.12.0-1-delphix-2020.02.08.11.34.22_all.deb ...
Unpacking bcc-tools (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Selecting previously unselected package libbcc-dbgsym.
Preparing to unpack .../libbcc-dbgsym_0.12.0-1-delphix-2020.02.08.11.34.22_amd64.ddeb ...
Unpacking libbcc-dbgsym (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Selecting previously unselected package libbcc-examples.
Preparing to unpack .../libbcc-examples_0.12.0-1-delphix-2020.02.08.11.34.22_amd64.deb ...
Unpacking libbcc-examples (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Selecting previously unselected package libbcc.
Preparing to unpack .../libbcc_0.12.0-1-delphix-2020.02.08.11.34.22_amd64.deb ...
Unpacking libbcc (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Selecting previously unselected package python-bcc.
Preparing to unpack .../python-bcc_0.12.0-1-delphix-2020.02.08.11.34.22_all.deb ...
Unpacking python-bcc (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Selecting previously unselected package python3-bcc.
Preparing to unpack .../python3-bcc_0.12.0-1-delphix-2020.02.08.11.34.22_all.deb ...
Unpacking python3-bcc (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Setting up libbcc (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Setting up python-bcc (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Setting up python3-bcc (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Setting up bcc-lua (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Setting up bcc-tools (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Setting up libbcc-dbgsym (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Setting up libbcc-examples (0.12.0-1-delphix-2020.02.08.11.34.22) ...
Processing triggers for libc-bin (2.27-3ubuntu1) ...
```
```
# /usr/share/bcc/tools/biolatency
Tracing block device I/O... Hit Ctrl-C to end.
^C
     usecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 53       |********************                    |
       512 -> 1023       : 64       |************************                |
      1024 -> 2047       : 63       |************************                |
      2048 -> 4095       : 105      |****************************************|
      4096 -> 8191       : 56       |*********************                   |
      8192 -> 16383      : 66       |*************************               |
     16384 -> 32767      : 35       |*************                           |
```