### PR TITLE
python binding: allow fully-specified probe names for USDT#enable_probe()

### DIFF
--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -77,6 +77,9 @@ const char *bcc_usdt_genargs(void **ctx_array, int len);
 const char *bcc_usdt_get_probe_argctype(
   void *ctx, const char* probe_name, const int arg_index
 );
+const char *bcc_usdt_get_fully_specified_probe_argctype(
+  void *ctx, const char* provider_name, const char* probe_name, const int arg_index
+);
 
 typedef void (*bcc_usdt_uprobe_cb)(const char *, const char *, uint64_t, int);
 void bcc_usdt_foreach_uprobe(void *usdt, bcc_usdt_uprobe_cb callback);

--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -506,6 +506,15 @@ const char *bcc_usdt_get_probe_argctype(
   return "";
 }
 
+const char *bcc_usdt_get_fully_specified_probe_argctype(
+  void *ctx, const char* provider_name, const char* probe_name, const int arg_index
+) {
+  USDT::Probe *p = static_cast<USDT::Context *>(ctx)->get(provider_name, probe_name);
+  if (p)
+    return p->get_arg_ctype(arg_index).c_str();
+  return "";
+}
+
 void bcc_usdt_foreach(void *usdt, bcc_usdt_cb callback) {
   USDT::Context *ctx = static_cast<USDT::Context *>(usdt);
   ctx->each(callback);

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -231,6 +231,9 @@ lib.bcc_usdt_genargs.argtypes = [ct.POINTER(ct.c_void_p), ct.c_int]
 lib.bcc_usdt_get_probe_argctype.restype = ct.c_char_p
 lib.bcc_usdt_get_probe_argctype.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_int]
 
+lib.bcc_usdt_get_fully_specified_probe_argctype.restype = ct.c_char_p
+lib.bcc_usdt_get_fully_specified_probe_argctype.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_char_p, ct.c_int]
+
 class bcc_usdt(ct.Structure):
     _fields_ = [
             ('provider', ct.c_char_p),

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -222,6 +222,9 @@ lib.bcc_usdt_close.argtypes = [ct.c_void_p]
 lib.bcc_usdt_enable_probe.restype = ct.c_int
 lib.bcc_usdt_enable_probe.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_char_p]
 
+lib.bcc_usdt_enable_fully_specified_probe.restype = ct.c_int
+lib.bcc_usdt_enable_fully_specified_probe.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_char_p, ct.c_char_p]
+
 lib.bcc_usdt_genargs.restype = ct.c_char_p
 lib.bcc_usdt_genargs.argtypes = [ct.POINTER(ct.c_void_p), ct.c_int]
 

--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -182,8 +182,14 @@ To check which probes are present in the process, use the tplist tool.
         return lib.bcc_usdt_genargs(ctx_array, 1).decode()
 
     def get_probe_arg_ctype(self, probe_name, arg_index):
-        return lib.bcc_usdt_get_probe_argctype(
-            self.context, probe_name.encode('ascii'), arg_index).decode()
+        probe_parts = probe_name.split(":", 1)
+        if len(probe_parts) == 1:
+            return lib.bcc_usdt_get_probe_argctype(
+                self.context, probe_name.encode('ascii'), arg_index).decode()
+        else:
+            (provider_name, probe) = probe_parts
+            return lib.bcc_usdt_get_fully_specified_probe_argctype(
+                self.context, provider_name.encode('ascii'), probe.encode('ascii'), arg_index).decode()
 
     def enumerate_probes(self):
         probes = []

--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -147,8 +147,17 @@ class USDT(object):
         lib.bcc_usdt_close(self.context)
 
     def enable_probe(self, probe, fn_name):
-        if lib.bcc_usdt_enable_probe(self.context, probe.encode('ascii'),
-                fn_name.encode('ascii')) != 0:
+        probe_parts = probe.split(":", 1)
+        if len(probe_parts) == 1:
+            ret = lib.bcc_usdt_enable_probe(
+                self.context, probe.encode('ascii'), fn_name.encode('ascii'))
+        else:
+            (provider_name, probe_name) = probe_parts
+            ret = lib.bcc_usdt_enable_fully_specified_probe(
+                self.context, provider_name.encode('ascii'), probe_name.encode('ascii'),
+                fn_name.encode('ascii'))
+
+        if ret != 0:
             raise USDTException(
 """Failed to enable USDT probe '%s':
 the specified pid might not contain the given language's runtime,

--- a/tests/python/test_usdt3.py
+++ b/tests/python/test_usdt3.py
@@ -20,6 +20,7 @@ class TestUDST(TestCase):
 static inline void record_val(int val)
 {
   FOLLY_SDT(test, probe, val);
+  FOLLY_SDT(test_dup_name, probe, val);
 }
 
 extern void record_a(int val);
@@ -110,7 +111,7 @@ int do_trace(struct pt_regs *ctx) {
     def test_attach1(self):
         # enable USDT probe from given PID and verifier generated BPF programs
         u = USDT(pid=int(self.app.pid))
-        u.enable_probe(probe="probe", fn_name="do_trace")
+        u.enable_probe(probe="test:probe", fn_name="do_trace")
         b = BPF(text=self.bpf_text, usdt_contexts=[u])
 
         # processing events


### PR DESCRIPTION
`USDT#enable_probe()` cannot enable probes if its basename is not unique, so providing a way to use fully-specified names (e.g. "provider:probe") is inevitable for some cases.

At first, I have created a path as https://github.com/iovisor/bcc/pull/2791, but I prefer this style to keep C API tidy. Sorry for annoying.