### PR TITLE
Fix the missing 'device' argument to bcc_func_load

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -625,7 +625,7 @@ StatusTuple BPF::load_func(const std::string& func_name, bpf_prog_type type,
   fd = bpf_module_->bcc_func_load(type, func_name.c_str(),
                      reinterpret_cast<struct bpf_insn*>(func_start), func_size,
                      bpf_module_->license(), bpf_module_->kern_version(),
-                     log_level, nullptr, 0);
+                     log_level, nullptr, 0, nullptr);
 
   if (fd < 0)
     return StatusTuple(-1, "Failed to load %s: %d", func_name.c_str(), fd);


### PR DESCRIPTION
commit d147588ebe35b7cd2b4d253a7da18bef253ea78d ("Support for hardware
offload (#2502)") added a device_name arg to bcc_fund_load() but ddn't
update one of the caller, this causes a egfault in libc with below
trace

```
(gdb) bt full
#0  strnlen () at ../sysdeps/x86_64/strlen.S:103
No locals.
#1  0x00007f82c1ce053e in __strncpy_sse2 (s1=0x7ffcfe71e690 "", s2=0xa <error: Cannot access memory at address 0xa>, n=16) at ./strncpy.c:29
        size = <optimised out>
#2  0x00007f82c1d62a16 in __GI___if_nametoindex (ifname=0xa <error: Cannot access memory at address 0xa>) at ../sysdeps/unix/sysv/linux/if_index.c:46
        ifr = {ifr_ifrn = {ifrn_name = "\000\351\243\000\000\000\000\000\260.?\302\202\177\000"}, ifr_ifru = {ifru_addr = {sa_family = 13008, sa_data = "?\302\202\177\000\000\335AY\000\000\000\000"},
            ifru_dstaddr = {sa_family = 13008, sa_data = "?\302\202\177\000\000\335AY\000\000\000\000"}, ifru_broadaddr = {sa_family = 13008, sa_data = "?\302\202\177\000\000\335AY\000\000\000\000"},
            ifru_netmask = {sa_family = 13008, sa_data = "?\302\202\177\000\000\335AY\000\000\000\000"}, ifru_hwaddr = {sa_family = 13008, sa_data = "?\302\202\177\000\000\335AY\000\000\000\000"},
            ifru_flags = 13008, ifru_ivalue = -1036045616, ifru_mtu = -1036045616, ifru_map = {mem_start = 140199581397712, mem_end = 5849565, base_addr = 59168, irq = 113 'q', dma = 254 '\376',
              port = 252 '\374'}, ifru_slave = "\320\062?\302\202\177\000\000\335AY\000\000\000\000", ifru_newname = "\320\062?\302\202\177\000\000\335AY\000\000\000\000",
            ifru_data = 0x7f82c23f32d0 "\001"}}
        fd = 5
#3  0x00007f82bd95abcb in ebpf::BPFModule::bcc_func_load(int, char const*, bpf_insn const*, int, char const*, unsigned int, int, char*, unsigned int, char const*) ()
   from /usr/lib/x86_64-linux-gnu/libbcc.so.0
```