### PR TITLE
tools: add option --cgroupmap to tcp tools

### DIFF
--- a/docs/filtering_by_cgroups.md
+++ b/docs/filtering_by_cgroups.md
@@ -8,6 +8,9 @@ Examples of commands:
 ```
 # ./opensnoop --cgroupmap /sys/fs/bpf/test01
 # ./execsnoop --cgroupmap /sys/fs/bpf/test01
+# ./tcpconnect --cgroupmap /sys/fs/bpf/test01
+# ./tcpaccept --cgroupmap /sys/fs/bpf/test01
+# ./tcptracer --cgroupmap /sys/fs/bpf/test01
 ```
 
 The commands above will only display results from processes that belong to one

--- a/man/man8/execsnoop.8
+++ b/man/man8/execsnoop.8
@@ -1,9 +1,9 @@
-.TH execsnoop 8  "2016-02-07" "USER COMMANDS"
+.TH execsnoop 8  "2020-02-20" "USER COMMANDS"
 .SH NAME
 execsnoop \- Trace new processes via exec() syscalls. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B execsnoop [\-h] [\-T] [\-t] [\-x] [\-q] [\-n NAME] [\-l LINE]
-.B           [\-\-max-args MAX_ARGS]
+.B           [\-\-max-args MAX_ARGS]  [\-\-cgroupmap MAPPATH]
 .SH DESCRIPTION
 execsnoop traces new processes, showing the filename executed and argument
 list.
@@ -46,6 +46,9 @@ Only print commands where arg contains this line (regex)
 .TP
 \--max-args MAXARGS
 Maximum number of arguments parsed and displayed, defaults to 20
+.TP
+\-\-cgroupmap MAPPATH
+Trace cgroups in this BPF map only (filtered in-kernel).
 .SH EXAMPLES
 .TP
 Trace all exec() syscalls:
@@ -71,6 +74,10 @@ Only trace exec()s where the filename contains "mount":
 Only trace exec()s where argument's line contains "testpkg":
 #
 .B execsnoop \-l testpkg
+.TP
+Trace a set of cgroups only (see filtering_by_cgroups.md from bcc sources for more details):
+#
+.B execsnoop \-\-cgroupmap /sys/fs/bpf/test01
 .SH FIELDS
 .TP
 TIME

--- a/man/man8/opensnoop.8
+++ b/man/man8/opensnoop.8
@@ -1,9 +1,10 @@
-.TH opensnoop 8  "2015-08-18" "USER COMMANDS"
+.TH opensnoop 8  "2020-02-20" "USER COMMANDS"
 .SH NAME
 opensnoop \- Trace open() syscalls. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B opensnoop.py [\-h] [\-T] [\-U] [\-x] [\-p PID] [\-t TID] [\-u UID]
              [\-d DURATION] [\-n NAME] [\-e] [\-f FLAG_FILTER]
+             [--cgroupmap MAPPATH]
 .SH DESCRIPTION
 opensnoop traces the open() syscall, showing which processes are attempting
 to open which files. This can be useful for determining the location of config
@@ -54,6 +55,9 @@ Show extended fields.
 .TP
 \-f FLAG
 Filter on open() flags, e.g., O_WRONLY.
+.TP
+\--cgroupmap MAPPATH
+Trace cgroups in this BPF map only (filtered in-kernel).
 .SH EXAMPLES
 .TP
 Trace all open() syscalls:
@@ -95,6 +99,10 @@ Show extended fields:
 Only print calls for writing:
 #
 .B opensnoop \-f O_WRONLY \-f O_RDWR
+.TP
+Trace a set of cgroups only (see filtering_by_cgroups.md from bcc sources for more details):
+#
+.B opensnoop \-\-cgroupmap /sys/fs/bpf/test01
 .SH FIELDS
 .TP
 TIME(s)
@@ -142,4 +150,4 @@ Unstable - in development.
 .SH AUTHOR
 Brendan Gregg
 .SH SEE ALSO
-funccount(1)
+execsnoop(8), funccount(1)

