### PR TITLE
GitHub Actions: optionally publish container image

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -92,3 +92,38 @@ jobs:
 #     https://github.com/marketplace/actions/debugging-with-tmate
 #    - name: Setup tmate session
 #      uses: mxschmitt/action-tmate@v1
+
+  # Optionally publish container images, guarded by the GitHub secret
+  # DOCKER_PUBLISH.
+  # GitHub secrets can be configured as follows:
+  #   - DOCKER_PUBLISH = 1
+  #   - DOCKER_IMAGE = docker.io/myorg/bcc
+  #   - DOCKER_USERNAME = username
+  #   - DOCKER_PASSWORD = password
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v1
+
+    - name: Initialize workflow variables
+      id: vars
+      shell: bash
+      run: |
+          echo ::set-output name=DOCKER_PUBLISH::${DOCKER_PUBLISH}
+      env:
+        DOCKER_PUBLISH: "${{ secrets.DOCKER_PUBLISH }}"
+
+    - name: Build container image and publish to registry
+      id: publish-registry
+      uses: elgohr/Publish-Docker-Github-Action@2.8
+      if: ${{ steps.vars.outputs.DOCKER_PUBLISH }}
+      with:
+        name: ${{ secrets.DOCKER_IMAGE }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        workdir: .
+        dockerfile: Dockerfile.ubuntu
+        snapshot: true
+        cache: ${{ github.event_name != 'schedule' }}

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -10,4 +10,7 @@ COPY ./ /root/bcc
 WORKDIR /root/bcc
 
 RUN /usr/lib/pbuilder/pbuilder-satisfydepends && \
-    ./scripts/build-deb.sh
+    ./scripts/build-deb.sh && \
+  apt-get update -y && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y python python3 binutils libelf1 && \
+  dpkg -i /root/bcc/*.deb


### PR DESCRIPTION
This is optional: this GitHub Action will only attempt to publish the
container image if the GitHub repository has been configured with GitHub
secrets (e.g. https://github.com/iovisor/bcc/settings/secrets).

The GitHub secrets can be configured as follows:
- DOCKER_PUBLISH = 1
- DOCKER_IMAGE = docker.io/myorg/bcc
- DOCKER_USERNAME = username
- DOCKER_PASSWORD = password

This is intended to make it easy for anyone to fork iovisor/bcc on
GitHub and publish custom container images with bcc.

-----

Open questions:
- I see that the built image is big: 1.3GB. Are there other attempts to build bcc container images with a smaller size?
- Dockerfile.ubuntu keeps the sources and the .deb files but didn't install them. Is it currently used somewhere? I couldn't find it in the bcc repository.