### PR TITLE
tools: add option --cgroupmap and --unique to capable.py

### DIFF
--- a/man/man8/capable.8
+++ b/man/man8/capable.8
@@ -1,8 +1,8 @@
-.TH capable 8  "2016-09-13" "USER COMMANDS"
+.TH capable 8  "2020-03-06" "USER COMMANDS"
 .SH NAME
 capable \- Trace security capability checks (cap_capable()).
 .SH SYNOPSIS
-.B capable [\-h] [\-v] [\-p PID] [\-K] [\-U]
+.B capable [\-h] [\-v] [\-p PID] [\-K] [\-U] [\-x] [\-\-cgroupmap MAPPATH]
 .SH DESCRIPTION
 This traces security capability checks in the kernel, and prints details for
 each call. This can be useful for general debugging, and also security
@@ -28,6 +28,9 @@ Include user-space stack traces to the output.
 .TP
 \-x
 Show extra fields in TID and INSETID columns.
+.TP
+\-\-cgroupmap MAPPATH
+Trace cgroups in this BPF map only (filtered in-kernel).
 .SH EXAMPLES
 .TP
 Trace all capability checks system-wide:
@@ -37,6 +40,11 @@ Trace all capability checks system-wide:
 Trace capability checks for PID 181:
 #
 .B capable \-p 181
+.TP
+Trace capability checks in a set of cgroups only (see filtering_by_cgroups.md
+from bcc sources for more details):
+#
+.B capable \-\-cgroupmap /sys/fs/bpf/test01
 .SH FIELDS
 .TP
 TIME(s)

--- a/man/man8/capable.8
+++ b/man/man8/capable.8
@@ -1,8 +1,9 @@
-.TH capable 8  "2020-03-06" "USER COMMANDS"
+.TH capable 8  "2020-03-08" "USER COMMANDS"
 .SH NAME
 capable \- Trace security capability checks (cap_capable()).
 .SH SYNOPSIS
 .B capable [\-h] [\-v] [\-p PID] [\-K] [\-U] [\-x] [\-\-cgroupmap MAPPATH]
+           [--unique]
 .SH DESCRIPTION
 This traces security capability checks in the kernel, and prints details for
 each call. This can be useful for general debugging, and also security
@@ -31,6 +32,9 @@ Show extra fields in TID and INSETID columns.
 .TP
 \-\-cgroupmap MAPPATH
 Trace cgroups in this BPF map only (filtered in-kernel).
+.TP
+\-\-unique
+Don't repeat stacks for the same PID or cgroup.
 .SH EXAMPLES
 .TP
 Trace all capability checks system-wide:

--- a/tools/capable_example.txt
+++ b/tools/capable_example.txt
@@ -88,6 +88,13 @@ TIME      UID    PID    COMM             CAP  NAME                 AUDIT
 Similarly, it is possible to include user-space stack with -U (or they can be
 used both at the same time to include user and kernel stack).
 
+Some processes can do a lot of security capability checks, generating a lot of
+ouput. In this case, the --unique option is useful to only print once the same
+set of capability, pid (or cgroup if --cgroupmap is used) and kernel/user
+stacks (if -K or -U are used).
+
+# ./capable.py -K -U --unique
+
 The --cgroupmap option filters based on a cgroup set. It is meant to be used
 with an externally created map.
 
@@ -100,6 +107,7 @@ USAGE:
 
 # ./capable.py -h
 usage: capable.py [-h] [-v] [-p PID] [-K] [-U] [-x] [--cgroupmap CGROUPMAP]
+                  [--unique]
 
 Trace security capability checks
 
@@ -112,6 +120,7 @@ optional arguments:
   -x, --extra           show extra fields in TID and INSETID columns
   --cgroupmap CGROUPMAP
                         trace cgroups in this BPF map only
+  --unique              don't repeat stacks for the same pid or cgroup
 
 examples:
     ./capable             # trace capability checks
@@ -120,4 +129,5 @@ examples:
     ./capable -K          # add kernel stacks to trace
     ./capable -U          # add user-space stacks to trace
     ./capable -x          # extra fields: show TID and INSETID columns
+    ./capable --unique    # don't repeat stacks for the same pid or cgroup
     ./capable --cgroupmap ./mappath  # only trace cgroups in this BPF map

--- a/tools/capable_example.txt
+++ b/tools/capable_example.txt
@@ -88,19 +88,30 @@ TIME      UID    PID    COMM             CAP  NAME                 AUDIT
 Similarly, it is possible to include user-space stack with -U (or they can be
 used both at the same time to include user and kernel stack).
 
+The --cgroupmap option filters based on a cgroup set. It is meant to be used
+with an externally created map.
+
+# ./capable.py --cgroupmap /sys/fs/bpf/test01
+
+For more details, see docs/filtering_by_cgroups.md
+
+
 USAGE:
 
 # ./capable.py -h
-usage: capable.py [-h] [-v] [-p PID] [-K] [-U]
+usage: capable.py [-h] [-v] [-p PID] [-K] [-U] [-x] [--cgroupmap CGROUPMAP]
 
 Trace security capability checks
 
 optional arguments:
-  -h, --help          show this help message and exit
-  -v, --verbose       include non-audit checks
-  -p PID, --pid PID   trace this PID only
-  -K, --kernel-stack  output kernel stack trace
-  -U, --user-stack    output user stack trace
+  -h, --help            show this help message and exit
+  -v, --verbose         include non-audit checks
+  -p PID, --pid PID     trace this PID only
+  -K, --kernel-stack    output kernel stack trace
+  -U, --user-stack      output user stack trace
+  -x, --extra           show extra fields in TID and INSETID columns
+  --cgroupmap CGROUPMAP
+                        trace cgroups in this BPF map only
 
 examples:
     ./capable             # trace capability checks
@@ -108,3 +119,5 @@ examples:
     ./capable -p 181      # only trace PID 181
     ./capable -K          # add kernel stacks to trace
     ./capable -U          # add user-space stacks to trace
+    ./capable -x          # extra fields: show TID and INSETID columns
+    ./capable --cgroupmap ./mappath  # only trace cgroups in this BPF map


### PR DESCRIPTION
`--cgroupmap` is the same option already introduced in other tools (execsnoop, opensnoop, and others)

Some processes can do a lot of security capability checks, generating a lot of ouput. In this case, the --unique option is useful to only print once the same set of capability, pid (or cgroup if --cgroupmap is used) and kernel/user stacks (if -K or -U are used).
```
  # ./capable.py -K -U --unique
```

Documentation (man page and example text) updated.
