### PR TITLE
Reduce container image size with multi-stage builds

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic as builder
 
 MAINTAINER Brenden Blanco <bblanco@gmail.com>
 
@@ -10,7 +10,14 @@ COPY ./ /root/bcc
 WORKDIR /root/bcc
 
 RUN /usr/lib/pbuilder/pbuilder-satisfydepends && \
-    ./scripts/build-deb.sh && \
+    ./scripts/build-deb.sh
+
+
+FROM ubuntu:bionic
+
+COPY --from=builder /root/bcc/*.deb /root/bcc/
+
+RUN \
   apt-get update -y && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y python python3 binutils libelf1 && \
   dpkg -i /root/bcc/*.deb


### PR DESCRIPTION
Before this patch, Dockerfile.ubuntu was generating an oversized image.
```
                       Uncompressed size      Compressed size
Before this patch:     1.3GB                  390MB
After this patch:      250MB                  110MB
```
-----
Follow up to https://github.com/iovisor/bcc/pull/2797