### PR TITLE
usdt.cc: make bcc_usdt_enable_probe() to accept a fully-specified probe name

### DIFF
--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -454,7 +454,15 @@ void bcc_usdt_close(void *usdt) {
 int bcc_usdt_enable_probe(void *usdt, const char *probe_name,
                           const char *fn_name) {
   USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
-  return ctx->enable_probe(probe_name, fn_name) ? 0 : -1;
+
+  const char *sep = std::strchr(probe_name, ':');
+  if (sep != nullptr) {
+    const std::string provider_name(probe_name, sep);
+    const std::string probe_base_name(sep+1);
+    return ctx->enable_probe(provider_name, probe_base_name, fn_name) ? 0 : -1;
+  } else {
+    return ctx->enable_probe(probe_name, fn_name) ? 0 : -1;
+  }
 }
 
 int bcc_usdt_enable_fully_specified_probe(void *usdt, const char *provider_name,

--- a/tests/python/test_usdt3.py
+++ b/tests/python/test_usdt3.py
@@ -20,6 +20,7 @@ class TestUDST(TestCase):
 static inline void record_val(int val)
 {
   FOLLY_SDT(test, probe, val);
+  FOLLY_SDT(test_fq_name, probe, val);
 }
 
 extern void record_a(int val);
@@ -110,7 +111,7 @@ int do_trace(struct pt_regs *ctx) {
     def test_attach1(self):
         # enable USDT probe from given PID and verifier generated BPF programs
         u = USDT(pid=int(self.app.pid))
-        u.enable_probe(probe="probe", fn_name="do_trace")
+        u.enable_probe(probe="test:probe", fn_name="do_trace")
         b = BPF(text=self.bpf_text, usdt_contexts=[u])
 
         # processing events


### PR DESCRIPTION
This is inevitable if multiple providers have the same probe name and we'd like to enable one of it.

There could be another way, for example defining a Python method to use `bcc_usdt_enable_fully_specified_probe()`, but because `enable_probe` is not performance-sensitive, I prefer the way this PR does.

What do you think of it?


