### PR TITLE
Update StatusTuple to use enum Code

### DIFF
--- a/src/cc/bcc_exception.h
+++ b/src/cc/bcc_exception.h
@@ -23,6 +23,22 @@ namespace ebpf {
 
 class StatusTuple {
 public:
+  enum class Code {
+    // Not an error, indicates success.
+    OK = 0,
+    // For any error that is not covered in the existing codes.
+    UNKNOWN,
+
+    INVALID_ARGUMENT,
+    PERMISSION_DENIED,
+    // For any error that was raised when making syscalls.
+    SYSTEM,
+  };
+
+  static StatusTuple OK() {
+    return StatusTuple(Code::OK, "");
+  }
+
   StatusTuple(int ret) : ret_(ret) {}
 
   StatusTuple(int ret, const char *msg) : ret_(ret), msg_(msg) {}
@@ -36,16 +52,34 @@ public:
     msg_ = std::string(buf);
   }
 
+  StatusTuple(Code code, const std::string &msg) : use_enum_code_(true), code_(code), msg_(msg) {}
+
   void append_msg(const std::string& msg) {
     msg_ += msg;
   }
 
-  int code() const { return ret_; }
+  bool ok() const {
+    if (use_enum_code_) {
+      return code_ == Code::OK;
+    }
+    return ret_ == 0;
+  }
+
+  int code() const {
+    if (use_enum_code_) {
+      return static_cast<int>(code_);
+    }
+    return ret_;
+  }
 
   const std::string& msg() const { return msg_; }
 
 private:
   int ret_;
+
+  bool use_enum_code_ = false;
+  Code code_;
+
   std::string msg_;
 };
 
@@ -56,5 +90,22 @@ private:
       return __stp;                  \
     }                                \
   } while (0)
+
+namespace error {
+
+#define DECLARE_ERROR(FN, CODE)                                                 \
+  inline StatusTuple FN(const std::string& msg) {                                      \
+    return StatusTuple(::ebpf::StatusTuple::Code::CODE, msg);                   \
+  }                                                                             \
+  inline bool Is##FN(const StatusTuple& status) {                               \
+    return status.code() == static_cast<int>(::ebpf::StatusTuple::Code::CODE);  \
+  }
+
+DECLARE_ERROR(Unknown, UNKNOWN)
+DECLARE_ERROR(InvalidArgument, INVALID_ARGUMENT)
+DECLARE_ERROR(PermissionDenied, PERMISSION_DENIED)
+DECLARE_ERROR(System, SYSTEM)
+
+}  // namespace error
 
 }  // namespace ebpf


### PR DESCRIPTION
The first step of #2697 (StatusTuple can have canonical error code).

Please suggest additional error code needed in BCC code base. So far I come up with 5.

This PR's purpose is to update StatusTuple to have a enum code, in addition to the integer code. This allows existing code to continue work, and other community members to continue work with the more familiar APIs.

Once this PR is submitted, I'll start to change existing code to use the new APIs. Hopefully further revise StatusTuple according to the learning gained in the process.