### PR TITLE
Allow specifying clang base directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,11 @@ find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM: ${LLVM_INCLUDE_DIRS} ${LLVM_PACKAGE_VERSION}")
 find_package(LibElf REQUIRED)
 
+if(CLANG_DIR)
+  set(CMAKE_FIND_ROOT_PATH "${CLANG_DIR}")
+  include_directories("${CLANG_DIR}/include")
+endif()
+
 # clang is linked as a library, but the library path searching is
 # primitively supported, unlike libLLVM
 set(CLANG_SEARCH "/opt/local/llvm/lib;/usr/lib/llvm-3.7/lib;${LLVM_LIBRARY_DIRS}")


### PR DESCRIPTION
The LLVM package provides a Cmake flag "LLVM_DIR", but there is no analogue for specifying the search for clang libraries or headers in this same way.

This PR introduces this, so that the following usage is valid:

```
cmake -DLLVM_DIR=${SOME_PATH_TO_LLVM}/lib/cmake/llvm
cmake -DCLANG_DIR=${SOME_PATH_TO_CLANG}
```

Note that LLVM_DIR points to the Cmake files for LLVM, and CLANG_DIR, points to a root director of a clang install, which has both "/lib" and "/include" in it, there is no need to load any CMake files for this and clang doesn't seem to export a cmake file for this / nor is it needed with the processing of clang libs below.

I happen to need this in order to override the LLVM and Clang paths to point to embedded ones, when building bpftrace for android https://github.com/iovisor/bpftrace/pull/1095 in this patch set https://gist.github.com/dalehamel/da2f73357cd8cc4e60a1218e562a472b