--- a/man/man8/tcpaccept.8
+++ b/man/man8/tcpaccept.8
@@ -1,8 +1,8 @@
-.TH tcpaccept 8  "2019-03-08" "USER COMMANDS"
+.TH tcpaccept 8  "2020-02-20" "USER COMMANDS"
 .SH NAME
 tcpaccept \- Trace TCP passive connections (accept()). Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B tcpaccept [\-h] [\-T] [\-t] [\-p PID] [\-P PORTS]
+.B tcpaccept [\-h] [\-T] [\-t] [\-p PID] [\-P PORTS] [\-\-cgroupmap MAPPATH]
 .SH DESCRIPTION
 This tool traces passive TCP connections (eg, via an accept() syscall;
 connect() are active connections). This can be useful for general
@@ -33,6 +33,9 @@ Trace this process ID only (filtered in-kernel).
 .TP
 \-P PORTS
 Comma-separated list of local ports to trace (filtered in-kernel).
+.TP
+\-\-cgroupmap MAPPATH
+Trace cgroups in this BPF map only (filtered in-kernel).
 .SH EXAMPLES
 .TP
 Trace all passive TCP connections (accept()s):
@@ -50,6 +53,10 @@ Trace connections to local ports 80 and 81 only:
 Trace PID 181 only:
 #
 .B tcpaccept \-p 181
+.TP
+Trace a set of cgroups only (see filtering_by_cgroups.md from bcc sources for more details):
+#
+.B tcpaccept \-\-cgroupmap /sys/fs/bpf/test01
 .SH FIELDS
 .TP
 TIME
@@ -99,4 +106,4 @@ Unstable - in development.
 .SH AUTHOR
 Brendan Gregg
 .SH SEE ALSO
-tcpconnect(8), funccount(8), tcpdump(8)
+tcptracer(8), tcpconnect(8), funccount(8), tcpdump(8)

--- a/man/man8/tcpconnect.8
+++ b/man/man8/tcpconnect.8
@@ -1,8 +1,8 @@
-.TH tcpconnect 8  "2015-08-25" "USER COMMANDS"
+.TH tcpconnect 8  "2020-02-20" "USER COMMANDS"
 .SH NAME
 tcpconnect \- Trace TCP active connections (connect()). Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B tcpconnect [\-h] [\-c] [\-t] [\-x] [\-p PID] [-P PORT]
+.B tcpconnect [\-h] [\-c] [\-t] [\-x] [\-p PID] [-P PORT] [\-\-cgroupmap MAPPATH]
 .SH DESCRIPTION
 This tool traces active TCP connections (eg, via a connect() syscall;
 accept() are passive connections). This can be useful for general
@@ -33,6 +33,9 @@ Trace this process ID only (filtered in-kernel).
 .TP
 \-P PORT
 Comma-separated list of destination ports to trace (filtered in-kernel).
+.TP
+\-\-cgroupmap MAPPATH
+Trace cgroups in this BPF map only (filtered in-kernel).
 .SH EXAMPLES
 .TP
 \-U
@@ -68,6 +71,10 @@ Trace UID 1000 only:
 Count connects per src ip and dest ip/port:
 #
 .B tcpconnect \-c
+.TP
+Trace a set of cgroups only (see filtering_by_cgroups.md from bcc sources for more details):
+#
+.B tcpconnect \-\-cgroupmap /sys/fs/bpf/test01
 .SH FIELDS
 .TP
 TIME(s)
@@ -116,4 +123,4 @@ Unstable - in development.
 .SH AUTHOR
 Brendan Gregg
 .SH SEE ALSO
-tcpaccept(8), funccount(8), tcpdump(8)
+tcptracer(8), tcpaccept(8), funccount(8), tcpdump(8)

--- a/man/man8/tcptracer.8
+++ b/man/man8/tcptracer.8
@@ -1,8 +1,8 @@
-.TH tcptracer 8  "2017-03-27" "USER COMMANDS"
+.TH tcptracer 8  "2020-02-20" "USER COMMANDS"
 .SH NAME
 tcptracer \- Trace TCP established connections. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B tcptracer [\-h] [\-v] [\-p PID] [\-N NETNS]
