### PR TITLE
snapcraft: add missing libfl-dev dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,7 @@ parts:
             - libedit-dev
             - libelf-dev
             - libllvm4.0
+            - libfl-dev
             - llvm-4.0-dev
             - zlib1g-dev
         prime:


### PR DESCRIPTION
Also need libfl-dev to build on other non-x86 targets

Signed-off-by: Colin Ian King <colin.king@canonical.com>