### PR TITLE
doc: add python3 doc to "Ubuntu - Source" section in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -118,7 +118,7 @@ sudo dnf install bcc
 
 **Note**: if you keep getting `Failed to load program: Operation not permitted` when
 trying to run the `hello_world.py` example as root then you might need to lift
-the so-called kernel lockdown (cf. 
+the so-called kernel lockdown (cf.
 [FAQ](https://github.com/iovisor/bcc/blob/c00d10d4552f647491395e326d2e4400f3a0b6c5/FAQ.txt#L24),
 [background article](https://gehrcke.de/2019/09/running-an-ebpf-program-may-require-lifting-the-kernel-lockdown)).
 
@@ -352,12 +352,18 @@ sudo apt-get -y install luajit luajit-5.1-dev
 ```
 
 ### Install and compile BCC
+
 ```
 git clone https://github.com/iovisor/bcc.git
 mkdir bcc/build; cd bcc/build
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr
 make
 sudo make install
+cmake -DPYTHON_CMD=python3 .. # build python3 binding
+pushd src/python/
+make
+sudo make install
+popd
 ```
 
 ## Fedora - Source


### PR DESCRIPTION
As an Ubuntu user, using Ubuntu 19.10, it seems to work. The commands are just copied from the "openSUSE - Source" section: https://github.com/iovisor/bcc/blob/0f92c845a7deb60e97f49425f181d7b7e9daf56b/INSTALL.md#install-and-compile-bcc-2

I think python3 should be the default in the future, but I'll make this PR before doing so.