### PR TITLE
libbpf-tools: optimize ksyms cache

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -1,2 +1,3 @@
 /.output
 /runqslower
+/drsnoop

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -6,7 +6,7 @@ BPFTOOL ?= bin/bpftool
 LIBBPF_SRC := $(abspath ../src/cc/libbpf/src)
 LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
 INCLUDES := -I$(OUTPUT)
-CFLAGS := -g -Wall
+CFLAGS := -g -O2 -Wall
 
 APPS = drsnoop runqslower
 

--- a/libbpf-tools/trace_helpers.h
+++ b/libbpf-tools/trace_helpers.h
@@ -3,18 +3,16 @@
 #define __TRACE_HELPERS_H
 
 struct ksym {
-	long addr;
 	const char *name;
+	unsigned long addr;
 };
 
-struct ksyms {
-	struct ksym *syms;
-	int syms_cnt;
-};
+struct ksyms;
 
 struct ksyms *ksyms__load(void);
 void ksyms__free(struct ksyms *ksyms);
-const struct ksym *ksyms__map_addr(const struct ksyms *ksyms, long addr);
+const struct ksym *ksyms__map_addr(const struct ksyms *ksyms,
+				   unsigned long addr);
 const struct ksym *ksyms__get_symbol(const struct ksyms *ksyms,
 				     const char *name);
 


### PR DESCRIPTION
Re-implement internals of ksyms cache to minimize memory overhead and
allocations. Addr is also changed to be unsigned long.

fscanf() can be further optimized into manual parsing, but it's low enough
overhead right now that I felt like readibility is more important.

Benchmarking ksyms loading/parsing parts:

BEFORE:
$ /usr/bin/time ./test
0.03user 0.04system 0:00.08elapsed 98%CPU (0avgtext+0avgdata 6968maxresident)k
0inputs+0outputs (0major+1512minor)pagefaults 0swaps

AFTER:
$ /usr/bin/time ./test
0.02user 0.03system 0:00.06elapsed 100%CPU (0avgtext+0avgdata 9508maxresident)k
  0inputs+0outputs (0major+2106minor)pagefaults 0swaps

RSS goes down from 9.5MB to <7MB, while CPU time went up about 20ms.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>