### PR TITLE
C++ API: add support for raw tracepoints

### DIFF
--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -91,6 +91,10 @@ class BPF {
                                 const std::string& probe_func);
   StatusTuple detach_tracepoint(const std::string& tracepoint);
 
+  StatusTuple attach_raw_tracepoint(const std::string& tracepoint,
+                                    const std::string& probe_func);
+  StatusTuple detach_raw_tracepoint(const std::string& tracepoint);
+
   StatusTuple attach_perf_event(uint32_t ev_type, uint32_t ev_config,
                                 const std::string& probe_func,
                                 uint64_t sample_period, uint64_t sample_freq,
@@ -248,6 +252,8 @@ class BPF {
   StatusTuple detach_uprobe_event(const std::string& event, open_probe_t& attr);
   StatusTuple detach_tracepoint_event(const std::string& tracepoint,
                                       open_probe_t& attr);
+  StatusTuple detach_raw_tracepoint_event(const std::string& tracepoint,
+                                          open_probe_t& attr);
   StatusTuple detach_perf_event_all_cpu(open_probe_t& attr);
 
   std::string attach_type_debug(bpf_probe_attach_type type) {
@@ -302,6 +308,7 @@ class BPF {
   std::map<std::string, open_probe_t> kprobes_;
   std::map<std::string, open_probe_t> uprobes_;
   std::map<std::string, open_probe_t> tracepoints_;
+  std::map<std::string, open_probe_t> raw_tracepoints_;
   std::map<std::string, BPFPerfBuffer*> perf_buffers_;
   std::map<std::string, BPFPerfEventArray*> perf_event_arrays_;
   std::map<std::pair<uint32_t, uint32_t>, open_probe_t> perf_events_;

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -1136,7 +1136,7 @@ int bpf_detach_tracepoint(const char *tp_category, const char *tp_name) {
   return 0;
 }
 
-int bpf_attach_raw_tracepoint(int progfd, char *tp_name)
+int bpf_attach_raw_tracepoint(int progfd, const char *tp_name)
 {
   int ret;
 

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -92,7 +92,7 @@ int bpf_attach_tracepoint(int progfd, const char *tp_category,
                           const char *tp_name);
 int bpf_detach_tracepoint(const char *tp_category, const char *tp_name);
 
-int bpf_attach_raw_tracepoint(int progfd, char *tp_name);
+int bpf_attach_raw_tracepoint(int progfd, const char *tp_name);
 
 void * bpf_open_perf_buffer(perf_reader_raw_cb raw_cb,
                             perf_reader_lost_cb lost_cb, void *cb_cookie,


### PR DESCRIPTION
libbpf already supported this, so this just adds the wrapper in the C++ API.