### PR TITLE
fix pid filter bug

### DIFF
--- a/tools/tcpconnlat.py
+++ b/tools/tcpconnlat.py
@@ -105,7 +105,7 @@ BPF_PERF_OUTPUT(ipv6_events);
 
 int trace_connect(struct pt_regs *ctx, struct sock *sk)
 {
-    u32 pid = bpf_get_current_pid_tgid();
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
     FILTER
     struct info_t info = {.pid = pid};
     info.ts = bpf_ktime_get_ns();


### PR DESCRIPTION
1. Wirte a simple go, just print pid and get some website.
```go
func main() {
	 pid := os.Getpid()
         fmt.Println(pid)
         response, err := http.Get("http://www.baidu.com")
         // ....
}
```

```bash
./main
3581
```

2. But when run `tcpconnlat`, we just go tid 3585, (not pid 3581)
```bash
#./tcpconnlat
PID    COMM         IP SADDR            DADDR            DPORT LAT(ms)
3585   main         4  10.0.2.15        180.101.49.11    80    60.68
```
3. So run `./tcpconnlat -p 3581` not work

I have tested this situation under kernel 3.10 and 5.0.9.