+.B tcptracer [\-h] [\-v] [\-p PID] [\-N NETNS] [\-\-cgroupmap MAPPATH]
 .SH DESCRIPTION
 This tool traces established TCP connections that open and close while tracing,
 and prints a line of output per connect, accept and close events. This includes
@@ -29,6 +29,8 @@ Trace this process ID only (filtered in-kernel).
 \-N NETNS
 Trace this network namespace only (filtered in-kernel).
 .TP
+\-\-cgroupmap MAPPATH
+Trace cgroups in this BPF map only (filtered in-kernel).
 .SH EXAMPLES
 .TP
 Trace all TCP established connections:
@@ -46,6 +48,10 @@ Trace PID 181 only:
 Trace connections in network namespace 4026531969 only:
 #
 .B tcptracer \-N 4026531969
+.TP
+Trace a set of cgroups only (see filtering_by_cgroups.md from bcc sources for more details):
+#
+.B tcptracer \-\-cgroupmap /sys/fs/bpf/test01
 .SH FIELDS
 .TP
 TYPE

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -29,6 +29,7 @@ examples = """examples:
     ./tcpaccept -t        # include timestamps
     ./tcpaccept -P 80,81  # only trace port 80 and 81
     ./tcpaccept -p 181    # only trace PID 181
+    ./tcpaccept --cgroupmap ./mappath  # only trace cgroups in this BPF map
 """
 parser = argparse.ArgumentParser(
     description="Trace TCP accepts",
@@ -42,6 +43,8 @@ parser.add_argument("-p", "--pid",
     help="trace this PID only")
 parser.add_argument("-P", "--port",
     help="comma-separated list of local ports to trace")
+parser.add_argument("--cgroupmap",
+    help="trace cgroups in this BPF map only")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
 args = parser.parse_args()
@@ -77,6 +80,11 @@ struct ipv6_data_t {
     char task[TASK_COMM_LEN];
 };
 BPF_PERF_OUTPUT(ipv6_events);
+
+#if CGROUPSET
+BPF_TABLE_PINNED("hash", u64, u64, cgroupset, 1024, "CGROUPPATH");
+#endif
+
 """
 
 #
@@ -89,6 +97,13 @@ BPF_PERF_OUTPUT(ipv6_events);
 bpf_text_kprobe = """
 int kretprobe__inet_csk_accept(struct pt_regs *ctx)
 {
+#if CGROUPSET
+    u64 cgroupid = bpf_get_current_cgroup_id();
+    if (cgroupset.lookup(&cgroupid) == NULL) {
+        return 0;
+    }
+#endif
+
     struct sock *newsk = (struct sock *)PT_REGS_RC(ctx);
     u32 pid = bpf_get_current_pid_tgid() >> 32;
 
@@ -184,6 +199,11 @@ if args.port:
     lports_if = ' && '.join(['lport != %d' % lport for lport in lports])
     bpf_text = bpf_text.replace('##FILTER_PORT##',
         'if (%s) { return 0; }' % lports_if)
+if args.cgroupmap:
+    bpf_text = bpf_text.replace('CGROUPSET', '1')
+    bpf_text = bpf_text.replace('CGROUPPATH', args.cgroupmap)
+else:
+    bpf_text = bpf_text.replace('CGROUPSET', '0')
 if debug or args.ebpf:
     print(bpf_text)
     if args.ebpf:

--- a/tools/tcpaccept_example.txt
+++ b/tools/tcpaccept_example.txt
@@ -33,22 +33,33 @@ TIME(s)  PID    COMM         IP RADDR            RPORT LADDR            LPORT
 1.984    907    sshd         4  127.0.0.1        51250 127.0.0.1        22
 
 
+The --cgroupmap option filters based on a cgroup set. It is meant to be used
+with an externally created map.
+
+# ./tcpaccept --cgroupmap /sys/fs/bpf/test01
+
+For more details, see docs/filtering_by_cgroups.md
+
+
 USAGE message:
 
 # ./tcpaccept -h
-usage: tcpaccept [-h] [-T] [-t] [-p PID] [-P PORTS]
+usage: tcpaccept.py [-h] [-T] [-t] [-p PID] [-P PORT] [--cgroupmap CGROUPMAP]
 
 Trace TCP accepts
 
 optional arguments:
-  -h, --help              show this help message and exit
-  -T, --time              include time column on output (HH:MM:SS)
-  -t, --timestamp         include timestamp on output
-  -p PID, --pid PID       trace this PID only
-  -P PORTS, --port PORTS  comma-separated list of local ports to trace
+  -h, --help            show this help message and exit
+  -T, --time            include time column on output (HH:MM:SS)
+  -t, --timestamp       include timestamp on output
+  -p PID, --pid PID     trace this PID only
+  -P PORT, --port PORT  comma-separated list of local ports to trace
+  --cgroupmap CGROUPMAP
+                        trace cgroups in this BPF map only
 
 examples:
     ./tcpaccept           # trace all TCP accept()s
     ./tcpaccept -t        # include timestamps
     ./tcpaccept -P 80,81  # only trace port 80 and 81
     ./tcpaccept -p 181    # only trace PID 181
+    ./tcpaccept --cgroupmap ./mappath  # only trace cgroups in this BPF map

--- a/tools/tcpconnect_example.txt
+++ b/tools/tcpconnect_example.txt
@@ -68,10 +68,19 @@ LADDR                 RADDR                      RPORT             CONNECTS
 [...]
 
 
+The --cgroupmap option filters based on a cgroup set. It is meant to be used
+with an externally created map.
+
+# ./tcpconnect --cgroupmap /sys/fs/bpf/test01
+
+For more details, see docs/filtering_by_cgroups.md
+
+
 USAGE message:
 
 # ./tcpconnect -h
-usage: tcpconnect [-h] [-c] [-t] [-p PID] [-P PORT]
+usage: tcpconnect.py [-h] [-t] [-p PID] [-P PORT] [-U] [-u UID] [-c]
+                     [--cgroupmap CGROUPMAP]
 
 Trace TCP connects
 
@@ -79,11 +88,12 @@ optional arguments:
   -h, --help            show this help message and exit
   -t, --timestamp       include timestamp on output
   -p PID, --pid PID     trace this PID only
-  -P PORT, --port PORT
-                        comma-separated list of destination ports to trace.
+  -P PORT, --port PORT  comma-separated list of destination ports to trace.
   -U, --print-uid       include UID on output
   -u UID, --uid UID     trace this UID only
   -c, --count           count connects per src ip and dest ip/port
+  --cgroupmap CGROUPMAP
+                        trace cgroups in this BPF map only
 
 examples:
     ./tcpconnect           # trace all TCP connect()s
@@ -94,3 +104,4 @@ examples:
     ./tcpconnect -U        # include UID
     ./tcpconnect -u 1000   # only trace UID 1000
     ./tcpconnect -c        # count connects per src ip and dest ip/port
+    ./tcpconnect --cgroupmap ./mappath  # only trace cgroups in this BPF map

--- a/tools/tcptracer_example.txt
+++ b/tools/tcptracer_example.txt
@@ -35,3 +35,11 @@ TIME(s)  T  PID    COMM             IP SADDR            DADDR            SPORT  
 3.546    C    748  curl             6  [::1]            [::1]            42592  80
 4.294    X  31002  telnet           4  192.168.1.2      192.168.1.1      42590  23
 ```
+
+
+The --cgroupmap option filters based on a cgroup set. It is meant to be used
+with an externally created map.
+
+# ./tcptracer --cgroupmap /sys/fs/bpf/test01
+
+For more details, see docs/filtering_by_cgroups.md


### PR DESCRIPTION
List of tcp tools updated: tcpaccept, tcpconnect, tcptracer.

This is the same pattern used initially in #2651 (opensnoop, execsnoop) and then in #2749 (bindsnoop).