### PR TITLE
tools/stackcount: Fix address resolution for user-space stack

### DIFF
--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -275,6 +275,12 @@ class Tool(object):
             self.kernel_stack = self.args.kernel_stacks_only
             self.user_stack = self.args.user_stacks_only
 
+        # For tracing single processes in isolation, explicitly set perpid
+        # to True, if not already set. This is required to generate the correct
+        # BPF program that can store pid in the tgid field of the key_t object.
+        if self.args.pid is not None and self.args.pid > 0:
+            self.args.perpid = True
+
         self.probe = Probe(self.args.pattern,
                            self.kernel_stack, self.user_stack,
                            self.args.regexp, self.args.pid, self.args.perpid, self.args.cpu)

--- a/tools/stackcount_example.txt
+++ b/tools/stackcount_example.txt
@@ -487,7 +487,7 @@ User-space functions can also be traced if a library name is provided. For
 example, to quickly identify code locations that allocate heap memory for
 PID 4902 (using -p), by tracing malloc from libc ("c:malloc"):
 
-# ./stackcount -P -p 4902 c:malloc
+# ./stackcount -p 4902 c:malloc
 Tracing 1 functions for "malloc"... Hit Ctrl-C to end.
 ^C
   malloc


### PR DESCRIPTION
This patch fixes issue #2748. The bug was that address-to-symbol resolution
didn't work for user-space stacks without the `-P` (per-pid) flag when tracing
single, isolated processes. The current documentation of the `-P` option
indicates that it's used to "display stacks separately for each process",
and this doesn't match with the intended usage.

This patch has two parts:

 - Fix `tools/stackcount.py` to explicitly set perpid to True if `-p <pid>`
   is used
 - Remove the `-P` option from the example of tracing single, isolated process
   in `tools/stackcount_example.txt`, since the usage of the option can
   be confusing (and unnecessary after the current change)