### PR TITLE
libbpf-tools: add links to BPF CO-RE posts

### DIFF
--- a/libbpf-tools/README.md
+++ b/libbpf-tools/README.md
@@ -1,3 +1,9 @@
+Useful links
+------------
+
+- [BPF Portability and CO-RE](https://facebookmicrosites.github.io/bpf/blog/2020/02/19/bpf-portability-and-co-re.html)
+- [HOWTO: BCC to libbpf conversion](https://facebookmicrosites.github.io/bpf/blog/2020/02/20/bcc-to-libbpf-howto-guide.html)
+
 Building
 -------
 


### PR DESCRIPTION
Add links to BPF CO-RE blog posts, explainint what it is, how to use it, and
giving practical recommendations on how to convert BCC BPF program to
libbpf-based one.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>