### PR TITLE
add man pages as html

### DIFF
--- a/man/man8/argdist.html
+++ b/man/man8/argdist.html
@@ -1,0 +1,257 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of argdist</TITLE>
+</HEAD><BODY>
+<H1>argdist</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-11<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+argdist - Trace a function and display a histogram or frequency count of its parameter values. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>argdist [-h] [-p PID] [-z STRING_SIZE] [-i INTERVAL] [-d DURATION] [-n COUNT] [-v] [-T TOP] [-H specifier] [-C specifier] [-I header]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+argdist attaches to function entry and exit points, collects specified parameter
+values, and stores them in a histogram or a frequency collection that counts
+the number of times a parameter value occurred. It can also filter parameter
+values and instrument multiple entry points at once.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-p PID<DD>
+Trace only functions in the process PID.
+<DT>-z STRING_SIZE<DD>
+When collecting string arguments (of type char*), collect up to STRING_SIZE 
+characters. Longer strings will be truncated.
+<DT>-i INTERVAL<DD>
+Print the collected data every INTERVAL seconds. The default is 1 second.
+<DT>-d DURATION<DD>
+Total duration of trace in seconds.
+<DT>-n NUMBER<DD>
+Print the collected data COUNT times and then exit.
+<DT>-v<DD>
+Display the generated BPF program, for debugging purposes.
+<DT>-T TOP<DD>
+When collecting frequency counts, display only the top TOP entries.
+<DT>-H specifiers, -C specifiers<DD>
+One or more probe specifications that instruct argdist which functions to
+probe, which parameters to collect, how to aggregate them, and whether to perform
+any filtering. See SPECIFIER SYNTAX below.
+<DT>-I header<DD>
+One or more header files that should be included in the BPF program. This 
+enables the use of structure definitions, enumerations, and constants that
+are available in these headers. You should provide the same path you would
+include in the BPF program, e.g. 'linux/blkdev.h' or 'linux/time.h'. Note: in
+many cases, argdist will deduce the necessary header files automatically. 
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>SPECIFIER SYNTAX</H2>
+
+The general specifier syntax is as follows:
+<P>
+<B>{p,r,t,u}:{[library],category}:function(signature)[:type[,type...]:expr[,expr...][:filter]][#label]</B>
+
+<DL COMPACT>
+<DT><B>{p,r,t,u}</B>
+
+<DD>
+Probe type - &quot;p&quot; for function entry, &quot;r&quot; for function return, &quot;t&quot; for kernel
+tracepoint, &quot;u&quot; for USDT probe; -H for histogram collection, -C for frequency count.
+Indicates where to place the probe and whether the probe should collect frequency
+count information, or aggregate the collected values into a histogram. Counting 
+probes will collect the number of times every parameter value was observed,
+whereas histogram probes will collect the parameter values into a histogram.
+Only integral types can be used with histogram probes; there is no such limitation
+for counting probes.
+<DT><B>[library]</B>
+
+<DD>
+Library containing the probe.
+Specify the full path to the .so or executable file where the function to probe
+resides. Alternatively, you can specify just the lib name: for example, &quot;c&quot;
+refers to libc. If no library name is specified, the kernel is assumed.
+<DT><B>category</B>
+
+<DD>
+The category of the kernel tracepoint. For example: net, sched, block.
+<DT><B>function(signature)</B>
+
+<DD>
+The function to probe, and its signature.
+The function name must match exactly for the probe to be placed. The signature,
+on the other hand, is only required if you plan to collect parameter values 
+based on that signature. For example, if you only want to collect the first
+parameter, you don't have to specify the rest of the parameters in the signature.
+When capturing kernel tracepoints, this should be the name of the event, e.g.
+net_dev_start_xmit. The signature for kernel tracepoints should be empty. When
+capturing USDT probes, this should be the name of the probe, e.g. reloc_complete.
+The signature for USDT probes should be empty.
+<DT><B>[type[,type...]]</B>
+
+<DD>
+The type(s) of the expression(s) to capture.
+This is the type of the keys in the histogram or raw event collection that are
+collected by the probes.
+<DT><B>[expr[,expr...]]</B>
+
+<DD>
+The expression(s) to capture.
+These are the values that are assigned to the histogram or raw event collection.
+You may use the parameters directly, or valid C expressions that involve the
+parameters, such as &quot;size % 10&quot;.
+Tracepoints may access a special structure called &quot;args&quot; that is formatted
+according to the tracepoint format (which you can obtain using tplist).
+For example, the block:block_rq_complete tracepoint can access args-&gt;nr_sector.
+USDT probes may access the arguments defined by the tracing program in the 
+special arg1, arg2, ... variables. To obtain their types, use the tplist tool.
+Return probes can use the argument values received by the
+function when it was entered, through the $entry(paramname) special variable.
+Return probes can also access the function's return value in $retval, and the
+function's execution time in nanoseconds in $latency. Note that adding the
+$latency or $entry(paramname) variables to the expression will introduce an
+additional probe at the function's entry to collect this data, and therefore
+introduce additional overhead.
+<DT><B>[filter]</B>
+
+<DD>
+The filter applied to the captured data.
+Only parameter values that pass the filter will be collected. This is any valid
+C expression that refers to the parameter values, such as &quot;fd == 1 &amp;&amp; length &gt; 16&quot;.
+The $entry, $retval, and $latency variables can be used here as well, in return
+probes.
+The filter expression may also use the STRCMP pseudo-function to compare
+a predefined string to a string argument. For example: STRCMP(&quot;test.txt&quot;, file).
+The order of arguments is important: the first argument MUST be a quoted
+literal string, and the second argument can be a runtime string.
+<DT><B>[label]</B>
+
+<DD>
+The label that will be displayed when printing the probed values. By default,
+this is the probe specifier. 
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Print a histogram of allocation sizes passed to kmalloc:<DD>
+#
+<B>argdist -H 'p::__kmalloc(u64 size):u64:size'</B>
+
+<DT>Print a count of how many times process 1005 called malloc with an allocation size of 16 bytes:<DD>
+#
+<B>argdist -p 1005 -C 'p:c:malloc(size_t size):size_t:size:size==16'</B>
+
+<DT>Snoop on all strings returned by gets():<DD>
+#
+<B>argdist -C 'r:c:gets():char*:$retval'</B>
+
+<DT>Print a histogram of read sizes that were longer than 1ms:<DD>
+#
+<B>argdist -H 'r::__vfs_read(void *file, void *buf, size_t count):size_t:$entry(count):$latency &gt; 1000000'</B>
+
+<DT>Print frequency counts of how many times writes were issued to a particular file descriptor number, in process 1005:<DD>
+#
+<B>argdist -p 1005 -C 'p:c:write(int fd):int:fd'</B>
+
+<DT>Print a histogram of error codes returned by read() in process 1005:<DD>
+#
+<B>argdist -p 1005 -H 'r:c:read()'</B>
+
+<DT>Print a histogram of buffer sizes passed to write() across all processes, where the file descriptor was 1 (STDOUT):<DD>
+#
+<B>argdist -H 'p:c:write(int fd, const void *buf, size_t count):size_t:count:fd==1'</B>
+
+<DT>Count fork() calls in libc across all processes, grouped by pid:<DD>
+#
+<B>argdist -C 'p:c:fork():int:$PID;fork per process'</B>
+
+<DT>Print histogram of number of sectors in completing block I/O requests:<DD>
+#
+<B>argdist -H 't:block:block_rq_complete():u32:nr_sector'</B>
+
+<DT>Aggregate interrupts by interrupt request (IRQ):<DD>
+#
+<B>argdist -C 't:irq:irq_handler_entry():int:irq'</B>
+
+<DT>Print the functions used as thread entry points and how common they are:<DD>
+#
+<B>argdist -C 'u:pthread:pthread_start():u64:arg2' -p 1337</B>
+
+<DT>Print histograms of sleep() and nanosleep() parameter values:<DD>
+#
+<B>argdist -H 'p:c:sleep(u32 seconds):u32:seconds' -H 'p:c:nanosleep(struct timespec *req):long:req-&gt;tv_nsec'</B>
+
+<DT>Spy on writes to STDOUT performed by process 2780, up to a string size of 120 characters:<DD>
+#
+<B>argdist -p 2780 -z 120 -C 'p:c:write(int fd, char* buf, size_t len):char*:buf:fd==1'</B>
+
+<DT>Group files being read from and the read sizes from __vfs_read:<DD>
+#
+<B>argdist -C 'p::__vfs_read(struct file *file, void *buf, size_t count):char*,size_t:file-&gt;f_path.dentry-&gt;d_iname,count:file-&gt;f_path.dentry-&gt;d_iname[0]!=0'</B>
+
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">SPECIFIER SYNTAX</A><DD>
+<DT><A HREF="#lbAH">EXAMPLES</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/bashreadline.html
+++ b/man/man8/bashreadline.html
@@ -1,0 +1,126 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of bashreadline</TITLE>
+</HEAD><BODY>
+<H1>bashreadline</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-01-28<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+bashreadline - Print entered bash commands system wide. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>bashreadline [-h] [-s SHARED]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+bashreadline traces the return of the readline() function using uprobes, to
+show the bash commands that were entered interactively, system wide. The
+entered command may fail: this is just showing what was entered.
+<P>
+This program is also a basic example of eBPF/bcc and uprobes.
+<P>
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-s<DD>
+Specify the location of libreadline.so shared library when you failed to run the
+script directly with error: &quot;Exception: could not determine address of symbol 
+'readline'&quot;. Default value is /lib/libreadline.so.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace bash commands system wide:<DD>
+#
+<B>bashreadline</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the command (HH:MM:SS).
+<DT>PID<DD>
+Process ID of the bash shell.
+<DT>COMMAND<DD>
+Entered command.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+As the rate of interactive bash commands is expected to be very low (&lt;&lt;100/s),
+the overhead of this program is expected to be negligible.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+opensnoop">opensnoop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/bindsnoop.html
+++ b/man/man8/bindsnoop.html
@@ -1,0 +1,189 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of bindsnoop</TITLE>
+</HEAD><BODY>
+<H1>bindsnoop</H1>
+Section:  (8)<BR>Updated: 12 February 2020<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+bindsnoop - Trace bind() system calls.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>bindsnoop.py [-h</B>] [<B>-w</B>] [<B>-t</B>] [<B>-p</B> PID] [<B>-P</B> PORT] [<B>-E</B>] [<B>-U</B>] [<B>-u</B> UID] [<B>--count</B>] [<B>--cgroupmap MAP</B>]
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+bindsnoop reports socket options set before the bind call that would impact this system call behavior.
+<P>
+
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS:</H2>
+
+<DL COMPACT><DT><DD>
+<DL COMPACT>
+<DT>Show help message and exit:<DD>
+<DT><B>-h</B>, <B>--help</B>
+
+<DD>
+<DT>Include timestamp on output:<DD>
+<DT><B>-t</B>, <B>--timestamp</B>
+
+<DD>
+<DT>Wider columns (fit IPv6):<DD>
+<DT><B>-w</B>, <B>--wide</B>
+
+<DD>
+<DT>Trace this PID only:<DD>
+<DT><B>-p</B> PID, <B>--pid</B> PID
+
+<DD>
+<DT>Comma-separated list of ports to trace:<DD>
+<DT><B>-P</B> PORT, <B>--port</B> PORT
+
+<DD>
+<DT>Trace cgroups in this BPF map:<DD>
+<DT><B>--cgroupmap</B> MAP
+
+<DD>
+<DT>Include errors in the output:<DD>
+<DT><B>-E</B>, <B>--errors</B>
+
+<DD>
+<DT>Include UID on output:<DD>
+<DT><B>-U</B>, <B>--print-uid</B>
+
+<DD>
+<DT>Trace this UID only:<DD>
+<DT><B>-u</B> UID, <B>--uid</B> UID
+
+<DD>
+<DT>Count binds per src ip and port:<DD>
+<DT><B>--count</B>
+
+<DD>
+</DL>
+</DL>
+
+<P>
+
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES:</H2>
+
+<DL COMPACT><DT><DD>
+<DL COMPACT>
+<DT>Trace all IPv4 and IPv6 <B>bind</B>()s<DD>
+<DT><B>bindsnoop</B>
+
+<DD>
+<DT>Include timestamps<DD>
+<DT><B>bindsnoop -t</B>
+
+<DD>
+<DT>Trace PID 181<DD>
+<DT><B>bindsnoop -p</B> 181
+
+<DD>
+<DT>Trace port 80<DD>
+<DT><B>bindsnoop -P</B> 80
+
+<DD>
+<DT>Trace port 80 and 81<DD>
+<DT><B>bindsnoop -P</B> 80,81
+
+<DD>
+<DT>Include UID<DD>
+<DT><B>bindsnoop -U</B>
+
+<DD>
+<DT>Trace UID 1000<DD>
+<DT><B>bindsnoop -u</B> 1000
+
+<DD>
+<DT>Report bind errors<DD>
+<DT><B>bindsnoop -E</B>
+
+<DD>
+<DT>Count bind per src ip<DD>
+<DT><B>bindsnoop --count</B>
+
+<DD>
+</DL>
+</DL>
+
+<P>
+
+Trace IPv4 and IPv6 bind system calls and report socket options that would impact bind call behavior:
+<DL COMPACT><DT><DD>
+<DL COMPACT>
+<DT>SOL_IP IP_FREEBIND              F....<DD>
+<DT>SOL_IP IP_TRANSPARENT           .T...<DD>
+<DT>SOL_IP IP_BIND_ADDRESS_NO_PORT  ..N..<DD>
+<DT>SOL_SOCKET SO_REUSEADDR         ...R.<DD>
+<DT>SOL_SOCKET SO_REUSEPORT         ....r<DD>
+</DL>
+<P>
+
+SO_BINDTODEVICE interface is reported as &quot;IF&quot; index
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAI">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAJ">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAK">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Pavel Dubovitsky
+<A NAME="lbAL">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcpaccept">tcpaccept</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS:</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES:</A><DD>
+<DT><A HREF="#lbAH">SOURCE</A><DD>
+<DT><A HREF="#lbAI">OS</A><DD>
+<DT><A HREF="#lbAJ">STABILITY</A><DD>
+<DT><A HREF="#lbAK">AUTHOR</A><DD>
+<DT><A HREF="#lbAL">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/biolatency.html
+++ b/man/man8/biolatency.html
@@ -1,0 +1,159 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of biolatency</TITLE>
+</HEAD><BODY>
+<H1>biolatency</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2019-12-12<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+biolatency - Summarize block device I/O latency as a histogram.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>biolatency [-h] [-F] [-T] [-Q] [-m] [-D] [interval [count]]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+biolatency traces block device I/O (disk I/O), and records the distribution
+of I/O latency (time). This is printed as a histogram either on Ctrl-C, or
+after a given interval in seconds.
+<P>
+The latency of disk I/O operations is measured from when requests are issued to the device
+up to completion. A -Q option can be used to include time queued in the kernel.
+<P>
+This tool uses in-kernel eBPF maps for storing timestamps and the histogram,
+for efficiency.
+<P>
+This works by tracing various kernel blk_*() functions using dynamic tracing,
+and will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-h
+Print usage message.
+<DL COMPACT>
+<DT>-T<DD>
+Include timestamps on output.
+<DT>-m<DD>
+Output histogram in milliseconds.
+<DT>-D<DD>
+Print a histogram per disk device.
+<DT>-F<DD>
+Print a histogram per set of I/O flags.
+<DT>interval<DD>
+Output interval, in seconds.
+<DT>count<DD>
+Number of outputs.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize block device I/O latency as a histogram:<DD>
+#
+<B>biolatency</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>biolatency 1 10</B>
+
+<DT>Print 1 second summaries, using milliseconds as units for the histogram, and<DD>
+include timestamps on output:
+#
+<B>biolatency -mT 1</B>
+
+<DT>Include OS queued time in I/O time:<DD>
+#
+<B>biolatency -Q</B>
+
+<DT>Show a latency histogram for each disk device separately:<DD>
+#
+<B>biolatency -D</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>usecs<DD>
+Microsecond range
+<DT>msecs<DD>
+Millisecond range
+<DT>count<DD>
+How many I/O fell into this range
+<DT>distribution<DD>
+An ASCII bar chart to visualize the distribution (count column)
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces kernel functions and maintains in-kernel timestamps and a histogram,
+which are asynchronously copied to user-space. This method is very efficient,
+and the overhead for most storage I/O rates (&lt; 10k IOPS) should be negligible.
+If you have a higher IOPS storage environment, test and quantify the overhead
+before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/biosnoop.html
+++ b/man/man8/biosnoop.html
@@ -1,0 +1,146 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of biosnoop</TITLE>
+</HEAD><BODY>
+<H1>biosnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-09-16<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+biosnoop - Trace block device I/O and print details incl. issuing PID.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>biosnoop [-hQ]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tools traces block device I/O (disk I/O), and prints a one-line summary
+for each I/O showing various details. These include the latency from the time of
+issue to the device to its completion, and the PID and process name from when
+the I/O was first created (which usually identifies the responsible process).
+<P>
+This uses in-kernel eBPF maps to cache process details (PID and comm) by I/O
+request, as well as a starting timestamp for calculating I/O latency.
+<P>
+This works by tracing various kernel blk_*() functions using dynamic tracing,
+and will need updating to match any changes to these functions.
+<P>
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-Q<DD>
+Include a column showing the time spent quueued in the OS.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all block device I/O and print a summary line per I/O:<DD>
+#
+<B>biosnoop</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of the I/O completion, in seconds since the first I/O was seen.
+<DT>COMM<DD>
+Cached process name, if present. This usually (but isn't guaranteed) to identify
+the responsible process for the I/O.
+<DT>PID<DD>
+Cached process ID, if present. This usually (but isn't guaranteed) to identify
+the responsible process for the I/O.
+<DT>DISK<DD>
+Disk device name.
+<DT>T<DD>
+Type of I/O: R = read, W = write. This is a simplification.
+<DT>SECTOR<DD>
+Device sector for the I/O.
+<DT>BYTES<DD>
+Size of the I/O, in bytes.
+<DT>QUE(ms)<DD>
+Time the I/O was queued in the OS before being issued to the device,
+in milliseconds.
+<DT>LAT(ms)<DD>
+Time for the I/O (latency) from the issue to the device, to its completion,
+in milliseconds.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Since block device I/O usually has a relatively low frequency (&lt; 10,000/s),
+the overhead for this tool is expected to be negligible. For high IOPS storage
+systems, test and quantify before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+disksnoop">disksnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?1+iostat">iostat</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/biotop.html
+++ b/man/man8/biotop.html
@@ -1,0 +1,164 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of biotop</TITLE>
+</HEAD><BODY>
+<H1>biotop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-06<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+biotop - Block device (disk) I/O by process top.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>biotop [-h] [-C] [-r MAXROWS] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is top for disks. 
+<P>
+This traces block device I/O (disk I/O), and prints a per-process summary every
+interval (by default, 1 second). The summary is sorted on the top disk
+consumers by throughput (Kbytes). The PID and process name shown are measured
+from when the I/O was first created, which usually identifies the responsible
+process.
+<P>
+For efficiency, this uses in-kernel eBPF maps to cache process details (PID and
+comm) by I/O request, as well as a starting timestamp for calculating I/O
+latency, and the final summary.
+<P>
+This works by tracing various kernel blk_*() functions using dynamic tracing,
+and will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-C<DD>
+Don't clear the screen.
+<DT>-r MAXROWS<DD>
+Maximum number of rows to print. Default is 20.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize block device I/O by process, 1 second screen refresh:<DD>
+#
+<B>biotop</B>
+
+<DT>Don't clear the screen:<DD>
+#
+<B>biotop -C</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>biotop 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg:<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Cached process ID, if present. This usually (but isn't guaranteed) to identify
+the responsible process for the I/O.
+<DT>COMM<DD>
+Cached process name, if present. This usually (but isn't guaranteed) to identify
+the responsible process for the I/O.
+<DT>D<DD>
+Direction: R == read, W == write. This is a simplification.
+<DT>MAJ<DD>
+Major device number.
+<DT>MIN<DD>
+Minor device number.
+<DT>DISK<DD>
+Disk device name.
+<DT>I/O<DD>
+Number of I/O during the interval.
+<DT>Kbytes<DD>
+Total Kbytes for these I/O, during the interval.
+<DT>AVGms<DD>
+Average time for the I/O (latency) from the issue to the device, to its
+completion, in milliseconds.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Since block device I/O usually has a relatively low frequency (&lt; 10,000/s),
+the overhead for this tool is expected to be low or negligible. For high IOPS
+storage systems, test and quantify before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>INSPIRATION</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+top">top</A>(1) by William LeFebvre
+<A NAME="lbAO">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+biolatency">biolatency</A>(8), <A HREF="https://iovisor.github.io/bcc?1+iostat">iostat</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">INSPIRATION</A><DD>
+<DT><A HREF="#lbAO">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/bitesize.html
+++ b/man/man8/bitesize.html
@@ -1,0 +1,113 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of bitesize</TITLE>
+</HEAD><BODY>
+<H1>bitesize</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-05<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+bitesize - Summarize block device I/O size as a histogram - Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>bitesize</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+Show I/O distribution for requested block sizes, by process name.
+<P>
+This works by tracing block:block_rq_issue and prints a historgram of I/O size.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Count I/O size per process until Ctrl-C is hit:<DD>
+#
+<B>bitesize</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>Kbtes<DD>
+Size in kilobytes of range
+<DT>count<DD>
+How many I/O fell into this range
+<DT>distribution<DD>
+An ASCII bar chart to visualize the distribution (count column)
+<P>
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces a block I/O tracepoint to update a histogram, which is
+asynchronously copied to user-space. This method is very efficient, and 
+the overhead for most storage I/O rates (&lt; 10k IOPS) should be negligible. 
+If you have a higher IOPS storage environment, test and quantify the overhead 
+before use.
+<P>
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Allan McAleavy
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://github.com/brendangregg/systemtap-lwtools/blob/master/disk/bitesize-nd.stp">https://github.com/brendangregg/systemtap-lwtools/blob/master/disk/bitesize-nd.stp</A>
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">FIELDS</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/bpflist.html
+++ b/man/man8/bpflist.html
@@ -1,0 +1,119 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of bpflist</TITLE>
+</HEAD><BODY>
+<H1>bpflist</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2017-03-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+bpflist - Display processes currently using BPF programs and maps.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>bpflist [-v]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool displays processes currently using BPF programs and maps, and
+optionally also kprobes and uprobes on the system. This is useful to understand
+which BPF programs are loaded on the system.
+<P>
+Currently, for lack of a better alternative, this tool pipes into 'ls' and
+parses its output to snoop for BPF file descriptors in all running processes.
+In the future, when BPF accounting is provided by the kernel, this tool should
+use these accounting features.
+<P>
+Only the root user can use this tool, because it accesses debugfs.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+bcc, debugfs
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-h
+Print usage message.
+<DL COMPACT>
+<DT>-v<DD>
+Count kprobes and uprobes as well as BPF programs. Repeating verbose mode twice
+also prints the kprobe and uprobe definitions in addition to counting them.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Display processes currently using BPF programs:<DD>
+#
+<B>bpflist</B>
+
+<DT>Also count kprobes and uprobes:<DD>
+#
+<B>bpflist -v</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>PID<DD>
+Process ID.
+<DT>COMM<DD>
+Process comm.
+<DT>TYPE<DD>
+The type of the data displayed: BPF program, BPF map, kprobe, or uprobe.
+<DT>COUNT<DD>
+The number of items of this type that belong to the specified process.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/bps.html
+++ b/man/man8/bps.html
@@ -1,0 +1,166 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of bps</TITLE>
+</HEAD><BODY>
+<H1>bps</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2017-10-19<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+bps - List all BPF programs. 'ps' for BPF programs.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>bps [bpf-prog-id]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+<B>bps</B>
+
+lists all BPF programs loaded into the kernel.  It is similar
+to the ps command but for the BPF programs.
+<P>
+Each loaded bpf program is identified by an unique integer (i.e.
+<B>bpf-prog-id</B>
+
+or simply BID).  If
+a
+<B>bpf-prog-id</B>
+
+is specified, the maps used by
+<B>bpf-prog-id</B>
+
+will also be listed.
+<P>
+<A NAME="lbAE">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>List all BPF programs loaded into the kernel:<DD>
+<B>bps</B>
+
+<DT>Show the details and maps of BID 6:<DD>
+<B>bps 6</B>
+
+</DL>
+<A NAME="lbAF">&nbsp;</A>
+<H2>BPF PROGRAM FIELDS</H2>
+
+<DL COMPACT>
+<DT><B>BID</B>
+
+<DD>
+BPF program ID.  It ends with '-' if it is not jitted.
+<DT><B>TYPE</B>
+
+<DD>
+The type of a BPF program. e.g. kprobe, tracepoint, xdp...etc.
+<DT><B>UID</B>
+
+<DD>
+The user ID that loaded the BPF program.
+<DT><B>#MAPS</B>
+
+<DD>
+Total number of maps used by a BPF program.
+<DT><B>LoadTime</B>
+
+<DD>
+When was the BPF program loaded?
+<DT><B>NAME</B>
+
+<DD>
+The name of a BPF program.  The user space library (like
+<B>bcc</B>
+
+) usually
+uses the C function name of the original BPF's source code as
+the program name.  It could be empty if the user space did not
+provide a name.
+<P>
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>BPF MAP FIELDS</H2>
+
+<DL COMPACT>
+<DT><B>MID</B>
+
+<DD>
+BPF map ID.
+<DT><B>TYPE</B>
+
+<DD>
+The type of a BPF map. e.g. hash, array, stack trace...etc.
+<DT><B>FLAGS</B>
+
+<DD>
+The flags used to create the BP map.
+<DT><B>KeySz</B>
+
+<DD>
+The key size of a BPF map.
+<DT><B>ValueSz</B>
+
+<DD>
+The value size of a BPF map.
+<DT><B>MaxEnts</B>
+
+<DD>
+The maximum number of entries of a map.
+<DT><B>NAME</B>
+
+<DD>
+The name of a BPF map.  The user space library (like
+<B>bcc</B>
+
+) usually uses the C variable name of the BPF map as its name.
+It could be empty if the user space did not provide a name.
+<P>
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAJ">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAK">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Martin Lau
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">EXAMPLES</A><DD>
+<DT><A HREF="#lbAF">BPF PROGRAM FIELDS</A><DD>
+<DT><A HREF="#lbAG">BPF MAP FIELDS</A><DD>
+<DT><A HREF="#lbAH">SOURCE</A><DD>
+<DT><A HREF="#lbAI">OS</A><DD>
+<DT><A HREF="#lbAJ">STABILITY</A><DD>
+<DT><A HREF="#lbAK">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/btrfsdist.html
+++ b/man/man8/btrfsdist.html
@@ -1,0 +1,144 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of btrfsdist</TITLE>
+</HEAD><BODY>
+<H1>btrfsdist</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-15<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+btrfsdist - Summarize btrfs operation latency. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>btrfsdist [-h] [-T] [-N] [-d] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes time (latency) spent in common btrfs file operations:
+reads, writes, opens, and syncs, and presents it as a power-of-2 histogram. It
+uses an in-kernel eBPF map to store the histogram for efficiency.
+<P>
+Since this works by tracing the btrfs_file_operations interface functions, it
+will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Don't include timestamps on interval output.
+<DT>-m<DD>
+Output in milliseconds.
+<DT>-p PID<DD>
+Trace this PID only.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace btrfs operation time, and print a summary on Ctrl-C:<DD>
+#
+<B>btrfsdist</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>btrfsdist -p 181</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>btrfsdist 1 10</B>
+
+<DT>1 second summaries, printed in milliseconds<DD>
+#
+<B>btrfsdist -m 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>msecs<DD>
+Range of milliseconds for this bucket.
+<DT>usecs<DD>
+Range of microseconds for this bucket.
+<DT>count<DD>
+Number of operations in this time range.
+<DT>distribution<DD>
+ASCII representation of the distribution (the count column).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to btrfs writes and fsyncs, as well
+as all system reads and opens (due to the current implementation of the
+btrfs_file_operations interface). Particularly, all reads and writes from
+the file system cache will incur extra overhead while tracing. Such reads and
+writes can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool may become noticeable.
+Measure and quantify before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+btrfsslower">btrfsslower</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/btrfsslower.html
+++ b/man/man8/btrfsslower.html
@@ -1,0 +1,180 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of btrfsslower</TITLE>
+</HEAD><BODY>
+<H1>btrfsslower</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-15<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+btrfsslower - Trace slow btrfs file operations, with per-event details.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>btrfsslower [-h] [-j] [-p PID] [min_ms] [-d DURATION]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces common btrfs file operations: reads, writes, opens, and
+syncs. It measures the time spent in these operations, and prints details
+for each that exceeded a threshold.
+<P>
+WARNING: See the OVERHEAD section.
+<P>
+By default, a minimum millisecond threshold of 10 is used. If a threshold of 0
+is used, all events are printed (warning: verbose).
+<P>
+Since this works by tracing the btrfs_file_operations interface functions, it
+will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-p PID
+Trace this PID only.
+<DL COMPACT>
+<DT>min_ms<DD>
+Minimum I/O latency (duration) to trace, in milliseconds. Default is 10 ms.
+<DT>-d DURATION<DD>
+Total duration of trace in seconds.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace synchronous file reads and writes slower than 10 ms:<DD>
+#
+<B>btrfsslower</B>
+
+<DT>Trace slower than 1 ms:<DD>
+#
+<B>btrfsslower 1</B>
+
+<DT>Trace slower than 1 ms, and output just the fields in parsable format (csv):<DD>
+#
+<B>btrfsslower -j 1</B>
+
+<DT>Trace all file reads and writes (warning: the output will be verbose):<DD>
+#
+<B>btrfsslower 0</B>
+
+<DT>Trace slower than 1 ms, for PID 181 only:<DD>
+#
+<B>btrfsslower -p 181 1</B>
+
+<DT>Trace for 10 seconds only:<DD>
+#
+<B>btrfsslower -d 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of I/O completion since the first I/O seen, in seconds.
+<DT>COMM<DD>
+Process name.
+<DT>PID<DD>
+Process ID.
+<DT>T<DD>
+Type of operation. R == read, W == write, O == open, S == fsync.
+<DT>OFF_KB<DD>
+File offset for the I/O, in Kbytes.
+<DT>BYTES<DD>
+Size of I/O, in bytes.
+<DT>LAT(ms)<DD>
+Latency (duration) of I/O, measured from when it was issued by VFS to the
+filesystem, to when it completed. This time is inclusive of block device I/O,
+file system CPU cycles, file system locks, run queue latency, etc. It's a more
+accurate measure of the latency suffered by applications performing file
+system I/O, than to measure this down at the block device interface.
+<DT>FILENAME<DD>
+A cached kernel file name (comes from dentry-&gt;d_name.name).
+<DT>ENDTIME_us<DD>
+Completion timestamp, microseconds (-j only).
+<DT>OFFSET_b<DD>
+File offset, bytes (-j only).
+<DT>LATENCY_us<DD>
+Latency (duration) of the I/O, in microseconds (-j only).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to btrfs writes and fsyncs, as well
+as all system reads and opens (due to the current implementation of the
+btrfs_file_operations interface). Particularly, all reads and writes from
+the file system cache will incur extra overhead while tracing. Such reads and
+writes can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool may become noticeable.
+Measure and quantify before use. If this
+continues to be a problem, consider switching to a tool that prints in-kernel
+summaries only, such as <A HREF="https://iovisor.github.io/bcc?8+btrfsdist">btrfsdist</A>(8).
+<P>
+
+Note that the overhead of this tool should be less than <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8), as
+this tool targets btrfs functions only, and not all file read/write paths
+(which can include socket I/O).
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+btrfsdist">btrfsdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/cachestat.html
+++ b/man/man8/cachestat.html
@@ -1,0 +1,140 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of cachestat</TITLE>
+</HEAD><BODY>
+<H1>cachestat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-01-30<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+cachestat - Statistics for linux page cache hit/miss ratios. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cachestat</B>
+
+[-T] [interval [count]]
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces four kernel functions and prints per-second summaries. This can
+be useful for general workload characterization, and looking for patterns
+in operation usage over time.
+<P>
+This works by tracing kernel page cache functions using dynamic tracing, and will
+need updating to match any changes to these functions. Edit the script to
+customize which functions are traced.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Print summaries every second:<DD>
+#
+<B>cachestat</B>
+
+<DT>Print summaries every second with timestamp:<DD>
+#
+<B>cachestat -T</B>
+
+<DT>Print output every five seconds, three times:<DD>
+#
+<B>cachestat 5 3</B>
+
+<DT>Print output with timestamp every five seconds, three times:<DD>
+#
+<B>cachestat -T 5 3</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Timestamp.
+<DT>HITS<DD>
+Number of page cache hits.
+<DT>MISSES<DD>
+Number of page cache misses.
+<DT>DIRTIES<DD>
+Number of dirty pages added to the page cache.
+<DT>HITRATIO<DD>
+The hit ratio as a percentage.
+<DT>READ_HIT%<DD>
+Read hit percent of page cache usage.
+<DT>WRITE_HIT%<DD>
+Write hit percent of page cache usage.
+<DT>BUFFERS_MB<DD>
+Buffers size taken from /proc/meminfo.
+<DT>CACHED_MB<DD>
+Cached amount of data in current page cache taken from /proc/meminfo.
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces various kernel page cache functions and maintains in-kernel counts, which
+are asynchronously copied to user-space. While the rate of operations can
+be very high (&gt;1G/sec) we can have up to 34% overhead, this is still a relatively efficient way to trace 
+these events, and so the overhead is expected to be small for normal workloads.
+Measure in a test environment.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Allan McAleavy
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://github.com/brendangregg/perf-tools/blob/master/fs/cachestat">https://github.com/brendangregg/perf-tools/blob/master/fs/cachestat</A>
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">FIELDS</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/cachetop.html
+++ b/man/man8/cachetop.html
@@ -1,0 +1,156 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of cachetop</TITLE>
+</HEAD><BODY>
+<H1>cachetop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-01-30<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+cachetop - Statistics for linux page cache hit/miss ratios per processes. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cachetop</B>
+
+[interval]
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces four kernel functions and prints per-processes summaries every
+<B>interval</B> seconds. This can be useful for processes workload characterization,
+and looking for patterns in operation usage over time. It provides a <B>top</B>-like interface
+which by default sorts by <B>HITS</B> in ascending order.
+<P>
+This works by tracing kernel page cache functions using dynamic tracing, and will
+need updating to match any changes to these functions. Edit the script to
+customize which functions are traced.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>KEYBINDINGS</H2>
+
+The following keybindings can be used to control the output of <B>cachetop</B>.
+<DL COMPACT>
+<DT><B>&lt;</B>
+
+<DD>
+Use the previous column for sorting.
+<DT><B>&gt;</B>
+
+<DD>
+Use the next column for sorting.
+<DT><B>r</B>
+
+<DD>
+Toggle sorting order (default ascending).
+<DT><B>q</B>
+
+<DD>
+Quit cachetop.
+</DL>
+<A NAME="lbAF">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Update summaries every five second:<DD>
+#
+<B>cachetop</B>
+
+<DT>Print summaries each second:<DD>
+#
+<B>cachetop 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>PID<DD>
+Process ID of the process causing the cache activity.
+<DT>UID<DD>
+User ID of the process causing the cache activity.
+<DT>HITS<DD>
+Number of page cache hits.
+<DT>MISSES<DD>
+Number of page cache misses.
+<DT>DIRTIES<DD>
+Number of dirty pages added to the page cache.
+<DT>READ_HIT%<DD>
+Read hit percent of page cache usage.
+<DT>WRITE_HIT%<DD>
+Write hit percent of page cache usage.
+<DT>BUFFERS_MB<DD>
+Buffers size taken from /proc/meminfo.
+<DT>CACHED_MB<DD>
+Cached amount of data in current page cache taken from /proc/meminfo.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces various kernel page cache functions and maintains in-kernel counts, which
+are asynchronously copied to user-space. While the rate of operations can
+be very high (&gt;1G/sec) we can have up to 34% overhead, this is still a relatively efficient way to trace
+these events, and so the overhead is expected to be small for normal workloads.
+Measure in a test environment.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Emmanuel Bretelle
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+cachestat (8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">KEYBINDINGS</A><DD>
+<DT><A HREF="#lbAF">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/capable.html
+++ b/man/man8/capable.html
@@ -1,0 +1,141 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of capable</TITLE>
+</HEAD><BODY>
+<H1>capable</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-09-13<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+capable - Trace security capability checks (cap_capable()).
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>capable [-h] [-v] [-p PID] [-K] [-U]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces security capability checks in the kernel, and prints details for
+each call. This can be useful for general debugging, and also security
+enforcement: determining a white list of capabilities an application needs.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF, bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-h
+USAGE message.
+<DL COMPACT>
+<DT>-v<DD>
+Include non-audit capability checks. These are those deemed not interesting and
+not necessary to audit, such as CAP_SYS_ADMIN checks on memory allocation to
+affect the behavior of overcommit.
+<DT>-K<DD>
+Include kernel stack traces to the output.
+<DT>-U<DD>
+Include user-space stack traces to the output.
+<DT>-x<DD>
+Show extra fields in TID and INSETID columns.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all capability checks system-wide:<DD>
+#
+<B>capable</B>
+
+<DT>Trace capability checks for PID 181:<DD>
+#
+<B>capable -p 181</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of capability check: HH:MM:SS.
+<DT>UID<DD>
+User ID.
+<DT>PID<DD>
+Process ID.
+<DT>COMM<DD>
+Process name.
+CAP
+Capability number.
+NAME
+Capability name. See <A HREF="https://iovisor.github.io/bcc?7+capabilities">capabilities</A>(7) for descriptions.
+<DT>AUDIT<DD>
+Whether this was an audit event. Use -v to include non-audit events.
+INSETID
+Whether the INSETID bit was set (Linux &gt;= 5.1).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to capability checks, which are expected
+to be low frequency, however, that depends on the application. Test in a lab
+environment before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?7+capabilities">capabilities</A>(7)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/cobjnew.html
+++ b/man/man8/cobjnew.html
@@ -1,0 +1,157 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uobjnew</TITLE>
+</HEAD><BODY>
+<H1>uobjnew</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uobjnew, cobjnew, javaobjnew, rubyobjnew, tclobjnew - Summarize object allocations in
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>javaobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>rubyobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>tclobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>uobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] [-l {c,java,ruby,tcl}] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uobjnew traces object allocations in high-level languages (including &quot;malloc&quot;)
+and prints summaries of the most frequently allocated types by number of
+objects or number of bytes.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+C, Java, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, the Java process
+must be started with the &quot;-XX:+ExtendedDTraceProbes&quot; flag.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-C TOP_COUNT<DD>
+Print the top object types sorted by number of instances.
+<DT>-S TOP_SIZE<DD>
+Print the top object types sorted by size.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{c,java,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Wait this many seconds and then print the summary and exit. By default, wait
+for Ctrl+C to exit.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace object allocations in a Ruby process:<DD>
+#
+<B>uobjnew ruby 148</B>
+
+<DT>Trace object allocations from &quot;malloc&quot; and print the top 10 by total size:<DD>
+#
+<B>uobjnew -S 10 c 1788</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TYPE<DD>
+The object type being allocated. For C (malloc), this is the block size.
+<DT>ALLOCS<DD>
+The number of objects allocated.
+<DT>BYTES<DD>
+The number of bytes allocated.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Object allocation events are quite frequent, and therefore the overhead from
+running this tool can be considerable. Use with caution and make sure to 
+test before using in a production environment. Nonetheless, even thousands of
+allocations per second will likely produce a reasonable overhead when 
+investigating a problem.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ugc">ugc</A>(8), <A HREF="https://iovisor.github.io/bcc?8+memleak">memleak</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/compactsnoop.html
+++ b/man/man8/compactsnoop.html
@@ -1,0 +1,247 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of compactsnoop</TITLE>
+</HEAD><BODY>
+<H1>compactsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2019-11-1<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+compactstall - Trace compact zone events. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>compactsnoop.py [-h] [-T] [-p PID] [-d DURATION] [-K] [-e]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+compactsnoop traces the compact zone events, showing which processes are
+allocing pages with memory compaction. This can be useful for discovering
+when compact_stall (/proc/vmstat) continues to increase, whether it is
+caused by some critical processes or not.
+<P>
+This works by tracing the compact zone events using raw_tracepoints and one
+kretprobe.
+<P>
+For the Centos 7.6 (3.10.x kernel), see the version under tools/old, which 
+uses an older memory compaction mechanism.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include a timestamp column.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-d DURATION<DD>
+Total duration of trace in seconds.
+<DT>-K<DD>
+Output kernel stack trace
+<DT>-e<DD>
+Show extended fields.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all compact zone events:<DD>
+#
+<B>compactsnoop</B>
+
+<DT>Trace all compact zone events, for 10 seconds only:<DD>
+#
+<B>compactsnoop -d 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of the call, in seconds.
+<DT>COMM<DD>
+Process name
+<DT>PID<DD>
+Process ID
+<DT>NODE<DD>
+Memory node
+<DT>ZONE<DD>
+Zone of the node (such as DMA, DMA32, NORMAL eg)
+<DT>ORDER<DD>
+Shows which order alloc cause memory compaction, -1 means all orders (eg: write
+to /proc/sys/vm/compact_memory)
+<DT>MODE<DD>
+SYNC OR ASYNC
+<DT>FRAGIDX (extra column)<DD>
+The FRAGIDX is short for fragmentation index, which only makes sense if an
+allocation of a requested size would fail. If that is true, the fragmentation
+index indicates whether external fragmentation or a lack of memory was the
+problem. The value can be used to determine if page reclaim or compaction
+should be used.
+</DL>
+<P>
+
+
+Index is between 0 and 1 so return within 3 decimal places
+<P>
+
+
+0 =&gt; allocation would fail due to lack of memory
+<P>
+
+
+1 =&gt; allocation would fail due to fragmentation
+<DL COMPACT>
+<DT>MIN (extra column)<DD>
+The min watermark of the zone
+<DT>LOW (extra column)<DD>
+The low watermark of the zone
+<DT>HIGH (extra column)<DD>
+The high watermark of the zone
+<DT>FREE (extra column)<DD>
+The nr_free_pages of the zone
+<DT>LAT(ms)<DD>
+compact zone's latency
+<DT>STATUS<DD>
+The compaction's result.
+</DL>
+<P>
+
+
+For (CentOS 7.6's kernel), the status include:
+<P>
+
+
+&quot;skipped&quot; (COMPACT_SKIPPED): compaction didn't start as it was not possible or 
+direct reclaim was more suitable
+<P>
+
+
+&quot;continue&quot; (COMPACT_CONTINUE): compaction should continue to another pageblock
+<P>
+
+
+&quot;partial&quot; (COMPACT_PARTIAL): direct compaction partially compacted a zone and 
+there are suitable pages
+<P>
+
+
+&quot;complete&quot; (COMPACT_COMPLETE): The full zone was compacted
+<P>
+
+
+For (kernel 4.7 and above):
+<P>
+
+
+&quot;not_suitable_zone&quot; (COMPACT_NOT_SUITABLE_ZONE): For more detailed tracepoint 
+output - internal to compaction
+<P>
+
+
+&quot;skipped&quot; (COMPACT_SKIPPED): compaction didn't start as it was not possible or 
+direct reclaim was more suitable
+<P>
+
+
+&quot;deferred&quot; (COMPACT_DEFERRED): compaction didn't start as it was deferred due 
+to past failures
+<P>
+
+
+&quot;no_suitable_page&quot; (COMPACT_NOT_SUITABLE_PAGE): For more detailed tracepoint 
+output - internal to compaction
+<P>
+
+
+&quot;continue&quot; (COMPACT_CONTINUE): compaction should continue to another pageblock
+<P>
+
+
+&quot;complete&quot; (COMPACT_COMPLETE): The full zone was compacted scanned but wasn't
+successful to compact suitable pages.
+<P>
+
+
+&quot;partial_skipped&quot; (COMPACT_PARTIAL_SKIPPED): direct compaction has scanned part
+of the zone but wasn't successful to compact suitable pages.
+<P>
+
+
+&quot;contended&quot; (COMPACT_CONTENDED): compaction terminated prematurely due to lock
+contentions
+<P>
+
+
+&quot;success&quot; (COMPACT_SUCCESS): direct compaction terminated after concluding that 
+the allocation should now succeed
+<P>
+
+
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel compact zone kprobe/kretprobe or raw_tracepoints and
+prints output for each event. As the rate of this is generally expected to be
+low (&lt; 1000/s), the overhead is also expected to be negligible.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Ethercflow
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/cpudist.html
+++ b/man/man8/cpudist.html
@@ -1,0 +1,164 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of cpudist</TITLE>
+</HEAD><BODY>
+<H1>cpudist</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-06-28<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+cpudist - On- and off-CPU task time as a histogram.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cpudist [-h] [-O] [-T] [-m] [-P] [-L] [-p PID] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This measures the time a task spends on the CPU before being descheduled, and
+shows the times as a histogram. Tasks that spend a very short time on the CPU
+can be indicative of excessive context-switches and poor workload distribution,
+and possibly point to a shared source of contention that keeps tasks switching
+in and out as it becomes available (such as a mutex).
+<P>
+Similarly, the tool can also measure the time a task spends off-CPU before it
+is scheduled again. This can be helpful in identifying long blocking and I/O
+operations, or alternatively very short descheduling times due to short-lived
+locks or timers.
+<P>
+This tool uses in-kernel eBPF maps for storing timestamps and the histogram,
+for efficiency. Despite this, the overhead of this tool may become significant
+for some workloads: see the OVERHEAD section.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-O<DD>
+Measure off-CPU time instead of on-CPU time.
+<DT>-T<DD>
+Include timestamps on output.
+<DT>-m<DD>
+Output histogram in milliseconds.
+<DT>-P<DD>
+Print a histogram for each PID (tgid from the kernel's perspective).
+<DT>-L<DD>
+Print a histogram for each TID (pid from the kernel's perspective).
+<DT>-p PID<DD>
+Only show this PID (filtered in kernel for efficiency).
+<DT>interval<DD>
+Output interval, in seconds.
+<DT>count<DD>
+Number of outputs.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize task on-CPU time as a histogram:<DD>
+#
+<B>cpudist</B>
+
+<DT>Summarize task off-CPU time as a histogram:<DD>
+#
+<B>cpudist -O</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>cpudist 1 10</B>
+
+<DT>Print 1 second summaries, using milliseconds as units for the histogram, and include timestamps on output:<DD>
+#
+<B>cpudist -mT 1</B>
+
+<DT>Trace PID 186 only, 1 second summaries:<DD>
+#
+<B>cpudist -P 185 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>usecs<DD>
+Microsecond range
+<DT>msecs<DD>
+Millisecond range
+<DT>count<DD>
+How many times a task event fell into this range
+<DT>distribution<DD>
+An ASCII bar chart to visualize the distribution (count column)
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces scheduler tracepoints, which can become very frequent. While eBPF
+has very low overhead, and this tool uses in-kernel maps for efficiency, the
+frequency of scheduler events for some workloads may be high enough that the
+overhead of this tool becomes significant. Measure in a lab environment
+to quantify the overhead before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+pidstat">pidstat</A>(1), <A HREF="https://iovisor.github.io/bcc?8+runqlat">runqlat</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/cpuunclaimed.html
+++ b/man/man8/cpuunclaimed.html
@@ -1,0 +1,171 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of cpuunclaimed</TITLE>
+</HEAD><BODY>
+<H1>cpuunclaimed</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-12-21<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+cpuunclaimed - Sample CPU run queues and calculate unclaimed idle CPU. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cpuunclaimed</B>
+
+[-T] [-j] [-J] [interval [count]]
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool samples the length of the run queues and determine when there are idle
+CPUs, yet queued threads waiting their turn. It reports the amount of idle
+(yet unclaimed by waiting threads) CPU as a system-wide percentage.
+<P>
+This situation can happen for a number of reasons:
+<DL COMPACT>
+<DT>-<DD>
+An application has been bound to some, but not all, CPUs, and has runnable
+threads that cannot migrate to other CPUs due to this configuration.
+<DT>-<DD>
+CPU affinity: an optimization that leaves threads on CPUs where the CPU
+caches are warm, even if this means short periods of waiting while other
+CPUs are idle. The wait period is tunale (see sysctl, kernel.sched*).
+<DT>-<DD>
+Scheduler bugs.
+</DL>
+<P>
+
+An unclaimed idle of &lt; 1% is likely to be CPU affinity, and not usually a
+cause for concern. By leaving the CPU idle, overall throughput of the system
+may be improved. This tool is best for identifying larger issues, &gt; 2%, due
+to the coarseness of its 99 Hertz samples.
+<P>
+This is an experimental tool that currently works by use of sampling to
+keep overheads low. Tool assumptions:
+<DL COMPACT>
+<DT>-<DD>
+CPU samples consistently fire around the same offset. There will sometimes
+be a lag as a sample is delayed by higher-priority interrupts, but it is
+assumed the subsequent samples will catch up to the expected offsets (as
+is seen in practice). You can use -J to inspect sample offsets. Some
+systems can power down CPUs when idle, and when they wake up again they
+may begin firing at a skewed offset: this tool will detect the skew, print
+an error, and exit.
+<DT>-<DD>
+All CPUs are online (see ncpu).
+</DL>
+<P>
+
+If this identifies unclaimed CPU, you can double check it by dumping raw
+samples (-j), as well as using other tracing tools to instrument scheduler
+events (although this latter approach has much higher overhead).
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Sample and calculate unclaimed idle CPUs, output every 1 second (default:<DD>
+#
+<B>cpuunclaimed</B>
+
+<DT>Print 5 second summaries, 10 times:<DD>
+#
+<B>cpuunclaimed 5 10</B>
+
+<DT>Print 1 second summaries with timestamps:<DD>
+#
+<B>cpuunclaimed -T 1</B>
+
+<DT>Raw dump of all samples (verbose), as comma-separated values:<DD>
+#
+<B>cpuunclaimed -j</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>%CPU<DD>
+CPU utilization as a system-wide percentage.
+<DT>unclaimed idle<DD>
+Percentage of CPU resources that were idle when work was queued on other CPUs,
+as a system-wide percentage.
+<DT>TIME<DD>
+Time (HH:MM:SS)
+<DT>TIMESTAMP_ns<DD>
+Timestamp, nanoseconds.
+<DT>CPU#<DD>
+CPU ID.
+<DT>OFFSET_ns_CPU#<DD>
+Time offset that a sample fired within a sample group for this CPU.
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+The overhead is expected to be low/negligible as this tool uses sampling at
+99 Hertz (on all CPUs), which has a fixed and low cost, rather than sampling
+every scheduler event as many other approaches use (which can involve
+instrumenting millions of events per second). Sampled CPUs, run queue lengths,
+and timestamps are written to ring buffers that are periodically read by
+user space for reporting. Measure overhead in a test environment.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+runqlen">runqlen</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">FIELDS</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/criticalstat.html
+++ b/man/man8/criticalstat.html
@@ -1,0 +1,135 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of criticalstat</TITLE>
+</HEAD><BODY>
+<H1>criticalstat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-06-07<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+criticalstat - A tracer to find and report long atomic critical sections in kernel
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>criticalstat [-h] [-p] [-i] [-d DURATION]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+<P>
+criticalstat traces and reports occurrences of atomic critical sections in the
+kernel with useful stacktraces showing the origin of them. Such critical
+sections frequently occur due to use of spinlocks, or if interrupts or
+preemption were explicitly disabled by a driver. IRQ routines in Linux are also
+executed with interrupts disabled. There are many reasons. Such critical
+sections are a source of long latency/responsive issues for real-time systems.
+<P>
+This works by probing the preempt/irq and cpuidle tracepoints in the kernel.
+Since this uses BPF, only the root user can use this tool. Further, the kernel
+has to be built with certain CONFIG options enabled. See below.
+<P>
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+Enable CONFIG_PREEMPTIRQ_EVENTS and CONFIG_DEBUG_PREEMPT. Additionally, the
+following options should be DISABLED on older kernels: CONFIG_PROVE_LOCKING,
+CONFIG_LOCKDEP.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-p<DD>
+Find long sections where preemption was disabled on local CPU.
+<DT>-i<DD>
+Find long sections where interrupt was disabled on local CPU.
+<DT>-d DURATION<DD>
+Only identify sections that are longer than DURATION in microseconds.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Run with default options: irq disabled for more than 100 uS<DD>
+#
+<B>criticalstat</B>
+
+<DT>Find sections with preemption disabled for more than 100 uS.<DD>
+#
+<B>criticalstat -p</B>
+
+<DT>Find sections with IRQ disabled for more than 500 uS.<DD>
+#
+<B>criticalstat -d 500</B>
+
+<DT>Find sections with preemption disabled for more than 500 uS.<DD>
+#
+<B>criticalstat -p -d 500</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This tool can cause overhead if the application is spending a lot of time in
+kernel mode. The overhead is variable but can be 2-4% of performance
+degradation. If overhead is seen to be too much, please pass a higher DURATION
+to the -d option to filter more aggressively.
+<P>
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Joel Fernandes
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+Linux kernel's preemptoff and irqoff tracers.
+<P>
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/cthreads.html
+++ b/man/man8/cthreads.html
@@ -1,0 +1,133 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uthreads</TITLE>
+</HEAD><BODY>
+<H1>uthreads</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uthreads, cthreads, javathreads - Trace thread creation events in Java or pthreads.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cthreads [-h] [-v] pid</B>
+
+
+<B>javathreads [-h] [-v] pid</B>
+
+
+<B>uthreads [-h] [-l {c,java,none}] [-v] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces thread creation events in Java processes, or pthread creation
+events in any process. When a thread is created, its name or start address
+is printed.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {c,java,none}<DD>
+The language to trace. C and none select tracing pthreads only, regardless
+of the runtime being traced.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace Java thread creations:<DD>
+#
+<B>uthreads -l java 148</B>
+
+<DT>Trace pthread creations:<DD>
+#
+<B>uthreads 1802</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+The event's time in seconds from the beginning of the trace.
+<DT>ID<DD>
+The thread's ID. The information in this column depends on the runtime.
+<DT>TYPE<DD>
+Event type -- thread start, stop, or pthread event.
+<DT>DESCRIPTION<DD>
+The thread's name or start address function name.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Thread start and stop events are usually not very frequent, which makes this
+tool's overhead negligible.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/dbslower.html
+++ b/man/man8/dbslower.html
@@ -1,0 +1,142 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of dbslower</TITLE>
+</HEAD><BODY>
+<H1>dbslower</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2017-02-15<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+dbslower - Trace MySQL/PostgreSQL server queries slower than a threshold.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>dbslower [-v] [-p PID [PID ...]] [-x PATH] [-m THRESHOLD] {mysql,postgres}</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces queries served by a MySQL or PostgreSQL server, and prints
+those that exceed a latency (query time) threshold. By default a threshold of
+1 ms is used.
+<P>
+This uses User Statically-Defined Tracing (USDT) probes, a feature added to
+MySQL and PostgreSQL for DTrace support, but which may not be enabled on a
+given installation. See requirements.
+Alternatively, MySQL queries can be traced without the USDT support using the
+-x option.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF, bcc, and MySQL server with USDT probe support (when configuring
+the build: -DENABLE_DTRACE=1) or PostgreSQL server with USDT probe support
+(when configuring the build: --enable-dtrace).
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-h
+Print usage message.
+<DL COMPACT>
+<DT>-p PID<DD>
+Trace this PID. If no PID is specified, the tool will attempt to automatically
+detect the MySQL or PostgreSQL processes running on the system.
+<DT>-x PATH<DD>
+Path to MySQL binary. This option allow to MySQL queries even when USDT probes
+aren't enabled on the MySQL server.
+<DT>-m THRESHOLD<DD>
+Minimum query latency (duration) to trace, in milliseconds. Default is 1 ms.
+<DT>{mysql,postgres}<DD>
+The database engine to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace MySQL server queries slower than 1 ms:<DD>
+#
+<B>dbslower mysql</B>
+
+<DT>Trace slower than 10 ms for PostgreSQL in process 408:<DD>
+#
+<B>dbslower postgres -p 408 -m 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of query start, in seconds.
+<DT>PID<DD>
+Process ID of the traced server.
+<DT>MS<DD>
+Milliseconds for the query, from start to end.
+<DT>QUERY<DD>
+Query string, truncated to 256 characters.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to queries, and only emits output
+data from kernel to user-level if they query exceeds the threshold. If the
+server query rate is less than 1,000/sec, the overhead is expected to be
+negligible. If the query rate is higher, test to gauge overhead.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein, Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+mysqld_qslower">mysqld_qslower</A>(8), <A HREF="https://iovisor.github.io/bcc?8+dbstat">dbstat</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/dbstat.html
+++ b/man/man8/dbstat.html
@@ -1,0 +1,132 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of dbstat</TITLE>
+</HEAD><BODY>
+<H1>dbstat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2017-02-15<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+dbstat - Collect histograms of MySQL/PostgreSQL query latencies.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>dbstat [-v] [-p PID [PID ...]] [-m THRESHOLD] [-u] [-i INTERVAL] {mysql,postgres}</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces queries served by a MySQL or PostgreSQL server, and collects a
+histogram of query latencies. The histogram is printed at the end of collection,
+or at specified intervals.
+<P>
+This uses User Statically-Defined Tracing (USDT) probes, a feature added to
+MySQL and PostgreSQL for DTrace support, but which may not be enabled on a
+given installation. See requirements.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF, bcc, and MySQL server with USDT probe support (when configuring
+the build: -DENABLE_DTRACE=1) or PostgreSQL server with USDT probe support
+(when configuring the build: --enable-dtrace).
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-h
+Print usage message.
+<DL COMPACT>
+<DT>-p PID<DD>
+Trace this PID. If no PID is specified, the tool will attempt to automatically
+detect the MySQL or PostgreSQL processes running on the system.
+<DT>-m THRESHOLD<DD>
+Minimum query latency (duration) to trace, in milliseconds.
+Default is all queries.
+<DT>-u<DD>
+Display query latencies in microseconds (default: milliseconds).
+<DT>-i INTERVAL<DD>
+Print summaries (histograms) at this interval, specified in seconds.
+<DT>{mysql,postgres}<DD>
+The database engine to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Display histogram of MySQL query latencies:<DD>
+#
+<B>dbstat mysql</B>
+
+<DT>Display histogram of PostgreSQL query latencies slower than 10ms in pid 408:<DD>
+#
+<B>dbstat postgres -p 408 -m 10</B>
+
+<DT>Display histogram of PostgreSQL query latencies at 3-second intervals:<DD>
+#
+<B>dbstat postgres -i 3</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to queries, and only emits output
+data from kernel to user-level if they query exceeds the threshold. If the
+server query rate is less than 1,000/sec, the overhead is expected to be
+negligible. If the query rate is higher, test to gauge overhead.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+dbslower">dbslower</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/dcsnoop.html
+++ b/man/man8/dcsnoop.html
@@ -1,0 +1,140 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of dcsnoop</TITLE>
+</HEAD><BODY>
+<H1>dcsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-10<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+dcsnoop - Trace directory entry cache (dcache) lookups. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>dcsnoop [-h] [-a]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+By default, this traces every failed dcache lookup (cache miss), and shows the
+process performing the lookup and the filename requested. A -a option can be
+used to show all lookups, not just failed ones.
+<P>
+The output of this tool can be verbose, and is intended for further
+investigations of dcache performance beyond <A HREF="https://iovisor.github.io/bcc?8+dcstat">dcstat</A>(8), which prints
+per-second summaries.
+<P>
+This uses kernel dynamic tracing of the d_lookup() function, and will need
+and will need updating to match any changes to this function.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-a<DD>
+Trace references, not just failed lookups.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace failed dcache lookups:<DD>
+#
+<B>dcsnoop</B>
+
+<DT>Trace all dcache lookups:<DD>
+#
+<B>dcsnoop -a</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of lookup, in seconds.
+<DT>PID<DD>
+Process ID.
+<DT>COMM<DD>
+Process name.
+<DT>T<DD>
+Type: R == reference (only visible with -a), M == miss. A miss will print two
+lines, one for the reference, and one for the miss.
+<DT>FILE<DD>
+The file name component that was being looked up. This contains trailing
+pathname components (after '/'), which will be the subject of subsequent
+lookups.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+File name lookups can be frequent (depending on the workload), and this tool
+prints a line for each failed lookup, and with -a, each reference as well. The
+output may be verbose, and the incurred overhead, while optimized to some
+extent, may still be from noticeable to significant. This is only really
+intended for deeper investigations beyond <A HREF="https://iovisor.github.io/bcc?8+dcstat">dcstat</A>(8), when absolutely necessary.
+Measure and quantify the overhead in a test environment before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+dcstat">dcstat</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/dcstat.html
+++ b/man/man8/dcstat.html
@@ -1,0 +1,122 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of dcstat</TITLE>
+</HEAD><BODY>
+<H1>dcstat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+dcstat - Directory entry cache (dcache) stats. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>dcstat</B>
+
+[interval [count]]
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+The Linux directory entry cache (dcache) improves the performance of file and
+directory name lookups. This tool provides per-second summary statistics of
+dcache performance.
+<P>
+This uses kernel dynamic tracing of kernel functions, lookup_fast() and
+d_lookup(), which will need to be modified to match kernel changes.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Print summaries each second:<DD>
+#
+<B>dcstat</B>
+
+<DT>Print output every five seconds, three times:<DD>
+#
+<B>dcstat 5 3</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>REFS/s<DD>
+Number dcache lookups (references) per second.
+<DT>SLOW/s<DD>
+Number of dcache lookups that failed the lookup_fast() path and executed the
+lookup_slow() path instead.
+<DT>MISS/s<DD>
+Number of dcache misses (failed both fast and slow lookups).
+<DT>HIT%<DD>
+Percentage of dcache hits over total references.
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+The overhead depends on the frequency of file and directory name lookups.
+While the per-event overhead is low, some applications may make over 100k
+lookups per second, and the low per-event overhead will begin to add up, and
+could begin to be measurable (over 10% CPU usage). Measure in a test
+environment.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+dcsnoop">dcsnoop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">FIELDS</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/deadlock.html
+++ b/man/man8/deadlock.html
@@ -1,0 +1,197 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of deadlock</TITLE>
+</HEAD><BODY>
+<H1>deadlock</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2017-02-01<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+deadlock - Find potential deadlocks (lock order inversions)
+in a running program.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>deadlock [-h] [--binary BINARY] [--dump-graph DUMP_GRAPH]</B>
+
+<B>[--verbose] [--lock-symbols LOCK_SYMBOLS]</B>
+
+<B>[--unlock-symbols UNLOCK_SYMBOLS]</B>
+
+<B>pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+deadlock finds potential deadlocks in a running process. The program
+attaches uprobes on `pthread_mutex_lock` and `pthread_mutex_unlock` by default
+to build a mutex wait directed graph, and then looks for a cycle in this graph.
+This graph has the following properties:
+<P>
+- Nodes in the graph represent mutexes.
+<P>
+- Edge (A, B) exists if there exists some thread T where lock(A) was called
+and lock(B) was called before unlock(A) was called.
+<P>
+If there is a cycle in this graph, this indicates that there is a lock order
+inversion (potential deadlock). If the program finds a lock order inversion, the
+program will dump the cycle of mutexes, dump the stack traces where each mutex
+was acquired, and then exit.
+<P>
+This program can only find potential deadlocks that occur while the program is
+tracing the process. It cannot find deadlocks that may have occurred before the
+program was attached to the process.
+<P>
+This tool does not work for shared mutexes or recursive mutexes.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h, --help<DD>
+show this help message and exit
+<DT>--binary BINARY<DD>
+If set, trace the mutexes from the binary at this path. For
+statically-linked binaries, this argument is not required.
+For dynamically-linked binaries, this argument is required and should be the
+path of the pthread library the binary is using.
+Example: /lib/x86_64-linux-gnu/libpthread.so.0
+<DT>--dump-graph DUMP_GRAPH<DD>
+If set, this will dump the mutex graph to the specified file.
+<DT>--verbose<DD>
+Print statistics about the mutex wait graph.
+<DT>--lock-symbols LOCK_SYMBOLS<DD>
+Comma-separated list of lock symbols to trace. Default is pthread_mutex_lock.
+These symbols cannot be inlined in the binary.
+<DT>--unlock-symbols UNLOCK_SYMBOLS<DD>
+Comma-separated list of unlock symbols to trace. Default is
+pthread_mutex_unlock. These symbols cannot be inlined in the binary.
+<DT>pid<DD>
+Pid to trace
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Find potential deadlocks in PID 181. The --binary argument is not needed for statically-linked binaries.<DD>
+#
+<B>deadlock 181</B>
+
+<DT>Find potential deadlocks in PID 181. If the process was created from a dynamically-linked executable, the --binary argument is required and must be the path of the pthread library:<DD>
+#
+<B>deadlock 181 --binary /lib/x86_64-linux-gnu/libpthread.so.0</B>
+
+<DT>Find potential deadlocks in PID 181. If the process was created from a statically-linked executable, optionally pass the location of the binary. On older kernels without <A HREF="https://lkml.org/lkml/2017/1/13/585,">https://lkml.org/lkml/2017/1/13/585,</A> binaries that contain `:` in the path cannot be attached with uprobes. As a workaround, we can create a symlink to the binary, and provide the symlink name instead with the `--binary` option:<DD>
+#
+<B>deadlock 181 --binary /usr/local/bin/lockinversion</B>
+
+<DT>Find potential deadlocks in PID 181 and dump the mutex wait graph to a file:<DD>
+#
+<B>deadlock 181 --dump-graph graph.json</B>
+
+<DT>Find potential deadlocks in PID 181 and print mutex wait graph statistics:<DD>
+#
+<B>deadlock 181 --verbose</B>
+
+<DT>Find potential deadlocks in PID 181 with custom mutexes:<DD>
+#
+<B>deadlock 181</B>
+
+<B>--lock-symbols custom_mutex1_lock,custom_mutex2_lock</B>
+
+<B>--unlock_symbols custom_mutex1_unlock,custom_mutex2_unlock</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OUTPUT</H2>
+
+This program does not output any fields. Rather, it will keep running until
+it finds a potential deadlock, or the user hits Ctrl-C. If the program finds
+a potential deadlock, it will output the stack traces and lock order inversion
+in the following format and exit:
+<DL COMPACT>
+<DT>Potential Deadlock Detected!<DD>
+<DT>Cycle in lock order graph: Mutex M0 =&gt; Mutex M1 =&gt; Mutex M0<DD>
+<DT>Mutex M1 acquired here while holding Mutex M0 in Thread T:<DD>
+<B>[stack trace]</B>
+
+<DT>Mutex M0 previously acquired by the same Thread T here:<DD>
+<B>[stack trace]</B>
+
+<DT>Mutex M0 acquired here while holding Mutex M1 in Thread S:<DD>
+<B>[stack trace]</B>
+
+<DT>Mutex M1 previously acquired by the same Thread S here:<DD>
+<B>[stack trace]</B>
+
+<DT>Thread T created by Thread R here:<DD>
+<B>[stack trace]</B>
+
+<DT>Thread S created by Thread Q here:<DD>
+<B>[stack trace]</B>
+
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces all mutex lock and unlock events and all thread creation events
+on the traced process. The overhead of this can be high if the process has many
+threads and mutexes. You should only run this on a process where the slowdown
+is acceptable.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Kenny Yu
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OUTPUT</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/drsnoop.html
+++ b/man/man8/drsnoop.html
@@ -1,0 +1,164 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of drsnoop</TITLE>
+</HEAD><BODY>
+<H1>drsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2019-02-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+drsnoop - Trace direct reclaim events. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>drsnoop.py [-h] [-T] [-U] [-p PID] [-t TID] [-u UID] [-d DURATION] [-n name] [-v]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+drsnoop trace direct reclaim events, showing which processes are allocing pages 
+with direct reclaiming. This can be useful for discovering when allocstall (/p-
+roc/vmstat) continues to increase, whether it is caused by some critical proc-
+esses or not.
+<P>
+This works by tracing the direct reclaim events using kernel tracepoints. 
+<P>
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include a timestamp column.
+<DT>-U<DD>
+Show UID.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-t TID<DD>
+Trace this thread ID only (filtered in-kernel).
+<DT>-u UID<DD>
+Trace this UID only (filtered in-kernel).
+<DT>-d DURATION<DD>
+Total duration of trace in seconds.
+<DT>-n name<DD>
+Only print processes where its name partially matches 'name'
+-v verbose         
+Run in verbose mode. Will output system memory state
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all direct reclaim events:<DD>
+#
+<B>drsnoop</B>
+
+<DT>Trace all direct reclaim events, for 10 seconds only:<DD>
+#
+<B>drsnoop -d 10</B>
+
+<DT>Trace all direct reclaim events, and include timestamps:<DD>
+#
+<B>drsnoop -T</B>
+
+<DT>Show UID:<DD>
+#
+<B>drsnoop -U</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>drsnoop -p 181</B>
+
+<DT>Trace UID 1000 only:<DD>
+#
+<B>drsnoop -u 1000</B>
+
+<DT>Trace all direct reclaim events from processes where its name partially match-<DD>
+es 'mond':
+#
+<B>drnsnoop -n mond</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of the call, in seconds.
+<DT>UID<DD>
+User ID
+<DT>PID<DD>
+Process ID
+<DT>TID<DD>
+Thread ID
+<DT>COMM<DD>
+Process name
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel direct reclaim tracepoints and prints output for each 
+event. As the rate of this is generally expected to be low (&lt; 1000/s), the 
+overhead is also expected to be negligible. 
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Ethercflow
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/execsnoop.html
+++ b/man/man8/execsnoop.html
@@ -1,0 +1,197 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of execsnoop</TITLE>
+</HEAD><BODY>
+<H1>execsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2020-02-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+execsnoop - Trace new processes via exec() syscalls. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>execsnoop [-h] [-T] [-t] [-x] [--cgroupmap CGROUPMAP] [-u USER]</B>
+
+<B>[-q] [-n NAME] [-l LINE] [-U] [--max-args MAX_ARGS]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+execsnoop traces new processes, showing the filename executed and argument
+list.
+<P>
+It works by traces the execve() system call (commonly used exec() variant).
+This catches new processes that follow the fork-&gt;exec sequence, as well as
+processes that re-exec() themselves. Some applications fork() but do not
+exec(), eg, for worker processes, which won't be included in the execsnoop
+output.
+<P>
+This works by tracing the kernel sys_execve() function using dynamic tracing,
+and will need updating to match any changes to this function.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include a time column (HH:MM:SS).
+<DT>-U<DD>
+Include UID column.
+<DT>-t<DD>
+Include a timestamp column.
+<DT>-u USER<DD>
+Filter by UID (or username)
+<DT>-x<DD>
+Include failed exec()s
+<DT>-q<DD>
+Add &quot;quotemarks&quot; around arguments. Escape quotemarks in arguments with a
+backslash. For tracing empty arguments or arguments that contain whitespace. 
+<DT>-n NAME<DD>
+Only print command lines matching this name (regex)
+<DT>-l LINE<DD>
+Only print commands where arg contains this line (regex)
+<DT>--max-args MAXARGS<DD>
+Maximum number of arguments parsed and displayed, defaults to 20
+<DT>--cgroupmap MAPPATH<DD>
+Trace cgroups in this BPF map only (filtered in-kernel).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all exec() syscalls:<DD>
+#
+<B>execsnoop</B>
+
+<DT>Trace all exec() syscalls, and include timestamps:<DD>
+#
+<B>execsnoop -t</B>
+
+<DT>Display process UID:<DD>
+#
+<B>execsnoop -U</B>
+
+<DT>Trace only UID 1000:<DD>
+#
+<B>execsnoop -u 1000</B>
+
+<DT>Trace only processes launched by root and display UID column:<DD>
+#
+<B>execsnoop -Uu root</B>
+
+<DT>Include failed exec()s:<DD>
+#
+<B>execsnoop -x</B>
+
+<DT>Put quotemarks around arguments. <DD>
+#
+<B>execsnoop -q</B>
+
+<DT>Only trace exec()s where the filename contains &quot;mount&quot;:<DD>
+#
+<B>execsnoop -n mount</B>
+
+<DT>Only trace exec()s where argument's line contains &quot;testpkg&quot;:<DD>
+#
+<B>execsnoop -l testpkg</B>
+
+<DT>Trace a set of cgroups only (see filtering_by_cgroups.md from bcc sources for more details):<DD>
+#
+<B>execsnoop --cgroupmap /sys/fs/bpf/test01</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of exec() return, in HH:MM:SS format.
+<DT>TIME(s)<DD>
+Time of exec() return, in seconds.
+<DT>UID<DD>
+User ID
+<DT>PCOMM<DD>
+Parent process/command name.
+<DT>PID<DD>
+Process ID
+<DT>PPID<DD>
+Parent process ID
+<DT>RET<DD>
+Return value of exec(). 0 == successs. Failures are only shown when using the
+-x option.
+<DT>ARGS<DD>
+Filename for the exec(), followed be up to 19 arguments. An ellipsis &quot;...&quot; is
+shown if the argument list is known to be truncated.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel execve function and prints output for each event. As the
+rate of this is generally expected to be low (&lt; 1000/s), the overhead is also
+expected to be negligible. If you have an application that is calling a high
+rate of exec()s, then test and understand overhead before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+opensnoop">opensnoop</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/exitsnoop.html
+++ b/man/man8/exitsnoop.html
@@ -1,0 +1,160 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of exitsnoop</TITLE>
+</HEAD><BODY>
+<H1>exitsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2019-05-28<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+exitsnoop - Trace all process termination (exit, fatal signal). Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>exitsnoop [-h] [-t] [--utc] [-x] [-p PID] [--label LABEL]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+exitsnoop traces process termination, showing the command name and reason for
+termination, either an exit or a fatal signal.
+<P>
+It catches processes of all users, processes in containers, as well
+as processes that become zombie.
+<P>
+This works by tracing the kernel sched_process_exit() function using dynamic tracing,
+and will need updating to match any changes to this function.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-t<DD>
+Include a timestamp column.
+<DT>--utc<DD>
+Include a timestamp column, use UTC timezone.
+<DT>-x<DD>
+Exclude successful exits, exit( 0 )
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>--label LABEL<DD>
+Label each line with LABEL (default 'exit') in first column (2nd if timestamp is present).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all process termination<DD>
+#
+<B>exitsnoop</B>
+
+<DT>Trace all process termination, and include timestamps:<DD>
+#
+<B>exitsnoop -t</B>
+
+<DT>Exclude successful exits, only include non-zero exit codes and fatal signals:<DD>
+#
+<B>exitsnoop -x</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>exitsnoop -p 181</B>
+
+<DT>Label each output line with 'EXIT':<DD>
+#
+<B>exitsnoop --label EXIT</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME-TZ<DD>
+Time of process termination HH:MM:SS.sss with milliseconds, where TZ is
+the local time zone, 'UTC' with --utc option.
+<DT>LABEL<DD>
+The optional label if --label option is used.  This is useful with the
+-t option for timestamps when the output of several tracing tools is
+sorted into one combined output.
+<DT>PCOMM<DD>
+Process/command name.
+<DT>PID<DD>
+Process ID
+<DT>PPID<DD>
+The process ID of the process that will be notified of PID termination.
+<DT>TID<DD>
+Thread ID.
+<DT>EXIT_CODE<DD>
+The exit code for exit() or the signal number for a fatal signal.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel sched_process_exit() function and prints output for each event.
+As the rate of this is generally expected to be low (&lt; 1000/s), the overhead is also
+expected to be negligible. If you have an application that has a high rate of
+process termination, then test and understand overhead before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Arturo Martin-de-Nicolas
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+execsnoop">execsnoop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/ext4dist.html
+++ b/man/man8/ext4dist.html
@@ -1,0 +1,142 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ext4dist</TITLE>
+</HEAD><BODY>
+<H1>ext4dist</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-12<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ext4dist - Summarize ext4 operation latency. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>ext4dist [-h] [-T] [-m] [-p PID] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes time (latency) spent in common ext4 file operations: reads,
+writes, opens, and syncs, and presents it as a power-of-2 histogram. It uses an
+in-kernel eBPF map to store the histogram for efficiency.
+<P>
+Since this works by tracing the ext4_file_operations interface functions, it
+will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Don't include timestamps on interval output.
+<DT>-m<DD>
+Output in milliseconds.
+<DT>-p PID<DD>
+Trace this PID only.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace ext4 operation time, and print a summary on Ctrl-C:<DD>
+#
+<B>ext4dist</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>ext4dist -p 181</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>ext4dist 1 10</B>
+
+<DT>1 second summaries, printed in milliseconds<DD>
+#
+<B>ext4dist -m 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>msecs<DD>
+Range of milliseconds for this bucket.
+<DT>usecs<DD>
+Range of microseconds for this bucket.
+<DT>count<DD>
+Number of operations in this time range.
+<DT>distribution<DD>
+ASCII representation of the distribution (the count column).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to these ext4 operations,
+including reads and writes from the file system cache. Such reads and writes
+can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool may become noticeable.
+Measure and quantify before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ext4snoop">ext4snoop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/ext4slower.html
+++ b/man/man8/ext4slower.html
@@ -1,0 +1,172 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ext4slower</TITLE>
+</HEAD><BODY>
+<H1>ext4slower</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-11<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ext4slower - Trace slow ext4 file operations, with per-event details.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>ext4slower [-h] [-j] [-p PID] [min_ms]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces common ext4 file operations: reads, writes, opens, and
+syncs. It measures the time spent in these operations, and prints details
+for each that exceeded a threshold.
+<P>
+WARNING: See the OVERHEAD section.
+<P>
+By default, a minimum millisecond threshold of 10 is used. If a threshold of 0
+is used, all events are printed (warning: verbose).
+<P>
+Since this works by tracing the ext4_file_operations interface functions, it
+will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-p PID
+Trace this PID only.
+<DL COMPACT>
+<DT>min_ms<DD>
+Minimum I/O latency (duration) to trace, in milliseconds. Default is 10 ms.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace synchronous file reads and writes slower than 10 ms:<DD>
+#
+<B>ext4slower</B>
+
+<DT>Trace slower than 1 ms:<DD>
+#
+<B>ext4slower 1</B>
+
+<DT>Trace slower than 1 ms, and output just the fields in parsable format (csv):<DD>
+#
+<B>ext4slower -j 1</B>
+
+<DT>Trace all file reads and writes (warning: the output will be verbose):<DD>
+#
+<B>ext4slower 0</B>
+
+<DT>Trace slower than 1 ms, for PID 181 only:<DD>
+#
+<B>ext4slower -p 181 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of I/O completion since the first I/O seen, in seconds.
+<DT>COMM<DD>
+Process name.
+<DT>PID<DD>
+Process ID.
+<DT>T<DD>
+Type of operation. R == read, W == write, O == open, S == fsync.
+<DT>OFF_KB<DD>
+File offset for the I/O, in Kbytes.
+<DT>BYTES<DD>
+Size of I/O, in bytes.
+<DT>LAT(ms)<DD>
+Latency (duration) of I/O, measured from when it was issued by VFS to the
+filesystem, to when it completed. This time is inclusive of block device I/O,
+file system CPU cycles, file system locks, run queue latency, etc. It's a more
+accurate measure of the latency suffered by applications performing file
+system I/O, than to measure this down at the block device interface.
+<DT>FILENAME<DD>
+A cached kernel file name (comes from dentry-&gt;d_name.name).
+<DT>ENDTIME_us<DD>
+Completion timestamp, microseconds (-j only).
+<DT>OFFSET_b<DD>
+File offset, bytes (-j only).
+<DT>LATENCY_us<DD>
+Latency (duration) of the I/O, in microseconds (-j only).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to these ext4 operations,
+including reads and writes from the file system cache. Such reads and writes
+can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool (even if it prints no &quot;slower&quot; events) can
+begin to become significant. Measure and quantify before use. If this
+continues to be a problem, consider switching to a tool that prints in-kernel
+summaries only.
+<P>
+
+Note that the overhead of this tool should be less than <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8), as
+this tool targets ext4 functions only, and not all file read/write paths
+(which can include socket I/O).
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/filelife.html
+++ b/man/man8/filelife.html
@@ -1,0 +1,132 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of filelife</TITLE>
+</HEAD><BODY>
+<H1>filelife</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-08<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+filelife - Trace the lifespan of short-lived files. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>filelife [-h] [-p PID]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces the creation and deletion of files, providing information
+on who deleted the file, the file age, and the file name. The intent is to
+provide information on short-lived files, for debugging or performance
+analysis.
+<P>
+This works by tracing the kernel vfs_create() and vfs_delete() functions (and
+maybe more, see the source) using dynamic tracing, and will need updating to
+match any changes to these functions.
+<P>
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all short-lived files, and print details:<DD>
+#
+<B>filelife</B>
+
+<DT>Trace all short-lived files created AND deleted by PID 181:<DD>
+#
+<B>filelife -p 181</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the deletion.
+<DT>PID<DD>
+Process ID that deleted the file.
+<DT>COMM<DD>
+Process name for the PID.
+<DT>AGE(s)<DD>
+Age of the file, from creation to deletion, in seconds.
+<DT>FILE<DD>
+Filename.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel VFS file create and delete functions and prints output
+for each delete. As the rate of this is generally expected to be low
+(&lt; 1000/s), the overhead is also expected to be negligible.
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+opensnoop">opensnoop</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/fileslower.html
+++ b/man/man8/fileslower.html
@@ -1,0 +1,178 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of fileslower</TITLE>
+</HEAD><BODY>
+<H1>fileslower</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-07<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+fileslower - Trace slow synchronous file reads and writes.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>fileslower [-h] [-p PID] [-a] [min_ms]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This script uses kernel dynamic tracing of synchronous reads and writes
+at the VFS interface, to identify slow file reads and writes for any file
+system.
+<P>
+This version traces __vfs_read() and __vfs_write() and only showing
+synchronous I/O (the path to new_sync_read() and new_sync_write()), and
+I/O with filenames. This approach provides a view of just two file
+system request types: file reads and writes. There are typically many others:
+asynchronous I/O, directory operations, file handle operations, file open()s,
+fflush(), etc.
+<P>
+WARNING: See the OVERHEAD section.
+<P>
+By default, a minimum millisecond threshold of 10 is used.
+<P>
+Since this works by tracing various kernel __vfs_*() functions using dynamic
+tracing, it will need updating to match any changes to these functions. A
+future version should switch to using FS tracepoints instead.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-p PID
+Trace this PID only.
+<DL COMPACT>
+<DT>-a<DD>
+Include non-regular file types in output (sockets, FIFOs, etc).
+<DT>min_ms<DD>
+Minimum I/O latency (duration) to trace, in milliseconds. Default is 10 ms.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace synchronous file reads and writes slower than 10 ms:<DD>
+#
+<B>fileslower</B>
+
+<DT>Trace slower than 1 ms:<DD>
+#
+<B>fileslower 1</B>
+
+<DT>Trace slower than 1 ms, for PID 181 only:<DD>
+#
+<B>fileslower -p 181 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of I/O completion since the first I/O seen, in seconds.
+<DT>COMM<DD>
+Process name.
+<DT>PID<DD>
+Process ID.
+<DT>D<DD>
+Direction of I/O. R == read, W == write.
+<DT>BYTES<DD>
+Size of I/O, in bytes.
+<DT>LAT(ms)<DD>
+Latency (duration) of I/O, measured from when the application issued it to VFS
+to when it completed. This time is inclusive of block device I/O, file system
+CPU cycles, file system locks, run queue latency, etc. It's a more accurate
+measure of the latency suffered by applications performing file system I/O,
+than to measure this down at the block device interface.
+<DT>FILENAME<DD>
+A cached kernel file name (comes from dentry-&gt;d_name.name).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Depending on the frequency of application reads and writes, overhead can become
+severe, in the worst case slowing applications by 2x. In the best case, the
+overhead is negligible. Hopefully for real world workloads the overhead is
+often at the lower end of the spectrum -- test before use. The reason for
+high overhead is that this traces VFS reads and writes, which includes FS
+cache reads and writes, and can exceed one million events per second if the
+application is I/O heavy. While the instrumentation is extremely lightweight,
+and uses in-kernel eBPF maps for efficient timing and filtering, multiply that
+cost by one million events per second and that cost becomes a million times
+worse. You can get an idea of the possible cost by just counting the
+instrumented events using the bcc funccount tool, eg:
+<P>
+
+# ./funccount.py -i 1 -r '^__vfs_(read|write)$'
+<P>
+
+This also costs overhead, but is somewhat less than fileslower.
+<P>
+
+If the overhead is prohibitive for your workload, I'd recommend moving
+down-stack a little from VFS into the file system functions (ext4, xfs, etc).
+Look for updates to bcc for specific file system tools that do this. The
+advantage of a per-file system approach is that we can trace post-cache,
+greatly reducing events and overhead. The disadvantage is needing custom
+tracing approaches for each different file system (whereas VFS is generic).
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/filetop.html
+++ b/man/man8/filetop.html
@@ -1,0 +1,178 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of filetop</TITLE>
+</HEAD><BODY>
+<H1>filetop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-08<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+filetop - File reads and writes by filename and process. Top for files.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>filetop [-h] [-C] [-r MAXROWS] [-s {reads,writes,rbytes,wbytes}] [-p PID] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is top for files.
+<P>
+This traces file reads and writes, and prints a per-file summary every interval
+(by default, 1 second). By default the summary is sorted on the highest read
+throughput (Kbytes). Sorting order can be changed via -s option. By default only
+IO on regular files is shown. The -a option will list all file types (sockets,
+FIFOs, etc).
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This script works by tracing the __vfs_read() and __vfs_write() functions using
+kernel dynamic tracing, which instruments explicit read and write calls. If
+files are read or written using another means (eg, via mmap()), then they
+will not be visible using this tool. Also, this tool will need updating to
+match any code changes to those vfs functions.
+<P>
+This should be useful for file system workload characterization when analyzing
+the performance of applications.
+<P>
+Note that tracing VFS level reads and writes can be a frequent activity, and
+this tool can begin to cost measurable overhead at high I/O rates.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-a<DD>
+Include non-regular file types (sockets, FIFOs, etc).
+<DT>-C<DD>
+Don't clear the screen.
+<DT>-r MAXROWS<DD>
+Maximum number of rows to print. Default is 20.
+<DT>-s {reads,writes,rbytes,wbytes}<DD>
+Sort column. Default is rbytes (read throughput).
+<DT>-p PID<DD>
+Trace this PID only.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+<P>
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize block device I/O by process, 1 second screen refresh:<DD>
+#
+<B>filetop</B>
+
+<DT>Don't clear the screen, and top 8 rows only:<DD>
+#
+<B>filetop -Cr 8</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>filetop 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg:<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Process ID.
+<DT>COMM<DD>
+Process name.
+<DT>READS<DD>
+Count of reads during interval.
+<DT>WRITES<DD>
+Count of writes during interval.
+<DT>R_Kb<DD>
+Total read Kbytes during interval.
+<DT>W_Kb<DD>
+Total write Kbytes during interval.
+<DT>T<DD>
+Type of file: R == regular, S == socket, O == other (pipe, etc).
+<DT>FILE<DD>
+Filename.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Depending on the frequency of application reads and writes, overhead can become
+significant, in the worst case slowing applications by over 50%. Hopefully for
+real world workloads the overhead is much less -- test before use. The reason
+for the high overhead is that VFS reads and writes can be a frequent event, and
+despite the eBPF overhead being very small per event, if you multiply this
+small overhead by a million events per second, it becomes a million times
+worse. Literally. You can gauge the number of reads and writes using the
+<A HREF="https://iovisor.github.io/bcc?8+vfsstat">vfsstat</A>(8) tool, also from bcc.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>INSPIRATION</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+top">top</A>(1) by William LeFebvre
+<A NAME="lbAO">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+vfsstat">vfsstat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+vfscount">vfscount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">INSPIRATION</A><DD>
+<DT><A HREF="#lbAO">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/funccount.html
+++ b/man/man8/funccount.html
@@ -1,0 +1,168 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of funccount</TITLE>
+</HEAD><BODY>
+<H1>funccount</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-08-18<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+funccount - Count function, tracepoint, and USDT probe calls matching a pattern. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>funccount [-h] [-p PID] [-i INTERVAL] [-d DURATION] [-T] [-r] [-D] pattern</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool is a quick way to determine which functions are being called,
+and at what rate. It uses in-kernel eBPF maps to count function calls.
+<P>
+WARNING: This uses dynamic tracing of (what can be many) functions, an
+activity that has had issues on some kernel versions (risk of panics or
+freezes). Test, and know what you are doing, before use.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+pattern
+Search pattern. Supports &quot;*&quot; wildcards. See EXAMPLES. You can also use -r for regular expressions.
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-p PID<DD>
+Trace this process ID only.
+<DT>-i INTERVAL<DD>
+Print output every interval seconds.
+<DT>-d DURATION<DD>
+Total duration of trace in seconds.
+<DT>-T<DD>
+Include timestamps on output.
+<DT>-r<DD>
+Use regular expressions for the search pattern.
+<DT>-D<DD>
+Print the BPF program before starting (for debugging purposes).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Count kernel functions beginning with &quot;vfs_&quot;, until Ctrl-C is hit:<DD>
+#
+<B>funccount 'vfs_*'</B>
+
+<DT>Count kernel functions beginning with &quot;tcp_send&quot;, until Ctrl-C is hit:<DD>
+#
+<B>funccount 'tcp_send*'</B>
+
+<DT>Print kernel functions beginning with &quot;vfs_&quot;, every second:<DD>
+#
+<B>funccount -i 1 'vfs_*'</B>
+
+<DT>Print kernel functions beginning with &quot;vfs_&quot;, for ten seconds only:<DD>
+#
+<B>funccount -d 10 'vfs_*'</B>
+
+<DT>Match kernel functions beginning with &quot;vfs_&quot;, using regular expressions:<DD>
+#
+<B>funccount -r '^vfs_.*'</B>
+
+<DT>Count vfs calls for process ID 181 only:<DD>
+#
+<B>funccount -p 181 'vfs_*'</B>
+
+<DT>Count calls to the sched_fork tracepoint, indicating a fork() performed:<DD>
+#
+<B>funccount t:sched:sched_fork</B>
+
+<DT>Count all GC USDT probes in the Node process:<DD>
+#
+<B>funccount -p 185 u:node:gc*</B>
+
+<DT>Count all malloc() calls in libc:<DD>
+#
+<B>funccount c:malloc</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>FUNC<DD>
+Function name
+<DT>COUNT<DD>
+Number of calls while tracing
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces functions and maintains in-kernel counts, which
+are asynchronously copied to user-space. While the rate of calls
+be very high (&gt;1M/sec), this is a relatively efficient way to trace these
+events, and so the overhead is expected to be small for normal workloads.
+Measure in a test environment before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg, Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+stackcount">stackcount</A>(8)
+<A HREF="https://iovisor.github.io/bcc?8+funclatency">funclatency</A>(8)
+<A HREF="https://iovisor.github.io/bcc?8+vfscount">vfscount</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/funclatency.html
+++ b/man/man8/funclatency.html
@@ -1,0 +1,191 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of funclatency</TITLE>
+</HEAD><BODY>
+<H1>funclatency</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-08-18<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+funclatency - Time functions and print latency as a histogram.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>funclatency [-h] [-p PID] [-i INTERVAL] [-d DURATION] [-T] [-u] [-m] [-F] [-r] [-v] pattern</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces function calls and times their duration (latency), and
+shows the latency distribution as a histogram. The time is measured from when
+the function is called to when it returns, and is inclusive of both on-CPU
+time and time spent blocked.
+<P>
+This tool uses in-kernel eBPF maps for storing timestamps and the histogram,
+for efficiency.
+<P>
+Currently nested or recursive functions are not supported properly, and
+timestamps will be overwritten, creating dubious output. Try to match single
+functions, or groups of functions that run at the same stack layer, and
+don't ultimately call each other.
+<P>
+WARNING: This uses dynamic tracing of (what can be many) functions, an
+activity that has had issues on some kernel versions (risk of panics or
+freezes). Test, and know what you are doing, before use.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+pattern
+Function name or search pattern. Supports &quot;*&quot; wildcards. See EXAMPLES.
+You can also use -r for regular expressions.
+-h
+Print usage message.
+<DL COMPACT>
+<DT>-p PID<DD>
+Trace this process ID only.
+<DT>-i INTERVAL<DD>
+Print output every interval seconds.
+<DT>-d DURATION<DD>
+Total duration of trace, in seconds.
+<DT>-T<DD>
+Include timestamps on output.
+<DT>-u<DD>
+Output histogram in microseconds.
+<DT>-m<DD>
+Output histogram in milliseconds.
+<DT>-F<DD>
+Print a separate histogram per function matched.
+<DT>-r<DD>
+Use regular expressions for the search pattern.
+<DT>-v<DD>
+Print the BPF program (for debugging purposes).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Time the do_sys_open() kernel function, and print the distribution as a histogram:<DD>
+#
+<B>funclatency do_sys_open</B>
+
+<DT>Time the read() function in libc across all processes on the system:<DD>
+#
+<B>funclatency c:read</B>
+
+<DT>Time vfs_read(), and print the histogram in units of microseconds:<DD>
+#
+<B>funclatency -u vfs_read</B>
+
+<DT>Time do_nanosleep(), and print the histogram in units of milliseconds:<DD>
+#
+<B>funclatency -m do_nanosleep</B>
+
+<DT>Time libc open(), and print output every 2 seconds, for duration 10 seconds:<DD>
+#
+<B>funclatency -i 2 -d 10 c:read</B>
+
+<DT>Time vfs_read(), and print output every 5 seconds, with timestamps:<DD>
+#
+<B>funclatency -mTi 5 vfs_read</B>
+
+<DT>Time vfs_read() for process ID 181 only:<DD>
+#
+<B>funclatency -p 181 vfs_read:</B>
+
+<DT>Time both vfs_fstat() and vfs_fstatat() calls, by use of a wildcard:<DD>
+#
+<B>funclatency 'vfs_fstat*'</B>
+
+<DT>Time both vfs_fstat* calls, and print a separate histogram for each:<DD>
+#
+<B>funclatency -F 'vfs_fstat*'</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>necs<DD>
+Nanosecond range
+<DT>usecs<DD>
+Microsecond range
+<DT>msecs<DD>
+Millisecond range
+<DT>count<DD>
+How many calls fell into this range
+<DT>distribution<DD>
+An ASCII bar chart to visualize the distribution (count column)
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces kernel functions and maintains in-kernel timestamps and a histogram,
+which are asynchronously copied to user-space. While this method is very
+efficient, the rate of kernel functions can also be very high (&gt;1M/sec), at
+which point the overhead is expected to be measurable. Measure in a test
+environment and understand overheads before use. You can also use funccount
+to measure the rate of kernel functions over a short duration, to set some
+expectations before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg, Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/funcslower.html
+++ b/man/man8/funcslower.html
@@ -1,0 +1,180 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of funcslower</TITLE>
+</HEAD><BODY>
+<H1>funcslower</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2017-03-30<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+funcslower - Trace slow kernel or user function calls.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>funcslower [-hf] [-p PID] [-U | -K] [-m MIN_MS] [-u MIN_US] [-a ARGUMENTS] [-T] [-t] [-v] function [function ...]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This script traces a kernel or user function's entry and return points, and
+prints a message when the function's latency exceeded the specified threshold.
+Multiple functions are supported, and you can mix kernel functions with user
+functions in different libraries.
+<P>
+WARNING: See the OVERHEAD section.
+<P>
+By default, a minimum millisecond threshold of 1 is used. Recursive functions
+are not supported: only the inner-most recursive invocation will be traced.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-p PID
+Trace this PID only.
+<DL COMPACT>
+<DT>-m MIN_NS<DD>
+Minimum duration to trace, in milliseconds. Default is 1 ms.
+<DT>-u MIN_US<DD>
+Minimum duration to trace, in microseconds.
+<DT>-a ARGUMENTS<DD>
+Print the function's arguments, up to 6.
+<DT>-T<DD>
+Print a HH:MM:SS timestamp with each entry.
+<DT>-t<DD>
+Print a seconds timestamp with each entry, at microsecond resolution.
+<DT>-f<DD>
+Print output in folded stack format.
+<DT>-U<DD>
+Show stacks from user space only (no kernel space stacks).
+<DT>-K<DD>
+Show stacks from kernel space only (no user space stacks).
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>function<DD>
+The function to trace -- multiple functions are supported. If a plain function
+name is provided, the function is assumed to be a kernel function. For user
+functions, provide the library name and the function name, e.g. bash:readline
+or c:malloc.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace vfs_write calls slower than 1ms:<DD>
+#
+<B>funcslower vfs_write</B>
+
+<DT>Trace open() calls in libc slower than 10us:<DD>
+#
+<B>funcslower -u 10 c:open</B>
+
+<DT>Trace both malloc() and free() slower than 10us, in pid 135 only:<DD>
+#
+<B>funcslower -p 135 -u 10 c:malloc c:free</B>
+
+<DT>Trace the write syscall and print its first 4 arguments:<DD>
+#
+<B>funcslower -a 4 SyS_write</B>
+
+<DT>Trace opens from libc and print the user and kernel stack frames:<DD>
+#
+<B>funcslower -UK c:open</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the event as a human-readable HH:MM:SS format, or a timestamp in seconds
+at microsecond-accuracy from the first event seen.
+<DT>COMM<DD>
+Process name.
+<DT>PID<DD>
+Process ID.
+<DT>LAT<DD>
+Latency of the operation in either microseconds (us) or milliseconds (ms).
+<DT>RVAL<DD>
+The return value from the function. Often useful for diagnosing a relationship
+between slow and failed function calls.
+<DT>FUNC<DD>
+The function name, followed by its arguments if requested.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Depending on the function(s) being traced, overhead can become severe. For 
+example, tracing a common function like malloc() can slow down a C/C++ program
+by a factor of 2 or more. On the other hand, tracing a low-frequency event like
+the SyS_setreuid() function will probably not be as prohibitive, and in fact
+negligible for functions that are called up to 100-1000 times per second.
+<P>
+You should first use the funclatency and argdist tools for investigation, 
+because they summarize data in-kernel and have a much lower overhead than this
+tool. To get a general idea of the number of times a particular function is
+called (and estimate the overhead), use the funccount tool, e.g.:
+<P>
+
+# funccount c:open
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funclatency">funclatency</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/gethostlatency.html
+++ b/man/man8/gethostlatency.html
@@ -1,0 +1,128 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of gethostlatency</TITLE>
+</HEAD><BODY>
+<H1>gethostlatency</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-01-28<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+gethostlatency - Show latency for getaddrinfo/gethostbyname[2] calls. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>gethostlatency</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces and prints when getaddrinfo(), gethostbyname(), and gethostbyname2()
+are called, system wide, and shows the responsible PID and command name,
+latency of the call (duration) in milliseconds, and the host string.
+<P>
+This tool can be useful for identifying DNS latency, by identifying which
+remote host name lookups were slow, and by how much.
+<P>
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism
+<P>
+This tool currently uses dynamic tracing of user-level functions and registers,
+and may need modifications to match your software and processor architecture.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-p PID<DD>
+Trace this process ID only.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace host lookups (getaddrinfo/gethostbyname[2]) system wide:<DD>
+#
+<B>gethostlatency</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the command (HH:MM:SS).
+<DT>PID<DD>
+Process ID of the client performing the call.
+<DT>COMM<DD>
+Process (command) name of the client performing the call.
+<DT>HOST<DD>
+Host name string: the target of the lookup.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+The rate of lookups should be relatively low, so the overhead is not expected
+to be a problem.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcpdump">tcpdump</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/hardirqs.html
+++ b/man/man8/hardirqs.html
@@ -1,0 +1,153 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of hardirqs</TITLE>
+</HEAD><BODY>
+<H1>hardirqs</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-10-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+hardirqs - Measure hard IRQ (hard interrupt) event time. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>hardirqs [-h] [-T] [-N] [-C] [-d] [interval] [outputs]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This summarizes the time spent servicing hard IRQs (hard interrupts), and can
+show this time as either totals or histogram distributions. A system-wide
+summary of this time is shown by the %irq column of <A HREF="https://iovisor.github.io/bcc?1+mpstat">mpstat</A>(1), and event
+counts (but not times) are shown by /proc/interrupts.
+<P>
+WARNING: This currently uses dynamic tracing of hard interrupts. You should
+understand what this means before use. Try in a test environment. Future
+versions should switch to tracepoints.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include timestamps on output.
+<DT>-N<DD>
+Output in nanoseconds.
+<DT>-C<DD>
+Count events only.
+<DT>-d<DD>
+Show IRQ time distribution as histograms.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Sum hard IRQ event time until Ctrl-C:<DD>
+#
+<B>hardirqs</B>
+
+<DT>Show hard IRQ event time as histograms:<DD>
+#
+<B>hardirqs -d</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>hardirqs 1 10</B>
+
+<DT>1 second summaries, printed in nanoseconds, with timestamps:<DD>
+#
+<B>hardirqs -NT 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>HARDIRQ<DD>
+The irq action name for this hard IRQ.
+<DT>TOTAL_usecs<DD>
+Total time spent in this hard IRQ in microseconds.
+<DT>TOTAL_nsecs<DD>
+Total time spent in this hard IRQ in nanoseconds.
+<DT>usecs<DD>
+Range of microseconds for this bucket.
+<DT>nsecs<DD>
+Range of nanoseconds for this bucket.
+<DT>count<DD>
+Number of hard IRQs in this time range.
+<DT>distribution<DD>
+ASCII representation of the distribution (the count column).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces kernel functions and maintains in-kernel counts, which
+are asynchronously copied to user-space. While the rate of interrupts
+be very high (&gt;1M/sec), this is a relatively efficient way to trace these
+events, and so the overhead is expected to be small for normal workloads, but
+could become noticeable for heavy workloads. Measure in a test environment
+before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+softirqs">softirqs</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/inject.html
+++ b/man/man8/inject.html
@@ -1,0 +1,181 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of inject</TITLE>
+</HEAD><BODY>
+<H1>inject</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-03-16<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<P>
+<P>
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+inject - injects appropriate error into function if input call chain and
+predicates are satisfied. Uses Linux eBPF/bcc.
+<P>
+<P>
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>inject -h [-I header] [-P probability] [-v] [-c count] &lt;mode&gt; &lt;spec&gt;</B>
+
+<P>
+<P>
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+inject injects errors into specified kernel functionality when a given call
+chain and associated predicates are satisfied.
+<P>
+WARNING: This tool injects failures into key kernel functions and may crash the
+kernel. You should know what you're doing if you're using this tool.
+<P>
+This makes use of a Linux 4.16 feature (bpf_override_return())
+<P>
+Since this uses BPF, only the root user can use this tool.
+<P>
+<P>
+<A NAME="lbAE">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-v<DD>
+Display the generated BPF program, for debugging or modification.
+<DT>-I header<DD>
+Necessary headers to be included.
+<DT>-P probability<DD>
+Optional probability of failure, default 1.
+<DT>-c count<DD>
+Number of errors to inject before stopping, default never stops.
+<P>
+<P>
+</DL>
+<A NAME="lbAF">&nbsp;</A>
+<H2>MODE</H2>
+
+<P>
+<DL COMPACT>
+<DT><B>kmalloc</B><DD>
+Make the following function indicate failure
+<DL COMPACT><DT><DD>
+int should_failslab(struct kmem_cache *s, gfp_t gfpflags)
+</DL>
+
+<P>
+<DT><B>bio</B><DD>
+Make the following function indicate failure
+<DL COMPACT><DT><DD>
+int should_fail_bio(struct bio *bio)
+</DL>
+
+<P>
+<DT><B>alloc_page</B><DD>
+Make the following function indicate failure
+<DL COMPACT><DT><DD>
+bool should_fail_alloc_page(gfp_t gfp_mask, unsigned int order)
+</DL>
+
+<P>
+<P>
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>SPEC</H2>
+
+<B>FUNCTION([ARGS])[(TEST)] [=&gt; ...]</B>
+
+<P>
+A list of predicates separated by &quot;=&gt;&quot;. A predicate is a function signature
+(name and arguments) in a call stack and a test on the function's arguments.
+<P>
+Missing predicates are implicitly true. Missing tests are implicitly true.
+Specifying the function arguments is optional if the test does not use them.
+If the error injection function is not listed as the first predicate, it is
+implicitly added.
+<P>
+Functions are listed in the reverse order that they are called, ie. if a()
+calls b(), the spec would be &quot;b() =&gt; a()&quot;.
+<P>
+<P>
+<A NAME="lbAH">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF, CONFIG_BPF_KPROBE_OVERRIDE, bcc
+<P>
+<P>
+<A NAME="lbAI">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+
+inject kmalloc -v 'SyS_mount()'
+
+<P>
+
+inject kmalloc -v 'mount_subtree() =&gt; btrfs_mount()'
+
+<P>
+
+inject -P 0.5 -c 100 alloc_page &quot;should_fail_alloc_page(gfp_t gfp_mask, unsigned int order) (order == 1) =&gt; qlge_refill_bq()&quot;
+
+<P>
+Please see the output of '-h' and tools/inject_example.txt for more examples.
+<P>
+<P>
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<P>
+<P>
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<P>
+<P>
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<P>
+<P>
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Howard McLauchlan
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">OPTIONS</A><DD>
+<DT><A HREF="#lbAF">MODE</A><DD>
+<DT><A HREF="#lbAG">SPEC</A><DD>
+<DT><A HREF="#lbAH">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAI">EXAMPLES</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/javacalls.html
+++ b/man/man8/javacalls.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ucalls</TITLE>
+</HEAD><BODY>
+<H1>ucalls</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ucalls, javacalls, perlcalls, phpcalls, pythoncalls, rubycalls, tclcalls - Summarize method calls
+from high-level languages and Linux syscalls.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javacalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>perlcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>phpcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>pythoncalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>rubycalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>tclcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>ucalls [-l {java,perl,php,python,ruby}] [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes method calls from high-level languages such as Java, Perl,
+PHP, Python, Ruby, and Tcl. It can also trace Linux system calls. Whenever a method
+is invoked, ucalls records the call count and optionally the method's execution
+time (latency) and displays a summary.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, method probes are
+not enabled by default, and can be turned on by running the Java process with
+the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the environment
+variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,perl,php,python,ruby,tcl}<DD>
+The language to trace. If not provided, only syscalls are traced (when the -S
+option is used).
+<DT>-T TOP<DD>
+Print only the top methods by frequency or latency.
+<DT>-L<DD>
+Collect method invocation latency (duration).
+<DT>-S<DD>
+Collect Linux syscalls frequency and timing.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds (the default is microseconds).
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Print summary after this number of seconds and then exit. By default, wait for
+Ctrl+C to terminate.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace the top 10 Ruby method calls:<DD>
+#
+<B>ucalls -T 10 -l ruby 1344</B>
+
+<DT>Trace Python method calls and Linux syscalls including latency in milliseconds:<DD>
+#
+<B>ucalls -l python -mL 2020</B>
+
+<DT>Trace only syscalls and print a summary after 10 seconds:<DD>
+#
+<B>ucalls -S 788 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Tracing individual method calls will produce a considerable overhead in all
+high-level languages. For languages with just-in-time compilation, such as
+Java, the overhead can be more considerable than for interpreted languages.
+On the other hand, syscall tracing will typically be tolerable for most
+processes, unless they have a very unusual rate of system calls.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/javaflow.html
+++ b/man/man8/javaflow.html
@@ -1,0 +1,170 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uflow</TITLE>
+</HEAD><BODY>
+<H1>uflow</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uflow, javaflow, perlflow, phpflow, pythonflow, rubyflow, tclflow - Print a flow graph of method
+calls in high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javaflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>perlflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>phpflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>pythonflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>rubyflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>tclflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>uflow [-h] [-M METHOD] [-C CLAZZ] [-v] [-l {java,perl,php,python,ruby,tcl}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uflow traces method calls and prints them in a flow graph that can facilitate
+debugging and diagnostics by following the program's execution (method flow).
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java processes, the
+startup flag &quot;-XX:+ExtendedDTraceProbes&quot; is required. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-M METHOD<DD>
+Print only method calls where the method name begins with this string.
+<DT>-C CLAZZ<DD>
+Print only method calls where the class name begins with this string. The class
+name interpretation strongly depends on the language. For example, in Java use
+&quot;package/subpackage/ClassName&quot; to refer to classes.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{java,perl,php,python,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Follow method flow in a Ruby process:<DD>
+#
+<B>uflow ruby 148</B>
+
+<DT>Follow method flow in a Java process where the class name is java.lang.Thread:<DD>
+#
+<B>uflow -C java/lang/Thread java 1802</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>CPU<DD>
+The CPU number on which the method was invoked. This is useful to easily see
+where the output skips to a different CPU.
+<DT>PID<DD>
+The process id.
+<DT>TID<DD>
+The thread id.
+<DT>TIME<DD>
+The duration of the method call.
+<DT>METHOD<DD>
+The method name.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This tool has extremely high overhead because it prints every method call. For
+some scenarios, you might see lost samples in the output as the tool is unable
+to keep up with the rate of data coming from the kernel. Filtering by class 
+or method prefix can help reduce the amount of data printed, but there is still
+a very high overhead in the collection mechanism. Do not use for performance-
+sensitive production scenarios, and always test first.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/javagc.html
+++ b/man/man8/javagc.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ugc</TITLE>
+</HEAD><BODY>
+<H1>ugc</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ugc, javagc, nodegc, pythongc, rubygc - Trace garbage collection events in
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javagc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>nodegc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>pythongc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>rubygc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>ugc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] [-l {java,node,python,ruby}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces garbage collection events as they occur, including their duration
+and any additional information (such as generation collected or type of GC)
+provided by the respective language's runtime.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Python, and Ruby. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds. The default is microseconds.
+<DT>-M MINIMUM<DD>
+Display only collections that are longer than this threshold. The value is
+given in milliseconds. The default is to display all collections.
+<DT>-F FILTER<DD>
+Display only collections whose textual description matches (contains) this
+string. The default is to display all collections. Note that the filtering here
+is performed in user-space, and not as part of the BPF program. This means that
+if you have thousands of collection events, specifying this filter will not
+reduce the amount of data that has to be transferred from the BPF program to
+the user-space script.
+<DT>{java,node,python,ruby}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace garbage collections in a specific Node process:<DD>
+#
+<B>ugc node 148</B>
+
+<DT>Trace garbage collections in a specific Java process, and print GC times in<DD>
+milliseconds:
+#
+<B>ugc -m java 6004</B>
+
+<DT>Trace garbage collections in a specific Java process, and display them only if<DD>
+they are longer than 10ms and have the string &quot;Tenured&quot; in their detailed
+description:
+#
+<B>ugc -M 10 -F Tenured java 6004</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>START<DD>
+The start time of the GC, in seconds from the beginning of the trace.
+<DT>TIME<DD>
+The duration of the garbage collection event.
+<DT>DESCRIPTION<DD>
+The runtime-provided description of this garbage collection event.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Garbage collection events, even if frequent, should not produce a considerable
+overhead when traced because they are still not very common. Even hundreds of 
+GCs per second (which is a very high rate) will still produce a fairly 
+negligible overhead.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+uobjnew">uobjnew</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/javaobjnew.html
+++ b/man/man8/javaobjnew.html
@@ -1,0 +1,157 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uobjnew</TITLE>
+</HEAD><BODY>
+<H1>uobjnew</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uobjnew, cobjnew, javaobjnew, rubyobjnew, tclobjnew - Summarize object allocations in
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>javaobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>rubyobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>tclobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>uobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] [-l {c,java,ruby,tcl}] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uobjnew traces object allocations in high-level languages (including &quot;malloc&quot;)
+and prints summaries of the most frequently allocated types by number of
+objects or number of bytes.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+C, Java, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, the Java process
+must be started with the &quot;-XX:+ExtendedDTraceProbes&quot; flag.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-C TOP_COUNT<DD>
+Print the top object types sorted by number of instances.
+<DT>-S TOP_SIZE<DD>
+Print the top object types sorted by size.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{c,java,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Wait this many seconds and then print the summary and exit. By default, wait
+for Ctrl+C to exit.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace object allocations in a Ruby process:<DD>
+#
+<B>uobjnew ruby 148</B>
+
+<DT>Trace object allocations from &quot;malloc&quot; and print the top 10 by total size:<DD>
+#
+<B>uobjnew -S 10 c 1788</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TYPE<DD>
+The object type being allocated. For C (malloc), this is the block size.
+<DT>ALLOCS<DD>
+The number of objects allocated.
+<DT>BYTES<DD>
+The number of bytes allocated.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Object allocation events are quite frequent, and therefore the overhead from
+running this tool can be considerable. Use with caution and make sure to 
+test before using in a production environment. Nonetheless, even thousands of
+allocations per second will likely produce a reasonable overhead when 
+investigating a problem.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ugc">ugc</A>(8), <A HREF="https://iovisor.github.io/bcc?8+memleak">memleak</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/javastat.html
+++ b/man/man8/javastat.html
@@ -1,0 +1,201 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ustat</TITLE>
+</HEAD><BODY>
+<H1>ustat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ustat, javastat, nodestat, perlstat, phpstat, pythonstat, rubystat, tclstat - Activity stats from
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javastat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>nodestat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>perlstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>phpstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>pythonstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>rubystat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>tclstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>ustat [-l {java,node,perl,php,python,ruby,tcl}] [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is &quot;top&quot; for high-level language events, such as garbage collections,
+exceptions, thread creations, object allocations, method calls, and more. The
+events are aggregated for each process and printed in a top-like table, which
+can be sorted by various fields. Not all language runtimes provide the same
+set of details.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with
+these probes, which in some cases requires building from source with a
+USDT-specific flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java,
+some probes are not enabled by default, and can be turned on by running the Java
+process with the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Newly-created processes will only be traced at the next interval. If you run
+this tool with a short interval (say, 1-5 seconds), this should be virtually
+unnoticeable. For longer intervals, you might miss processes that were started
+and terminated during the interval window.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,node,perl,php,python,ruby,tcl}<DD>
+The language to trace. By default, all languages are traced.
+<DT>-C<DD>
+Do not clear the screen between updates.
+<DT>-S {cload,excp,gc,method,objnew,thread}<DD>
+Sort the output by the specified field.
+<DT>-r MAXROWS<DD>
+Do not print more than this number of rows.
+<DT>-d<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize activity in high-level languages, 1 second refresh:<DD>
+#
+<B>ustat</B>
+
+<DT>Don't clear the screen, and top 8 rows only:<DD>
+#
+<B>ustat -Cr 8</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>ustat 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Process ID.
+<DT>CMDLINE<DD>
+Process command line (often the second and following arguments will give you a
+hint as to which application is being run.
+<DT>METHOD/s<DD>
+Count of method invocations during interval.
+<DT>GC/s<DD>
+Count of garbage collections during interval.
+<DT>OBJNEW/s<DD>
+Count of objects allocated during interval.
+<DT>CLOAD/s<DD>
+Count of classes loaded during interval.
+<DT>EXC/s<DD>
+Count of exceptions thrown during interval.
+<DT>THR/s<DD>
+Count of threads created during interval.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+When using this tool with high-frequency events, such as method calls, a very
+significant slow-down can be expected. However, many of the high-level
+languages covered by this tool already have a fairly high per-method invocation
+cost, especially when running in interpreted mode. For the lower-frequency
+events, such as garbage collections or thread creations, the overhead should
+not be significant. Specifically, when probing Java processes and not using the
+&quot;-XX:+ExtendedDTraceProbes&quot; flag, the most expensive probes are not emitted,
+and the overhead should be acceptable.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tplist">tplist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/javathreads.html
+++ b/man/man8/javathreads.html
@@ -1,0 +1,133 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uthreads</TITLE>
+</HEAD><BODY>
+<H1>uthreads</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uthreads, cthreads, javathreads - Trace thread creation events in Java or pthreads.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cthreads [-h] [-v] pid</B>
+
+
+<B>javathreads [-h] [-v] pid</B>
+
+
+<B>uthreads [-h] [-l {c,java,none}] [-v] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces thread creation events in Java processes, or pthread creation
+events in any process. When a thread is created, its name or start address
+is printed.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {c,java,none}<DD>
+The language to trace. C and none select tracing pthreads only, regardless
+of the runtime being traced.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace Java thread creations:<DD>
+#
+<B>uthreads -l java 148</B>
+
+<DT>Trace pthread creations:<DD>
+#
+<B>uthreads 1802</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+The event's time in seconds from the beginning of the trace.
+<DT>ID<DD>
+The thread's ID. The information in this column depends on the runtime.
+<DT>TYPE<DD>
+Event type -- thread start, stop, or pthread event.
+<DT>DESCRIPTION<DD>
+The thread's name or start address function name.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Thread start and stop events are usually not very frequent, which makes this
+tool's overhead negligible.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/killsnoop.html
+++ b/man/man8/killsnoop.html
@@ -1,0 +1,144 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of killsnoop</TITLE>
+</HEAD><BODY>
+<H1>killsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-08-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+killsnoop - Trace signals issued by the kill() syscall. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>killsnoop [-h] [-x] [-p PID]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+killsnoop traces the kill() syscall, to show signals sent via this method. This
+may be useful to troubleshoot failing applications, where an unknown mechanism
+is sending signals.
+<P>
+This works by tracing the kernel sys_kill() function using dynamic tracing, and
+will need updating to match any changes to this function.
+<P>
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-x<DD>
+Only print failed kill() syscalls.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all kill() syscalls:<DD>
+#
+<B>killsnoop</B>
+
+<DT>Trace only kill() syscalls that failed:<DD>
+#
+<B>killsnoop -x</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>killsnoop -p 181</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the kill call.
+<DT>PID<DD>
+Source process ID
+<DT>COMM<DD>
+Source process name
+<DT>SIG<DD>
+Signal number. See <A HREF="https://iovisor.github.io/bcc?7+signal">signal</A>(7).
+<DT>TPID<DD>
+Target process ID
+<DT>RES<DD>
+Result. 0 == success, a negative value (of the error code) for failure.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel kill function and prints output for each event. As the
+rate of this is generally expected to be low (&lt; 100/s), the overhead is also
+expected to be negligible. If you have an application that is calling a very
+high rate of kill()s for some reason, then test and understand overhead before
+use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+opensnoop">opensnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/klockstat.html
+++ b/man/man8/klockstat.html
@@ -1,0 +1,242 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of klockstat</TITLE>
+</HEAD><BODY>
+<H1>klockstat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2019-10-22<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+klockstat - Traces kernel mutex lock events and display locks statistics. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>klockstat [-h] [-i] [-n] [-s] [-c] [-S FIELDS] [-p] [-t] [-d DURATION]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+klockstat traces kernel mutex lock events and display locks statistics
+and displays following data:
+<P>
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Caller&nbsp;&nbsp;&nbsp;Avg&nbsp;Spin&nbsp;&nbsp;Count&nbsp;&nbsp;&nbsp;Max&nbsp;spin&nbsp;Total&nbsp;spin
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;psi_avgs_work+0x2e&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3675&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;5468&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;18379
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flush_to_ldisc+0x22&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2833&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4210&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;5667
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;n_tty_write+0x30c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3914&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3914&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3914
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;isig+0x5d&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2390&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2390&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2390
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tty_buffer_flush+0x2a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1604&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1604&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1604
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;commit_echoes+0x22&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1400&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1400&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1400
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;n_tty_receive_buf_common+0x3b9&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1399&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1399&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1399
+<P>
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Caller&nbsp;&nbsp;&nbsp;Avg&nbsp;Hold&nbsp;&nbsp;Count&nbsp;&nbsp;&nbsp;Max&nbsp;hold&nbsp;Total&nbsp;hold
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flush_to_ldisc+0x22&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;42558&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;76135&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;85116
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;psi_avgs_work+0x2e&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;14821&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;20446&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;74106
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;n_tty_receive_buf_common+0x3b9&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;12300&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;12300&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;12300
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;n_tty_write+0x30c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;10712&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;10712&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;10712
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;isig+0x5d&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3362&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3362&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3362
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tty_buffer_flush+0x2a&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3078&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3078&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3078
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;commit_echoes+0x22&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3017&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3017&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3017
+<P>
+<P>
+Every caller to using kernel's mutex is displayed on every line.
+<P>
+First portion of lines show the lock acquiring data, showing the
+amount of time it took to acquired given lock.
+<P>
+<BR>&nbsp;&nbsp;'Caller'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;symbol&nbsp;acquiring&nbsp;the&nbsp;mutex
+<BR>&nbsp;&nbsp;'Average&nbsp;Spin'&nbsp;-&nbsp;average&nbsp;time&nbsp;to&nbsp;acquire&nbsp;the&nbsp;mutex
+<BR>&nbsp;&nbsp;'Count'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;number&nbsp;of&nbsp;times&nbsp;mutex&nbsp;was&nbsp;acquired
+<BR>&nbsp;&nbsp;'Max&nbsp;spin'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;maximum&nbsp;time&nbsp;to&nbsp;acquire&nbsp;the&nbsp;mutex
+<BR>&nbsp;&nbsp;'Total&nbsp;spin'&nbsp;&nbsp;&nbsp;-&nbsp;total&nbsp;time&nbsp;spent&nbsp;in&nbsp;acquiring&nbsp;the&nbsp;mutex
+<P>
+Second portion of lines show the lock holding data, showing the
+amount of time it took to hold given lock.
+<P>
+<BR>&nbsp;&nbsp;'Caller'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;symbol&nbsp;holding&nbsp;the&nbsp;mutex
+<BR>&nbsp;&nbsp;'Average&nbsp;Hold'&nbsp;-&nbsp;average&nbsp;time&nbsp;mutex&nbsp;was&nbsp;held
+<BR>&nbsp;&nbsp;'Count'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;number&nbsp;of&nbsp;times&nbsp;mutex&nbsp;was&nbsp;held
+<BR>&nbsp;&nbsp;'Max&nbsp;hold'&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;maximum&nbsp;time&nbsp;mutex&nbsp;was&nbsp;held
+<BR>&nbsp;&nbsp;'Total&nbsp;hold'&nbsp;&nbsp;&nbsp;-&nbsp;total&nbsp;time&nbsp;spent&nbsp;in&nbsp;holding&nbsp;the&nbsp;mutex
+<P>
+This works by tracing mutex_lock/unlock kprobes, updating the
+lock stats in maps and processing them in the python part.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-i SEC<DD>
+print summary at this interval (seconds)
+<DT>-c CALLER<DD>
+print locks taken by given caller filter (e.g., pipe_)
+<DT>-S FIELDS<DD>
+sort data on specific columns defined by FIELDS string (by default the data is sorted by Max columns)
+<P>
+FIELDS string contains 1 or 2 fields describing columns to sort on
+for both acquiring and holding data. Following fields are available:
+<P>
+<BR>&nbsp;&nbsp;acq_max&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;for&nbsp;'Max&nbsp;spin'&nbsp;column
+<BR>&nbsp;&nbsp;acq_total&nbsp;&nbsp;&nbsp;&nbsp;for&nbsp;'Total&nbsp;spin'&nbsp;column
+<BR>&nbsp;&nbsp;acq_count&nbsp;&nbsp;&nbsp;&nbsp;for&nbsp;'Count'&nbsp;column
+<P>
+<BR>&nbsp;&nbsp;hld_max&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;for&nbsp;'Max&nbsp;hold'&nbsp;column
+<BR>&nbsp;&nbsp;hld_total&nbsp;&nbsp;&nbsp;&nbsp;for&nbsp;'Total&nbsp;hold'&nbsp;column
+<BR>&nbsp;&nbsp;hld_count&nbsp;&nbsp;&nbsp;&nbsp;for&nbsp;'Count'&nbsp;column
+<P>
+See EXAMPLES.
+<P>
+<DT>-n COUNT<DD>
+print COUNT number of locks
+<DT>-s COUNT<DD>
+print COUNT number of stack entries
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-t TID<DD>
+Trace this thread ID only (filtered in-kernel).
+<DT>-d DURATION<DD>
+Total duration of trace in seconds.
+<DT>--stack-storage-size STACK_STORAGE_SIZE<DD>
+Change the number of unique stack traces that can be stored and displayed.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Sort lock acquired results on acquired count:<DD>
+#
+<B>klockstat -S acq_count</B>
+
+<P>
+<DT>Sort lock held results on total held time:<DD>
+#
+<B>klockstat -S hld_total</B>
+
+<P>
+<DT>Combination of above:<DD>
+#
+<B>klockstat -S acq_count,hld_total</B>
+
+<P>
+<DT>Trace system wide:<DD>
+#
+<B>klockstat</B>
+
+<P>
+<DT>Trace for 5 seconds only:<DD>
+#
+<B>klockstat -d 5</B>
+
+<P>
+<DT>Display stats every 5 seconds<DD>
+#
+<B>klockstat -i 5</B>
+
+<P>
+<DT>Trace locks for PID 123:<DD>
+#
+<B>klockstat -p 123</B>
+
+<P>
+<DT>Trace locks for PID 321:<DD>
+#
+<B>klockstat -t 321</B>
+
+<P>
+<DT>Display stats only for lock callers with 'pipe_' substring<DD>
+#
+<B>klockstat -c pipe_</B>
+
+<P>
+<DT>Display 3 locks:<DD>
+#
+<B>klockstat -n 3</B>
+
+<P>
+<DT>Display 10 levels of stack for the most expensive lock:<DD>
+#
+<B>klockstat -n 1 -s 10</B>
+
+<P>
+Tracing lock events... Hit Ctrl-C to end.
+^C
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Caller&nbsp;&nbsp;&nbsp;Avg&nbsp;Spin&nbsp;&nbsp;Count&nbsp;&nbsp;&nbsp;Max&nbsp;spin&nbsp;Total&nbsp;spin
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pipe_wait+0xa9&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;670&nbsp;397691&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;17273&nbsp;&nbsp;266775437
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pipe_wait+0xa9
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pipe_read+0x206
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;new_sync_read+0x12a
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vfs_read+0x9d
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ksys_read+0x5f
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;do_syscall_64+0x5b
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;entry_SYSCALL_64_after_hwframe+0x44
+<P>
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Caller&nbsp;&nbsp;&nbsp;Avg&nbsp;Hold&nbsp;&nbsp;Count&nbsp;&nbsp;&nbsp;Max&nbsp;hold&nbsp;Total&nbsp;hold
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flush_to_ldisc+0x22&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;28381&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;65484&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;85144
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flush_to_ldisc+0x22
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;process_one_work+0x1b0
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;worker_thread+0x50
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;kthread+0xfb
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ret_from_fork+0x35
+<P>
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAI">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAJ">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAK">&nbsp;</A>
+<H2>CREDITS</H2>
+
+This tool is based on work of David Valin &lt;<A HREF="mailto:dvalin@redhat.com">dvalin@redhat.com</A>&gt; and his script.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Jiri Olsa
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">SOURCE</A><DD>
+<DT><A HREF="#lbAI">OS</A><DD>
+<DT><A HREF="#lbAJ">STABILITY</A><DD>
+<DT><A HREF="#lbAK">CREDITS</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/llcstat.html
+++ b/man/man8/llcstat.html
@@ -1,0 +1,134 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of llcstat</TITLE>
+</HEAD><BODY>
+<H1>llcstat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-08-18<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+llcstat - Summarize CPU cache references and misses by process. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>llcstat [-h] [-c SAMPLE_PERIOD] [duration]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+llcstat instruments CPU cache references and cache misses system-side, and
+summarizes them by PID and CPU. These events have different meanings on
+different architecture. For x86-64, they mean misses and references to LLC.
+This can be useful to locate and debug performance issues
+caused by cache hit rate.
+<P>
+This works by sampling corresponding events defined in uapi/linux/perf_event.h,
+namely PERF_COUNT_HW_CACHE_REFERENCES and PERF_COUNT_HW_CACHE_MISSES, using
+BPF perf event tracing. Upon each sampled event, the attached BPF program
+records the PID and CPU ID on which the event happened, and stores it in table.
+<P>
+This makes use of a Linux 4.9 feature (BPF_PROG_TYPE_PERF_EVENT).
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-c SAMPLE_PERIOD<DD>
+Sample one in this many cache reference and cache miss events.
+<DT>duration<DD>
+Duration to trace, in seconds.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Sample one in 100 events, trace for 20 seconds:<DD>
+#
+<B>llcstat -c 100 20</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>PID<DD>
+Process ID
+<DT>NAME<DD>
+Process name
+<DT>CPU<DD>
+CPU ID
+<DT>REFERENCE<DD>
+Number of cache reference events
+<DT>MISS<DD>
+Number of cache miss events
+<DT>HIT%<DD>
+Cache hit ratio
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Teng Qin
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<DL COMPACT>
+<DT>Perf can be used as a generic event counter tool. An example for LLC:<DD>
+#
+<B>perf top -e cache-misses -e cache-references -a -ns pid,cpu,comm</B>
+
+<P>
+</DL>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/mdflush.html
+++ b/man/man8/mdflush.html
@@ -1,0 +1,118 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of pidpersec</TITLE>
+</HEAD><BODY>
+<H1>pidpersec</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-13<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+mdflush - Trace md flush events. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>mdflush</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces flush events by md, the Linux multiple device driver
+(software RAID). The timestamp and md device for the flush are printed.
+Knowing when these flushes happen can be useful for correlation with
+unexplained spikes in disk latency.
+<P>
+This works by tracing the kernel md_flush_request() function using dynamic
+tracing, and will need updating to match any changes to this function.
+<P>
+Note that the flushes themselves are likely to originate from higher in the
+I/O stack, such as from the file systems.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace md flush events:<DD>
+#
+<B>mdflush</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the flush event (HH:MM:SS).
+<DT>PID<DD>
+The process ID that was on-CPU when the event was issued. This may identify
+the cause of the flush (eg, the &quot;sync&quot; command), but will often identify a
+kernel worker thread that was managing I/O.
+<DT>COMM<DD>
+The command name for the PID.
+<DT>DEVICE<DD>
+The md device name.
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Expected to be negligible.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">FIELDS</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/memleak.html
+++ b/man/man8/memleak.html
@@ -1,0 +1,185 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of memleak</TITLE>
+</HEAD><BODY>
+<H1>memleak</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-01-14<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+memleak - Print a summary of outstanding allocations and their call stacks to detect memory leaks. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>memleak [-h] [-p PID] [-t] [-a] [-o OLDER] [-c COMMAND] [--combined-only]</B>
+
+[-s SAMPLE_RATE] [-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE] [-O OBJ] [INTERVAL]
+[COUNT]
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+memleak traces and matches memory allocation and deallocation requests, and
+collects call stacks for each allocation. memleak can then print a summary
+of which call stacks performed allocations that weren't subsequently freed.
+<P>
+When tracing a specific process, memleak instruments a list of allocation
+functions from libc, specifically: malloc, calloc, realloc, posix_memalign,
+valloc, memalign, pvalloc, aligned_alloc, and free.
+When tracing all processes, memleak instruments kmalloc/kfree,
+kmem_cache_alloc/kmem_cache_free, and also page allocations made by
+get_free_pages/free_pages.
+<P>
+memleak may introduce significant overhead when tracing processes that allocate
+and free many blocks very quickly. See the OVERHEAD section below.
+<P>
+This tool only works on Linux 4.6+. Stack traces are obtained using the new BPF_STACK_TRACE` APIs.
+For kernels older than 4.6, see the version under tools/old.
+Kernel memory allocations are intercepted through tracepoints, which are
+available on Linux 4.7+.
+<P>
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel). This traces libc allocator.
+<DT>-t<DD>
+Print a trace of all allocation and free requests and results.
+<DT>-a<DD>
+Print a list of allocations that weren't freed (and their sizes) in addition to their call stacks.
+<DT>-o OLDER<DD>
+Print only allocations older than OLDER milliseconds. Useful to remove false positives.
+The default value is 500 milliseconds.
+<DT>-c COMMAND<DD>
+Run the specified command and trace its allocations only. This traces libc allocator.
+<DT>--combined-only<DD>
+Use statistics precalculated in kernel space. Amount of data to be pulled from
+kernel significantly decreases, at the cost of losing capabilities of time-based
+false positives filtering (-o).
+<DT>-s SAMPLE_RATE<DD>
+Record roughly every SAMPLE_RATE-th allocation to reduce overhead.
+<DT>-t TOP<DD>
+Print only the top TOP stacks (sorted by size).
+The default value is 10.
+<DT>-z MIN_SIZE<DD>
+Capture only allocations that are larger than or equal to MIN_SIZE bytes.
+<DT>-Z MAX_SIZE<DD>
+Capture only allocations that are smaller than or equal to MAX_SIZE bytes.
+<DT>-O OBJ<DD>
+Attach to allocation functions in specified object instead of resolving libc. Ignored when kernel allocations are profiled.
+<DT>INTERVAL<DD>
+Print a summary of outstanding allocations and their call stacks every INTERVAL seconds.
+The default interval is 5 seconds.
+<DT>COUNT<DD>
+Print the outstanding allocations summary COUNT times and then exit.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Print outstanding kernel allocation stacks every 3 seconds:<DD>
+#
+<B>memleak 3</B>
+
+<DT>Print user outstanding allocation stacks and allocation details for the process 1005:<DD>
+#
+<B>memleak -p 1005 -a</B>
+
+<DT>Sample roughly every 5th allocation (~20%) of the call stacks and print the top 5<DD>
+stacks 10 times before quitting.
+#
+<B>memleak -s 5 --top=5 10</B>
+
+<DT>Run ./allocs and print outstanding allocation stacks for that process: <DD>
+#
+<B>memleak -c ./allocs</B>
+
+<DT>Capture only allocations between 16 and 32 bytes in size:<DD>
+#
+<B>memleak -z 16 -Z 32</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+memleak can have significant overhead if the target process or kernel performs
+allocations at a very high rate. Pathological cases may exhibit up to 100x
+degradation in running time. Most of the time, however, memleak shouldn't cause
+a significant slowdown. You can use the -s switch to reduce the overhead
+further by capturing only every N-th allocation. The -z and -Z switches can
+also reduce overhead by capturing only allocations of specific sizes.
+<P>
+Additionally, option --combined-only saves processing time by reusing already
+calculated allocation statistics from kernel. It's faster, but lacks information
+about particular allocations.
+<P>
+To determine the rate at which your application is calling malloc/free, or the
+rate at which your kernel is calling kmalloc/kfree, place a probe with perf and
+collect statistics. For example, to determine how many calls to __kmalloc are
+placed in a typical period of 10 seconds:
+<P>
+#
+<B>perf probe '__kmalloc'</B>
+
+<P>
+#
+<B>perf stat -a -e 'probe:__kmalloc' -- sleep 10</B>
+
+<P>
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/mountsnoop.html
+++ b/man/man8/mountsnoop.html
@@ -1,0 +1,110 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of mountsnoop</TITLE>
+</HEAD><BODY>
+<H1>mountsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-10-14<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+mountsnoop - Trace mount() and umount() syscalls. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>mountsnoop</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+mountsnoop traces the mount() and umount() syscalls, showing which processes
+are mounting and unmounting filesystems in what mount namespaces. This can be
+useful for troubleshooting system and container setup.
+<P>
+This works by tracing the kernel sys_mount() and sys_umount() functions using
+dynamic tracing, and will need updating to match any changes to this function.
+<P>
+This makes use of a Linux 4.8 feature (bpf_get_current_task()).
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>COMM<DD>
+Process name
+<DT>PID<DD>
+Process ID
+<DT>TID<DD>
+Thread ID
+<DT>MNT_NS<DD>
+Mount namespace inode number
+<DT>CALL<DD>
+System call, arguments, and return value
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel mount and umount functions and prints output for each
+event. As the rate of these calls is generally expected to be very low, the
+overhead is also expected to be negligible. If your system calls mount() and
+umount() at a high rate, then test and understand overhead before use.
+<A NAME="lbAH">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAI">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAJ">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAK">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Omar Sandoval
+<A NAME="lbAL">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?2+mount">mount</A>(2)
+<A HREF="https://iovisor.github.io/bcc?2+umount">umount</A>(2)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">FIELDS</A><DD>
+<DT><A HREF="#lbAG">OVERHEAD</A><DD>
+<DT><A HREF="#lbAH">SOURCE</A><DD>
+<DT><A HREF="#lbAI">OS</A><DD>
+<DT><A HREF="#lbAJ">STABILITY</A><DD>
+<DT><A HREF="#lbAK">AUTHOR</A><DD>
+<DT><A HREF="#lbAL">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/mysqld_qslower.html
+++ b/man/man8/mysqld_qslower.html
@@ -1,0 +1,131 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of mysqld_qslower</TITLE>
+</HEAD><BODY>
+<H1>mysqld_qslower</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-08-01<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+mysqld_qslower - Trace MySQL server queries slower than a threshold.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>mysqld_qslower PID [min_ms]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces queries served by a MySQL server, and prints those that exceed a
+custom latency (query duration) threshold. By default, a minimum threshold of 1
+millisecond is used. If a threshold of 0 is used, all queries are printed.
+<P>
+This uses User Statically-Defined Tracing (USDT) probes, a feature added to
+MySQL for DTrace support, but which may not be enabled on a given MySQL
+installation. See requirements.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF, bcc, and MySQL server with USDT probe support (when configuring
+the build: -DENABLE_DTRACE=1).
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+PID
+Trace this mysqld PID.
+<DL COMPACT>
+<DT>min_ms<DD>
+Minimum query latency (duration) to trace, in milliseconds. Default is 1 ms.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace MySQL server queries slower than 1 ms for PID 1981:<DD>
+#
+<B>mysqld_qslower 1981</B>
+
+<DT>Trace slower than 10 ms for PID 1981:<DD>
+#
+<B>mysqld_qslower 1981 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of query start, in seconds.
+<DT>PID<DD>
+Process ID of the traced server.
+<DT>MS<DD>
+Milliseconds for the query, from start to end.
+<DT>QUERY<DD>
+Query string, truncated to 128 characters.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to MySQL queries, and only emits output
+data from kernel to user-level if they query exceeds the threshold. If the
+server query rate is less than 1,000/sec, the overhead is expected to be
+negligible. If the query rate is higher, test to gauge overhead.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/nfsdist.html
+++ b/man/man8/nfsdist.html
@@ -1,0 +1,142 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of nfsdist</TITLE>
+</HEAD><BODY>
+<H1>nfsdist</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2017-09-08<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+nfsdist - Summarize NFS operation latency. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>nfsdist [-h] [-T] [-m] [-p PID] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes time (latency) spent in common NFS file operations: reads,
+writes, opens, and getattrs, and presents it as a power-of-2 histogram. It uses an
+in-kernel eBPF map to store the histogram for efficiency.
+<P>
+Since this works by tracing the nfs_file_operations interface functions, it
+will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Don't include timestamps on interval output.
+<DT>-m<DD>
+Output in milliseconds.
+<DT>-p PID<DD>
+Trace this PID only.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace NFS operation time, and print a summary on Ctrl-C:<DD>
+#
+<B>nfsdist</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>nfsdist -p 181</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>nfsdist 1 10</B>
+
+<DT>1 second summaries, printed in milliseconds<DD>
+#
+<B>nfsdist -m 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>msecs<DD>
+Range of milliseconds for this bucket.
+<DT>usecs<DD>
+Range of microseconds for this bucket.
+<DT>count<DD>
+Number of operations in this time range.
+<DT>distribution<DD>
+ASCII representation of the distribution (the count column).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to these NFS operations,
+including reads and writes from the file system cache. Such reads and writes
+can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool may become noticeable.
+Measure and quantify before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Samuel Nair
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+nfsslower">nfsslower</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/nfsslower.html
+++ b/man/man8/nfsslower.html
@@ -1,0 +1,180 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of nfsslower</TITLE>
+</HEAD><BODY>
+<H1>nfsslower</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2017-09-01<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+nfsslower - Trace slow NFS file operations, with per-event details.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>nfsslower [-h] [-j] [-p PID] [min_ms]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces common NFSv3 &amp; NFSv4 file operations: reads, writes, opens, and
+getattrs. It measures the time spent in these operations, and prints details
+for each that exceeded a threshold.
+<P>
+WARNING: See the OVERHEAD section.
+<P>
+By default, a minimum millisecond threshold of 10 is used. If a threshold of 0
+is used, all events are printed (warning: verbose).
+<P>
+Since this works by tracing the nfs_file_operations interface functions, it
+will need updating to match any changes to these functions.
+<P>
+This tool uses kprobes to instrument the kernel for entry and exit
+information, in the future a preferred way would be to use tracepoints.
+Currently there aren't any tracepoints available for nfs_read_file,
+nfs_write_file and nfs_open_file, nfs_getattr does have entry and exit
+tracepoints but we chose to use kprobes for consistency
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-p PID
+Trace this PID only.
+<DL COMPACT>
+<DT>-j<DD>
+Trace output in CSV format.
+<DT>min_ms<DD>
+Minimum I/O latency (duration) to trace, in milliseconds. Default is 10 ms.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace synchronous file reads and writes slower than 10 ms:<DD>
+#
+<B>nfsslower</B>
+
+<DT>Trace slower than 1 ms:<DD>
+#
+<B>nfsslower 1</B>
+
+<DT>Trace slower than 1 ms, and output just the fields in parsable format (CSV):<DD>
+#
+<B>nfsslower -j 1</B>
+
+<DT>Trace all file reads and writes (warning: the output will be verbose):<DD>
+#
+<B>nfsslower 0</B>
+
+<DT>Trace slower than 1 ms, for PID 181 only:<DD>
+#
+<B>nfsslower -p 181 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of I/O completion since the first I/O seen, in seconds.
+<DT>COMM<DD>
+Process name.
+<DT>PID<DD>
+Process ID.
+<DT>T<DD>
+Type of operation. R == read, W == write, O == open, G == getattr.
+<DT>OFF_KB<DD>
+File offset for the I/O, in Kbytes.
+<DT>BYTES<DD>
+Size of I/O, in bytes.
+<DT>LAT(ms)<DD>
+Latency (duration) of I/O, measured from when it was issued by VFS to the
+filesystem, to when it completed. This time is inclusive of RPC latency,
+network latency, cache lookup, remote fileserver processing latency, etc. 
+Its a more accurate measure of the latency suffered by applications performing
+NFS read/write calls to a fileserver.
+<DT>FILENAME<DD>
+A cached kernel file name (comes from dentry-&gt;d_name.name).
+<DT>ENDTIME_us<DD>
+Completion timestamp, microseconds (-j only).
+<DT>OFFSET_b<DD>
+File offset, bytes (-j only).
+<DT>LATENCY_us<DD>
+Latency (duration) of the I/O, in microseconds (-j only).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to NFS operations,
+including reads and writes from the file system cache. Such read, writes and
+particularly getattrs can be very frequent (depending on the workload; eg, 1M/sec),
+at which point the overhead of this tool (even if it prints no &quot;slower&quot; events) can
+begin to become significant. Measure and quantify before use. If this
+continues to be a problem, consider switching to a tool that prints in-kernel
+summaries only. This tool has been tested with NFSv3 &amp; NVSv4, but it might work
+with NFSv{1,2}, since it is tracing the generic functions from nfs_file_operations.
+<P>
+
+Note that the overhead of this tool should be less than <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8), as
+this tool targets NFS functions only, and not all file read/write paths.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion nfsslower_examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Samuel Nair
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/nodegc.html
+++ b/man/man8/nodegc.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ugc</TITLE>
+</HEAD><BODY>
+<H1>ugc</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ugc, javagc, nodegc, pythongc, rubygc - Trace garbage collection events in
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javagc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>nodegc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>pythongc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>rubygc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>ugc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] [-l {java,node,python,ruby}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces garbage collection events as they occur, including their duration
+and any additional information (such as generation collected or type of GC)
+provided by the respective language's runtime.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Python, and Ruby. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds. The default is microseconds.
+<DT>-M MINIMUM<DD>
+Display only collections that are longer than this threshold. The value is
+given in milliseconds. The default is to display all collections.
+<DT>-F FILTER<DD>
+Display only collections whose textual description matches (contains) this
+string. The default is to display all collections. Note that the filtering here
+is performed in user-space, and not as part of the BPF program. This means that
+if you have thousands of collection events, specifying this filter will not
+reduce the amount of data that has to be transferred from the BPF program to
+the user-space script.
+<DT>{java,node,python,ruby}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace garbage collections in a specific Node process:<DD>
+#
+<B>ugc node 148</B>
+
+<DT>Trace garbage collections in a specific Java process, and print GC times in<DD>
+milliseconds:
+#
+<B>ugc -m java 6004</B>
+
+<DT>Trace garbage collections in a specific Java process, and display them only if<DD>
+they are longer than 10ms and have the string &quot;Tenured&quot; in their detailed
+description:
+#
+<B>ugc -M 10 -F Tenured java 6004</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>START<DD>
+The start time of the GC, in seconds from the beginning of the trace.
+<DT>TIME<DD>
+The duration of the garbage collection event.
+<DT>DESCRIPTION<DD>
+The runtime-provided description of this garbage collection event.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Garbage collection events, even if frequent, should not produce a considerable
+overhead when traced because they are still not very common. Even hundreds of 
+GCs per second (which is a very high rate) will still produce a fairly 
+negligible overhead.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+uobjnew">uobjnew</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/nodestat.html
+++ b/man/man8/nodestat.html
@@ -1,0 +1,201 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ustat</TITLE>
+</HEAD><BODY>
+<H1>ustat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ustat, javastat, nodestat, perlstat, phpstat, pythonstat, rubystat, tclstat - Activity stats from
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javastat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>nodestat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>perlstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>phpstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>pythonstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>rubystat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>tclstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>ustat [-l {java,node,perl,php,python,ruby,tcl}] [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is &quot;top&quot; for high-level language events, such as garbage collections,
+exceptions, thread creations, object allocations, method calls, and more. The
+events are aggregated for each process and printed in a top-like table, which
+can be sorted by various fields. Not all language runtimes provide the same
+set of details.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with
+these probes, which in some cases requires building from source with a
+USDT-specific flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java,
+some probes are not enabled by default, and can be turned on by running the Java
+process with the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Newly-created processes will only be traced at the next interval. If you run
+this tool with a short interval (say, 1-5 seconds), this should be virtually
+unnoticeable. For longer intervals, you might miss processes that were started
+and terminated during the interval window.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,node,perl,php,python,ruby,tcl}<DD>
+The language to trace. By default, all languages are traced.
+<DT>-C<DD>
+Do not clear the screen between updates.
+<DT>-S {cload,excp,gc,method,objnew,thread}<DD>
+Sort the output by the specified field.
+<DT>-r MAXROWS<DD>
+Do not print more than this number of rows.
+<DT>-d<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize activity in high-level languages, 1 second refresh:<DD>
+#
+<B>ustat</B>
+
+<DT>Don't clear the screen, and top 8 rows only:<DD>
+#
+<B>ustat -Cr 8</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>ustat 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Process ID.
+<DT>CMDLINE<DD>
+Process command line (often the second and following arguments will give you a
+hint as to which application is being run.
+<DT>METHOD/s<DD>
+Count of method invocations during interval.
+<DT>GC/s<DD>
+Count of garbage collections during interval.
+<DT>OBJNEW/s<DD>
+Count of objects allocated during interval.
+<DT>CLOAD/s<DD>
+Count of classes loaded during interval.
+<DT>EXC/s<DD>
+Count of exceptions thrown during interval.
+<DT>THR/s<DD>
+Count of threads created during interval.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+When using this tool with high-frequency events, such as method calls, a very
+significant slow-down can be expected. However, many of the high-level
+languages covered by this tool already have a fairly high per-method invocation
+cost, especially when running in interpreted mode. For the lower-frequency
+events, such as garbage collections or thread creations, the overhead should
+not be significant. Specifically, when probing Java processes and not using the
+&quot;-XX:+ExtendedDTraceProbes&quot; flag, the most expensive probes are not emitted,
+and the overhead should be acceptable.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tplist">tplist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/offcputime.html
+++ b/man/man8/offcputime.html
@@ -1,0 +1,169 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of offcputime</TITLE>
+</HEAD><BODY>
+<H1>offcputime</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-01-14<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+offcputime - Summarize off-CPU time by kernel stack trace. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>offcputime [-h] [-p PID | -t TID | -u | -k] [-U | -K] [-d] [-f] [--stack-storage-size STACK_STORAGE_SIZE] [-m MIN_BLOCK_TIME] [-M MAX_BLOCK_TIME] [--state STATE] [duration]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This program shows stack traces and task names that were blocked and &quot;off-CPU&quot;,
+and the total duration they were not running: their &quot;off-CPU time&quot;.
+It works by tracing when threads block and when they return to CPU, measuring
+both the time they were off-CPU and the blocked stack trace and the task name.
+This data is summarized in the kernel using an eBPF map, and by summing the
+off-CPU time by unique stack trace and task name.
+<P>
+The output summary will help you identify reasons why threads were blocking,
+and quantify the time they were off-CPU. This spans all types of blocking
+activity: disk I/O, network I/O, locks, page faults, involuntary context
+switches, etc.
+<P>
+This is complementary to CPU profiling (e.g., CPU flame graphs) which shows
+the time spent on-CPU. This shows the time spent off-CPU, and the output,
+especially the -f format, can be used to generate an &quot;off-CPU time flame graph&quot;.
+<P>
+See <A HREF="http://www.brendangregg.com/FlameGraphs/offcpuflamegraphs.html">http://www.brendangregg.com/FlameGraphs/offcpuflamegraphs.html</A>
+<P>
+This tool only works on Linux 4.6+. It uses the new `BPF_STACK_TRACE` table
+APIs to generate the in-kernel stack traces.
+For kernels older than 4.6, see the version under tools/old.
+<P>
+Note: this tool only traces off-CPU times that began and ended while tracing.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-t TID<DD>
+Trace this thread ID only (filtered in-kernel).
+<DT>-u<DD>
+Only trace user threads (no kernel threads).
+<DT>-k<DD>
+Only trace kernel threads (no user threads).
+<DT>-U<DD>
+Show stacks from user space only (no kernel space stacks).
+<DT>-K<DD>
+Show stacks from kernel space only (no user space stacks).
+<DT>-d<DD>
+Insert delimiter between kernel/user stacks.
+<DT>-f<DD>
+Print output in folded stack format.
+<DT>--stack-storage-size STACK_STORAGE_SIZE<DD>
+Change the number of unique stack traces that can be stored and displayed.
+<DT>-m MIN_BLOCK_TIME<DD>
+The minimum time in microseconds over which we store traces (default 1)
+<DT>-M MAX_BLOCK_TIME<DD>
+The maximum time in microseconds under which we store traces (default U64_MAX)
+<DT>--state<DD>
+Filter on this thread state bitmask (eg, 2 == TASK_UNINTERRUPTIBLE).
+See include/linux/sched.h for states.
+<DT>duration<DD>
+Duration to trace, in seconds.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all thread blocking events, and summarize (in-kernel) by kernel stack trace and total off-CPU time:<DD>
+#
+<B>offcputime</B>
+
+<DT>Trace for 5 seconds only:<DD>
+#
+<B>offcputime 5</B>
+
+<DT>Trace for 5 seconds, and emit output in folded stack format (suitable for flame graphs):<DD>
+#
+<B>offcputime -f 5</B>
+
+<DT>Trace PID 185 only:<DD>
+#
+<B>offcputime -p 185</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This summarizes unique stack traces in-kernel for efficiency, allowing it to
+trace a higher rate of events than methods that post-process in user space. The
+stack trace and time data is only copied to user space once, when the output is
+printed. While these techniques greatly lower overhead, scheduler events are
+still a high frequency event, as they can exceed 1 million events per second,
+and so caution should still be used. Test before production use.
+<P>
+If the overhead is still a problem, take a look at the MINBLOCK_US tunable in
+the code. If your aim is to chase down longer blocking events, then this could
+be increased to filter shorter blocking events, further lowering overhead.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+stackcount">stackcount</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/offwaketime.html
+++ b/man/man8/offwaketime.html
@@ -1,0 +1,162 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of offwaketime</TITLE>
+</HEAD><BODY>
+<H1>offwaketime</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-01-30<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+offwaketime - Summarize blocked time by off-CPU stack + waker stack. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>offwaketime [-h] [-p PID | -t TID | -u | -k] [-U | -K] [-f] [--stack-storage-size STACK_STORAGE_SIZE] [-m MIN_BLOCK_TIME] [-M MAX_BLOCK_TIME] [duration]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This program shows kernel stack traces and task names that were blocked and
+&quot;off-CPU&quot;, along with the stack traces and task names for the threads that woke
+them, and the total elapsed time from when they blocked to when they were woken
+up.  This combines the summaries from both the offcputime and wakeuptime tools.
+The time measurement will be very similar to off-CPU time, however, off-CPU time
+may include a little extra time spent waiting on a run queue to be scheduled.
+The combined stacks, task names, and total time is summarized in kernel context
+for efficiency, using an eBPF map.
+<P>
+The output summary will further help you identify reasons why threads
+were blocking, and quantify the time from when they were blocked to woken up.
+This spans all types of blocking activity: disk I/O, network I/O, locks, page
+faults, swapping, sleeping, involuntary context switches, etc.
+<P>
+This is complementary to CPU profiling (e.g., CPU flame graphs) which shows
+the time spent on-CPU. This shows the time spent blocked off-CPU, and the
+output, especially the -f format, can be used to generate an &quot;off-wake time
+flame graph&quot;.
+<P>
+See <A HREF="http://www.brendangregg.com/FlameGraphs/offcpuflamegraphs.html">http://www.brendangregg.com/FlameGraphs/offcpuflamegraphs.html</A>
+<P>
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-f<DD>
+Print output in folded stack format.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-t TID<DD>
+Trace this thread ID only (filtered in-kernel).
+<DT>-u<DD>
+Only trace user threads (no kernel threads).
+<DT>-k<DD>
+Only trace kernel threads (no user threads).
+<DT>-U<DD>
+Show stacks from user space only (no kernel space stacks).
+<DT>-K<DD>
+Show stacks from kernel space only (no user space stacks).
+<DT>--stack-storage-size STACK_STORAGE_SIZE<DD>
+Change the number of unique stack traces that can be stored and displayed.
+<DT>duration<DD>
+Duration to trace, in seconds.
+<DT>-m MIN_BLOCK_TIME<DD>
+The amount of time in microseconds over which we store traces (default 1)
+<DT>-M MAX_BLOCK_TIME<DD>
+The amount of time in microseconds under which we store traces (default U64_MAX)
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all thread blocking events, and summarize (in-kernel) by user and kernel off-CPU stack trace, waker stack traces, task names, and total blocked time:<DD>
+#
+<B>offwaketime</B>
+
+<DT>Trace for 5 seconds only:<DD>
+#
+<B>offwaketime 5</B>
+
+<DT>Trace for 5 seconds, and emit output in folded stack format (suitable for flame graphs), user-mode threads only:<DD>
+#
+<B>offwaketime -fu 5</B>
+
+<DT>Trace PID 185 only:<DD>
+#
+<B>offwaketime -p 185</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This summarizes unique stack trace pairs in-kernel for efficiency, allowing it
+to trace a higher rate of events than methods that post-process in user space.
+The stack trace and time data is only copied to user space once, when the output
+is printed. While these techniques greatly lower overhead, scheduler events are
+still a high frequency event, as they can exceed 1 million events per second,
+and so caution should still be used. Test before production use.
+<P>
+If the overhead is still a problem, take a look at the min block option.
+If your aim is to chase down longer blocking events, then this could
+be increased to filter shorter blocking events, further lowering overhead.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+offcputime">offcputime</A>(8), <A HREF="https://iovisor.github.io/bcc?8+wakeuptime">wakeuptime</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/oomkill.html
+++ b/man/man8/oomkill.html
@@ -1,0 +1,117 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of oomkill</TITLE>
+</HEAD><BODY>
+<H1>oomkill</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+oomkill - Trace oom_kill_process(). Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>oomkill</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces the kernel out-of-memory killer, and prints basic details,
+including the system load averages at the time of the OOM kill. This can
+provide more context on the system state at the time: was it getting busier
+or steady, based on the load averages? This tool may also be useful to
+customize for investigations; for example, by adding other task_struct
+details at the time of OOM.
+<P>
+This program is also a basic example of eBPF/bcc.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace OOM kill events:<DD>
+#
+<B>oomkill</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>Triggered by ...<DD>
+The process ID and process name of the task that was running when another task was OOM
+killed.
+<DT>OOM kill of ...<DD>
+The process ID and name of the target process that was OOM killed.
+<DT>loadavg<DD>
+Contents of /proc/loadavg. The first three numbers are 1, 5, and 15 minute
+load averages (where the average is an exponentially damped moving sum, and
+those numbers are constants in the equation); then there is the number of
+running tasks, a slash, and the total number of tasks; and then the last number
+is the last PID to be created.
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Negligible.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+memleak">memleak</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">FIELDS</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/opensnoop.html
+++ b/man/man8/opensnoop.html
@@ -1,0 +1,202 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of opensnoop</TITLE>
+</HEAD><BODY>
+<H1>opensnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2020-02-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+opensnoop - Trace open() syscalls. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>opensnoop.py [-h] [-T] [-U] [-x] [-p PID] [-t TID] [-u UID]</B>
+
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-d&nbsp;DURATION]&nbsp;[-n&nbsp;NAME]&nbsp;[-e]&nbsp;[-f&nbsp;FLAG_FILTER]
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[--cgroupmap&nbsp;MAPPATH]
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+opensnoop traces the open() syscall, showing which processes are attempting
+to open which files. This can be useful for determining the location of config
+and log files, or for troubleshooting applications that are failing, specially
+on startup.
+<P>
+This works by tracing the kernel sys_open() function using dynamic tracing, and
+will need updating to match any changes to this function.
+<P>
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include a timestamp column.
+<DT>-U<DD>
+Show UID.
+<DT>-x<DD>
+Only print failed opens.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-t TID<DD>
+Trace this thread ID only (filtered in-kernel).
+<DT>-u UID<DD>
+Trace this UID only (filtered in-kernel).
+<DT>-d DURATION<DD>
+Total duration of trace in seconds.
+<DT>-n name<DD>
+Only print processes where its name partially matches 'name'
+<DT>-e<DD>
+Show extended fields.
+<DT>-f FLAG<DD>
+Filter on open() flags, e.g., O_WRONLY.
+<DT>--cgroupmap MAPPATH<DD>
+Trace cgroups in this BPF map only (filtered in-kernel).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all open() syscalls:<DD>
+#
+<B>opensnoop</B>
+
+<DT>Trace all open() syscalls, for 10 seconds only:<DD>
+#
+<B>opensnoop -d 10</B>
+
+<DT>Trace all open() syscalls, and include timestamps:<DD>
+#
+<B>opensnoop -T</B>
+
+<DT>Show UID:<DD>
+#
+<B>opensnoop -U</B>
+
+<DT>Trace only open() syscalls that failed:<DD>
+#
+<B>opensnoop -x</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>opensnoop -p 181</B>
+
+<DT>Trace UID 1000 only:<DD>
+#
+<B>opensnoop -u 1000</B>
+
+<DT>Trace all open() syscalls from processes where its name partially matches 'ed':<DD>
+#
+<B>opensnoop -n ed</B>
+
+<DT>Show extended fields:<DD>
+#
+<B>opensnoop -e</B>
+
+<DT>Only print calls for writing:<DD>
+#
+<B>opensnoop -f O_WRONLY -f O_RDWR</B>
+
+<DT>Trace a set of cgroups only (see filtering_by_cgroups.md from bcc sources for more details):<DD>
+#
+<B>opensnoop --cgroupmap /sys/fs/bpf/test01</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of the call, in seconds.
+<DT>UID<DD>
+User ID
+<DT>PID<DD>
+Process ID
+<DT>TID<DD>
+Thread ID
+<DT>COMM<DD>
+Process name
+<DT>FD<DD>
+File descriptor (if success), or -1 (if failed)
+<DT>ERR<DD>
+Error number (see the system's errno.h)
+<DT>FLAGS<DD>
+Flags passed to <A HREF="https://iovisor.github.io/bcc?2+open">open</A>(2), in octal
+<DT>PATH<DD>
+Open path
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel open function and prints output for each event. As the
+rate of this is generally expected to be low (&lt; 1000/s), the overhead is also
+expected to be negligible. If you have an application that is calling a high
+rate of open()s, then test and understand overhead before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+execsnoop">execsnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?1+funccount">funccount</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/perlcalls.html
+++ b/man/man8/perlcalls.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ucalls</TITLE>
+</HEAD><BODY>
+<H1>ucalls</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ucalls, javacalls, perlcalls, phpcalls, pythoncalls, rubycalls, tclcalls - Summarize method calls
+from high-level languages and Linux syscalls.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javacalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>perlcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>phpcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>pythoncalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>rubycalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>tclcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>ucalls [-l {java,perl,php,python,ruby}] [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes method calls from high-level languages such as Java, Perl,
+PHP, Python, Ruby, and Tcl. It can also trace Linux system calls. Whenever a method
+is invoked, ucalls records the call count and optionally the method's execution
+time (latency) and displays a summary.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, method probes are
+not enabled by default, and can be turned on by running the Java process with
+the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the environment
+variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,perl,php,python,ruby,tcl}<DD>
+The language to trace. If not provided, only syscalls are traced (when the -S
+option is used).
+<DT>-T TOP<DD>
+Print only the top methods by frequency or latency.
+<DT>-L<DD>
+Collect method invocation latency (duration).
+<DT>-S<DD>
+Collect Linux syscalls frequency and timing.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds (the default is microseconds).
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Print summary after this number of seconds and then exit. By default, wait for
+Ctrl+C to terminate.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace the top 10 Ruby method calls:<DD>
+#
+<B>ucalls -T 10 -l ruby 1344</B>
+
+<DT>Trace Python method calls and Linux syscalls including latency in milliseconds:<DD>
+#
+<B>ucalls -l python -mL 2020</B>
+
+<DT>Trace only syscalls and print a summary after 10 seconds:<DD>
+#
+<B>ucalls -S 788 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Tracing individual method calls will produce a considerable overhead in all
+high-level languages. For languages with just-in-time compilation, such as
+Java, the overhead can be more considerable than for interpreted languages.
+On the other hand, syscall tracing will typically be tolerable for most
+processes, unless they have a very unusual rate of system calls.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/perlflow.html
+++ b/man/man8/perlflow.html
@@ -1,0 +1,170 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uflow</TITLE>
+</HEAD><BODY>
+<H1>uflow</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uflow, javaflow, perlflow, phpflow, pythonflow, rubyflow, tclflow - Print a flow graph of method
+calls in high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javaflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>perlflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>phpflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>pythonflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>rubyflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>tclflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>uflow [-h] [-M METHOD] [-C CLAZZ] [-v] [-l {java,perl,php,python,ruby,tcl}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uflow traces method calls and prints them in a flow graph that can facilitate
+debugging and diagnostics by following the program's execution (method flow).
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java processes, the
+startup flag &quot;-XX:+ExtendedDTraceProbes&quot; is required. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-M METHOD<DD>
+Print only method calls where the method name begins with this string.
+<DT>-C CLAZZ<DD>
+Print only method calls where the class name begins with this string. The class
+name interpretation strongly depends on the language. For example, in Java use
+&quot;package/subpackage/ClassName&quot; to refer to classes.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{java,perl,php,python,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Follow method flow in a Ruby process:<DD>
+#
+<B>uflow ruby 148</B>
+
+<DT>Follow method flow in a Java process where the class name is java.lang.Thread:<DD>
+#
+<B>uflow -C java/lang/Thread java 1802</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>CPU<DD>
+The CPU number on which the method was invoked. This is useful to easily see
+where the output skips to a different CPU.
+<DT>PID<DD>
+The process id.
+<DT>TID<DD>
+The thread id.
+<DT>TIME<DD>
+The duration of the method call.
+<DT>METHOD<DD>
+The method name.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This tool has extremely high overhead because it prints every method call. For
+some scenarios, you might see lost samples in the output as the tool is unable
+to keep up with the rate of data coming from the kernel. Filtering by class 
+or method prefix can help reduce the amount of data printed, but there is still
+a very high overhead in the collection mechanism. Do not use for performance-
+sensitive production scenarios, and always test first.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/perlstat.html
+++ b/man/man8/perlstat.html
@@ -1,0 +1,201 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ustat</TITLE>
+</HEAD><BODY>
+<H1>ustat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ustat, javastat, nodestat, perlstat, phpstat, pythonstat, rubystat, tclstat - Activity stats from
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javastat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>nodestat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>perlstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>phpstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>pythonstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>rubystat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>tclstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>ustat [-l {java,node,perl,php,python,ruby,tcl}] [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is &quot;top&quot; for high-level language events, such as garbage collections,
+exceptions, thread creations, object allocations, method calls, and more. The
+events are aggregated for each process and printed in a top-like table, which
+can be sorted by various fields. Not all language runtimes provide the same
+set of details.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with
+these probes, which in some cases requires building from source with a
+USDT-specific flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java,
+some probes are not enabled by default, and can be turned on by running the Java
+process with the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Newly-created processes will only be traced at the next interval. If you run
+this tool with a short interval (say, 1-5 seconds), this should be virtually
+unnoticeable. For longer intervals, you might miss processes that were started
+and terminated during the interval window.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,node,perl,php,python,ruby,tcl}<DD>
+The language to trace. By default, all languages are traced.
+<DT>-C<DD>
+Do not clear the screen between updates.
+<DT>-S {cload,excp,gc,method,objnew,thread}<DD>
+Sort the output by the specified field.
+<DT>-r MAXROWS<DD>
+Do not print more than this number of rows.
+<DT>-d<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize activity in high-level languages, 1 second refresh:<DD>
+#
+<B>ustat</B>
+
+<DT>Don't clear the screen, and top 8 rows only:<DD>
+#
+<B>ustat -Cr 8</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>ustat 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Process ID.
+<DT>CMDLINE<DD>
+Process command line (often the second and following arguments will give you a
+hint as to which application is being run.
+<DT>METHOD/s<DD>
+Count of method invocations during interval.
+<DT>GC/s<DD>
+Count of garbage collections during interval.
+<DT>OBJNEW/s<DD>
+Count of objects allocated during interval.
+<DT>CLOAD/s<DD>
+Count of classes loaded during interval.
+<DT>EXC/s<DD>
+Count of exceptions thrown during interval.
+<DT>THR/s<DD>
+Count of threads created during interval.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+When using this tool with high-frequency events, such as method calls, a very
+significant slow-down can be expected. However, many of the high-level
+languages covered by this tool already have a fairly high per-method invocation
+cost, especially when running in interpreted mode. For the lower-frequency
+events, such as garbage collections or thread creations, the overhead should
+not be significant. Specifically, when probing Java processes and not using the
+&quot;-XX:+ExtendedDTraceProbes&quot; flag, the most expensive probes are not emitted,
+and the overhead should be acceptable.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tplist">tplist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/phpcalls.html
+++ b/man/man8/phpcalls.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ucalls</TITLE>
+</HEAD><BODY>
+<H1>ucalls</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ucalls, javacalls, perlcalls, phpcalls, pythoncalls, rubycalls, tclcalls - Summarize method calls
+from high-level languages and Linux syscalls.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javacalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>perlcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>phpcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>pythoncalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>rubycalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>tclcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>ucalls [-l {java,perl,php,python,ruby}] [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes method calls from high-level languages such as Java, Perl,
+PHP, Python, Ruby, and Tcl. It can also trace Linux system calls. Whenever a method
+is invoked, ucalls records the call count and optionally the method's execution
+time (latency) and displays a summary.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, method probes are
+not enabled by default, and can be turned on by running the Java process with
+the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the environment
+variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,perl,php,python,ruby,tcl}<DD>
+The language to trace. If not provided, only syscalls are traced (when the -S
+option is used).
+<DT>-T TOP<DD>
+Print only the top methods by frequency or latency.
+<DT>-L<DD>
+Collect method invocation latency (duration).
+<DT>-S<DD>
+Collect Linux syscalls frequency and timing.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds (the default is microseconds).
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Print summary after this number of seconds and then exit. By default, wait for
+Ctrl+C to terminate.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace the top 10 Ruby method calls:<DD>
+#
+<B>ucalls -T 10 -l ruby 1344</B>
+
+<DT>Trace Python method calls and Linux syscalls including latency in milliseconds:<DD>
+#
+<B>ucalls -l python -mL 2020</B>
+
+<DT>Trace only syscalls and print a summary after 10 seconds:<DD>
+#
+<B>ucalls -S 788 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Tracing individual method calls will produce a considerable overhead in all
+high-level languages. For languages with just-in-time compilation, such as
+Java, the overhead can be more considerable than for interpreted languages.
+On the other hand, syscall tracing will typically be tolerable for most
+processes, unless they have a very unusual rate of system calls.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/phpflow.html
+++ b/man/man8/phpflow.html
@@ -1,0 +1,170 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uflow</TITLE>
+</HEAD><BODY>
+<H1>uflow</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uflow, javaflow, perlflow, phpflow, pythonflow, rubyflow, tclflow - Print a flow graph of method
+calls in high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javaflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>perlflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>phpflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>pythonflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>rubyflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>tclflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>uflow [-h] [-M METHOD] [-C CLAZZ] [-v] [-l {java,perl,php,python,ruby,tcl}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uflow traces method calls and prints them in a flow graph that can facilitate
+debugging and diagnostics by following the program's execution (method flow).
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java processes, the
+startup flag &quot;-XX:+ExtendedDTraceProbes&quot; is required. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-M METHOD<DD>
+Print only method calls where the method name begins with this string.
+<DT>-C CLAZZ<DD>
+Print only method calls where the class name begins with this string. The class
+name interpretation strongly depends on the language. For example, in Java use
+&quot;package/subpackage/ClassName&quot; to refer to classes.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{java,perl,php,python,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Follow method flow in a Ruby process:<DD>
+#
+<B>uflow ruby 148</B>
+
+<DT>Follow method flow in a Java process where the class name is java.lang.Thread:<DD>
+#
+<B>uflow -C java/lang/Thread java 1802</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>CPU<DD>
+The CPU number on which the method was invoked. This is useful to easily see
+where the output skips to a different CPU.
+<DT>PID<DD>
+The process id.
+<DT>TID<DD>
+The thread id.
+<DT>TIME<DD>
+The duration of the method call.
+<DT>METHOD<DD>
+The method name.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This tool has extremely high overhead because it prints every method call. For
+some scenarios, you might see lost samples in the output as the tool is unable
+to keep up with the rate of data coming from the kernel. Filtering by class 
+or method prefix can help reduce the amount of data printed, but there is still
+a very high overhead in the collection mechanism. Do not use for performance-
+sensitive production scenarios, and always test first.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/phpstat.html
+++ b/man/man8/phpstat.html
@@ -1,0 +1,201 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ustat</TITLE>
+</HEAD><BODY>
+<H1>ustat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ustat, javastat, nodestat, perlstat, phpstat, pythonstat, rubystat, tclstat - Activity stats from
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javastat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>nodestat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>perlstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>phpstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>pythonstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>rubystat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>tclstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>ustat [-l {java,node,perl,php,python,ruby,tcl}] [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is &quot;top&quot; for high-level language events, such as garbage collections,
+exceptions, thread creations, object allocations, method calls, and more. The
+events are aggregated for each process and printed in a top-like table, which
+can be sorted by various fields. Not all language runtimes provide the same
+set of details.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with
+these probes, which in some cases requires building from source with a
+USDT-specific flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java,
+some probes are not enabled by default, and can be turned on by running the Java
+process with the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Newly-created processes will only be traced at the next interval. If you run
+this tool with a short interval (say, 1-5 seconds), this should be virtually
+unnoticeable. For longer intervals, you might miss processes that were started
+and terminated during the interval window.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,node,perl,php,python,ruby,tcl}<DD>
+The language to trace. By default, all languages are traced.
+<DT>-C<DD>
+Do not clear the screen between updates.
+<DT>-S {cload,excp,gc,method,objnew,thread}<DD>
+Sort the output by the specified field.
+<DT>-r MAXROWS<DD>
+Do not print more than this number of rows.
+<DT>-d<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize activity in high-level languages, 1 second refresh:<DD>
+#
+<B>ustat</B>
+
+<DT>Don't clear the screen, and top 8 rows only:<DD>
+#
+<B>ustat -Cr 8</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>ustat 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Process ID.
+<DT>CMDLINE<DD>
+Process command line (often the second and following arguments will give you a
+hint as to which application is being run.
+<DT>METHOD/s<DD>
+Count of method invocations during interval.
+<DT>GC/s<DD>
+Count of garbage collections during interval.
+<DT>OBJNEW/s<DD>
+Count of objects allocated during interval.
+<DT>CLOAD/s<DD>
+Count of classes loaded during interval.
+<DT>EXC/s<DD>
+Count of exceptions thrown during interval.
+<DT>THR/s<DD>
+Count of threads created during interval.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+When using this tool with high-frequency events, such as method calls, a very
+significant slow-down can be expected. However, many of the high-level
+languages covered by this tool already have a fairly high per-method invocation
+cost, especially when running in interpreted mode. For the lower-frequency
+events, such as garbage collections or thread creations, the overhead should
+not be significant. Specifically, when probing Java processes and not using the
+&quot;-XX:+ExtendedDTraceProbes&quot; flag, the most expensive probes are not emitted,
+and the overhead should be acceptable.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tplist">tplist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/pidpersec.html
+++ b/man/man8/pidpersec.html
@@ -1,0 +1,101 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of pidpersec</TITLE>
+</HEAD><BODY>
+<H1>pidpersec</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-08-18<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+pidpersec - Count new processes (via fork()). Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>pidpersec</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+pidpersec shows how many new processes were created each second. There
+can be performance issues caused by many short-lived processes, which may not
+be visible in sampling tools like <A HREF="https://iovisor.github.io/bcc?1+top">top</A>(1). pidpersec provides one way to
+investigate this behavior.
+<P>
+This works by tracing the kernel sched_fork() function using dynamic tracing,
+and will need updating to match any changes to this function.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Count new processes created each second:<DD>
+#
+<B>pidpersec</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel fork function, and maintains an in-kernel count which is
+read asynchronously from user-space. As the rate of this is generally expected to
+be low (&lt;&lt; 1000/s), the overhead is also expected to be negligible.
+<A NAME="lbAH">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAI">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAJ">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAK">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAL">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+top">top</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">OVERHEAD</A><DD>
+<DT><A HREF="#lbAH">SOURCE</A><DD>
+<DT><A HREF="#lbAI">OS</A><DD>
+<DT><A HREF="#lbAJ">STABILITY</A><DD>
+<DT><A HREF="#lbAK">AUTHOR</A><DD>
+<DT><A HREF="#lbAL">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/profile.html
+++ b/man/man8/profile.html
@@ -1,0 +1,205 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of profile</TITLE>
+</HEAD><BODY>
+<H1>profile</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-07-17<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+profile - Profile CPU usage by sampling stack traces. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>profile [-adfh] [-p PID | -L TID] [-U | -K] [-F FREQUENCY | -c COUNT]</B>
+
+<B>[--stack-storage-size COUNT] [duration]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is a CPU profiler. It works by taking samples of stack traces at timed
+intervals. It will help you understand and quantify CPU usage: which code is
+executing, and by how much, including both user-level and kernel code.
+<P>
+By default this samples at 49 Hertz (samples per second), across all CPUs.
+This frequency can be tuned using a command line option. The reason for 49, and
+not 50, is to avoid lock-step sampling.
+<P>
+This is also an efficient profiler, as stack traces are frequency counted in
+kernel context, rather than passing each stack to user space for frequency
+counting there. Only the unique stacks and counts are passed to user space
+at the end of the profile, greatly reducing the kernel&lt;-&gt;user transfer.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<P>
+This also requires Linux 4.9+ (BPF_PROG_TYPE_PERF_EVENT support). See tools/old
+for an older version that may work on Linux 4.6 - 4.8.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-L TID<DD>
+Trace this thread ID only (filtered in-kernel).
+<DT>-F frequency<DD>
+Frequency to sample stacks.
+<DT>-c count<DD>
+Sample stacks every one in this many events.
+<DT>-f<DD>
+Print output in folded stack format.
+<DT>-d<DD>
+Include an output delimiter between kernel and user stacks (either &quot;--&quot;, or,
+in folded mode, &quot;-&quot;).
+<DT>-U<DD>
+Show stacks from user space only (no kernel space stacks).
+<DT>-K<DD>
+Show stacks from kernel space only (no user space stacks).
+<DT>-I<DD>
+Include CPU idle stacks (by default these are excluded).
+<DT>--stack-storage-size COUNT<DD>
+The maximum number of unique stack traces that the kernel will count (default
+16384). If the sampled count exceeds this, a warning will be printed.
+<DT>-C cpu<DD>
+Collect stacks only from specified cpu.
+<DT>duration<DD>
+Duration to trace, in seconds.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Profile (sample) stack traces system-wide at 49 Hertz (samples per second) until Ctrl-C:<DD>
+#
+<B>profile</B>
+
+<DT>Profile for 5 seconds only:<DD>
+#
+<B>profile 5</B>
+
+<DT>Profile at 99 Hertz for 5 seconds only:<DD>
+#
+<B>profile -F 99 5</B>
+
+<DT>Profile 1 in a million events for 5 seconds only:<DD>
+#
+<B>profile -c 1000000 5</B>
+
+<DT>Profile process with PID 181 only:<DD>
+#
+<B>profile -p 181</B>
+
+<DT>Profile thread with TID 181 only:<DD>
+#
+<B>profile -L 181</B>
+
+<DT>Profile for 5 seconds and output in folded stack format (suitable as input for flame graphs), including a delimiter between kernel and user stacks:<DD>
+#
+<B>profile -df 5</B>
+
+<DT>Profile kernel stacks only:<DD>
+#
+<B>profile -K</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>DEBUGGING</H2>
+
+See &quot;[unknown]&quot; frames with bogus addresses? This can happen for different
+reasons. Your best approach is to get Linux perf to work first, and then to
+try this tool. Eg, &quot;perf record -F 49 -a -g -- sleep 1; perf script&quot;, and
+to check for unknown frames there.
+<P>
+The most common reason for &quot;[unknown]&quot; frames is that the target software has
+not been compiled
+with frame pointers, and so we can't use that simple method for walking the
+stack. The fix in that case is to use software that does have frame pointers,
+eg, gcc -fno-omit-frame-pointer, or Java's -XX:+PreserveFramePointer.
+<P>
+Another reason for &quot;[unknown]&quot; frames is JIT compilers, which don't use a
+traditional symbol table. The fix in that case is to populate a
+/tmp/perf-PID.map file with the symbols, which this tool should read. How you
+do this depends on the runtime (Java, Node.js).
+<P>
+If you seem to have unrelated samples in the output, check for other
+sampling or tracing tools that may be running. The current version of this
+tool can include their events if profiling happened concurrently. Those
+samples may be filtered in a future version.
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This is an efficient profiler, as stack traces are frequency counted in
+kernel context, and only the unique stacks and their counts are passed to
+user space. Contrast this with the current &quot;perf record -F 99 -a&quot; method
+of profiling, which writes each sample to user space (via a ring buffer),
+and then to the file system (perf.data), which must be post-processed.
+<P>
+This uses perf_event_open to setup a timer which is instrumented by BPF,
+and for efficiency it does not initialize the perf ring buffer, so the
+redundant perf samples are not collected.
+<P>
+It's expected that the overhead while sampling at 49 Hertz (the default),
+across all CPUs, should be negligible. If you increase the sample rate, the
+overhead might begin to be measurable.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+offcputime">offcputime</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">DEBUGGING</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/pythoncalls.html
+++ b/man/man8/pythoncalls.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ucalls</TITLE>
+</HEAD><BODY>
+<H1>ucalls</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ucalls, javacalls, perlcalls, phpcalls, pythoncalls, rubycalls, tclcalls - Summarize method calls
+from high-level languages and Linux syscalls.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javacalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>perlcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>phpcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>pythoncalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>rubycalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>tclcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>ucalls [-l {java,perl,php,python,ruby}] [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes method calls from high-level languages such as Java, Perl,
+PHP, Python, Ruby, and Tcl. It can also trace Linux system calls. Whenever a method
+is invoked, ucalls records the call count and optionally the method's execution
+time (latency) and displays a summary.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, method probes are
+not enabled by default, and can be turned on by running the Java process with
+the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the environment
+variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,perl,php,python,ruby,tcl}<DD>
+The language to trace. If not provided, only syscalls are traced (when the -S
+option is used).
+<DT>-T TOP<DD>
+Print only the top methods by frequency or latency.
+<DT>-L<DD>
+Collect method invocation latency (duration).
+<DT>-S<DD>
+Collect Linux syscalls frequency and timing.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds (the default is microseconds).
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Print summary after this number of seconds and then exit. By default, wait for
+Ctrl+C to terminate.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace the top 10 Ruby method calls:<DD>
+#
+<B>ucalls -T 10 -l ruby 1344</B>
+
+<DT>Trace Python method calls and Linux syscalls including latency in milliseconds:<DD>
+#
+<B>ucalls -l python -mL 2020</B>
+
+<DT>Trace only syscalls and print a summary after 10 seconds:<DD>
+#
+<B>ucalls -S 788 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Tracing individual method calls will produce a considerable overhead in all
+high-level languages. For languages with just-in-time compilation, such as
+Java, the overhead can be more considerable than for interpreted languages.
+On the other hand, syscall tracing will typically be tolerable for most
+processes, unless they have a very unusual rate of system calls.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/pythonflow.html
+++ b/man/man8/pythonflow.html
@@ -1,0 +1,170 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uflow</TITLE>
+</HEAD><BODY>
+<H1>uflow</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uflow, javaflow, perlflow, phpflow, pythonflow, rubyflow, tclflow - Print a flow graph of method
+calls in high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javaflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>perlflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>phpflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>pythonflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>rubyflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>tclflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>uflow [-h] [-M METHOD] [-C CLAZZ] [-v] [-l {java,perl,php,python,ruby,tcl}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uflow traces method calls and prints them in a flow graph that can facilitate
+debugging and diagnostics by following the program's execution (method flow).
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java processes, the
+startup flag &quot;-XX:+ExtendedDTraceProbes&quot; is required. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-M METHOD<DD>
+Print only method calls where the method name begins with this string.
+<DT>-C CLAZZ<DD>
+Print only method calls where the class name begins with this string. The class
+name interpretation strongly depends on the language. For example, in Java use
+&quot;package/subpackage/ClassName&quot; to refer to classes.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{java,perl,php,python,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Follow method flow in a Ruby process:<DD>
+#
+<B>uflow ruby 148</B>
+
+<DT>Follow method flow in a Java process where the class name is java.lang.Thread:<DD>
+#
+<B>uflow -C java/lang/Thread java 1802</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>CPU<DD>
+The CPU number on which the method was invoked. This is useful to easily see
+where the output skips to a different CPU.
+<DT>PID<DD>
+The process id.
+<DT>TID<DD>
+The thread id.
+<DT>TIME<DD>
+The duration of the method call.
+<DT>METHOD<DD>
+The method name.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This tool has extremely high overhead because it prints every method call. For
+some scenarios, you might see lost samples in the output as the tool is unable
+to keep up with the rate of data coming from the kernel. Filtering by class 
+or method prefix can help reduce the amount of data printed, but there is still
+a very high overhead in the collection mechanism. Do not use for performance-
+sensitive production scenarios, and always test first.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/pythongc.html
+++ b/man/man8/pythongc.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ugc</TITLE>
+</HEAD><BODY>
+<H1>ugc</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ugc, javagc, nodegc, pythongc, rubygc - Trace garbage collection events in
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javagc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>nodegc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>pythongc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>rubygc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>ugc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] [-l {java,node,python,ruby}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces garbage collection events as they occur, including their duration
+and any additional information (such as generation collected or type of GC)
+provided by the respective language's runtime.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Python, and Ruby. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds. The default is microseconds.
+<DT>-M MINIMUM<DD>
+Display only collections that are longer than this threshold. The value is
+given in milliseconds. The default is to display all collections.
+<DT>-F FILTER<DD>
+Display only collections whose textual description matches (contains) this
+string. The default is to display all collections. Note that the filtering here
+is performed in user-space, and not as part of the BPF program. This means that
+if you have thousands of collection events, specifying this filter will not
+reduce the amount of data that has to be transferred from the BPF program to
+the user-space script.
+<DT>{java,node,python,ruby}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace garbage collections in a specific Node process:<DD>
+#
+<B>ugc node 148</B>
+
+<DT>Trace garbage collections in a specific Java process, and print GC times in<DD>
+milliseconds:
+#
+<B>ugc -m java 6004</B>
+
+<DT>Trace garbage collections in a specific Java process, and display them only if<DD>
+they are longer than 10ms and have the string &quot;Tenured&quot; in their detailed
+description:
+#
+<B>ugc -M 10 -F Tenured java 6004</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>START<DD>
+The start time of the GC, in seconds from the beginning of the trace.
+<DT>TIME<DD>
+The duration of the garbage collection event.
+<DT>DESCRIPTION<DD>
+The runtime-provided description of this garbage collection event.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Garbage collection events, even if frequent, should not produce a considerable
+overhead when traced because they are still not very common. Even hundreds of 
+GCs per second (which is a very high rate) will still produce a fairly 
+negligible overhead.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+uobjnew">uobjnew</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/pythonstat.html
+++ b/man/man8/pythonstat.html
@@ -1,0 +1,201 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ustat</TITLE>
+</HEAD><BODY>
+<H1>ustat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ustat, javastat, nodestat, perlstat, phpstat, pythonstat, rubystat, tclstat - Activity stats from
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javastat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>nodestat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>perlstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>phpstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>pythonstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>rubystat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>tclstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>ustat [-l {java,node,perl,php,python,ruby,tcl}] [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is &quot;top&quot; for high-level language events, such as garbage collections,
+exceptions, thread creations, object allocations, method calls, and more. The
+events are aggregated for each process and printed in a top-like table, which
+can be sorted by various fields. Not all language runtimes provide the same
+set of details.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with
+these probes, which in some cases requires building from source with a
+USDT-specific flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java,
+some probes are not enabled by default, and can be turned on by running the Java
+process with the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Newly-created processes will only be traced at the next interval. If you run
+this tool with a short interval (say, 1-5 seconds), this should be virtually
+unnoticeable. For longer intervals, you might miss processes that were started
+and terminated during the interval window.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,node,perl,php,python,ruby,tcl}<DD>
+The language to trace. By default, all languages are traced.
+<DT>-C<DD>
+Do not clear the screen between updates.
+<DT>-S {cload,excp,gc,method,objnew,thread}<DD>
+Sort the output by the specified field.
+<DT>-r MAXROWS<DD>
+Do not print more than this number of rows.
+<DT>-d<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize activity in high-level languages, 1 second refresh:<DD>
+#
+<B>ustat</B>
+
+<DT>Don't clear the screen, and top 8 rows only:<DD>
+#
+<B>ustat -Cr 8</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>ustat 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Process ID.
+<DT>CMDLINE<DD>
+Process command line (often the second and following arguments will give you a
+hint as to which application is being run.
+<DT>METHOD/s<DD>
+Count of method invocations during interval.
+<DT>GC/s<DD>
+Count of garbage collections during interval.
+<DT>OBJNEW/s<DD>
+Count of objects allocated during interval.
+<DT>CLOAD/s<DD>
+Count of classes loaded during interval.
+<DT>EXC/s<DD>
+Count of exceptions thrown during interval.
+<DT>THR/s<DD>
+Count of threads created during interval.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+When using this tool with high-frequency events, such as method calls, a very
+significant slow-down can be expected. However, many of the high-level
+languages covered by this tool already have a fairly high per-method invocation
+cost, especially when running in interpreted mode. For the lower-frequency
+events, such as garbage collections or thread creations, the overhead should
+not be significant. Specifically, when probing Java processes and not using the
+&quot;-XX:+ExtendedDTraceProbes&quot; flag, the most expensive probes are not emitted,
+and the overhead should be acceptable.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tplist">tplist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/reset-trace.html
+++ b/man/man8/reset-trace.html
@@ -1,0 +1,114 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of reset-trace</TITLE>
+</HEAD><BODY>
+<H1>reset-trace</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-10-18<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+reset-trace - reset the state of tracing.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>reset-trace [-F] [-h] [-q] [-v]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+You will probably never need this tool. If you kill -9 a bcc tool (plus other
+signals, like SIGTERM), or if a bcc tool crashes, then kernel tracing can be
+left in a semi-enabled state. It's not as bad as it sounds: there may just be
+overhead for writing to ring buffers that are never read. This tool can be
+used to clean up the tracing state, and reset and disable active tracing.
+<P>
+Make sure no other tracing sessions are active. This tool might stop them from
+functioning (perhaps ungracefully).
+<P>
+This specifically clears the state in at least the following files in
+/sys/kernel/debug/tracing: kprobe_events, uprobe_events, trace_pipe.
+Other tracing facilities (ftrace) are checked, and if not in an expected state,
+a note is printed. All tracing files can be reset with -F for force, but this
+will interfere with any other running tracing sessions (eg, ftrace).
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+/sys/kernel/debug mounted as debugfs
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-F<DD>
+Force. Will reset all tracing facilities, including those not used by bcc
+(ftrace). You shouldn't need to use this.
+<DT>-h<DD>
+USAGE message.
+<DT>-q<DD>
+Quiet. No output while working.
+<DT>-v<DD>
+Verbose: print what it is doing.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Reset the state of tracing:<DD>
+#
+<B>reset-trace</B>
+
+<DT>Verbose:<DD>
+#
+<B>reset-trace -v</B>
+
+<DT></DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>SOURCE</H2>
+
+<DD>
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAI">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAJ">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAK">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">SOURCE</A><DD>
+<DT><A HREF="#lbAI">OS</A><DD>
+<DT><A HREF="#lbAJ">STABILITY</A><DD>
+<DT><A HREF="#lbAK">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/rubycalls.html
+++ b/man/man8/rubycalls.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ucalls</TITLE>
+</HEAD><BODY>
+<H1>ucalls</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ucalls, javacalls, perlcalls, phpcalls, pythoncalls, rubycalls, tclcalls - Summarize method calls
+from high-level languages and Linux syscalls.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javacalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>perlcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>phpcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>pythoncalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>rubycalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>tclcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>ucalls [-l {java,perl,php,python,ruby}] [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes method calls from high-level languages such as Java, Perl,
+PHP, Python, Ruby, and Tcl. It can also trace Linux system calls. Whenever a method
+is invoked, ucalls records the call count and optionally the method's execution
+time (latency) and displays a summary.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, method probes are
+not enabled by default, and can be turned on by running the Java process with
+the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the environment
+variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,perl,php,python,ruby,tcl}<DD>
+The language to trace. If not provided, only syscalls are traced (when the -S
+option is used).
+<DT>-T TOP<DD>
+Print only the top methods by frequency or latency.
+<DT>-L<DD>
+Collect method invocation latency (duration).
+<DT>-S<DD>
+Collect Linux syscalls frequency and timing.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds (the default is microseconds).
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Print summary after this number of seconds and then exit. By default, wait for
+Ctrl+C to terminate.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace the top 10 Ruby method calls:<DD>
+#
+<B>ucalls -T 10 -l ruby 1344</B>
+
+<DT>Trace Python method calls and Linux syscalls including latency in milliseconds:<DD>
+#
+<B>ucalls -l python -mL 2020</B>
+
+<DT>Trace only syscalls and print a summary after 10 seconds:<DD>
+#
+<B>ucalls -S 788 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Tracing individual method calls will produce a considerable overhead in all
+high-level languages. For languages with just-in-time compilation, such as
+Java, the overhead can be more considerable than for interpreted languages.
+On the other hand, syscall tracing will typically be tolerable for most
+processes, unless they have a very unusual rate of system calls.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/rubyflow.html
+++ b/man/man8/rubyflow.html
@@ -1,0 +1,170 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uflow</TITLE>
+</HEAD><BODY>
+<H1>uflow</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uflow, javaflow, perlflow, phpflow, pythonflow, rubyflow, tclflow - Print a flow graph of method
+calls in high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javaflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>perlflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>phpflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>pythonflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>rubyflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>tclflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>uflow [-h] [-M METHOD] [-C CLAZZ] [-v] [-l {java,perl,php,python,ruby,tcl}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uflow traces method calls and prints them in a flow graph that can facilitate
+debugging and diagnostics by following the program's execution (method flow).
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java processes, the
+startup flag &quot;-XX:+ExtendedDTraceProbes&quot; is required. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-M METHOD<DD>
+Print only method calls where the method name begins with this string.
+<DT>-C CLAZZ<DD>
+Print only method calls where the class name begins with this string. The class
+name interpretation strongly depends on the language. For example, in Java use
+&quot;package/subpackage/ClassName&quot; to refer to classes.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{java,perl,php,python,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Follow method flow in a Ruby process:<DD>
+#
+<B>uflow ruby 148</B>
+
+<DT>Follow method flow in a Java process where the class name is java.lang.Thread:<DD>
+#
+<B>uflow -C java/lang/Thread java 1802</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>CPU<DD>
+The CPU number on which the method was invoked. This is useful to easily see
+where the output skips to a different CPU.
+<DT>PID<DD>
+The process id.
+<DT>TID<DD>
+The thread id.
+<DT>TIME<DD>
+The duration of the method call.
+<DT>METHOD<DD>
+The method name.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This tool has extremely high overhead because it prints every method call. For
+some scenarios, you might see lost samples in the output as the tool is unable
+to keep up with the rate of data coming from the kernel. Filtering by class 
+or method prefix can help reduce the amount of data printed, but there is still
+a very high overhead in the collection mechanism. Do not use for performance-
+sensitive production scenarios, and always test first.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/rubygc.html
+++ b/man/man8/rubygc.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ugc</TITLE>
+</HEAD><BODY>
+<H1>ugc</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ugc, javagc, nodegc, pythongc, rubygc - Trace garbage collection events in
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javagc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>nodegc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>pythongc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>rubygc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>ugc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] [-l {java,node,python,ruby}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces garbage collection events as they occur, including their duration
+and any additional information (such as generation collected or type of GC)
+provided by the respective language's runtime.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Python, and Ruby. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds. The default is microseconds.
+<DT>-M MINIMUM<DD>
+Display only collections that are longer than this threshold. The value is
+given in milliseconds. The default is to display all collections.
+<DT>-F FILTER<DD>
+Display only collections whose textual description matches (contains) this
+string. The default is to display all collections. Note that the filtering here
+is performed in user-space, and not as part of the BPF program. This means that
+if you have thousands of collection events, specifying this filter will not
+reduce the amount of data that has to be transferred from the BPF program to
+the user-space script.
+<DT>{java,node,python,ruby}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace garbage collections in a specific Node process:<DD>
+#
+<B>ugc node 148</B>
+
+<DT>Trace garbage collections in a specific Java process, and print GC times in<DD>
+milliseconds:
+#
+<B>ugc -m java 6004</B>
+
+<DT>Trace garbage collections in a specific Java process, and display them only if<DD>
+they are longer than 10ms and have the string &quot;Tenured&quot; in their detailed
+description:
+#
+<B>ugc -M 10 -F Tenured java 6004</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>START<DD>
+The start time of the GC, in seconds from the beginning of the trace.
+<DT>TIME<DD>
+The duration of the garbage collection event.
+<DT>DESCRIPTION<DD>
+The runtime-provided description of this garbage collection event.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Garbage collection events, even if frequent, should not produce a considerable
+overhead when traced because they are still not very common. Even hundreds of 
+GCs per second (which is a very high rate) will still produce a fairly 
+negligible overhead.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+uobjnew">uobjnew</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/rubyobjnew.html
+++ b/man/man8/rubyobjnew.html
@@ -1,0 +1,157 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uobjnew</TITLE>
+</HEAD><BODY>
+<H1>uobjnew</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uobjnew, cobjnew, javaobjnew, rubyobjnew, tclobjnew - Summarize object allocations in
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>javaobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>rubyobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>tclobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>uobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] [-l {c,java,ruby,tcl}] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uobjnew traces object allocations in high-level languages (including &quot;malloc&quot;)
+and prints summaries of the most frequently allocated types by number of
+objects or number of bytes.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+C, Java, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, the Java process
+must be started with the &quot;-XX:+ExtendedDTraceProbes&quot; flag.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-C TOP_COUNT<DD>
+Print the top object types sorted by number of instances.
+<DT>-S TOP_SIZE<DD>
+Print the top object types sorted by size.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{c,java,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Wait this many seconds and then print the summary and exit. By default, wait
+for Ctrl+C to exit.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace object allocations in a Ruby process:<DD>
+#
+<B>uobjnew ruby 148</B>
+
+<DT>Trace object allocations from &quot;malloc&quot; and print the top 10 by total size:<DD>
+#
+<B>uobjnew -S 10 c 1788</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TYPE<DD>
+The object type being allocated. For C (malloc), this is the block size.
+<DT>ALLOCS<DD>
+The number of objects allocated.
+<DT>BYTES<DD>
+The number of bytes allocated.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Object allocation events are quite frequent, and therefore the overhead from
+running this tool can be considerable. Use with caution and make sure to 
+test before using in a production environment. Nonetheless, even thousands of
+allocations per second will likely produce a reasonable overhead when 
+investigating a problem.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ugc">ugc</A>(8), <A HREF="https://iovisor.github.io/bcc?8+memleak">memleak</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/rubystat.html
+++ b/man/man8/rubystat.html
@@ -1,0 +1,201 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ustat</TITLE>
+</HEAD><BODY>
+<H1>ustat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ustat, javastat, nodestat, perlstat, phpstat, pythonstat, rubystat, tclstat - Activity stats from
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javastat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>nodestat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>perlstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>phpstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>pythonstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>rubystat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>tclstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>ustat [-l {java,node,perl,php,python,ruby,tcl}] [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is &quot;top&quot; for high-level language events, such as garbage collections,
+exceptions, thread creations, object allocations, method calls, and more. The
+events are aggregated for each process and printed in a top-like table, which
+can be sorted by various fields. Not all language runtimes provide the same
+set of details.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with
+these probes, which in some cases requires building from source with a
+USDT-specific flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java,
+some probes are not enabled by default, and can be turned on by running the Java
+process with the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Newly-created processes will only be traced at the next interval. If you run
+this tool with a short interval (say, 1-5 seconds), this should be virtually
+unnoticeable. For longer intervals, you might miss processes that were started
+and terminated during the interval window.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,node,perl,php,python,ruby,tcl}<DD>
+The language to trace. By default, all languages are traced.
+<DT>-C<DD>
+Do not clear the screen between updates.
+<DT>-S {cload,excp,gc,method,objnew,thread}<DD>
+Sort the output by the specified field.
+<DT>-r MAXROWS<DD>
+Do not print more than this number of rows.
+<DT>-d<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize activity in high-level languages, 1 second refresh:<DD>
+#
+<B>ustat</B>
+
+<DT>Don't clear the screen, and top 8 rows only:<DD>
+#
+<B>ustat -Cr 8</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>ustat 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Process ID.
+<DT>CMDLINE<DD>
+Process command line (often the second and following arguments will give you a
+hint as to which application is being run.
+<DT>METHOD/s<DD>
+Count of method invocations during interval.
+<DT>GC/s<DD>
+Count of garbage collections during interval.
+<DT>OBJNEW/s<DD>
+Count of objects allocated during interval.
+<DT>CLOAD/s<DD>
+Count of classes loaded during interval.
+<DT>EXC/s<DD>
+Count of exceptions thrown during interval.
+<DT>THR/s<DD>
+Count of threads created during interval.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+When using this tool with high-frequency events, such as method calls, a very
+significant slow-down can be expected. However, many of the high-level
+languages covered by this tool already have a fairly high per-method invocation
+cost, especially when running in interpreted mode. For the lower-frequency
+events, such as garbage collections or thread creations, the overhead should
+not be significant. Specifically, when probing Java processes and not using the
+&quot;-XX:+ExtendedDTraceProbes&quot; flag, the most expensive probes are not emitted,
+and the overhead should be acceptable.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tplist">tplist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/runqlat.html
+++ b/man/man8/runqlat.html
@@ -1,0 +1,170 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of runqlat</TITLE>
+</HEAD><BODY>
+<H1>runqlat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-07<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+runqlat - Run queue (scheduler) latency as a histogram.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>runqlat [-h] [-T] [-m] [-P] [--pidnss] [-L] [-p PID] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This measures the time a task spends waiting on a run queue (or equivalent
+scheduler data structure) for a turn on-CPU, and shows this time as a
+histogram. This time should be small, but a task may need to wait its turn due
+to CPU load. The higher the CPU load, the longer a task will generally need to
+wait its turn.
+<P>
+This tool measures two types of run queue latency:
+<P>
+1. The time from a task being enqueued on a run queue to its context switch
+and execution. This traces ttwu_do_wakeup(), wake_up_new_task() -&gt;
+finish_task_switch() with either raw tracepoints (if supported) or kprobes
+and instruments the run queue latency after a voluntary context switch.
+<P>
+2. The time from when a task was involuntary context switched and still
+in the runnable state, to when it next executed. This is instrumented
+from finish_task_switch() alone.
+<P>
+This tool uses in-kernel eBPF maps for storing timestamps and the histogram,
+for efficiency. Despite this, the overhead of this tool may become significant
+for some workloads: see the OVERHEAD section.
+<P>
+This works by tracing various kernel scheduler functions using dynamic tracing,
+and will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include timestamps on output.
+<DT>-m<DD>
+Output histogram in milliseconds.
+<DT>-P<DD>
+Print a histogram for each PID.
+<DT>--pidnss<DD>
+Print a histogram for each PID namespace (short for PID namespaces). For
+container analysis.
+<DT>-L<DD>
+Print a histogram for each thread ID.
+<DT>-p PID<DD>
+Only show this PID (filtered in kernel for efficiency).
+<DT>interval<DD>
+Output interval, in seconds.
+<DT>count<DD>
+Number of outputs.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize run queue latency as a histogram:<DD>
+#
+<B>runqlat</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>runqlat 1 10</B>
+
+<DT>Print 1 second summaries, using milliseconds as units for the histogram, and include timestamps on output:<DD>
+#
+<B>runqlat -mT 1</B>
+
+<DT>Trace PID 186 only, 1 second summaries:<DD>
+#
+<B>runqlat -P 185 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>usecs<DD>
+Microsecond range
+<DT>msecs<DD>
+Millisecond range
+<DT>count<DD>
+How many times a task event fell into this range
+<DT>distribution<DD>
+An ASCII bar chart to visualize the distribution (count column)
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces scheduler functions, which can become very frequent. While eBPF
+has very low overhead, and this tool uses in-kernel maps for efficiency, the
+frequency of scheduler events for some workloads may be high enough that the
+overhead of this tool becomes significant. Measure in a lab environment
+to quantify the overhead before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+runqlen">runqlen</A>(8), <A HREF="https://iovisor.github.io/bcc?8+runqslower">runqslower</A>(8), <A HREF="https://iovisor.github.io/bcc?1+pidstat">pidstat</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/runqlen.html
+++ b/man/man8/runqlen.html
@@ -1,0 +1,147 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of runqlen</TITLE>
+</HEAD><BODY>
+<H1>runqlen</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-12-12<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+runqlen - Scheduler run queue length as a histogram.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>runqlen [-h] [-T] [-O] [-C] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This program summarizes scheduler queue length as a histogram, and can also
+show run queue occupancy. It works by sampling the run queue length on all
+CPUs at 99 Hertz.
+<P>
+This tool can be used to identify imbalances, eg, when processes are bound
+to CPUs causing queueing, or interrupt mappings causing the same.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include timestamps on output.
+<DT>-O<DD>
+Report run queue occupancy.
+<DT>-C<DD>
+Report for each CPU.
+<DT>interval<DD>
+Output interval, in seconds.
+<DT>count<DD>
+Number of outputs.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize run queue length as a histogram:<DD>
+#
+<B>runqlen</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>runqlen 1 10</B>
+
+<DT>Print output every second, with timestamps, and show each CPU separately:<DD>
+#
+<B>runqlen -CT 1</B>
+
+<DT>Print run queue occupancy every second:<DD>
+#
+<B>runqlen -O 1</B>
+
+<DT>Print run queue occupancy, with timestamps, for each CPU:<DD>
+#
+<B>runqlen -COT 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>runqlen<DD>
+Scheduler run queue length: the number of threads (tasks) waiting to run,
+(excluding including the currently running task).
+<DT>count<DD>
+Number of samples at this queue length.
+<DT>distribution<DD>
+An ASCII bar chart to visualize the distribution (count column)
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This uses sampling at 99 Hertz (on all CPUs), and in-kernel summaries, which
+should make overhead negligible. This does not trace scheduler events, like
+runqlen does, which comes at a much higher overhead cost.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+runqlat">runqlat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+runqslower">runqslower</A>(8), <A HREF="https://iovisor.github.io/bcc?1+pidstat">pidstat</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/runqslower.html
+++ b/man/man8/runqslower.html
@@ -1,0 +1,152 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of runqslower</TITLE>
+</HEAD><BODY>
+<H1>runqslower</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-07<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+runqslower - Trace long process scheduling delays.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>runqslower [-p PID] [-t TID] [min_us]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This measures the time a task spends waiting on a run queue (or equivalent
+scheduler data structure) for a turn on-CPU, and shows occurrences of time
+exceeding passed threshold. This time should be small, but a task may need
+to wait its turn due to CPU load. The higher the CPU load, the longer a task
+will generally need to wait its turn.
+<P>
+This tool measures two types of run queue latency:
+<P>
+1. The time from a task being enqueued on a run queue to its context switch
+and execution. This traces ttwu_do_wakeup(), wake_up_new_task() -&gt;
+finish_task_switch() with either raw tracepoints (if supported) or kprobes
+and instruments the run queue latency after a voluntary context switch.
+<P>
+2. The time from when a task was involuntary context switched and still
+in the runnable state, to when it next executed. This is instrumented
+from finish_task_switch() alone.
+<P>
+The overhead of this tool may become significant for some workloads:
+see the OVERHEAD section.
+<P>
+This works by tracing various kernel scheduler functions using dynamic tracing,
+and will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-p PID<DD>
+Only show this PID (filtered in kernel for efficiency).
+<DT>-t TID<DD>
+Only show this TID (filtered in kernel for efficiency).
+<DT>min_us<DD>
+Minimum scheduling delay in microseconds to output.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Show scheduling delays longer than 10ms:<DD>
+#
+<B>runqslower</B>
+
+<DT>Show scheduling delays longer than 1ms for process with PID 123:<DD>
+#
+<B>runqslower -p 123 1000</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of when scheduling event occurred.
+<DT>COMM<DD>
+Process name.
+<DT>PID<DD>
+Process ID.
+<DT>LAT(us)<DD>
+Scheduling latency from time when task was ready to run to the time it was
+assigned to a CPU to run.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces scheduler functions, which can become very frequent. While eBPF
+has very low overhead, and this tool uses in-kernel maps for efficiency, the
+frequency of scheduler events for some workloads may be high enough that the
+overhead of this tool becomes significant. Measure in a lab environment
+to quantify the overhead before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Ivan Babrou, original BCC Python version
+Andrii Nakryiko, CO-RE version
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+runqlen">runqlen</A>(8), <A HREF="https://iovisor.github.io/bcc?8+runqlat">runqlat</A>(8), <A HREF="https://iovisor.github.io/bcc?1+pidstat">pidstat</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/shmsnoop.html
+++ b/man/man8/shmsnoop.html
@@ -1,0 +1,130 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of shmsnoop</TITLE>
+</HEAD><BODY>
+<H1>shmsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-09-24<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+shmsnoop - Trace System V shared memory syscalls. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>shmsnoop [-h] [-T] [-p] [-t] [-d DURATION] [-n NAME]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+shmsnoop traces System V shared memory syscalls: shmget, shmat, shmdt, shmctl
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include a timestamp column.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-t TID<DD>
+Trace this thread ID only (filtered in-kernel).
+<DT>-d DURATION<DD>
+Total duration of trace in seconds.
+<DT>-n NAME<DD>
+Only print command lines matching this command name (regex)
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all shm* syscalls:<DD>
+#
+<B>shmsnoop</B>
+
+<DT>Trace all shm* syscalls, and include timestamps:<DD>
+#
+<B>shmsnoop -T</B>
+
+<DT>Only trace shm* syscalls where the process contains &quot;server&quot;:<DD>
+#
+<B>shmsnoop -n server</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of shm syscall return, in seconds.
+<DT>PID<DD>
+Process ID
+<DT>COMM<DD>
+Process/command name.
+<DT>RET<DD>
+Return value of shm syscall.
+<DT>ARGS<DD>
+&quot;arg: value&quot; couples that represent given syscall arguments as described in their manpage
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Jiri Olsa
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+opensnoop">opensnoop</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/slabratetop.html
+++ b/man/man8/slabratetop.html
@@ -1,0 +1,138 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of slabratetop</TITLE>
+</HEAD><BODY>
+<H1>slabratetop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-10-17<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+slabratetop - Kernel SLAB/SLUB memory cache allocation rate top.
+Uses Linux BPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>slabratetop [-h] [-C] [-r MAXROWS] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is top for the the rate of kernel SLAB/SLUB memory allocations.
+It works by tracing kmem_cache_alloc() calls, a commonly used interface for
+kernel memory allocation (SLAB or SLUB). It summarizes the rate and total bytes
+allocated of these calls per interval: the activity. Compare this to
+<A HREF="https://iovisor.github.io/bcc?1+slabtop">slabtop</A>(1), which shows the current static volume of the caches.
+<P>
+This tool uses kernel dynamic tracing of the kmem_cache_alloc() function.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-C<DD>
+Don't clear the screen.
+<DT>-r MAXROWS<DD>
+Maximum number of rows to print. Default is 20.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize active kernel SLAB/SLUB calls (kmem_cache_alloc()), showing the top 20 caches every second:<DD>
+#
+<B>slabratetop</B>
+
+<DT>Don't clear the screen, and top 8 rows only:<DD>
+#
+<B>slabratetop -Cr 8</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>slabratetop 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg:<DD>
+The contents of /proc/loadavg
+<DT>CACHE<DD>
+Kernel cache name.
+<DT>ALLOCS<DD>
+Allocations (number of calls).
+<DT>BYTES<DD>
+Total bytes allocated.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+If kmem_cache_alloc() is called at a high rate (eg, &gt;100k/second) the overhead
+of this tool might begin to be measurable. The rate can be seen in the ALLOCS
+column of the output.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+slabtop">slabtop</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/sofdsnoop.html
+++ b/man/man8/sofdsnoop.html
@@ -1,0 +1,110 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of SOFDSNOOP</TITLE>
+</HEAD><BODY>
+<H1>SOFDSNOOP</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2019-07-29<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+sofdsnoop - traces FDs passed by sockets
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+usage: sofdsnoop [-h] [-T] [-p PID] [-t TID] [-n NAME] [-d DURATION]
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+Trace file descriptors passed via socket
+<A NAME="lbAE">&nbsp;</A>
+<H3>optional arguments:</H3>
+
+<DL COMPACT>
+<DT><B>-h</B>, <B>--help</B><DD>
+show this help message and exit
+<DT><B>-T</B>, <B>--timestamp</B><DD>
+include timestamp on output
+<DT><B>-p</B> PID, <B>--pid</B> PID<DD>
+trace this PID only
+<DT><B>-t</B> TID, <B>--tid</B> TID<DD>
+trace this TID only
+<DT><B>-n</B> NAME, <B>--name</B> NAME<DD>
+only print process names containing this name
+<DT><B>-d</B> DURATION, <B>--duration</B> DURATION<DD>
+total duration of trace in seconds
+</DL>
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace passed file descriptors<DD>
+#
+<B>sofdsnoop</B>
+
+<DT>Include timestamps<DD>
+#
+<B>sofdsnoop -T</B>
+
+<DT>Only trace PID 181<DD>
+#
+<B>sofdsnoop -p</B> 181
+
+<DT>Only trace TID 123<DD>
+#
+<B>sofdsnoop -t</B> 123
+
+<DT>Trace for 10 seconds only<DD>
+#
+<B>sofdsnoop -d</B> 10
+
+<DT>Only print process names containing &quot;main&quot;<DD>
+#
+<B>sofdsnoop -n</B> main
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAH">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAI">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DL>
+<DT><A HREF="#lbAE">optional arguments:</A><DD>
+</DL>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">SOURCE</A><DD>
+<DT><A HREF="#lbAH">OS</A><DD>
+<DT><A HREF="#lbAI">STABILITY</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/softirqs.html
+++ b/man/man8/softirqs.html
@@ -1,0 +1,152 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of softirqs</TITLE>
+</HEAD><BODY>
+<H1>softirqs</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-10-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+softirqs - Measure soft IRQ (soft interrupt) event time. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>softirqs [-h] [-T] [-N] [-d] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This summarizes the time spent servicing soft IRQs (soft interrupts), and can
+show this time as either totals or histogram distributions. A system-wide
+summary of this time is shown by the %soft column of <A HREF="https://iovisor.github.io/bcc?1+mpstat">mpstat</A>(1), and soft IRQ
+event counts (but not times) are available in /proc/softirqs.
+<P>
+This tool uses the irq:softirq_enter and irq:softirq_exit kernel tracepoints,
+which is a stable tracing mechanism. BPF programs can attach to tracepoints
+from Linux 4.7 only. An older version of this tool is available in tools/old,
+and uses kprobes instead of tracepoints.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include timestamps on output.
+<DT>-N<DD>
+Output in nanoseconds
+<DT>-d<DD>
+Show IRQ time distribution as histograms
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Sum soft IRQ event time until Ctrl-C:<DD>
+#
+<B>softirqs</B>
+
+<DT>Show soft IRQ event time as histograms:<DD>
+#
+<B>softirqs -d</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>softirqs 1 10</B>
+
+<DT>1 second summaries, printed in nanoseconds, with timestamps:<DD>
+#
+<B>softirqs -NT 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>SOFTIRQ<DD>
+The kernel function name that performs the soft IRQ action.
+<DT>TOTAL_usecs<DD>
+Total time spent in this soft IRQ function in microseconds.
+<DT>TOTAL_nsecs<DD>
+Total time spent in this soft IRQ function in nanoseconds.
+<DT>usecs<DD>
+Range of microseconds for this bucket.
+<DT>nsecs<DD>
+Range of nanoseconds for this bucket.
+<DT>count<DD>
+Number of soft IRQs in this time range.
+<DT>distribution<DD>
+ASCII representation of the distribution (the count column).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces kernel functions and maintains in-kernel counts, which
+are asynchronously copied to user-space. While the rate of interrupts
+be very high (&gt;1M/sec), this is a relatively efficient way to trace these
+events, and so the overhead is expected to be small for normal workloads, but
+could become noticeable for heavy workloads. Measure in a test environment
+before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHORS</H2>
+
+Brendan Gregg, Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+hardirqs">hardirqs</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHORS</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/solisten.html
+++ b/man/man8/solisten.html
@@ -1,0 +1,99 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of SOLISTEN</TITLE>
+</HEAD><BODY>
+<H1>SOLISTEN</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2019-07-29<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+solisten - Trace listening socket
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+usage: solisten [-h] [--show-netns] [-p PID] [-n NETNS]
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+All IPv4 and IPv6 listen attempts are traced, even if they ultimately
+fail or the listening program is not willing to accept().
+<A NAME="lbAE">&nbsp;</A>
+<H3>optional arguments:</H3>
+
+<DL COMPACT>
+<DT><B>-h</B>, <B>--help</B><DD>
+show this help message and exit
+<DT><B>--show-netns</B><DD>
+show network namespace
+<DT><B>-p</B> PID, <B>--pid</B> PID<DD>
+trace this PID only
+<DT><B>-n</B> NETNS, <B>--netns</B> NETNS<DD>
+trace this Network Namespace only
+</DL>
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Stream socket listen:<DD>
+#
+<B>solisten</B>
+
+<DT>Stream socket listen for specified PID only<DD>
+#
+<B>solisten -p 1234</B>
+
+<DT>Stream socket listen for the specified network namespace ID only<DD>
+#
+<B>solisten --netns 4242</B>
+
+<DT>Show network ns ID (useful for containers)<DD>
+#
+<B>solisten --show-netns</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAH">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAI">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DL>
+<DT><A HREF="#lbAE">optional arguments:</A><DD>
+</DL>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">SOURCE</A><DD>
+<DT><A HREF="#lbAH">OS</A><DD>
+<DT><A HREF="#lbAI">STABILITY</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/spfdsnoop.html
+++ b/man/man8/spfdsnoop.html
@@ -1,0 +1,139 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of sofdsnoop</TITLE>
+</HEAD><BODY>
+<H1>sofdsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-11-08<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+sofdsnoop - Trace FDs passed through unix sockets. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>sofdsnoop [-h] [-T] [-p PID] [-t TID] [-n NAME] [-d DURATION]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+sofdsnoop traces FDs passed through unix sockets
+<P>
+Every file descriptor that is passed via unix sockets os displayed
+on separate line together with process info (TID/COMM columns),
+ACTION details (SEND/RECV), file descriptor number (FD) and its
+translation to file if available (NAME).
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include a timestamp column.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-t TID<DD>
+Trace this thread ID only (filtered in-kernel).
+<DT>-d DURATION<DD>
+Total duration of trace in seconds.
+<DT>-n NAME<DD>
+Only print command lines matching this command name (regex)
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all sockets:<DD>
+#
+<B>sofdsnoop</B>
+
+<DT>Trace all sockets, and include timestamps:<DD>
+#
+<B>sofdsnoop -T</B>
+
+<DT>Only trace sockets where the process contains &quot;server&quot;:<DD>
+#
+<B>sofdsnoop -n server</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of SEDN/RECV actions, in seconds.
+<DT>ACTION<DD>
+Operation on the fd SEND/RECV.
+<DT>TID<DD>
+Process TID
+<DT>COMM<DD>
+Parent process/command name.
+<DT>SOCKET<DD>
+The socket carrier.
+<DT>FD<DD>
+file descriptor number
+<DT>NAME<DD>
+file name for SEND lines
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Jiri Olsa
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+opensnoop">opensnoop</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/sslsniff.html
+++ b/man/man8/sslsniff.html
@@ -1,0 +1,108 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of sslsniff</TITLE>
+</HEAD><BODY>
+<H1>sslsniff</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-08-16<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+sslsniff - Print data passed to OpenSSL, GnuTLS or NSS. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>sslsniff [-h] [-p PID] [-c COMM] [-o] [-g] [-n] [-d]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+sslsniff prints data sent to write/send and read/recv functions of
+OpenSSL, GnuTLS and NSS, allowing us to read plain text content before
+encryption (when writing) and after decryption (when reading).
+<P>
+This works reading the second parameter of both functions (*buf).
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Print all calls to SSL write/send and read/recv system-wide:<DD>
+#
+<B>sslsniff</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>FUNC<DD>
+Which function is being called (write/send or read/recv)
+<DT>TIME<DD>
+Time of the command, in seconds.
+<DT>COMM<DD>
+Entered command.
+<DT>PID<DD>
+Process ID calling SSL.
+<DT>LEN<DD>
+Bytes written or read by SSL functions.
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAI">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAJ">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAK">&nbsp;</A>
+<H2>AUTHORS</H2>
+
+Adrian Lopez and Mark Drayton
+<A NAME="lbAL">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">FIELDS</A><DD>
+<DT><A HREF="#lbAH">SOURCE</A><DD>
+<DT><A HREF="#lbAI">OS</A><DD>
+<DT><A HREF="#lbAJ">STABILITY</A><DD>
+<DT><A HREF="#lbAK">AUTHORS</A><DD>
+<DT><A HREF="#lbAL">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/stackcount.html
+++ b/man/man8/stackcount.html
@@ -1,0 +1,208 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of stackcount</TITLE>
+</HEAD><BODY>
+<H1>stackcount</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-01-14<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+stackcount - Count function calls and their stack traces. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>stackcount [-h] [-p PID] [-c CPU] [-i INTERVAL] [-D DURATION] [-T]</B>
+
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-r]&nbsp;[-s]&nbsp;[-P]&nbsp;[-K]&nbsp;[-U]&nbsp;[-v]&nbsp;[-d]&nbsp;[-f]&nbsp;[--debug]&nbsp;pattern
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+stackcount traces functions and frequency counts them with their entire
+stack trace, kernel stack and user stack, summarized in-kernel for efficiency.
+This allows higher frequency events to be studied. The output consists of
+unique stack traces, and their occurrence counts. In addition to kernel and
+user functions, kernel tracepoints and USDT tracepoint are also supported.
+<P>
+The pattern is a string with optional '*' wildcards, similar to file globbing.
+If you'd prefer to use regular expressions, use the -r option.
+<P>
+This tool only works on Linux 4.6+. Stack traces are obtained using the new `BPF_STACK_TRACE` APIs.
+For kernels older than 4.6, see the version under tools/old.
+<P>
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-r<DD>
+Allow regular expressions for the search pattern. The default allows &quot;*&quot;
+wildcards only.
+<DT>-s<DD>
+Show address offsets.
+<DT>-P<DD>
+Display stacks separately for each process.
+<DT>-K<DD>
+Show kernel stack only.
+<DT>-U<DD>
+Show user stack only.
+<DT>-T<DD>
+Include a timestamp with interval output.
+<DT>-v<DD>
+Show raw addresses.
+<DT>-d<DD>
+Print a delimiter (&quot;--&quot;) in-between the kernel and user stacks.
+<DT>--debug<DD>
+Print the source of the BPF program when loading it (for debugging purposes).
+<DT>-i interval<DD>
+Summary interval, in seconds.
+<DT>-D duration<DD>
+Total duration of trace, in seconds.
+-f
+Folded output format.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-c CPU<DD>
+Trace this CPU only (filtered in-kernel).
+<DT><DT>pattern<DD>
+<DD>
+A function name, or a search pattern. Can include wildcards (&quot;*&quot;). If the
+-r option is used, can include regular expressions.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Count kernel and user stack traces for submit_bio():<DD>
+#
+<B>stackcount submit_bio</B>
+
+<DT>Count stacks with a delimiter for submit_bio():<DD>
+#
+<B>stackcount -d submit_bio</B>
+
+<DT>Count kernel stack trace only for submit_bio():<DD>
+#
+<B>stackcount -K submit_bio</B>
+
+<DT>Count user stack trace only for submit_bio():<DD>
+#
+<B>stackcount -U submit_bio</B>
+
+<DT>Count stack traces for ip_output():<DD>
+#
+<B>stackcount ip_output</B>
+
+<DT>Show symbol offsets:<DD>
+#
+<B>stackcount -s ip_output</B>
+
+<DT>Show offsets and raw addresses (verbose):<DD>
+#
+<B>stackcount -sv ip_output</B>
+
+<DT>Count stacks for kernel functions matching tcp_send*:<DD>
+#
+<B>stackcount 'tcp_send*'</B>
+
+<DT>Same as previous, but using regular expressions:<DD>
+#
+<B>stackcount -r '^tcp_send.*'</B>
+
+<DT>Output every 5 seconds, with timestamps:<DD>
+#
+<B>stackcount -Ti 5 ip_output</B>
+
+<DT>Only count stacks when PID 185 is on-CPU:<DD>
+#
+<B>stackcount -p 185 ip_output</B>
+
+<DT>Only count stacks for CPU 1:<DD>
+#
+<B>stackcount -c 1 put_prev_entity</B>
+
+<DT>Count user stacks for dynamic heap allocations with malloc in PID 185:<DD>
+#
+<B>stackcount -p 185 c:malloc</B>
+
+<DT>Count user stacks for thread creation (USDT tracepoint) in PID 185:<DD>
+#
+<B>stackcount -p 185 u:pthread:pthread_create</B>
+
+<DT>Count stacks for context switch events using a kernel tracepoint:<DD>
+#
+<B>stackcount t:sched:sched_switch</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This summarizes unique stack traces in-kernel for efficiency, allowing it to
+trace a higher rate of function calls than methods that post-process in user
+space. The stack trace data is only copied to user space when the output is
+printed, which usually only happens once. The stack walking also happens in an
+optimized code path in the kernel thanks to the new BPF_STACK_TRACE table APIs,
+which should be more efficient than the manual walker in the eBPF tracer which
+older versions of this script used. With this in mind, call rates of &lt;
+10,000/sec would incur negligible overhead. Test before production use. You can
+also use funccount to get a handle on function call rates first.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg, Sasha Goldshtein
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+stacksnoop">stacksnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/statsnoop.html
+++ b/man/man8/statsnoop.html
@@ -1,0 +1,151 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of statsnoop</TITLE>
+</HEAD><BODY>
+<H1>statsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-08<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+statsnoop - Trace stat() syscalls. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>statsnoop [-h] [-t] [-x] [-p PID]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+statsnoop traces the different stat() syscalls, showing which processes are
+attempting to read information about which files. This can be useful for
+determining the location of config and log files, or for troubleshooting
+applications that are failing, especially on startup.
+<P>
+This works by tracing various kernel sys_stat() functions using dynamic
+tracing, and will need updating to match any changes to these functions.
+<P>
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-t<DD>
+Include a timestamp column: in seconds since the first event, with decimal
+places.
+<DT>-x<DD>
+Only print failed stats.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all stat() syscalls:<DD>
+#
+<B>statsnoop</B>
+
+<DT>Trace all stat() syscalls, and include timestamps:<DD>
+#
+<B>statsnoop -t</B>
+
+<DT>Trace only stat() syscalls that failed:<DD>
+#
+<B>statsnoop -x</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>statsnoop -p 181</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of the call, in seconds.
+<DT>PID<DD>
+Process ID
+<DT>COMM<DD>
+Process name
+<DT>FD<DD>
+File descriptor (if success), or -1 (if failed)
+<DT>ERR<DD>
+Error number (see the system's errno.h)
+<DT>PATH<DD>
+Open path
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel stat function and prints output for each event. As the
+rate of this is generally expected to be low (&lt; 1000/s), the overhead is also
+expected to be negligible. If you have an application that is calling a high
+rate of stat()s, then test and understand overhead before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+opensnoop">opensnoop</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/syncsnoop.html
+++ b/man/man8/syncsnoop.html
@@ -1,0 +1,116 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of syncsnoop</TITLE>
+</HEAD><BODY>
+<H1>syncsnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-08-18<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+syncsnoop - Trace sync() syscall. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>syncsnoop</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+syncsnoop traces calls to sync(), which flushes file system buffers to
+storage devices. These calls can cause performance perturbations, and it can
+be useful to know if they are happening and how frequently.
+<P>
+This works by tracing the kernel sys_sync() function using dynamic tracing, and
+will need updating to match any changes to this function.
+<P>
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism.
+<P>
+This program is also a basic example of eBPF/bcc.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace calls to sync():<DD>
+#
+<B>syncsnoop</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of the call, in seconds.
+<DT>CALL<DD>
+Call traced.
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel sync function and prints output for each event. As the
+rate of this is generally expected to be low (&lt;&lt; 100/s), the overhead is also
+expected to be negligible.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+iostat">iostat</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">FIELDS</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/syscount.html
+++ b/man/man8/syscount.html
@@ -1,0 +1,165 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of syscount</TITLE>
+</HEAD><BODY>
+<H1>syscount</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2017-02-15<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+syscount - Summarize syscall counts and latencies.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>syscount [-h] [-p PID] [-i INTERVAL] [-d DURATION] [-T TOP] [-x] [-e ERRNO] [-L] [-m] [-P] [-l]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces syscall entry and exit tracepoints and summarizes either the
+number of syscalls of each type, or the number of syscalls per process. It can
+also collect latency (invocation time) for each syscall or each process.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc. Linux 4.7+ is required to attach a BPF program to the
+raw_syscalls:sys_{enter,exit} tracepoints, used by this tool.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-p PID<DD>
+Trace only this process.
+<DT>-i INTERVAL<DD>
+Print the summary at the specified interval (in seconds).
+<DT>-d DURATION<DD>
+Total duration of trace (in seconds).
+<DT>-T TOP<DD>
+Print only this many entries. Default: 10.
+<DT>-x<DD>
+Trace only failed syscalls (i.e., the return value from the syscall was &lt; 0).
+<DT>-e ERRNO<DD>
+Trace only syscalls that failed with that error (e.g. -e EPERM or -e 1).
+<DT>-m<DD>
+Display times in milliseconds. Default: microseconds.
+<DT>-P<DD>
+Summarize by process and not by syscall.
+<DT>-l<DD>
+List the syscalls recognized by the tool (hard-coded list). Syscalls beyond this
+list will still be displayed, as &quot;[unknown: nnn]&quot; where nnn is the syscall
+number.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize all syscalls by syscall:<DD>
+#
+<B>syscount</B>
+
+<DT>Summarize all syscalls by process:<DD>
+#
+<B>syscount -P</B>
+
+<DT>Summarize only failed syscalls:<DD>
+#
+<B>syscount -x</B>
+
+<DT>Summarize only syscalls that failed with EPERM:<DD>
+#
+<B>syscount -e EPERM</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>syscount -p 181</B>
+
+<DT>Summarize syscalls counts and latencies:<DD>
+#
+<B>syscount -L</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>PID<DD>
+Process ID
+<DT>COMM<DD>
+Process name
+<DT>SYSCALL<DD>
+Syscall name, or &quot;[unknown: nnn]&quot; for syscalls that aren't recognized
+<DT>COUNT<DD>
+The number of events
+<DT>TIME<DD>
+The total elapsed time (in us or ms)
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+For most applications, the overhead should be manageable if they perform 1000's
+or even 10,000's of syscalls per second. For higher rates, the overhead may
+become considerable. For example, tracing a loop of 4 million calls to geteuid(),
+slows it down by 1.85x when tracing only syscall counts, and slows it down by
+more than 5x when tracing syscall counts and latencies. However, this represents
+a rate of &gt;3.5 million syscalls per second, which should not be typical.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ucalls">ucalls</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funclatency">funclatency</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tclcalls.html
+++ b/man/man8/tclcalls.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ucalls</TITLE>
+</HEAD><BODY>
+<H1>ucalls</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ucalls, javacalls, perlcalls, phpcalls, pythoncalls, rubycalls, tclcalls - Summarize method calls
+from high-level languages and Linux syscalls.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javacalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>perlcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>phpcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>pythoncalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>rubycalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>tclcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>ucalls [-l {java,perl,php,python,ruby}] [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes method calls from high-level languages such as Java, Perl,
+PHP, Python, Ruby, and Tcl. It can also trace Linux system calls. Whenever a method
+is invoked, ucalls records the call count and optionally the method's execution
+time (latency) and displays a summary.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, method probes are
+not enabled by default, and can be turned on by running the Java process with
+the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the environment
+variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,perl,php,python,ruby,tcl}<DD>
+The language to trace. If not provided, only syscalls are traced (when the -S
+option is used).
+<DT>-T TOP<DD>
+Print only the top methods by frequency or latency.
+<DT>-L<DD>
+Collect method invocation latency (duration).
+<DT>-S<DD>
+Collect Linux syscalls frequency and timing.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds (the default is microseconds).
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Print summary after this number of seconds and then exit. By default, wait for
+Ctrl+C to terminate.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace the top 10 Ruby method calls:<DD>
+#
+<B>ucalls -T 10 -l ruby 1344</B>
+
+<DT>Trace Python method calls and Linux syscalls including latency in milliseconds:<DD>
+#
+<B>ucalls -l python -mL 2020</B>
+
+<DT>Trace only syscalls and print a summary after 10 seconds:<DD>
+#
+<B>ucalls -S 788 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Tracing individual method calls will produce a considerable overhead in all
+high-level languages. For languages with just-in-time compilation, such as
+Java, the overhead can be more considerable than for interpreted languages.
+On the other hand, syscall tracing will typically be tolerable for most
+processes, unless they have a very unusual rate of system calls.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tclflow.html
+++ b/man/man8/tclflow.html
@@ -1,0 +1,170 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uflow</TITLE>
+</HEAD><BODY>
+<H1>uflow</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uflow, javaflow, perlflow, phpflow, pythonflow, rubyflow, tclflow - Print a flow graph of method
+calls in high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javaflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>perlflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>phpflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>pythonflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>rubyflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>tclflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>uflow [-h] [-M METHOD] [-C CLAZZ] [-v] [-l {java,perl,php,python,ruby,tcl}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uflow traces method calls and prints them in a flow graph that can facilitate
+debugging and diagnostics by following the program's execution (method flow).
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java processes, the
+startup flag &quot;-XX:+ExtendedDTraceProbes&quot; is required. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-M METHOD<DD>
+Print only method calls where the method name begins with this string.
+<DT>-C CLAZZ<DD>
+Print only method calls where the class name begins with this string. The class
+name interpretation strongly depends on the language. For example, in Java use
+&quot;package/subpackage/ClassName&quot; to refer to classes.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{java,perl,php,python,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Follow method flow in a Ruby process:<DD>
+#
+<B>uflow ruby 148</B>
+
+<DT>Follow method flow in a Java process where the class name is java.lang.Thread:<DD>
+#
+<B>uflow -C java/lang/Thread java 1802</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>CPU<DD>
+The CPU number on which the method was invoked. This is useful to easily see
+where the output skips to a different CPU.
+<DT>PID<DD>
+The process id.
+<DT>TID<DD>
+The thread id.
+<DT>TIME<DD>
+The duration of the method call.
+<DT>METHOD<DD>
+The method name.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This tool has extremely high overhead because it prints every method call. For
+some scenarios, you might see lost samples in the output as the tool is unable
+to keep up with the rate of data coming from the kernel. Filtering by class 
+or method prefix can help reduce the amount of data printed, but there is still
+a very high overhead in the collection mechanism. Do not use for performance-
+sensitive production scenarios, and always test first.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tclobjnew.html
+++ b/man/man8/tclobjnew.html
@@ -1,0 +1,157 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uobjnew</TITLE>
+</HEAD><BODY>
+<H1>uobjnew</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uobjnew, cobjnew, javaobjnew, rubyobjnew, tclobjnew - Summarize object allocations in
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>javaobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>rubyobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>tclobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>uobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] [-l {c,java,ruby,tcl}] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uobjnew traces object allocations in high-level languages (including &quot;malloc&quot;)
+and prints summaries of the most frequently allocated types by number of
+objects or number of bytes.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+C, Java, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, the Java process
+must be started with the &quot;-XX:+ExtendedDTraceProbes&quot; flag.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-C TOP_COUNT<DD>
+Print the top object types sorted by number of instances.
+<DT>-S TOP_SIZE<DD>
+Print the top object types sorted by size.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{c,java,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Wait this many seconds and then print the summary and exit. By default, wait
+for Ctrl+C to exit.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace object allocations in a Ruby process:<DD>
+#
+<B>uobjnew ruby 148</B>
+
+<DT>Trace object allocations from &quot;malloc&quot; and print the top 10 by total size:<DD>
+#
+<B>uobjnew -S 10 c 1788</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TYPE<DD>
+The object type being allocated. For C (malloc), this is the block size.
+<DT>ALLOCS<DD>
+The number of objects allocated.
+<DT>BYTES<DD>
+The number of bytes allocated.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Object allocation events are quite frequent, and therefore the overhead from
+running this tool can be considerable. Use with caution and make sure to 
+test before using in a production environment. Nonetheless, even thousands of
+allocations per second will likely produce a reasonable overhead when 
+investigating a problem.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ugc">ugc</A>(8), <A HREF="https://iovisor.github.io/bcc?8+memleak">memleak</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tclstat.html
+++ b/man/man8/tclstat.html
@@ -1,0 +1,201 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ustat</TITLE>
+</HEAD><BODY>
+<H1>ustat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ustat, javastat, nodestat, perlstat, phpstat, pythonstat, rubystat, tclstat - Activity stats from
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javastat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>nodestat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>perlstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>phpstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>pythonstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>rubystat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>tclstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>ustat [-l {java,node,perl,php,python,ruby,tcl}] [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is &quot;top&quot; for high-level language events, such as garbage collections,
+exceptions, thread creations, object allocations, method calls, and more. The
+events are aggregated for each process and printed in a top-like table, which
+can be sorted by various fields. Not all language runtimes provide the same
+set of details.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with
+these probes, which in some cases requires building from source with a
+USDT-specific flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java,
+some probes are not enabled by default, and can be turned on by running the Java
+process with the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Newly-created processes will only be traced at the next interval. If you run
+this tool with a short interval (say, 1-5 seconds), this should be virtually
+unnoticeable. For longer intervals, you might miss processes that were started
+and terminated during the interval window.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,node,perl,php,python,ruby,tcl}<DD>
+The language to trace. By default, all languages are traced.
+<DT>-C<DD>
+Do not clear the screen between updates.
+<DT>-S {cload,excp,gc,method,objnew,thread}<DD>
+Sort the output by the specified field.
+<DT>-r MAXROWS<DD>
+Do not print more than this number of rows.
+<DT>-d<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize activity in high-level languages, 1 second refresh:<DD>
+#
+<B>ustat</B>
+
+<DT>Don't clear the screen, and top 8 rows only:<DD>
+#
+<B>ustat -Cr 8</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>ustat 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Process ID.
+<DT>CMDLINE<DD>
+Process command line (often the second and following arguments will give you a
+hint as to which application is being run.
+<DT>METHOD/s<DD>
+Count of method invocations during interval.
+<DT>GC/s<DD>
+Count of garbage collections during interval.
+<DT>OBJNEW/s<DD>
+Count of objects allocated during interval.
+<DT>CLOAD/s<DD>
+Count of classes loaded during interval.
+<DT>EXC/s<DD>
+Count of exceptions thrown during interval.
+<DT>THR/s<DD>
+Count of threads created during interval.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+When using this tool with high-frequency events, such as method calls, a very
+significant slow-down can be expected. However, many of the high-level
+languages covered by this tool already have a fairly high per-method invocation
+cost, especially when running in interpreted mode. For the lower-frequency
+events, such as garbage collections or thread creations, the overhead should
+not be significant. Specifically, when probing Java processes and not using the
+&quot;-XX:+ExtendedDTraceProbes&quot; flag, the most expensive probes are not emitted,
+and the overhead should be acceptable.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tplist">tplist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tcpaccept.html
+++ b/man/man8/tcpaccept.html
@@ -1,0 +1,164 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tcpaccept</TITLE>
+</HEAD><BODY>
+<H1>tcpaccept</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2020-02-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tcpaccept - Trace TCP passive connections (accept()). Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tcpaccept [-h] [-T] [-t] [-p PID] [-P PORTS] [--cgroupmap MAPPATH]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces passive TCP connections (eg, via an accept() syscall;
+connect() are active connections). This can be useful for general
+troubleshooting to see what new connections the local server is accepting.
+<P>
+This uses dynamic tracing of the kernel inet_csk_accept() socket function (from
+tcp_prot.accept), and will need to be modified to match kernel changes.
+<P>
+This tool only traces successful TCP accept()s. Connection attempts to closed
+ports will not be shown (those can be traced via other functions).
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Include a time column on output (HH:MM:SS).
+<DT>-t<DD>
+Include a timestamp column.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-P PORTS<DD>
+Comma-separated list of local ports to trace (filtered in-kernel).
+<DT>--cgroupmap MAPPATH<DD>
+Trace cgroups in this BPF map only (filtered in-kernel).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all passive TCP connections (accept()s):<DD>
+#
+<B>tcpaccept</B>
+
+<DT>Trace all TCP accepts, and include timestamps:<DD>
+#
+<B>tcpaccept -t</B>
+
+<DT>Trace connections to local ports 80 and 81 only:<DD>
+#
+<B>tcpaccept -P 80,81</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>tcpaccept -p 181</B>
+
+<DT>Trace a set of cgroups only (see filtering_by_cgroups.md from bcc sources for more details):<DD>
+#
+<B>tcpaccept --cgroupmap /sys/fs/bpf/test01</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the event, in HH:MM:SS format.
+<DT>TIME(s)<DD>
+Time of the event, in seconds.
+<DT>PID<DD>
+Process ID
+<DT>COMM<DD>
+Process name
+<DT>IP<DD>
+IP address family (4 or 6)
+<DT>RADDR<DD>
+Remote IP address.
+<DT>RPORT<DD>
+Remote port
+<DT>LADDR<DD>
+Local IP address.
+<DT>LPORT<DD>
+Local port
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel inet_csk_accept function and prints output for each event.
+The rate of this depends on your server application. If it is a web or proxy server
+accepting many tens of thousands of connections per second, then the overhead
+of this tool may be measurable (although, still a lot better than tracing
+every packet). If it is less than a thousand a second, then the overhead is
+expected to be negligible. Test and understand this overhead before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcptracer">tcptracer</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpconnect">tcpconnect</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpdump">tcpdump</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tcpconnect.html
+++ b/man/man8/tcpconnect.html
@@ -1,0 +1,179 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tcpconnect</TITLE>
+</HEAD><BODY>
+<H1>tcpconnect</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2020-02-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tcpconnect - Trace TCP active connections (connect()). Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tcpconnect [-h] [-c] [-t] [-x] [-p PID] [-P PORT] [--cgroupmap MAPPATH]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces active TCP connections (eg, via a connect() syscall;
+accept() are passive connections). This can be useful for general
+troubleshooting to see what connections are initiated by the local server.
+<P>
+All connection attempts are traced, even if they ultimately fail.
+<P>
+This works by tracing the kernel tcp_v4_connect() and tcp_v6_connect() functions
+using dynamic tracing, and will need updating to match any changes to these
+functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-t<DD>
+Include a timestamp column.
+<DT>-c<DD>
+Count connects per src ip and dest ip/port.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-P PORT<DD>
+Comma-separated list of destination ports to trace (filtered in-kernel).
+<DT>--cgroupmap MAPPATH<DD>
+Trace cgroups in this BPF map only (filtered in-kernel).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>-U<DD>
+Include a UID column.
+<DT>-u UID<DD>
+Trace this UID only (filtered in-kernel).
+<DT>Trace all active TCP connections:<DD>
+#
+<B>tcpconnect</B>
+
+<DT>Trace all TCP connects, and include timestamps:<DD>
+#
+<B>tcpconnect -t</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>tcpconnect -p 181</B>
+
+<DT>Trace ports 80 and 81 only:<DD>
+#
+<B>tcpconnect -P 80,81</B>
+
+<DT>Trace all TCP connects, and include UID:<DD>
+#
+<B>tcpconnect -U</B>
+
+<DT>Trace UID 1000 only:<DD>
+#
+<B>tcpconnect -u 1000</B>
+
+<DT>Count connects per src ip and dest ip/port:<DD>
+#
+<B>tcpconnect -c</B>
+
+<DT>Trace a set of cgroups only (see filtering_by_cgroups.md from bcc sources for more details):<DD>
+#
+<B>tcpconnect --cgroupmap /sys/fs/bpf/test01</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of the call, in seconds.
+<DT>UID<DD>
+User ID
+<DT>PID<DD>
+Process ID
+<DT>COMM<DD>
+Process name
+<DT>IP<DD>
+IP address family (4 or 6)
+<DT>SADDR<DD>
+Source IP address.
+<DT>DADDR<DD>
+Destination IP address.
+<DT>DPORT<DD>
+Destination port
+<DT>CONNECTS<DD>
+Accumulated active connections since start.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel tcp_v[46]_connect functions and prints output for each
+event. As the rate of this is generally expected to be low (&lt; 1000/s), the
+overhead is also expected to be negligible. If you have an application that
+is calling a high rate of connect()s, such as a proxy server, then test and
+understand this overhead before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcptracer">tcptracer</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpaccept">tcpaccept</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpdump">tcpdump</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tcpconnlat.html
+++ b/man/man8/tcpconnlat.html
@@ -1,0 +1,166 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tcpconnlat</TITLE>
+</HEAD><BODY>
+<H1>tcpconnlat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-19<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tcpconnlat - Trace TCP active connection latency. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tcpconnlat [-h] [-t] [-p PID] [-v] [min_ms]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces active TCP connections
+(eg, via a connect() syscall), and shows the latency (time) for the connection
+as measured locally: the time from SYN sent to the response packet.
+This is a useful performance metric that typically spans kernel TCP/IP
+processing and the network round trip time (not application runtime).
+<P>
+All connection attempts are traced, even if they ultimately fail (RST packet
+in response).
+<P>
+This tool works by use of kernel dynamic tracing of TCP/IP functions, and will
+need updating to match any changes to these functions. This tool should be
+updated in the future to use static tracepoints, once they are available.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-t<DD>
+Include a timestamp column.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>min_ms<DD>
+Minimum duration to trace, in milliseconds.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all active TCP connections, and show connection latency (SYN-&gt;response round trip):<DD>
+#
+<B>tcpconnlat</B>
+
+<DT>Include timestamps:<DD>
+#
+<B>tcpconnlat -t</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>tcpconnlat -p 181</B>
+
+<DT>Trace connects with latency longer than 10 ms:<DD>
+#
+<B>tcpconnlat 10</B>
+
+<DT>Print the BPF program:<DD>
+#
+<B>tcpconnlat -v</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of the response packet, in seconds.
+<DT>PID<DD>
+Process ID that initiated the connection.
+<DT>COMM<DD>
+Process name that initiated the connection.
+<DT>IP<DD>
+IP address family (4 or 6).
+<DT>SADDR<DD>
+Source IP address.
+<DT>DADDR<DD>
+Destination IP address.
+<DT>DPORT<DD>
+Destination port
+<DT>LAT(ms)<DD>
+The time from when a TCP connect was issued (measured in-kernel) to when a
+response packet was received for this connection (can be SYN,ACK, or RST, etc).
+This time spans kernel to kernel latency, involving kernel TCP/IP processing
+and the network round trip in between. This typically does not include
+time spent by the application processing the new connection.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel tcp_v[46]_connect functions and prints output for each
+event. As the rate of this is generally expected to be low (&lt; 1000/s), the
+overhead is also expected to be negligible. If you have an application that
+is calling a high rate of connects()s, such as a proxy server, then test and
+understand this overhead before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcpconnect">tcpconnect</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpaccept">tcpaccept</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpdump">tcpdump</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tcpdrop.html
+++ b/man/man8/tcpdrop.html
@@ -1,0 +1,129 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tcpdrop</TITLE>
+</HEAD><BODY>
+<H1>tcpdrop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-05-30<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tcpdrop - Trace kernel-based TCP packet drops with details. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tcpdrop [-h]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces TCP packets or segments that were dropped by the kernel, and
+shows details from the IP and TCP headers, the socket state, and the
+kernel stack trace. This is useful for debugging cases of high kernel drops,
+which can cause timer-based retransmits and performance issues.
+<P>
+This tool works using dynamic tracing of the tcp_drop() kernel function,
+which requires a recent kernel version.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<B>tcpdrop</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the drop, in HH:MM:SS format.
+<DT>PID<DD>
+Process ID that was on-CPU during the drop. This may be unrelated, as drops
+can occur on the receive interrupt and be unrelated to the PID that was
+interrupted.
+<DT>IP<DD>
+IP address family (4 or 6)
+<DT>SADDR<DD>
+Source IP address.
+<DT>SPORT<DD>
+Source TCP port.
+<DT>DADDR<DD>
+Destination IP address.
+<DT>DPORT<DD>
+Destionation TCP port.
+<DT>STATE<DD>
+TCP session state (&quot;ESTABLISHED&quot;, etc).
+<DT>FLAGS<DD>
+TCP flags (&quot;SYN&quot;, etc).
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel tcp_drop() function, which should be low frequency,
+and therefore the overhead of this tool should be negligible.
+<P>
+As always, test and understand this tools overhead for your types of
+workloads before production use.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcplife">tcplife</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpaccept">tcpaccept</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpconnect">tcpconnect</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcptop">tcptop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">FIELDS</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tcplife.html
+++ b/man/man8/tcplife.html
@@ -1,0 +1,180 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tcplife</TITLE>
+</HEAD><BODY>
+<H1>tcplife</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-10-19<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tcplife - Trace TCP sessions and summarize lifespan. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tcplife [-h] [-T] [-t] [-w] [-s] [-p PID] [-D PORTS] [-L PORTS]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces TCP sessions that open and close while tracing, and prints
+a line of output to summarize each one. This includes the IP addresses, ports,
+duration, and throughput for the session. This is useful for workload
+characterisation and flow accounting: identifying what connections are
+happening, with the bytes transferred.
+<P>
+This tool works using the sock:inet_sock_set_state tracepoint if it exists,
+added to Linux 4.16, and switches to using kernel dynamic tracing for older
+kernels. Only TCP state changes are traced, so it is expected that the
+overhead of this tool is much lower than typical send/receive tracing.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-s<DD>
+Comma separated values output (parseable).
+<DT>-t<DD>
+Include a timestamp column (seconds).
+<DT>-T<DD>
+Include a time column (HH:MM:SS).
+<DT>-w<DD>
+Wide column output (fits IPv6 addresses).
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-L PORTS<DD>
+Comma-separated list of local ports to trace (filtered in-kernel).
+<DT>-D PORTS<DD>
+Comma-separated list of destination ports to trace (filtered in-kernel).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all TCP sessions, and summarize lifespan and throughput:<DD>
+#
+<B>tcplife</B>
+
+<DT>Include a timestamp column, and wide column output:<DD>
+#
+<B>tcplife -tw</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>tcplife -p 181</B>
+
+<DT>Trace connections to local ports 80 and 81 only:<DD>
+#
+<B>tcplife -L 80,81</B>
+
+<DT>Trace connections to remote port 80 only:<DD>
+#
+<B>tcplife -D 80</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the call, in HH:MM:SS format.
+<DT>TIME(s)<DD>
+Time of the call, in seconds.
+<DT>PID<DD>
+Process ID
+<DT>COMM<DD>
+Process name
+<DT>IP<DD>
+IP address family (4 or 6)
+<DT>LADDR<DD>
+Local IP address.
+<DT>RADDR<DD>
+Remote IP address.
+<DT>LPORT<DD>
+Local port.
+<DT>RPORT<DD>
+Remote port.
+<DT>TX_KB<DD>
+Total transmitted Kbytes.
+<DT>RX_KB<DD>
+Total received Kbytes.
+<DT>MS<DD>
+Lifespan of the session, in milliseconds.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel TCP set state function, which should be called much
+less often than send/receive tracing, and therefore have lower overhead. The
+overhead of the tool is relative to the rate of new TCP sessions: if this is
+high, over 10,000 per second, then there may be noticeable overhead just to
+print out 10k lines of formatted output per second.
+<P>
+You can find out the rate of new TCP sessions using &quot;sar -n TCP 1&quot;, and
+adding the active/s and passive/s columns.
+<P>
+As always, test and understand this tools overhead for your types of
+workloads before production use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcpaccept">tcpaccept</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpconnect">tcpconnect</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcptop">tcptop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tcpretrans.html
+++ b/man/man8/tcpretrans.html
@@ -1,0 +1,148 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tcpretrans</TITLE>
+</HEAD><BODY>
+<H1>tcpretrans</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-14<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tcpretrans - Trace or count TCP retransmits and TLPs. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tcpretrans [-h] [-l] [-c]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces TCP retransmits, showing address, port, and TCP state information,
+and sometimes the PID (although usually not, since retransmits are usually
+sent by the kernel on timeouts). To keep overhead very low, only
+the TCP retransmit functions are traced. This does not trace every packet
+(like <A HREF="https://iovisor.github.io/bcc?8+tcpdump">tcpdump</A>(8) or a packet sniffer). Optionally, it can count retransmits
+over a user signalled interval to spot potentially dropping network paths the
+flows are traversing. 
+<P>
+This uses dynamic tracing of the kernel tcp_retransmit_skb() and
+tcp_send_loss_probe() functions, and will need to be updated to
+match kernel changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-l<DD>
+Include tail loss probe attempts (in some cases the kernel may not
+complete the TLP send).
+<DT>-c<DD>
+Count occurring retransmits per flow. 
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace TCP retransmits:<DD>
+#
+<B>tcpretrans</B>
+
+<DT>Trace TCP retransmits and TLP attempts:<DD>
+#
+<B>tcpretrans -l</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the retransmit.
+<DT>PID<DD>
+Process ID that was on-CPU. This is less useful than it might sound, as it
+may usually be 0, for the kernel, for timer-based retransmits.
+<DT>IP<DD>
+IP address family (4 or 6).
+<DT>LADDR<DD>
+Local IP address.
+<DT>LPORT<DD>
+Local port.
+<DT>T&gt;<DD>
+Type of event: R&gt; == retransmit, L&gt; == tail loss probe.
+<DT>RADDR<DD>
+Remote IP address.
+<DT>RPORT<DD>
+Remote port.
+<DT>STATE<DD>
+TCP session state.
+<DT>RETRANSMITS<DD>
+Accumulated occurred retransmits since start.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Should be negligible: TCP retransmit events should be low (&lt;1000/s), and the
+low overhead this tool adds to each event should make the cost negligible.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcpconnect">tcpconnect</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpaccept">tcpaccept</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tcpstates.html
+++ b/man/man8/tcpstates.html
@@ -1,0 +1,181 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tcpstates</TITLE>
+</HEAD><BODY>
+<H1>tcpstates</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-03-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tcpstates - Trace TCP session state changes with durations. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tcpstates [-h] [-T] [-t] [-w] [-s] [-D PORTS] [-L PORTS] [-Y]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces TCP session state changes while tracing, and prints details
+including the duration in each state. This can help explain the latency of
+TCP connections: whether the time is spent in the ESTABLISHED state (data
+transfer), or initialization state (SYN_SENT), etc.
+<P>
+This tool works using the sock:inet_sock_set_state tracepoint, which was
+added to Linux 4.16. Linux 4.16 also included extra state transitions so that
+all TCP transitions could be observed by this tracepoint.
+<P>
+Only TCP state changes are traced, so it is expected that the
+overhead of this tool is much lower than typical send/receive tracing.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc, and the sock:inet_sock_set_state tracepoint.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-s<DD>
+Comma separated values output (parseable).
+<DT>-t<DD>
+Include a timestamp column (seconds).
+<DT>-T<DD>
+Include a time column (HH:MM:SS).
+<DT>-w<DD>
+Wide column output (fits IPv6 addresses).
+<DT>-L PORTS<DD>
+Comma-separated list of local ports to trace (filtered in-kernel).
+<DT>-D PORTS<DD>
+Comma-separated list of destination ports to trace (filtered in-kernel).
+<DT>-Y<DD>
+Log session state changes to the systemd journal.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all TCP sessions, and show all state changes:<DD>
+#
+<B>tcpstates</B>
+
+<DT>Include a timestamp column, and wide column output:<DD>
+#
+<B>tcpstates -tw</B>
+
+<DT>Trace connections to local ports 80 and 81 only:<DD>
+#
+<B>tcpstates -L 80,81</B>
+
+<DT>Trace connections to remote port 80 only:<DD>
+#
+<B>tcpstates -D 80</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+Time of the change, in HH:MM:SS format.
+<DT>TIME(s)<DD>
+Time of the change, in seconds.
+<DT>C-PID<DD>
+The current on-CPU process ID. This may show the process that owns the TCP
+session if the state change executes in synchronous process context, else it
+is likely to show the kernel (asynchronous state change).
+<DT>C-COMM<DD>
+The current on-CPU process name. This may show the process that owns the TCP
+session if the state change executes in synchronous process context, else it
+is likely to show the kernel (asynchronous state change).
+<DT>IP<DD>
+IP address family (4 or 6)
+<DT>LADDR<DD>
+Local IP address.
+<DT>RADDR<DD>
+Remote IP address.
+<DT>LPORT<DD>
+Local port.
+<DT>RPORT<DD>
+Remote port.
+<DT>OLDSTATE<DD>
+Previous TCP state.
+<DT>NEWSTATE<DD>
+New TCP state.
+<DT>MS<DD>
+Duration of this state.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel TCP set state function, which should be called much
+less often than send/receive tracing, and therefore have lower overhead. The
+overhead of the tool is relative to the rate of new TCP sessions: if this is
+high, over 10,000 per second, then there may be noticeable overhead just to
+print out 10k lines of formatted output per second.
+<P>
+You can find out the rate of new TCP sessions using &quot;sar -n TCP 1&quot;, and
+adding the active/s and passive/s columns.
+<P>
+As always, test and understand this tools overhead for your types of
+workloads before production use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcpaccept">tcpaccept</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpconnect">tcpconnect</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcptop">tcptop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcplife">tcplife</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tcpsubnet.html
+++ b/man/man8/tcpsubnet.html
@@ -1,0 +1,161 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tcpsubnet</TITLE>
+</HEAD><BODY>
+<H1>tcpsubnet</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-03-01<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tcpsubnet - Summarize and aggregate IPv4 TCP traffic by subnet.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tcpsubnet [-h] [-v] [--ebpf] [-J] [-f FORMAT] [-i INTERVAL] [subnets]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes and aggregates IPv4 TCP sent to the subnets
+passed in argument and prints to stdout on a fixed interval.
+<P>
+This uses dynamic tracing of kernel TCP send/receive functions, and will
+need to be updated to match kernel changes.
+<P>
+The traced data is summarized in-kernel using a BPF map to reduce overhead.
+At very high TCP event rates, the overhead may still be measurable.
+See the OVERHEAD section for more details.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print USAGE message.
+<DT>-v<DD>
+Run in verbose mode. Will output subnet evaluation and the BPF program
+<DT>-J<DD>
+Format output in JSON.
+<DT>-i<DD>
+Interval between updates, seconds (default 1).
+<DT>-f<DD>
+Format output units. Supported values are bkmBKM. When using
+kmKM the output will be rounded to floor.
+<DT>--ebpf<DD>
+Prints the BPF program.
+<DT>subnets<DD>
+Comma separated list of subnets. Traffic will be categorized
+in theses subnets. Order matters.
+(default 127.0.0.1/32,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,0.0.0.0/0)
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize TCP traffic by the default subnets:<DD>
+#
+<B>tcpsubnet</B>
+
+<DT>Summarize all TCP traffic:<DD>
+#
+<B>tcpsubnet 0.0.0.0/0</B>
+
+<DT>Summarize all TCP traffic and output in JSON and Kb:<DD>
+#
+<B>tcpsubnet -J -fk 0.0.0.0/0</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>(Standad output) Left hand side column:<DD>
+Subnet
+<DT>(Standard output) Right hand side column:<DD>
+Aggregate traffic in units passed as argument
+<DT>(JSON output) date<DD>
+Current date formatted in the system locale
+<DT>(JSON output) time<DD>
+Current time formatted in the system locale
+<DT>(JSON output) entries<DD>
+Map of subnets to aggregates. Values will be in format passed to -f
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces all tcp_sendmsg function calls in the TCP/IP stack.
+It summarizes data in-kernel to reduce overhead.
+A simple iperf test (v2.0.5) with the default values shows a loss
+of ~5% throughput. On 10 runs without tcpsubnet running the average
+throughput was 32.42Gb/s, with tcpsubnet enabled it was 31.26Gb/s.
+This is not meant to be used as a long running service. Use it
+for troubleshooting or for a controlled interval. As always,
+try it out in a test environment first.
+<P>
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Rodrigo Manyari
+<A NAME="lbAN">&nbsp;</A>
+<H2>INSPIRATION</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcptop">tcptop</A>(8) by Brendan Gregg
+<A NAME="lbAO">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?7+netlink">netlink</A>(7)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">INSPIRATION</A><DD>
+<DT><A HREF="#lbAO">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tcptop.html
+++ b/man/man8/tcptop.html
@@ -1,0 +1,170 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tcptop</TITLE>
+</HEAD><BODY>
+<H1>tcptop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-09-13<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tcptop - Summarize TCP send/recv throughput by host. Top for TCP.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tcptop [-h] [-C] [-S] [-p PID] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is top for TCP sessions.
+<P>
+This summarizes TCP send/receive Kbytes by host, and prints a summary that
+refreshes, along other system-wide metrics.
+<P>
+This uses dynamic tracing of kernel TCP send/receive functions, and will
+need to be updated to match kernel changes.
+<P>
+The traced TCP functions are usually called at a lower rate than
+per-packet functions, and therefore have lower overhead. The traced data is
+summarized in-kernel using a BPF map to further reduce overhead. At very high
+TCP event rates, the overhead may still be measurable. See the OVERHEAD
+section for more details.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print USAGE message.
+<DT>-C<DD>
+Don't clear the screen.
+<DT>-S<DD>
+Don't print the system summary line (load averages).
+<DT>-p PID<DD>
+Trace this PID only.
+<DT>interval<DD>
+Interval between updates, seconds (default 1).
+<DT>count<DD>
+Number of interval summaries (default is many).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize TCP throughput by active sessions, 1 second refresh:<DD>
+#
+<B>tcptop</B>
+
+<DT>Don't clear the screen (rolling output), and 5 second summaries:<DD>
+#
+<B>tcptop -C 5</B>
+
+<DT>Trace PID 181 only, and don't clear the screen:<DD>
+#
+<B>tcptop -Cp 181</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg:<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Process ID.
+<DT>COMM<DD>
+Process name.
+<DT>LADDR<DD>
+Local address (IPv4), and TCP port
+<DT>RADDR<DD>
+Remote address (IPv4), and TCP port
+<DT>LADDR6<DD>
+Source address (IPv6), and TCP port
+<DT>RADDR6<DD>
+Destination address (IPv6), and TCP port
+<DT>RX_KB<DD>
+Received Kbytes
+<DT>TX_KB<DD>
+Transmitted Kbytes
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces all send/receives in TCP, high in the TCP/IP stack (close to the
+application) which are usually called at a lower rate than per-packet
+functions, lowering overhead. It also summarizes data in-kernel to further
+reduce overhead. These techniques help, but there may still be measurable
+overhead at high send/receive rates, eg, ~13% of one CPU at 100k events/sec.
+use funccount to count the kprobes in the tool to find out this rate, as the
+overhead is relative to the rate. Some sample production servers tested found
+total TCP event rates of 4k to 15k per second, and the CPU overhead at these
+rates ranged from 0.5% to 2.0% of one CPU. If your send/receive rate is low
+(eg, &lt;1000/sec) then the overhead is expected to be negligible; Test in a lab
+environment first.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>INSPIRATION</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+top">top</A>(1) by William LeFebvre
+<A NAME="lbAO">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcpconnect">tcpconnect</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpaccept">tcpaccept</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">INSPIRATION</A><DD>
+<DT><A HREF="#lbAO">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tcptracer.html
+++ b/man/man8/tcptracer.html
@@ -1,0 +1,160 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tcptracer</TITLE>
+</HEAD><BODY>
+<H1>tcptracer</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2020-02-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tcptracer - Trace TCP established connections. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tcptracer [-h] [-v] [-p PID] [-N NETNS] [--cgroupmap MAPPATH]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces established TCP connections that open and close while tracing,
+and prints a line of output per connect, accept and close events. This includes
+the type of event, PID, IP addresses and ports.
+<P>
+This tool works by using kernel dynamic tracing, and will need to be updated if
+the kernel implementation changes. Only established TCP connections are traced,
+so it is expected that the overhead of this tool is rather low.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-v<DD>
+Print full lines, with long event type names and network namespace numbers.
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>-N NETNS<DD>
+Trace this network namespace only (filtered in-kernel).
+<DT>--cgroupmap MAPPATH<DD>
+Trace cgroups in this BPF map only (filtered in-kernel).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all TCP established connections:<DD>
+#
+<B>tcptracer</B>
+
+<DT>Trace all TCP established connections with verbose lines:<DD>
+#
+<B>tcptracer -v</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>tcptracer -p 181</B>
+
+<DT>Trace connections in network namespace 4026531969 only:<DD>
+#
+<B>tcptracer -N 4026531969</B>
+
+<DT>Trace a set of cgroups only (see filtering_by_cgroups.md from bcc sources for more details):<DD>
+#
+<B>tcptracer --cgroupmap /sys/fs/bpf/test01</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TYPE<DD>
+Type of event. In non-verbose mode: C for connect, A for accept, X for close.
+<DT>PID<DD>
+Process ID
+<DT>COMM<DD>
+Process name
+<DT>IP<DD>
+IP address family (4 or 6)
+<DT>SADDR<DD>
+Source IP address.
+<DT>DADDR<DD>
+Destination IP address.
+<DT>SPORT<DD>
+Source port.
+<DT>DPORT<DD>
+Destination port.
+<DT>NETNS<DD>
+Network namespace where the event originated.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces the kernel inet accept function, and the TCP connect, close,
+and set state functions. However, it only prints information for connections
+that are established, so it shouldn't have a huge overhead.
+<P>
+As always, test and understand this tools overhead for your types of workloads
+before production use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Iago López Galeiras
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+tcpaccept">tcpaccept</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcpconnect">tcpconnect</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcptop">tcptop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tcplife">tcplife</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/tplist.html
+++ b/man/man8/tplist.html
@@ -1,0 +1,113 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of tplist</TITLE>
+</HEAD><BODY>
+<H1>tplist</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-03-20<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+tplist - Display kernel tracepoints or USDT probes and their formats.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>tplist [-p PID] [-l LIB] [-v] [filter]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+tplist lists all kernel tracepoints, and can optionally print out the tracepoint
+format; namely, the variables that you can trace when the tracepoint is hit. 
+tplist can also list USDT probes embedded in a specific library or executable,
+and can list USDT probes for all the libraries loaded by a specific process.
+These features are usually used in conjunction with the argdist and/or trace tools.
+<P>
+On a typical system, accessing the tracepoint list and format requires root.
+However, accessing USDT probes does not require root.
+<A NAME="lbAE">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-p PID<DD>
+Display the USDT probes from all the libraries loaded by the specified process.
+<DT>-l LIB<DD>
+Display the USDT probes from the specified library or executable. If the librar
+or executable can be found in the standard paths, a full path is not required.
+<DT>-v<DD>
+Increase the verbosity level. Can be used to display the variables, locations,
+and arguments of tracepoints and USDT probes.
+<DT>[filter]<DD>
+A wildcard expression that specifies which tracepoints or probes to print.
+For example, block:* will print all block tracepoints (block:block_rq_complete,
+etc.). Regular expressions are not supported.
+</DL>
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Print all kernel tracepoints:<DD>
+#
+<B>tplist</B>
+
+<DT>Print all net tracepoints with their format:<DD>
+#
+<B>tplist -v 'net:*'</B>
+
+<DT>Print all USDT probes in libpthread:<DD>
+$ 
+<B>tplist -l pthread</B>
+
+<DT>Print all USDT probes in process 4717 from the libc provider:<DD>
+$
+<B>tplist -p 4717 'libc:*'</B>
+
+<DT>Print all the USDT probes in the node executable:<DD>
+$
+<B>tplist -l node</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAI">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">OPTIONS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">SOURCE</A><DD>
+<DT><A HREF="#lbAH">OS</A><DD>
+<DT><A HREF="#lbAI">STABILITY</A><DD>
+<DT><A HREF="#lbAJ">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/trace.html
+++ b/man/man8/trace.html
@@ -1,0 +1,267 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of trace</TITLE>
+</HEAD><BODY>
+<H1>trace</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-18<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+trace - Trace a function and print its arguments or return value, optionally evaluating a filter. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>trace [-h] [-b BUFFER_PAGES] [-p PID] [-L TID] [-v] [-Z STRING_SIZE] [-S] [-s SYM_FILE_LIST]</B>
+
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-M&nbsp;MAX_EVENTS]&nbsp;[-t]&nbsp;[-u]&nbsp;[-T]&nbsp;[-C]&nbsp;[-K]&nbsp;[-U]&nbsp;[-a]&nbsp;[-I&nbsp;header]
+<BR>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;probe&nbsp;[probe&nbsp;...]
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+trace probes functions you specify and displays trace messages if a particular
+condition is met. You can control the message format to display function 
+arguments and return values. 
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-p PID<DD>
+Trace only functions in the process PID.
+<DT>-L TID<DD>
+Trace only functions in the thread TID.
+<DT>-v<DD>
+Display the generated BPF program, for debugging purposes.
+<DT>-z STRING_SIZE<DD>
+When collecting string arguments (of type char*), collect up to STRING_SIZE
+characters. Longer strings will be truncated.
+<DT>-s SYM_FILE_LIST<DD>
+When collecting stack trace in build id format, use the coma separated list for
+symbol resolution.
+<DT>-S<DD>
+If set, trace messages from trace's own process. By default, this is off to
+avoid tracing storms -- for example, if you trace the write system call, and
+consider that trace is writing to the standard output.
+<DT>-M MAX_EVENTS<DD>
+Print up to MAX_EVENTS trace messages and then exit.
+<DT>-t<DD>
+Print times relative to the beginning of the trace (offsets), in seconds.
+<DT>-u<DD>
+Print UNIX timestamps instead of offsets from trace beginning, requires -t.
+<DT>-T<DD>
+Print the time column.
+<DT>-C<DD>
+Print CPU id.
+<DT>-c CGROUP_PATH<DD>
+Trace only functions in processes under CGROUP_PATH hierarchy.
+<DT>-n NAME<DD>
+Only print process names containing this name.
+<DT>-f MSG_FILTER<DD>
+Only print message of event containing this string.
+<DT>-B<DD>
+Treat argument of STRCMP helper as a binary value
+<DT>-K<DD>
+Print the kernel stack for each event.
+<DT>-U<DD>
+Print the user stack for each event.
+-a
+Print virtual address in kernel and user stacks.
+<DT>-I header<DD>
+Additional header files to include in the BPF program. This is needed if your
+filter or print expressions use types or data structures that are not available
+in the standard headers. For example: 'linux/mm.h'
+<DT>probe [probe ...]<DD>
+One or more probes that attach to functions, filter conditions, and print
+information. See PROBE SYNTAX below.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>PROBE SYNTAX</H2>
+
+The general probe syntax is as follows:
+<P>
+<B>[{p,r}]:[library]:function[(signature)] [(predicate)] [format string[, arguments]]</B>
+
+<P>
+<B>{t:category:event,u:library:probe} [(predicate)] [format string[, arguments]]</B>
+
+<DL COMPACT>
+<DT><B>{[{p,r}],t,u}</B>
+
+<DD>
+Probe type - &quot;p&quot; for function entry, &quot;r&quot; for function return, &quot;t&quot; for kernel
+tracepoint, &quot;u&quot; for USDT probe. The default probe type is &quot;p&quot;.
+<DT><B>[library]</B>
+
+<DD>
+Library containing the probe.
+Specify the full path to the .so or executable file where the function to probe
+resides. Alternatively, you can specify just the lib name: for example, &quot;c&quot;
+refers to libc. If no library name is specified, the kernel is assumed. Also,
+you can specify an executable name (without a full path) if it is in the PATH.
+For example, &quot;bash&quot;.
+<DT><B>category</B>
+
+<DD>
+The tracepoint category. For example, &quot;sched&quot; or &quot;irq&quot;.
+<DT><B>function</B>
+
+<DD>
+The function to probe.
+<DT><B>signature</B>
+
+<DD>
+The optional signature of the function to probe. This can make it easier to
+access the function's arguments, instead of using the &quot;arg1&quot;, &quot;arg2&quot; etc.
+argument specifiers. For example, &quot;(struct timespec *ts)&quot; in the signature
+position lets you use &quot;ts&quot; in the filter or print expressions.
+<DT><B>event</B>
+
+<DD>
+The tracepoint event. For example, &quot;block_rq_complete&quot;.
+<DT><B>probe</B>
+
+<DD>
+The USDT probe name. For example, &quot;pthread_create&quot;.
+<DT><B>[(predicate)]</B>
+
+<DD>
+The filter applied to the captured data. Only if the filter evaluates as true,
+the trace message will be printed. The filter can use any valid C expression
+that refers to the argument values: arg1, arg2, etc., or to the return value
+retval in a return probe. If necessary, use C cast operators to coerce the
+arguments to the desired type. For example, if arg1 is of type int, use the
+expression ((int)arg1 &lt; 0) to trace only invocations where arg1 is negative.
+Note that only arg1-arg6 are supported, and only if the function is using the
+standard x86_64 convention where the first six arguments are in the RDI, RSI, 
+RDX, RCX, R8, R9 registers. If no predicate is specified, all function 
+invocations are traced.
+<P>
+The predicate expression may also use the STRCMP pseudo-function to compare
+a predefined string to a string argument. For example: STRCMP(&quot;test&quot;, arg1).
+The order of arguments is important: the first argument MUST be a quoted
+literal string, and the second argument can be a runtime string, most typically
+an argument. 
+<DT><B>[format string[, arguments]]</B>
+
+<DD>
+A printf-style format string that will be used for the trace message. You can
+use the following format specifiers: %s, %d, %u, %lld, %llu, %hd, %hu, %c,
+%x, %llx -- with the same semantics as printf's. Make sure to pass the exact
+number of arguments as there are placeholders in the format string. The
+format specifier replacements may be any C expressions, and may refer to the
+same special keywords as in the predicate (arg1, arg2, etc.).
+<P>
+In addition to the above format specifiers, you can also use %K and %U when
+the expression is an address that potentially points to executable code (i.e.,
+a symbol). trace will resolve %K specifiers to a kernel symbol, such as
+vfs__read, and will resolve %U specifiers to a user-space symbol in that
+process, such as sprintf.
+<P>
+In tracepoints, both the predicate and the arguments may refer to the tracepoint
+format structure, which is stored in the special &quot;args&quot; variable. For example, the
+block:block_rq_complete tracepoint can print or filter by args-&gt;nr_sector. To 
+discover the format of your tracepoint, use the tplist tool. 
+<P>
+In USDT probes, the arg1, ..., argN variables refer to the probe's arguments.
+To determine which arguments your probe has, use the tplist tool.
+<P>
+The predicate expression and the format specifier replacements for printing
+may also use the following special keywords: $pid, $tgid to refer to the 
+current process' pid and tgid; $uid, $gid to refer to the current user's
+uid and gid; $cpu to refer to the current processor number.
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all invocations of the open system call with the name of the file being opened:<DD>
+#
+<B>trace '::do_sys_open %s, arg2'</B>
+
+<DT>Trace all invocations of the read system call where the number of bytes requested is greater than 20,000:<DD>
+#
+<B>trace '::sys_read (arg3 &gt; 20000) read %d bytes, arg3'</B>
+
+<DT>Trace all malloc calls and print the size of the requested allocation:<DD>
+#
+<B>trace ':c:malloc size = %d, arg1'</B>
+
+<DT>Trace returns from the readline function in bash and print the return value as a string:<DD>
+#
+<B>trace 'r:bash:readline %s, retval' </B>
+
+<DT>Trace the block:block_rq_complete tracepoint and print the number of sectors completed:<DD>
+#
+<B>trace 't:block:block_rq_complete %d sectors, args-&gt;nr_sector'</B>
+
+<DT>Trace the pthread_create USDT probe from the pthread library and print the address of the thread's start function:<DD>
+#
+<B>trace 'u:pthread:pthread_create start addr = %llx, arg3'</B>
+
+<DT>Trace the nanosleep system call and print the sleep duration in nanoseconds:<DD>
+#
+<B>trace 'p::SyS_nanosleep(struct timespec *ts) sleep for %lld ns, ts-&gt;tv_nsec'</B>
+
+<DT>Trace the inet_pton system call using build id mechanism and print the stack<DD>
+#
+<B>trace -s /lib/x86_64-linux-gnu/libc.so.6,/bin/ping 'p:c:inet_pton' -U</B>
+
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">PROBE SYNTAX</A><DD>
+<DT><A HREF="#lbAH">EXAMPLES</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/ttysnoop.html
+++ b/man/man8/ttysnoop.html
@@ -1,0 +1,123 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ttysnoop</TITLE>
+</HEAD><BODY>
+<H1>ttysnoop</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-08<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ttysnoop - Watch output from a tty or pts device. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>ttysnoop [-h] [-C] device</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+ttysnoop watches a tty or pts device, and prints the same output that is
+appearing on that device. It can be used to mirror the output from a shell
+session, or the system console.
+<P>
+This works by use of kernel dynamic tracing of the tty_write() function.
+This tool will need updating in case that kernel function changes in a future
+kernel version.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-C<DD>
+Don't clear the screen.
+<DT>device<DD>
+Either a path to a tty device (eg, /dev/tty0) or a pts number (eg, the &quot;3&quot;
+from /dev/pts/3).
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Snoop output from /dev/pts/2<DD>
+#
+<B>ttysnoop /dev/pts/2</B>
+
+<DT>Snoop output from /dev/pts/2 (shortcut)<DD>
+#
+<B>ttysnoop 2</B>
+
+<DT>Snoop output from the system console<DD>
+#
+<B>ttysnoop /dev/console</B>
+
+<DT>Snoop output from /dev/tty0<DD>
+#
+<B>ttysnoop /dev/tty0</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+As the rate of tty_write() is expected to be very low (&lt;100/s), the overhead
+of this tool is expected to be negligible.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?1+opensnoop">opensnoop</A>(1)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/ucalls.html
+++ b/man/man8/ucalls.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ucalls</TITLE>
+</HEAD><BODY>
+<H1>ucalls</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ucalls, javacalls, perlcalls, phpcalls, pythoncalls, rubycalls, tclcalls - Summarize method calls
+from high-level languages and Linux syscalls.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javacalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>perlcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>phpcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>pythoncalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>rubycalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>tclcalls [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<BR>
+
+<B>ucalls [-l {java,perl,php,python,ruby}] [-h] [-T TOP] [-L] [-S] [-v] [-m] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes method calls from high-level languages such as Java, Perl,
+PHP, Python, Ruby, and Tcl. It can also trace Linux system calls. Whenever a method
+is invoked, ucalls records the call count and optionally the method's execution
+time (latency) and displays a summary.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, method probes are
+not enabled by default, and can be turned on by running the Java process with
+the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the environment
+variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,perl,php,python,ruby,tcl}<DD>
+The language to trace. If not provided, only syscalls are traced (when the -S
+option is used).
+<DT>-T TOP<DD>
+Print only the top methods by frequency or latency.
+<DT>-L<DD>
+Collect method invocation latency (duration).
+<DT>-S<DD>
+Collect Linux syscalls frequency and timing.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds (the default is microseconds).
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Print summary after this number of seconds and then exit. By default, wait for
+Ctrl+C to terminate.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace the top 10 Ruby method calls:<DD>
+#
+<B>ucalls -T 10 -l ruby 1344</B>
+
+<DT>Trace Python method calls and Linux syscalls including latency in milliseconds:<DD>
+#
+<B>ucalls -l python -mL 2020</B>
+
+<DT>Trace only syscalls and print a summary after 10 seconds:<DD>
+#
+<B>ucalls -S 788 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Tracing individual method calls will produce a considerable overhead in all
+high-level languages. For languages with just-in-time compilation, such as
+Java, the overhead can be more considerable than for interpreted languages.
+On the other hand, syscall tracing will typically be tolerable for most
+processes, unless they have a very unusual rate of system calls.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/uflow.html
+++ b/man/man8/uflow.html
@@ -1,0 +1,170 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uflow</TITLE>
+</HEAD><BODY>
+<H1>uflow</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uflow, javaflow, perlflow, phpflow, pythonflow, rubyflow, tclflow - Print a flow graph of method
+calls in high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javaflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>perlflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>phpflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>pythonflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>rubyflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>tclflow [-h] [-M METHOD] [-C CLAZZ] [-v] pid</B>
+
+<BR>
+
+<B>uflow [-h] [-M METHOD] [-C CLAZZ] [-v] [-l {java,perl,php,python,ruby,tcl}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uflow traces method calls and prints them in a flow graph that can facilitate
+debugging and diagnostics by following the program's execution (method flow).
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java processes, the
+startup flag &quot;-XX:+ExtendedDTraceProbes&quot; is required. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-M METHOD<DD>
+Print only method calls where the method name begins with this string.
+<DT>-C CLAZZ<DD>
+Print only method calls where the class name begins with this string. The class
+name interpretation strongly depends on the language. For example, in Java use
+&quot;package/subpackage/ClassName&quot; to refer to classes.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{java,perl,php,python,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Follow method flow in a Ruby process:<DD>
+#
+<B>uflow ruby 148</B>
+
+<DT>Follow method flow in a Java process where the class name is java.lang.Thread:<DD>
+#
+<B>uflow -C java/lang/Thread java 1802</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>CPU<DD>
+The CPU number on which the method was invoked. This is useful to easily see
+where the output skips to a different CPU.
+<DT>PID<DD>
+The process id.
+<DT>TID<DD>
+The thread id.
+<DT>TIME<DD>
+The duration of the method call.
+<DT>METHOD<DD>
+The method name.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This tool has extremely high overhead because it prints every method call. For
+some scenarios, you might see lost samples in the output as the tool is unable
+to keep up with the rate of data coming from the kernel. Filtering by class 
+or method prefix can help reduce the amount of data printed, but there is still
+a very high overhead in the collection mechanism. Do not use for performance-
+sensitive production scenarios, and always test first.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/ugc.html
+++ b/man/man8/ugc.html
@@ -1,0 +1,167 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ugc</TITLE>
+</HEAD><BODY>
+<H1>ugc</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ugc, javagc, nodegc, pythongc, rubygc - Trace garbage collection events in
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javagc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>nodegc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>pythongc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>rubygc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] pid</B>
+
+<BR>
+
+<B>ugc [-h] [-v] [-m] [-M MINIMUM] [-F FILTER] [-l {java,node,python,ruby}] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces garbage collection events as they occur, including their duration
+and any additional information (such as generation collected or type of GC)
+provided by the respective language's runtime.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Python, and Ruby. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>-m<DD>
+Print times in milliseconds. The default is microseconds.
+<DT>-M MINIMUM<DD>
+Display only collections that are longer than this threshold. The value is
+given in milliseconds. The default is to display all collections.
+<DT>-F FILTER<DD>
+Display only collections whose textual description matches (contains) this
+string. The default is to display all collections. Note that the filtering here
+is performed in user-space, and not as part of the BPF program. This means that
+if you have thousands of collection events, specifying this filter will not
+reduce the amount of data that has to be transferred from the BPF program to
+the user-space script.
+<DT>{java,node,python,ruby}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace garbage collections in a specific Node process:<DD>
+#
+<B>ugc node 148</B>
+
+<DT>Trace garbage collections in a specific Java process, and print GC times in<DD>
+milliseconds:
+#
+<B>ugc -m java 6004</B>
+
+<DT>Trace garbage collections in a specific Java process, and display them only if<DD>
+they are longer than 10ms and have the string &quot;Tenured&quot; in their detailed
+description:
+#
+<B>ugc -M 10 -F Tenured java 6004</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>START<DD>
+The start time of the GC, in seconds from the beginning of the trace.
+<DT>TIME<DD>
+The duration of the garbage collection event.
+<DT>DESCRIPTION<DD>
+The runtime-provided description of this garbage collection event.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Garbage collection events, even if frequent, should not produce a considerable
+overhead when traced because they are still not very common. Even hundreds of 
+GCs per second (which is a very high rate) will still produce a fairly 
+negligible overhead.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+uobjnew">uobjnew</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/uobjnew.html
+++ b/man/man8/uobjnew.html
@@ -1,0 +1,157 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uobjnew</TITLE>
+</HEAD><BODY>
+<H1>uobjnew</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uobjnew, cobjnew, javaobjnew, rubyobjnew, tclobjnew - Summarize object allocations in
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>javaobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>rubyobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>tclobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] pid [interval]</B>
+
+<BR>
+
+<B>uobjnew [-h] [-C TOP_COUNT] [-S TOP_SIZE] [-v] [-l {c,java,ruby,tcl}] pid [interval]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+uobjnew traces object allocations in high-level languages (including &quot;malloc&quot;)
+and prints summaries of the most frequently allocated types by number of
+objects or number of bytes.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+C, Java, Ruby, and Tcl. It requires a runtime instrumented with these
+probes, which in some cases requires building from source with a USDT-specific
+flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java, the Java process
+must be started with the &quot;-XX:+ExtendedDTraceProbes&quot; flag.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-C TOP_COUNT<DD>
+Print the top object types sorted by number of instances.
+<DT>-S TOP_SIZE<DD>
+Print the top object types sorted by size.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>{c,java,ruby,tcl}<DD>
+The language to trace.
+<DT>pid<DD>
+The process id to trace.
+<DT>interval<DD>
+Wait this many seconds and then print the summary and exit. By default, wait
+for Ctrl+C to exit.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace object allocations in a Ruby process:<DD>
+#
+<B>uobjnew ruby 148</B>
+
+<DT>Trace object allocations from &quot;malloc&quot; and print the top 10 by total size:<DD>
+#
+<B>uobjnew -S 10 c 1788</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TYPE<DD>
+The object type being allocated. For C (malloc), this is the block size.
+<DT>ALLOCS<DD>
+The number of objects allocated.
+<DT>BYTES<DD>
+The number of bytes allocated.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Object allocation events are quite frequent, and therefore the overhead from
+running this tool can be considerable. Use with caution and make sure to 
+test before using in a production environment. Nonetheless, even thousands of
+allocations per second will likely produce a reasonable overhead when 
+investigating a problem.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+ugc">ugc</A>(8), <A HREF="https://iovisor.github.io/bcc?8+memleak">memleak</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/ustat.html
+++ b/man/man8/ustat.html
@@ -1,0 +1,201 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of ustat</TITLE>
+</HEAD><BODY>
+<H1>ustat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+ustat, javastat, nodestat, perlstat, phpstat, pythonstat, rubystat, tclstat - Activity stats from
+high-level languages.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>javastat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>nodestat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>perlstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>phpstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>pythonstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>rubystat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>tclstat [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<BR>
+
+<B>ustat [-l {java,node,perl,php,python,ruby,tcl}] [-C] [-S {cload,excp,gc,method,objnew,thread}] [-r MAXROWS] [-d] [interval [count]]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This is &quot;top&quot; for high-level language events, such as garbage collections,
+exceptions, thread creations, object allocations, method calls, and more. The
+events are aggregated for each process and printed in a top-like table, which
+can be sorted by various fields. Not all language runtimes provide the same
+set of details.
+<P>
+This uses in-kernel eBPF maps to store per process summaries for efficiency.
+<P>
+This tool relies on USDT probes embedded in many high-level languages, such as
+Java, Node, Perl, PHP, Python, Ruby, and Tcl. It requires a runtime instrumented with
+these probes, which in some cases requires building from source with a
+USDT-specific flag, such as &quot;--enable-dtrace&quot; or &quot;--with-dtrace&quot;. For Java,
+some probes are not enabled by default, and can be turned on by running the Java
+process with the &quot;-XX:+ExtendedDTraceProbes&quot; flag. For PHP processes, the
+environment variable USE_ZEND_DTRACE must be set to 1.
+<P>
+Newly-created processes will only be traced at the next interval. If you run
+this tool with a short interval (say, 1-5 seconds), this should be virtually
+unnoticeable. For longer intervals, you might miss processes that were started
+and terminated during the interval window.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {java,node,perl,php,python,ruby,tcl}<DD>
+The language to trace. By default, all languages are traced.
+<DT>-C<DD>
+Do not clear the screen between updates.
+<DT>-S {cload,excp,gc,method,objnew,thread}<DD>
+Sort the output by the specified field.
+<DT>-r MAXROWS<DD>
+Do not print more than this number of rows.
+<DT>-d<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>interval<DD>
+Interval between updates, seconds.
+<DT>count<DD>
+Number of interval summaries.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Summarize activity in high-level languages, 1 second refresh:<DD>
+#
+<B>ustat</B>
+
+<DT>Don't clear the screen, and top 8 rows only:<DD>
+#
+<B>ustat -Cr 8</B>
+
+<DT>5 second summaries, 10 times only:<DD>
+#
+<B>ustat 5 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>loadavg<DD>
+The contents of /proc/loadavg
+<DT>PID<DD>
+Process ID.
+<DT>CMDLINE<DD>
+Process command line (often the second and following arguments will give you a
+hint as to which application is being run.
+<DT>METHOD/s<DD>
+Count of method invocations during interval.
+<DT>GC/s<DD>
+Count of garbage collections during interval.
+<DT>OBJNEW/s<DD>
+Count of objects allocated during interval.
+<DT>CLOAD/s<DD>
+Count of classes loaded during interval.
+<DT>EXC/s<DD>
+Count of exceptions thrown during interval.
+<DT>THR/s<DD>
+Count of threads created during interval.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+When using this tool with high-frequency events, such as method calls, a very
+significant slow-down can be expected. However, many of the high-level
+languages covered by this tool already have a fairly high per-method invocation
+cost, especially when running in interpreted mode. For the lower-frequency
+events, such as garbage collections or thread creations, the overhead should
+not be significant. Specifically, when probing Java processes and not using the
+&quot;-XX:+ExtendedDTraceProbes&quot; flag, the most expensive probes are not emitted,
+and the overhead should be acceptable.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8), <A HREF="https://iovisor.github.io/bcc?8+argdist">argdist</A>(8), <A HREF="https://iovisor.github.io/bcc?8+tplist">tplist</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/uthreads.html
+++ b/man/man8/uthreads.html
@@ -1,0 +1,133 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of uthreads</TITLE>
+</HEAD><BODY>
+<H1>uthreads</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2018-10-09<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+uthreads, cthreads, javathreads - Trace thread creation events in Java or pthreads.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>cthreads [-h] [-v] pid</B>
+
+
+<B>javathreads [-h] [-v] pid</B>
+
+
+<B>uthreads [-h] [-l {c,java,none}] [-v] pid</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces thread creation events in Java processes, or pthread creation
+events in any process. When a thread is created, its name or start address
+is printed.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-l {c,java,none}<DD>
+The language to trace. C and none select tracing pthreads only, regardless
+of the runtime being traced.
+<DT>-v<DD>
+Print the resulting BPF program, for debugging purposes.
+<DT>pid<DD>
+The process id to trace.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace Java thread creations:<DD>
+#
+<B>uthreads -l java 148</B>
+
+<DT>Trace pthread creations:<DD>
+#
+<B>uthreads 1802</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME<DD>
+The event's time in seconds from the beginning of the trace.
+<DT>ID<DD>
+The thread's ID. The information in this column depends on the runtime.
+<DT>TYPE<DD>
+Event type -- thread start, stop, or pthread event.
+<DT>DESCRIPTION<DD>
+The thread's name or start address function name.
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+Thread start and stop events are usually not very frequent, which makes this
+tool's overhead negligible.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _example.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Sasha Goldshtein
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+ustat">ustat</A>(8), <A HREF="https://iovisor.github.io/bcc?8+trace">trace</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/vfscount.html
+++ b/man/man8/vfscount.html
@@ -1,0 +1,128 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of vfscount</TITLE>
+</HEAD><BODY>
+<H1>vfscount</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-08-18<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+vfscount - Count VFS calls (&quot;vfs_*&quot;). Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>vfscount [duration]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This counts VFS calls. This can be useful for general workload
+characterization of these operations.
+<P>
+This works by tracing all kernel functions beginning with &quot;vfs_&quot; using dynamic
+tracing. This may match more functions than you are interested in measuring:
+Edit the script to customize which functions to trace.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>duration<DD>
+duration of the trace in seconds.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Count some VFS calls until Ctrl-C is hit:<DD>
+#
+<B>vfscount</B>
+
+<DT>Count some VFS calls in ten seconds<DD>
+#
+<B>vfscount 10</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>ADDR<DD>
+Address of the instruction pointer that was traced (only useful if the FUNC column is suspicious and you would like to double check the translation).
+<DT>FUNC<DD>
+Kernel function name
+<DT>COUNT<DD>
+Number of calls while tracing
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces kernel vfs functions and maintains in-kernel counts, which
+are asynchronously copied to user-space. While the rate of VFS operations can
+be very high (&gt;1M/sec), this is a relatively efficient way to trace these
+events, and so the overhead is expected to be small for normal workloads.
+Measure in a test environment, and if overheads are an issue, edit the script
+to reduce the types of vfs functions traced (currently all beginning with
+&quot;vfs_&quot;).
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+vfsstat">vfsstat</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/vfsstat.html
+++ b/man/man8/vfsstat.html
@@ -1,0 +1,125 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of vfsstat</TITLE>
+</HEAD><BODY>
+<H1>vfsstat</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2015-08-18<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+vfsstat - Statistics for some common VFS calls. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>vfsstat</B>
+
+[interval [count]]
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This traces some common VFS calls and prints per-second summaries. This can
+be useful for general workload characterization, and looking for patterns
+in operation usage over time.
+<P>
+This works by tracing some kernel vfs functions using dynamic tracing, and will
+need updating to match any changes to these functions. Edit the script to
+customize which functions are traced. Also see vfscount, which is more
+easily customized to trace multiple functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Print summaries each second:<DD>
+#
+<B>vfsstat</B>
+
+<DT>Print output every five seconds, three times:<DD>
+#
+<B>vfsstat 5 3</B>
+
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>READ/s<DD>
+Number of vfs_read() calls as a per-second average.
+<DT>WRITE/s<DD>
+Number of vfs_write() calls as a per-second average.
+<DT>CREATE/s<DD>
+Number of vfs_create() calls as a per-second average.
+<DT>OPEN/s<DD>
+Number of vfs_open() calls as a per-second average.
+<DT>FSYNC/s<DD>
+Number of vfs_fsync() calls as a per-second average.
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This traces various kernel vfs functions and maintains in-kernel counts, which
+are asynchronously copied to user-space. While the rate of VFS operations can
+be very high (&gt;1M/sec), this is a relatively efficient way to trace these
+events, and so the overhead is expected to be small for normal workloads.
+Measure in a test environment.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+vfscount">vfscount</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">EXAMPLES</A><DD>
+<DT><A HREF="#lbAG">FIELDS</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/wakeuptime.html
+++ b/man/man8/wakeuptime.html
@@ -1,0 +1,160 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of wakeuptime</TITLE>
+</HEAD><BODY>
+<H1>wakeuptime</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-01-27<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+wakeuptime - Summarize sleep to wakeup time by waker kernel stack. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>wakeuptime [-h] [-u] [-p PID] [-v] [-f] [--stack-storage-size STACK_STORAGE_SIZE] [-m MIN_BLOCK_TIME] [-M MAX_BLOCK_TIME] [duration]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This program shows the kernel stack traces for threads that woke up other 
+blocked threads, along with the process names of the waker and target, along
+with a sum of the time that the target was blocked: the &quot;blocked time&quot;.
+It works by tracing when threads block and when they were then woken up, and
+measuring the time delta. This time measurement will be very similar to off-CPU
+time, however, off-CPU time may include a little extra time spent waiting
+on a run queue to be scheduled. The stack traces, process names, and time spent
+blocked is summarized in the kernel using an eBPF map for efficiency.
+<P>
+The output summary will help you identify reasons why threads
+were blocking by showing who woke them up, along with the time they were
+blocked. This spans all types of blocking activity: disk I/O, network I/O,
+locks, page faults, involuntary context switches, etc.
+<P>
+This can be used in conjunction with offcputime, which shows the stack trace
+of the blocked thread. wakeuptime shows the stack trace of the waker thread.
+<P>
+See <A HREF="http://www.brendangregg.com/FlameGraphs/offcpuflamegraphs.html">http://www.brendangregg.com/FlameGraphs/offcpuflamegraphs.html</A>
+<P>
+This tool only works on Linux 4.6+. It uses the new `BPF_STACK_TRACE` table
+APIs to generate the in-kernel stack traces.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-f<DD>
+Print output in folded stack format.
+<DT>-u<DD>
+Only trace user threads (not kernel threads).
+<DT>-v<DD>
+Show raw addresses (for non-folded format).
+<DT>-p PID<DD>
+Trace this process ID only (filtered in-kernel).
+<DT>--stack-storage-size STACK_STORAGE_SIZE<DD>
+Change the number of unique stack traces that can be stored and displayed.
+<DT>duration<DD>
+Duration to trace, in seconds.
+<DT>-m MIN_BLOCK_TIME<DD>
+The amount of time in microseconds over which we store traces (default 1)
+<DT>-M MAX_BLOCK_TIME<DD>
+The amount of time in microseconds under which we store traces (default U64_MAX)
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace all thread blocking events, and summarize (in-kernel) by kernel stack trace and total blocked time:<DD>
+#
+<B>wakeuptime</B>
+
+<DT>Trace user-mode target threads only:<DD>
+#
+<B>wakeuptime -u</B>
+
+<DT>Trace for 5 seconds only:<DD>
+#
+<B>wakeuptime 5</B>
+
+<DT>Trace for 5 seconds, and emit output in folded stack format (suitable for flame graphs):<DD>
+#
+<B>wakeuptime -f 5</B>
+
+<DT>Trace PID 185 only:<DD>
+#
+<B>wakeuptime -p 185</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This summarizes unique stack traces in-kernel for efficiency, allowing it to
+trace a higher rate of events than methods that post-process in user space. The
+stack trace and time data is only copied to user space once, when the output is
+printed. While these techniques greatly lower overhead, scheduler events are
+still a high frequency event, as they can exceed 1 million events per second,
+and so caution should still be used. Test before production use.
+<P>
+If the overhead is still a problem, take a look at the min block option.
+If your aim is to chase down longer blocking events, then this could
+be increased to filter shorter blocking events, further lowering overhead.
+<A NAME="lbAI">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAK">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAL">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAM">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+offcputime">offcputime</A>(8), <A HREF="https://iovisor.github.io/bcc?8+stackcount">stackcount</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">OVERHEAD</A><DD>
+<DT><A HREF="#lbAI">SOURCE</A><DD>
+<DT><A HREF="#lbAJ">OS</A><DD>
+<DT><A HREF="#lbAK">STABILITY</A><DD>
+<DT><A HREF="#lbAL">AUTHOR</A><DD>
+<DT><A HREF="#lbAM">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/xfsdist.html
+++ b/man/man8/xfsdist.html
@@ -1,0 +1,142 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of xfsdist</TITLE>
+</HEAD><BODY>
+<H1>xfsdist</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-12<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+xfsdist - Summarize XFS operation latency. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>xfsdist [-h] [-T] [-m] [-p PID] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes time (latency) spent in common XFS file operations: reads,
+writes, opens, and syncs, and presents it as a power-of-2 histogram. It uses an
+in-kernel eBPF map to store the histogram for efficiency.
+<P>
+Since this works by tracing the xfs_file_operations interface functions, it
+will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Don't include timestamps on interval output.
+<DT>-m<DD>
+Output in milliseconds.
+<DT>-p PID<DD>
+Trace this PID only.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace XFS operation time, and print a summary on Ctrl-C:<DD>
+#
+<B>xfsdist</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>xfsdist -p 181</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>xfsdist 1 10</B>
+
+<DT>1 second summaries, printed in milliseconds<DD>
+#
+<B>xfsdist -m 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>msecs<DD>
+Range of milliseconds for this bucket.
+<DT>usecs<DD>
+Range of microseconds for this bucket.
+<DT>count<DD>
+Number of operations in this time range.
+<DT>distribution<DD>
+ASCII representation of the distribution (the count column).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to these XFS operations,
+including reads and writes from the file system cache. Such reads and writes
+can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool may become noticeable.
+Measure and quantify before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+xfssnoop">xfssnoop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/xfsslower.html
+++ b/man/man8/xfsslower.html
@@ -1,0 +1,172 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of xfsslower</TITLE>
+</HEAD><BODY>
+<H1>xfsslower</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-11<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+xfsslower - Trace slow xfs file operations, with per-event details.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>xfsslower [-h] [-j] [-p PID] [min_ms]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces common XFS file operations: reads, writes, opens, and
+syncs. It measures the time spent in these operations, and prints details
+for each that exceeded a threshold.
+<P>
+WARNING: See the OVERHEAD section.
+<P>
+By default, a minimum millisecond threshold of 10 is used. If a threshold of 0
+is used, all events are printed (warning: verbose).
+<P>
+Since this works by tracing the xfs_file_operations interface functions, it
+will need updating to match any changes to these functions.
+<P>
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-p PID
+Trace this PID only.
+<DL COMPACT>
+<DT>min_ms<DD>
+Minimum I/O latency (duration) to trace, in milliseconds. Default is 10 ms.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace synchronous file reads and writes slower than 10 ms:<DD>
+#
+<B>xfsslower</B>
+
+<DT>Trace slower than 1 ms:<DD>
+#
+<B>xfsslower 1</B>
+
+<DT>Trace slower than 1 ms, and output just the fields in parsable format (csv):<DD>
+#
+<B>xfsslower -j 1</B>
+
+<DT>Trace all file reads and writes (warning: the output will be verbose):<DD>
+#
+<B>xfsslower 0</B>
+
+<DT>Trace slower than 1 ms, for PID 181 only:<DD>
+#
+<B>xfsslower -p 181 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of I/O completion since the first I/O seen, in seconds.
+<DT>COMM<DD>
+Process name.
+<DT>PID<DD>
+Process ID.
+<DT>T<DD>
+Type of operation. R == read, W == write, O == open, S == fsync.
+<DT>OFF_KB<DD>
+File offset for the I/O, in Kbytes.
+<DT>BYTES<DD>
+Size of I/O, in bytes.
+<DT>LAT(ms)<DD>
+Latency (duration) of I/O, measured from when it was issued by VFS to the
+filesystem, to when it completed. This time is inclusive of block device I/O,
+file system CPU cycles, file system locks, run queue latency, etc. It's a more
+accurate measure of the latency suffered by applications performing file
+system I/O, than to measure this down at the block device interface.
+<DT>FILENAME<DD>
+A cached kernel file name (comes from dentry-&gt;d_name.name).
+<DT>ENDTIME_us<DD>
+Completion timestamp, microseconds (-j only).
+<DT>OFFSET_b<DD>
+File offset, bytes (-j only).
+<DT>LATENCY_us<DD>
+Latency (duration) of the I/O, in microseconds (-j only).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to these XFS operations,
+including reads and writes from the file system cache. Such reads and writes
+can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool (even if it prints no &quot;slower&quot; events) can
+begin to become significant. Measure and quantify before use. If this
+continues to be a problem, consider switching to a tool that prints in-kernel
+summaries only.
+<P>
+
+Note that the overhead of this tool should be less than <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8), as
+this tool targets xfs functions only, and not all file read/write paths
+(which can include socket I/O).
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/zfsdist.html
+++ b/man/man8/zfsdist.html
@@ -1,0 +1,147 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of zfsdist</TITLE>
+</HEAD><BODY>
+<H1>zfsdist</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-12<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+zfsdist - Summarize ZFS operation latency. Uses Linux eBPF/bcc.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>zfsdist [-h] [-T] [-m] [-p PID] [interval] [count]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool summarizes time (latency) spent in common ZFS file operations: reads,
+writes, opens, and syncs, and presents it as a power-of-2 histogram. It uses an
+in-kernel eBPF map to store the histogram for efficiency.
+<P>
+This uses kernel dynamic tracing of the ZPL interface (ZFS POSIX
+Layer), and will need updates to match any changes to this interface.
+<DL COMPACT>
+<DT>This is intended to work with the ZFS on Linux project:<DD>
+<A HREF="http://zfsonlinux.org">http://zfsonlinux.org</A>
+</DL>
+<P>
+
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+<DL COMPACT>
+<DT>-h<DD>
+Print usage message.
+<DT>-T<DD>
+Don't include timestamps on interval output.
+<DT>-m<DD>
+Output in milliseconds.
+<DT>-p PID<DD>
+Trace this PID only.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace ZFS operation time, and print a summary on Ctrl-C:<DD>
+#
+<B>zfsdist</B>
+
+<DT>Trace PID 181 only:<DD>
+#
+<B>zfsdist -p 181</B>
+
+<DT>Print 1 second summaries, 10 times:<DD>
+#
+<B>zfsdist 1 10</B>
+
+<DT>1 second summaries, printed in milliseconds<DD>
+#
+<B>zfsdist -m 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>msecs<DD>
+Range of milliseconds for this bucket.
+<DT>usecs<DD>
+Range of microseconds for this bucket.
+<DT>count<DD>
+Number of operations in this time range.
+<DT>distribution<DD>
+ASCII representation of the distribution (the count column).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to these ZFS operations,
+including reads and writes from the file system cache. Such reads and writes
+can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool may become noticeable.
+Measure and quantify before use.
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+zfssnoop">zfssnoop</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>

--- a/man/man8/zfsslower.html
+++ b/man/man8/zfsslower.html
@@ -1,0 +1,177 @@
+Content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<HTML><HEAD><TITLE>Man page of zfsslower</TITLE>
+</HEAD><BODY>
+<H1>zfsslower</H1>
+Section: Maintenance Commands (8)<BR>Updated: 2016-02-11<BR><A HREF="#index">Index</A>
+<A HREF="https://iovisor.github.io/bcc">Return to Main Contents</A><HR>
+
+<A NAME="lbAB">&nbsp;</A>
+<H2>NAME</H2>
+
+zfsslower - Trace slow zfs file operations, with per-event details.
+<A NAME="lbAC">&nbsp;</A>
+<H2>SYNOPSIS</H2>
+
+<B>zfsslower [-h] [-j] [-p PID] [min_ms]</B>
+
+<A NAME="lbAD">&nbsp;</A>
+<H2>DESCRIPTION</H2>
+
+This tool traces common ZFS file operations: reads, writes, opens, and
+syncs. It measures the time spent in these operations, and prints details
+for each that exceeded a threshold.
+<P>
+WARNING: See the OVERHEAD section.
+<P>
+By default, a minimum millisecond threshold of 10 is used. If a threshold of 0
+is used, all events are printed (warning: verbose).
+<P>
+This uses kernel dynamic tracing of the ZPL interface (ZFS POSIX
+Layer), and will need updates to match any changes to this interface.
+<DL COMPACT>
+<DT>This is intended to work with the ZFS on Linux project:<DD>
+<A HREF="http://zfsonlinux.org">http://zfsonlinux.org</A>
+</DL>
+<P>
+
+Since this uses BPF, only the root user can use this tool.
+<A NAME="lbAE">&nbsp;</A>
+<H2>REQUIREMENTS</H2>
+
+CONFIG_BPF and bcc.
+<A NAME="lbAF">&nbsp;</A>
+<H2>OPTIONS</H2>
+
+-p PID
+Trace this PID only.
+<DL COMPACT>
+<DT>min_ms<DD>
+Minimum I/O latency (duration) to trace, in milliseconds. Default is 10 ms.
+</DL>
+<A NAME="lbAG">&nbsp;</A>
+<H2>EXAMPLES</H2>
+
+<DL COMPACT>
+<DT>Trace synchronous file reads and writes slower than 10 ms:<DD>
+#
+<B>zfsslower</B>
+
+<DT>Trace slower than 1 ms:<DD>
+#
+<B>zfsslower 1</B>
+
+<DT>Trace slower than 1 ms, and output just the fields in parsable format (csv):<DD>
+#
+<B>zfsslower -j 1</B>
+
+<DT>Trace all file reads and writes (warning: the output will be verbose):<DD>
+#
+<B>zfsslower 0</B>
+
+<DT>Trace slower than 1 ms, for PID 181 only:<DD>
+#
+<B>zfsslower -p 181 1</B>
+
+</DL>
+<A NAME="lbAH">&nbsp;</A>
+<H2>FIELDS</H2>
+
+<DL COMPACT>
+<DT>TIME(s)<DD>
+Time of I/O completion since the first I/O seen, in seconds.
+<DT>COMM<DD>
+Process name.
+<DT>PID<DD>
+Process ID.
+<DT>T<DD>
+Type of operation. R == read, W == write, O == open, S == fsync.
+<DT>OFF_KB<DD>
+File offset for the I/O, in Kbytes.
+<DT>BYTES<DD>
+Size of I/O, in bytes.
+<DT>LAT(ms)<DD>
+Latency (duration) of I/O, measured from when it was issued by VFS to the
+filesystem, to when it completed. This time is inclusive of block device I/O,
+file system CPU cycles, file system locks, run queue latency, etc. It's a more
+accurate measure of the latency suffered by applications performing file
+system I/O, than to measure this down at the block device interface.
+<DT>FILENAME<DD>
+A cached kernel file name (comes from dentry-&gt;d_name.name).
+<DT>ENDTIME_us<DD>
+Completion timestamp, microseconds (-j only).
+<DT>OFFSET_b<DD>
+File offset, bytes (-j only).
+<DT>LATENCY_us<DD>
+Latency (duration) of the I/O, in microseconds (-j only).
+</DL>
+<A NAME="lbAI">&nbsp;</A>
+<H2>OVERHEAD</H2>
+
+This adds low-overhead instrumentation to these ZFS operations,
+including reads and writes from the file system cache. Such reads and writes
+can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool (even if it prints no &quot;slower&quot; events) can
+begin to become significant. Measure and quantify before use. If this
+continues to be a problem, consider switching to a tool that prints in-kernel
+summaries only.
+<P>
+
+Note that the overhead of this tool should be less than <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8), as
+this tool targets zfs functions only, and not all file read/write paths
+(which can include socket I/O).
+<A NAME="lbAJ">&nbsp;</A>
+<H2>SOURCE</H2>
+
+This is from bcc.
+<DL COMPACT>
+<DT><DD>
+<A HREF="https://github.com/iovisor/bcc">https://github.com/iovisor/bcc</A>
+</DL>
+<P>
+
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+<A NAME="lbAK">&nbsp;</A>
+<H2>OS</H2>
+
+Linux
+<A NAME="lbAL">&nbsp;</A>
+<H2>STABILITY</H2>
+
+Unstable - in development.
+<A NAME="lbAM">&nbsp;</A>
+<H2>AUTHOR</H2>
+
+Brendan Gregg
+<A NAME="lbAN">&nbsp;</A>
+<H2>SEE ALSO</H2>
+
+<A HREF="https://iovisor.github.io/bcc?8+biosnoop">biosnoop</A>(8), <A HREF="https://iovisor.github.io/bcc?8+funccount">funccount</A>(8), <A HREF="https://iovisor.github.io/bcc?8+fileslower">fileslower</A>(8)
+<P>
+
+<HR>
+<A NAME="index">&nbsp;</A><H2>Index</H2>
+<DL>
+<DT><A HREF="#lbAB">NAME</A><DD>
+<DT><A HREF="#lbAC">SYNOPSIS</A><DD>
+<DT><A HREF="#lbAD">DESCRIPTION</A><DD>
+<DT><A HREF="#lbAE">REQUIREMENTS</A><DD>
+<DT><A HREF="#lbAF">OPTIONS</A><DD>
+<DT><A HREF="#lbAG">EXAMPLES</A><DD>
+<DT><A HREF="#lbAH">FIELDS</A><DD>
+<DT><A HREF="#lbAI">OVERHEAD</A><DD>
+<DT><A HREF="#lbAJ">SOURCE</A><DD>
+<DT><A HREF="#lbAK">OS</A><DD>
+<DT><A HREF="#lbAL">STABILITY</A><DD>
+<DT><A HREF="#lbAM">AUTHOR</A><DD>
+<DT><A HREF="#lbAN">SEE ALSO</A><DD>
+</DL>
+<HR>
+This document was created by
+<A HREF="https://iovisor.github.io/bcc">man2html</A>,
+using the manual pages.<BR>
+Time: 17:11:49 GMT, February 25, 2020
+</BODY>
+</HTML>


### PR DESCRIPTION
This is an initial commit for https://iovisor.github.io/bcc/ to add man pages as html. We can automate this, and make a listing of man pages (scraped from README.md), in future commits.

FWIW, I generated them from bcc master branch using:

```
tmp=/tmp/man
site=https://iovisor.github.io/bcc
mkdir $tmp
cd man/man8
for f in *.8; do
	fname=${f%.*}
	man2html -M $site $f > $tmp/$fname.html
done
```