### PR TITLE
latency between add1 and add2

### DIFF
--- a/tools/latency.py
+++ b/tools/latency.py
@@ -1,0 +1,290 @@
+#!/usr/bin/python
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# Copyright (C) 2020 hongzhi-yang.
+# python latency.py -i 1 -C "${BIN_PATH}:0x228e811-0x228eff7:latency>16384" -v -n 1 -p 124
+
+from bcc import BPF, USDT
+import ctypes as ct
+from time import sleep, strftime
+import argparse
+import re
+import traceback
+import os
+import sys
+
+lib = ct.CDLL("libbcc.so.0", use_errno=True)
+_SYM_CB_TYPE = ct.CFUNCTYPE(ct.c_int, ct.c_char_p, ct.c_ulonglong)
+
+def start_func_info(binary_path, start, end):
+    assert start < end, "start must > end"
+
+    start_addr_max = ["", -1]
+    end_addr_max = ["", -1]
+    def sym_cb(sym_name, addr):
+        if addr < start and start_addr_max[1] < addr:
+            start_addr_max[0] = sym_name
+            start_addr_max[1] = addr
+        if addr < end and end_addr_max[1] < addr:
+            end_addr_max[0] = sym_name
+            end_addr_max[1] = addr
+        return 0
+    res = lib.bcc_foreach_function_symbol(binary_path, _SYM_CB_TYPE(sym_cb))
+    assert res >= 0, "Error %d enumerating symbols in %s" % (res, binary_path)
+
+    assert start_addr_max[1] == end_addr_max[1], "start end must belongs to same func"
+    return start_addr_max
+
+def func_addr_offset(binary_path, func, func_addr, pid):
+    (binary_path, bind_addr) = BPF._check_path_symbol(binary_path, func, func_addr, pid)
+    return binary_path, (func_addr - bind_addr)
+
+def specifier_format(specifier):
+    specifier_spans = specifier.split(":")
+    assert len(specifier_spans) in {2, 3}
+
+    start_addr = 0
+    end_addr = 0
+    try:
+        addr_s = specifier_spans[1].split("-")
+        start_addr = int(addr_s[0],16)
+        end_addr = int(addr_s[1], 16)
+    except:
+        raise ValueError("second field format must be %s".format("0x120-0x130"))
+
+    specifier_info = {
+        "binary_path":specifier_spans[0],
+        "start_addr":start_addr,
+        "end_addr":end_addr,
+        "latency_span":""
+    }
+    if (len(specifier_spans) == 3):
+        specifier_info["latency_span"] = specifier_spans[2].replace("latency", "")
+
+    return specifier_info
+
+class Probe(object):
+    bpf_start = """
+        #include <uapi/linux/ptrace.h>           
+            
+        BPF_HASH(__latency, u32, u64);
+        int __probe_start(struct pt_regs *ctx )
+        {
+            u64 __pid_tgid = bpf_get_current_pid_tgid();
+            u32 __pid      = __pid_tgid;    // lower 32 bits
+            u32 __tgid     = __pid_tgid >> 32;  // upper 32 bits
+
+            PID_FILTER
+                
+            u64 __time = bpf_ktime_get_ns();
+            __latency.update(&__pid, &__time);
+            return 0;
+        }
+
+        int __probe_free(struct pt_regs *ctx){
+            u64 __pid_tgid = bpf_get_current_pid_tgid();
+            u32 __pid      = __pid_tgid;    // lower 32 bits
+                
+            __latency.delete(&__pid);
+            return 0;
+        }
+        """
+
+    bpf_end_histogram = """
+        BPF_HISTOGRAM(_hash_res, unsigned int);
+        int __probe_end(struct pt_regs *ctx )
+        {
+            u64 __pid_tgid = bpf_get_current_pid_tgid();
+            u32 __pid      = __pid_tgid;    // lower 32 bits
+                
+            u64 *____start_time = __latency.lookup(&__pid);
+            if (____start_time == 0) { return 0 ; }
+
+            LATENCY_VALUE
+            LATENCY_FILTER
+            _hash_res.increment(bpf_log2l(__latency_value));
+            return 0;
+        }
+        """
+
+    bpf_end_count= """
+        struct _hash_res_key_t {
+            u32 v0;
+        };
+        BPF_HASH(_hash_res, struct _hash_res_key_t, u64);
+        int __probe_end(struct pt_regs *ctx )
+        {
+            u64 __pid_tgid = bpf_get_current_pid_tgid();
+            u32 __pid      = __pid_tgid;    // lower 32 bits
+               
+            u64 *____start_time = __latency.lookup(&__pid);
+            if (____start_time == 0) { return 0 ; }
+
+            LATENCY_VALUE
+            LATENCY_FILTER
+
+            struct _hash_res_key_t __key = {};
+            __key.v0 = __latency_value;
+            _hash_res.increment(__key);
+            return 0;
+        }
+        """
+
+    def __init__(self, args, latency_span):
+        pid_filter_code = "if (__tgid != %d) { return 0; }" % args.pid if args.pid > 0 else ""
+        bpf_source = self.bpf_start.replace("PID_FILTER", pid_filter_code)
+
+        if (args.histogram):
+            bpf_source = bpf_source + self.bpf_end_histogram
+        else:
+            bpf_source = bpf_source + self.bpf_end_count
+
+        latency_filter_code = "if (__latency_value %s){return 0;}" % latency_span if latency_span else ""
+        bpf_source = bpf_source.replace("LATENCY_FILTER", latency_filter_code)
+
+        latency_value_code = "unsigned int __latency_value = ((bpf_ktime_get_ns() - *____start_time)) / %d;"
+        latency_value_code = latency_value_code % {
+            "s":1000000000,
+            "ms":1000000,
+            "us":1000,
+            "ns":1,
+        }[args.unit]
+        bpf_source = bpf_source.replace("LATENCY_VALUE", latency_value_code)
+
+        self.bpf = BPF(text=bpf_source)
+    
+    def attach(self, path, addr, fn_name, pid):
+        fn = self.bpf.load_func(fn_name, BPF.KPROBE)
+        ev_name = self.bpf._get_uprobe_evname(b"p", path, addr, pid)
+        fd = lib.bpf_attach_uprobe(fn.fd, 0, ev_name, path, addr, pid)
+        assert fd > 0, "Failed to attach BPF to uprobe"
+
+        self.bpf._add_uprobe_fd(ev_name, fd)
+
+    def attach_ret(self, path, addr, fn_name, pid):
+        fn = self.bpf.load_func(fn_name, BPF.KPROBE)
+        ev_name = self.bpf._get_uprobe_evname(b"r", path, addr, pid)
+        fd = lib.bpf_attach_uprobe(fn.fd, 1, ev_name, path, addr, pid)
+        assert fd > 0, "Failed to attach BPF to uretprobe"
+
+        self.bpf._add_uprobe_fd(ev_name, fd)
+
+    def display_histogram(self, unit, clear_old=False):
+        data = self.bpf.get_table("_hash_res")
+        data.print_log2_hist(val_type="run latency (%s)" % unit)
+        if (clear_old):
+            data.clear()
+
+    def display_call_count(self, unit, top=None, clear_old=False):
+        data = self.bpf.get_table("_hash_res")
+        print("run latency (%s)" % unit)
+        print("\t%-10s %s" % ("COUNT", "LATENCY"))
+        sdata = sorted(data.items(), key=lambda p: p[1].value)
+        if top is not None:
+            sdata = sdata[-top:]
+        for key, value in sdata:
+            print("\t%-10s %s" % (str(value.value), str(key.v0)))
+        if (clear_old):
+            data.clear()
+
+class Tool(object):
+    examples = """
+Probe specifier syntax:
+        library:start_addr-end_addr[:filter]
+Where:
+        library    -- the library that contains the function
+                      (leave empty for kernel functions)
+        start_addr -- the start of address to collect
+                      (get addr by object/gdb ...)
+        end_addr   -- the end of address to collect
+        filter     -- expr such as (latency>100  latench<1000)
+
+EXAMPLES:
+
+./latency.py -H "/home/vagrant/a.out:660-667" -i 10 -p 1005
+        Print a histogram of latency between 660-667 of a.out's assembly codes in process 1005
+./latency.py -C "/home/vagrant/a.out:660-667" -i 10 -u ms
+        Print frequency of latency(ms) between 660-667 of a.out's assembly codes
+./latency.py -H "/home/vagrant/a.out:660-667:latency>101000000" -i 10 -u ns
+        Print a histogram of latency(ns) between 660-667 of a.out's assembly codes
+"""
+
+    def __init__(self):
+        parser = argparse.ArgumentParser(description="",
+          formatter_class=argparse.RawDescriptionHelpFormatter,
+          epilog=Tool.examples)
+        parser.add_argument("-p", "--pid", type=int, default=-1,
+          help="id of the process to trace (optional)")
+          
+        parser.add_argument("-H", "--histogram", default = "",
+          help="probe specifier to capture histogram of " +
+          "(see examples below)")
+        parser.add_argument("-T", "--top", type=int,
+          help="number of top results to show (not applicable to histograms)")
+        parser.add_argument("-C", "--count", default = "",
+          help="probe specifier to capture count of (see examples below)")
+
+        parser.add_argument("-c", "--cumulative", action="store_true",
+          help="do not clear histograms and freq counts at each interval")
+        parser.add_argument("-i", "--interval", default=1, type=int,
+          help="output interval, in seconds (default 1 second)")
+        parser.add_argument("-d", "--duration", type=int,
+          help="total duration of trace, in seconds")
+        parser.add_argument("-n", "--number", type=int, help="number of outputs")
+        parser.add_argument("-u", "--unit", type=str, default="ms", choices=["s", "ms", "us", "ns"],
+          help="the unit of latency: s/ms/us/ns")
+
+        parser.add_argument("-v", "--verbose", action="store_true",
+          help="print resulting BPF program code before executing")
+        
+        self.args = parser.parse_args()
+        if len(self.args.histogram) != 0:
+            assert len(self.args.count)==0, "histogram | count must set one"
+            assert self.args.top <= 0, "histogram no need top"
+            self.specifier = self.args.histogram
+        elif len(self.args.count) != 0:
+            self.specifier = self.args.count
+        else:
+            raise ValueError("histogram | count must set one")
+
+        self._bpf_attach()
+
+    def _bpf_attach(self):
+        specifier_info = specifier_format(self.specifier)
+
+        t = start_func_info(specifier_info["binary_path"], specifier_info["start_addr"], specifier_info["end_addr"])
+        (path, offset) = func_addr_offset(specifier_info["binary_path"], t[0], t[1], self.args.pid)
+        
+        self.probe = Probe(self.args, specifier_info["latency_span"])
+        self.probe.attach(path, specifier_info["start_addr"]-offset, "__probe_start", self.args.pid)
+        self.probe.attach(path, specifier_info["end_addr"]-offset, "__probe_end", self.args.pid)
+        self.probe.attach_ret(path, t[1]-offset, "__probe_free", self.args.pid) 
+
+    def _display(self):
+        print("[%s]" % strftime("%H:%M:%S"))
+        if (self.args.histogram):
+               self.probe.display_histogram(self.args.unit, self.args.cumulative)
+        else:
+               self.probe.display_call_count(self.args.unit, self.args.top, self.args.cumulative)
+
+    def latency_loop(self):
+        count_so_far = 0
+        seconds = 0
+        while True:
+            try:
+                sleep(self.args.interval)
+                seconds += self.args.interval
+            except KeyboardInterrupt:
+                exit()
+            
+            self._display()
+
+            count_so_far += 1
+            if self.args.number is not None and count_so_far >= self.args.number:
+                exit()
+            if self.args.duration and seconds >= self.args.duration:
+                exit()
+
+if __name__ == "__main__":
+    Tool().latency_loop()
+

