### PR TITLE
tools/profile: fix kernel delimiter when folding

### DIFF
--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -98,9 +98,6 @@ parser.add_argument("--ebpf", action="store_true",
 args = parser.parse_args()
 folded = args.folded
 duration = int(args.duration)
-need_delimiter = args.delimited and not any([args.folded,
-                                         args.kernel_stacks_only,
-                                         args.user_stacks_only])
 
 # signal handler
 def signal_ignore(signal, frame):
@@ -295,6 +292,8 @@ missing_stacks = 0
 has_enomem = False
 counts = b.get_table("counts")
 stack_traces = b.get_table("stack_traces")
+need_delimiter = args.delimited and not (args.kernel_stacks_only or
+                                         args.user_stacks_only)
 for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
     # handle get_stackid errors
     if not args.user_stacks_only:

--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -98,6 +98,9 @@ parser.add_argument("--ebpf", action="store_true",
 args = parser.parse_args()
 folded = args.folded
 duration = int(args.duration)
+need_delimiter = args.delimited and not any([args.folded,
+                                         args.kernel_stacks_only,
+                                         args.user_stacks_only])
 
 # signal handler
 def signal_ignore(signal, frame):
@@ -292,8 +295,6 @@ missing_stacks = 0
 has_enomem = False
 counts = b.get_table("counts")
 stack_traces = b.get_table("stack_traces")
-need_delimiter = args.delimited and not (args.kernel_stacks_only or
-                                         args.user_stacks_only)
 for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
     # handle get_stackid errors
     if not args.user_stacks_only:

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -118,9 +118,8 @@ args = parser.parse_args()
 pid = int(args.pid) if args.pid is not None else -1
 duration = int(args.duration)
 debug = 0
-need_delimiter = args.delimited and not any([args.folded,
-                                         args.kernel_stacks_only,
-                                         args.user_stacks_only])
+need_delimiter = args.delimited and not (args.kernel_stacks_only or
+    args.user_stacks_only)
 # TODO: add stack depth, and interval
 
 #
@@ -333,7 +332,7 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
             else:
                 line.extend([b.sym(addr, k.pid) for addr in reversed(user_stack)])
         if not args.user_stacks_only:
-            line.extend(b["-"] if (need_delimiter and k.kernel_stack_id >= 0 and k.user_stack_id >= 0) else [])
+            line.extend([b"-"] if (need_delimiter and k.kernel_stack_id >= 0 and k.user_stack_id >= 0) else [])
             if stack_id_err(k.kernel_stack_id):
                 line.append(b"[Missed Kernel Stack]")
             else:

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -118,8 +118,9 @@ args = parser.parse_args()
 pid = int(args.pid) if args.pid is not None else -1
 duration = int(args.duration)
 debug = 0
-need_delimiter = args.delimited and not (args.kernel_stacks_only or
-    args.user_stacks_only)
+need_delimiter = args.delimited and not any([args.folded,
+                                         args.kernel_stacks_only,
+                                         args.user_stacks_only])
 # TODO: add stack depth, and interval
 
 #
@@ -296,8 +297,6 @@ missing_stacks = 0
 has_enomem = False
 counts = b.get_table("counts")
 stack_traces = b.get_table("stack_traces")
-need_delimiter = args.delimited and not (args.kernel_stacks_only or
-                                         args.user_stacks_only)
 for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
     # handle get_stackid errors
     if not args.user_stacks_only and stack_id_err(k.kernel_stack_id):


### PR DESCRIPTION
When combining delmiiter and folding options: `profile -d -f`, this exception is thrown:

```
Traceback (most recent call last):
  File "./profile", line 337, in <module>
    line.extend(b["-"] if (need_delimiter and k.kernel_stack_id >= 0 and k.user_stack_id >= 0) else [])
  File "/usr/local/lib/python2.7/dist-packages/bcc/__init__.py", line 508, in __getitem__
    self.tables[key] = self.get_table(key)
  File "/usr/local/lib/python2.7/dist-packages/bcc/__init__.py", line 493, in get_table
    raise KeyError
KeyError
```

This change eliminates the delimiter when folding is enabled.