--- a/tools/latency_example.txt
+++ b/tools/latency_example.txt
@@ -1,0 +1,154 @@
+Demonstrations of latency.
+
+
+latency probe code block specify and collects latency values into a
+histogram or a frequency count. 
+
+For example, suppose you want to find what allocation sizes are common in
+your application:
+
++--------------------test code-------------------------+
+|  #include <unistd.h>   | 000000000000064a <main>:    |
+|  int main() {          |    64e:   sub    $0x10,%rsp | 
+|      int n = 1;        |    652:   movl   $0x1,-0x4  | 
+|      while(1) {        |    659:   addl   $0x1,-0x4  | 
+|  	n++;             |    65d:   mov    -0x4(%rbp) |
+|  	usleep(n);       |    660:   mov    %eax,%edi  |
+|     }                  |    662:   callq  520 <uslee | 
+|  }                     |    667:   jmp    659 <main  | 
+|------------------------------------------------------| 
+
+
+# python latency.py -H "/home/vagrant/a.out:660-667" -i 10 -c
+[12:44:30]
+     run latency (ms)    : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 1374     |****************************************|
+         4 -> 7          : 1182     |**********************************      |
+         8 -> 15         : 1        |                                        |
+[12:44:40]
+     run latency (ms)    : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 1636     |****************************************|
+         8 -> 15         : 5        |                                        |
+[12:44:50]
+     run latency (ms)    : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 31       |*****                                   |
+         8 -> 15         : 224      |****************************************|
+        16 -> 31         : 15       |**                                      |
+        32 -> 63         : 16       |**                                      |
+        64 -> 127        : 17       |***                                     |
+       128 -> 255        : 8        |*                                       |
+       256 -> 511        : 10       |*                                       |
+^C
+
+# python latency.py -C "/home/vagrant/a.out:660-667" -i 10 -u ms
+[12:59:56]
+run latency (ms)
+	COUNT      LATENCY
+	1          7
+	1          10
+	1          9
+	1          11
+	3          6
+	6          5
+	375        4
+	720        0
+	883        2
+	998        3
+	1010       1
+^C
+
+# python latency.py -H "/home/vagrant/a.out:660-667:latency>101000000" -i 10 -u ns
+[13:02:26]
+     run latency (ns)    : count     distribution
+     ...
+     32768 -> 65535      : 0        |                                        |
+     65536 -> 131071     : 0        |                                        |
+    131072 -> 262143     : 0        |                                        |
+    262144 -> 524287     : 0        |                                        |
+    524288 -> 1048575    : 0        |                                        |
+   1048576 -> 2097151    : 0        |                                        |
+   2097152 -> 4194303    : 0        |                                        |
+   4194304 -> 8388607    : 0        |                                        |
+   8388608 -> 16777215   : 55       |*******                                 |
+  16777216 -> 33554431   : 306      |****************************************|
+  33554432 -> 67108863   : 10       |*                                       |
+  67108864 -> 134217727  : 1        |                                        |
+^C
+
+# python latency.py -H "/home/vagrant/a.out:660-667" -i 10 -n 2 -u ms
+[13:03:40]
+     run latency (ms)    : count     distribution
+         0 -> 1          : 1312     |***************************             |
+         2 -> 3          : 1929     |****************************************|
+         4 -> 7          : 476      |*********                               |
+         8 -> 15         : 6        |                                        |
+        16 -> 31         : 1        |                                        |
+        32 -> 63         : 0        |                                        |
+        64 -> 127        : 1        |                                        |
+       128 -> 255        : 2        |                                        |
+[13:03:50]
+     run latency (ms)    : count     distribution
+         0 -> 1          : 1312     |***************************             |
+         2 -> 3          : 1929     |****************************************|
+         4 -> 7          : 1665     |**********************************      |
+         8 -> 15         : 106      |**                                      |
+        16 -> 31         : 9        |                                        |
+        32 -> 63         : 14       |                                        |
+        64 -> 127        : 8        |                                        |
+       128 -> 255        : 7        |                                        |
+       256 -> 511        : 1        |                                        |
+
+
+USAGE message:
+
+# python latency.py -h
+usage: latency.py [-h] [-p PID] [-H HISTOGRAM] [-T TOP] [-C COUNT] [-c]
+                  [-i INTERVAL] [-d DURATION] [-n NUMBER] [-u {s,ms,us,ns}]
+                  [-v]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PID, --pid PID     id of the process to trace (optional)
+  -H HISTOGRAM, --histogram HISTOGRAM
+                        probe specifier to capture histogram of (see examples
+                        below)
+  -T TOP, --top TOP     number of top results to show (not applicable to
+                        histograms)
+  -C COUNT, --count COUNT
+                        probe specifier to capture count of (see examples
+                        below)
+  -c, --cumulative      do not clear histograms and freq counts at each
+                        interval
+  -i INTERVAL, --interval INTERVAL
+                        output interval, in seconds (default 1 second)
+  -d DURATION, --duration DURATION
+                        total duration of trace, in seconds
+  -n NUMBER, --number NUMBER
+                        number of outputs
+  -u {s,ms,us,ns}, --unit {s,ms,us,ns}
+                        the unit of latency: s/ms/us/ns
+  -v, --verbose         print resulting BPF program code before executing
+
+Probe specifier syntax:
+        library:start_addr-end_addr[:filter]
+Where:
+        library    -- the library that contains the function
+                      (leave empty for kernel functions)
+        start_addr -- the start of address to collect
+                      (get addr by object/gdb ...)
+        end_addr   -- the end of address to collect
+        filter     -- expr such as (latency>100  latench<1000)
+
+EXAMPLES:
+
+./latency.py -H "/home/vagrant/a.out:660-667" -i 10 -p 1005
+        Print a histogram of latency between 660-667 of a.out's assembly codes in process 1005
+./latency.py -C "/home/vagrant/a.out:660-667" -i 10 -u ms
+        Print frequency of latency(ms) between 660-667 of a.out's assembly codes
+./latency.py -H "/home/vagrant/a.out:660-667:latency>101000000" -i 10 -u ns
+        Print a histogram of latency(ns) between 660-667 of a.out's assembly codes


### PR DESCRIPTION
A tool to get the latency of any code block

for example: the latency between 660 and667 in a.out's assembly codes

# python latency.py -H "/home/vagrant/a.out:660-667" -i 10 -c
[12:44:30]
     run latency (ms)    : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 1374     |****************************************|
         4 -> 7          : 1182     |**********************************      |
         8 -> 15         : 1        |                                        |
[12:44:40]
     run latency (ms)    : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 1636     |****************************************|
         8 -> 15         : 5        |                                        |
^C