### PR TITLE
WIP: libbpf-tools: add CO-RE execsnoop

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -1,5 +1,6 @@
 /.output
 /drsnoop
+/execsnoop
 /filelife
 /opensnoop
 /runqslower

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -9,7 +9,7 @@ INCLUDES := -I$(OUTPUT)
 CFLAGS := -g -O2 -Wall
 ARCH := $(shell uname -m | sed 's/x86_64/x86/')
 
-APPS = drsnoop filelife opensnoop runqslower vfsstat xfsslower
+APPS = drsnoop execsnoop filelife opensnoop runqslower vfsstat xfsslower
 
 .PHONY: all
 all: $(APPS)

--- a/libbpf-tools/execsnoop.bpf.c
+++ b/libbpf-tools/execsnoop.bpf.c
@@ -1,0 +1,128 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include "execsnoop.h"
+
+const volatile bool ignore_failed = true;
+const volatile uid_t targ_uid = INVALID_UID;
+const volatile int max_args = DEFAULT_MAXARGS;
+
+static const struct event empty_event = {};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, pid_t);
+	__type(value, struct event);
+} execs SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(u32));
+} events SEC(".maps");
+
+static __always_inline bool valid_uid(uid_t uid) {
+	return uid != INVALID_UID;
+}
+
+SEC("tracepoint/syscalls/sys_enter_execve")
+int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter* ctx)
+{
+	u64 id;
+	pid_t pid, tgid;
+	unsigned int ret;
+	struct event *event;
+	struct task_struct *task;
+	const char **args = (const char **)(ctx->args[1]);
+	const char *argp;
+	uid_t uid = (u32)bpf_get_current_uid_gid();
+
+	if (valid_uid(targ_uid) && targ_uid != uid)
+		return 0;
+
+	id = bpf_get_current_pid_tgid();
+	pid = (pid_t)id;
+	tgid = id >> 32;
+	if (bpf_map_update_elem(&execs, &pid, &empty_event, BPF_NOEXIST))
+		return 0;
+
+	event = bpf_map_lookup_elem(&execs, &pid);
+	if (!event)
+		return 0;
+
+	event->pid = pid;
+	event->tgid = tgid;
+	event->uid = uid;
+	task = (struct task_struct*)bpf_get_current_task();
+	event->ppid = (pid_t)BPF_CORE_READ(task, real_parent, tgid);
+	event->args_count = 0;
+	event->args_size = 0;
+
+	ret = bpf_probe_read_str(event->args, ARGSIZE, (const char*)ctx->args[0]);
+	if (ret <= ARGSIZE) {
+		event->args_size += ret;
+	} else {
+		/* write an empty string */
+		event->args[0] = '\0';
+		event->args_size++;
+	}
+
+	event->args_count++;
+	#pragma unroll
+	for (int i = 1; i < TOTAL_MAX_ARGS && i < max_args; i++) {
+		bpf_probe_read(&argp, sizeof(argp), &args[i]);
+		if (!argp)
+			return 0;
+
+		if (event->args_size > LAST_ARG)
+			return 0;
+
+		ret = bpf_probe_read_str(&event->args[event->args_size], ARGSIZE, argp);
+		if (ret > ARGSIZE)
+			return 0;
+
+		event->args_count++;
+		event->args_size += ret;
+	}
+	/* try to read one more argument to check if there is one */
+	bpf_probe_read(&argp, sizeof(argp), &args[max_args]);
+	if (!argp)
+		return 0;
+
+	/* pointer to max_args+1 isn't null, asume we have more arguments */
+	event->args_count++;
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_execve")
+int tracepoint__syscalls__sys_exit_execve(struct trace_event_raw_sys_exit* ctx)
+{
+	u64 id;
+	pid_t pid;
+	int ret;
+	struct event *event;
+	u32 uid = (u32)bpf_get_current_uid_gid();
+
+	if (valid_uid(targ_uid) && targ_uid != uid)
+		return 0;
+	id = bpf_get_current_pid_tgid();
+	pid = (pid_t)id;
+	event = bpf_map_lookup_elem(&execs, &pid);
+	if (!event)
+		return 0;
+	ret = ctx->ret;
+	if (ignore_failed && ret < 0)
+		goto cleanup;
+
+	event->retval = ret;
+	bpf_get_current_comm(&event->comm, sizeof(event->comm));
+	size_t len = EVENT_SIZE(event);
+	if (len <= sizeof(*event))
+		bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event, len);
+cleanup:
+	bpf_map_delete_elem(&execs, &pid);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -1,0 +1,340 @@
+// Based on execsnoop(8) from BCC by Brendan Gregg and others.
+//
+#include <argp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "execsnoop.h"
+#include "execsnoop.skel.h"
+
+#define PERF_BUFFER_PAGES   64
+#define NSEC_PER_SEC 1000000000L
+#define NSEC_PRECISION (NSEC_PER_SEC / 1000)
+#define MAX_ARGS_KEY 259
+
+static struct env {
+	bool time;
+	bool timestamp;
+	bool fails;
+	uid_t uid;
+	bool quote;
+	const char *name;
+	const char *line;
+	bool print_uid;
+	bool verbose;
+	int max_args;
+} env = {
+	.max_args = DEFAULT_MAXARGS,
+	.uid = INVALID_UID
+};
+
+static struct timespec start_time;
+
+const char *argp_program_version = "execsnoop 0.1";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
+const char argp_program_doc[] =
+"Trace open family syscalls\n"
+"\n"
+"USAGE: execsnoop [-h] [-T] [-t] [-x] [-u UID] [-q] [-n NAME] [-l LINE] [-U]\n"
+"                 [--max-args MAX_ARGS]\n"
+"\n"
+"EXAMPLES:\n"
+"   ./execsnoop           # trace all exec() syscalls\n"
+"   ./execsnoop -x        # include failed exec()s\n"
+"   ./execsnoop -T        # include time (HH:MM:SS)\n"
+"   ./execsnoop -U        # include UID\n"
+"   ./execsnoop -u 1000   # only trace UID 1000\n"
+"   ./execsnoop -t        # include timestamps\n"
+"   ./execsnoop -q        # add \"quotemarks\" around arguments\n"
+"   ./execsnoop -n main   # only print command lines containing \"main\"\n"
+"   ./execsnoop -l tpkg   # only print command where arguments contains \"tpkg\"";
+
+static const struct argp_option opts[] = {
+	{ "time", 'T', NULL, 0, "include time column on output (HH:MM:SS)"},
+	{ "timestamp", 't', NULL, 0, "include timestamp on output"},
+	{ "fails", 'x', NULL, 0, "include failed exec()s"},
+	{ "uid", 'u', "UID", 0, "trace this UID only"},
+	{ "quote", 'q', NULL, 0, "Add quotemarks (\") around arguments"},
+	{ "name", 'n', "NAME", 0, "only print commands matching this name, any arg"},
+	{ "line", 'l', "LINE", 0, "only print commands where arg contains this line"},
+	{ "print-uid", 'U', NULL, 0, "print UID column"},
+	{ "max-args", MAX_ARGS_KEY, "MAX_ARGS", 0,
+		"maximum number of arguments parsed and displayed, defaults to 20"},
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	long int uid, max_args;
+
+	switch (key) {
+	case 'h':
+		argp_usage(state);
+		break;
+	case 'T':
+		env.time = true;
+		break;
+	case 't':
+		env.timestamp = true;
+		break;
+	case 'x':
+		env.fails = true;
+		break;
+	case 'u':
+		errno = 0;
+		uid = strtol(arg, NULL, 10);
+		if (errno || uid < 0 || uid >= INVALID_UID) {
+			fprintf(stderr, "Invalid UID %s\n", arg);
+			argp_usage(state);
+		}
+		env.uid = uid;
+		break;
+	case 'q':
+		env.quote = true;
+		break;
+	case 'n':
+		env.name = arg;
+		break;
+	case 'l':
+		env.line = arg;
+		break;
+	case 'U':
+		env.print_uid = true;
+		break;
+	case 'v':
+		env.verbose = true;
+		break;
+	case MAX_ARGS_KEY:
+		errno = 0;
+		max_args = strtol(arg, NULL, 10);
+		if (errno || max_args < 1 || max_args > TOTAL_MAX_ARGS) {
+			fprintf(stderr, "Invalid MAX_ARGS %s, should be in [1, %d] range\n",
+					arg, TOTAL_MAX_ARGS);
+
+			argp_usage(state);
+		}
+		env.max_args = max_args;
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static int bump_memlock_rlimit(void)
+{
+	struct rlimit rlim_new = {
+		.rlim_cur	= RLIM_INFINITY,
+		.rlim_max	= RLIM_INFINITY,
+	};
+
+	return setrlimit(RLIMIT_MEMLOCK, &rlim_new);
+}
+
+int libbpf_print_fn(enum libbpf_print_level level,
+            const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void time_since_start()
+{
+	long nsec, sec;
+	static struct timespec cur_time;
+	double time_diff;
+
+	clock_gettime(CLOCK_MONOTONIC, &cur_time);
+	nsec = cur_time.tv_nsec - start_time.tv_nsec;
+	sec = cur_time.tv_sec - start_time.tv_sec;
+	if (nsec < 0) {
+		nsec += NSEC_PER_SEC;
+		sec--;
+	}
+	time_diff = sec + (double)nsec / NSEC_PER_SEC;
+	printf("%-8.3f", time_diff);
+}
+
+static void inline quoted_symbol(char c) {
+	switch(c) {
+		case '"':
+			putchar('\\');
+			putchar('"');
+			break;
+		case '\t':
+			putchar('\\');
+			putchar('t');
+			break;
+		case '\n':
+			putchar('\\');
+			putchar('n');
+			break;
+		default:
+			putchar(c);
+			break;
+	}
+}
+
+static void print_args(const struct event *e, bool quote)
+{
+	int args_counter = 0;
+
+	if (env.quote)
+		putchar('"');
+
+	for (int i = 0; i < e->args_size && args_counter < e->args_count; i++) {
+		char c = e->args[i];
+		if (env.quote) {
+			if (c == '\0') {
+				args_counter++;
+				putchar('"');
+				putchar(' ');
+				if (args_counter < e->args_count) {
+					putchar('"');
+				}
+			} else {
+				quoted_symbol(c);
+			}
+		} else {
+			if (c == '\0') {
+				args_counter++;
+				putchar(' ');
+			} else {
+				putchar(c);
+			}
+		}
+	}
+	if (e->args_count == env.max_args + 1) {
+		fputs(" ...", stdout);
+	}
+}
+
+void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+{
+	const struct event *e = data;
+	time_t t;
+	struct tm *tm;
+	char ts[32];
+
+	/* TODO: use pcre lib */
+	if (env.name && strstr(e->comm, env.name) == NULL)
+		return;
+
+	/* TODO: use pcre lib */
+	if (env.line && strstr(e->comm, env.line) == NULL)
+		return;
+
+	time(&t);
+	tm = localtime(&t);
+	strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+
+	if (env.time) {
+		printf("%-8s ", ts);
+	}
+	if (env.timestamp) {
+		time_since_start();
+	}
+
+	if (env.print_uid)
+		printf("%-6d", e->uid);
+
+	printf("%-16s %-6d %-6d %3d ", e->comm, e->pid, e->ppid, e->retval);
+	print_args(e, env.quote);
+	putchar('\n');
+}
+
+void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	fprintf(stderr, "Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct perf_buffer_opts pb_opts;
+	struct perf_buffer *pb = NULL;
+	struct execsnoop_bpf *obj;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	err = bump_memlock_rlimit();
+	if (err) {
+		fprintf(stderr, "failed to increase rlimit: %d\n", err);
+		return 1;
+	}
+
+	obj = execsnoop_bpf__open();
+	if (!obj) {
+		fprintf(stderr, "failed to open and/or load BPF object\n");
+		return 1;
+	}
+
+	/* initialize global data (filtering options) */
+	obj->rodata->ignore_failed = !env.fails;
+	obj->rodata->targ_uid = env.uid;
+	obj->rodata->max_args = env.max_args;
+
+	err = execsnoop_bpf__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF object: %d\n", err);
+		goto cleanup;
+	}
+
+	clock_gettime(CLOCK_MONOTONIC, &start_time);
+	err = execsnoop_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+	/* print headers */
+	if (env.time) {
+		printf("%-9s", "TIME");
+	}
+	if (env.timestamp) {
+		printf("%-8s ", "TIME(s)");
+	}
+	if (env.print_uid) {
+		printf("%-6s ", "UID");
+	}
+
+	printf("%-16s %-6s %-6s %3s %s\n", "PCOMM", "PID", "PPID", "RET", "ARGS");
+
+	/* setup event callbacks */
+	pb_opts.sample_cb = handle_event;
+	pb_opts.lost_cb = handle_lost_events;
+	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), PERF_BUFFER_PAGES, &pb_opts);
+	err = libbpf_get_error(pb);
+	if (err) {
+		pb = NULL;
+		fprintf(stderr, "failed to open perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	/* main: poll */
+	while ((err = perf_buffer__poll(pb, 100)) >= 0)
+		;
+	printf("Error polling perf buffer: %d\n", err);
+
+cleanup:
+	perf_buffer__free(pb);
+	execsnoop_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/libbpf-tools/execsnoop.h
+++ b/libbpf-tools/execsnoop.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __EXECSNOOP_H
+#define __EXECSNOOP_H
+
+#define ARGSIZE  128
+#define TASK_COMM_LEN 16
+#define TOTAL_MAX_ARGS 60
+#define DEFAULT_MAXARGS 20
+#define FULL_MAX_ARGS_ARR (TOTAL_MAX_ARGS * ARGSIZE)
+#define INVALID_UID ((uid_t)-1)
+#define BASE_EVENT_SIZE (size_t)(&((struct event*)0)->args)
+#define EVENT_SIZE(e) (BASE_EVENT_SIZE + e->args_size)
+#define LAST_ARG (FULL_MAX_ARGS_ARR - ARGSIZE)
+
+struct event {
+	pid_t pid;
+	pid_t tgid;
+	pid_t ppid;
+	uid_t uid;
+	int retval;
+	int args_count;
+	unsigned int args_size;
+	char comm[TASK_COMM_LEN];
+	char args[FULL_MAX_ARGS_ARR];
+};
+
+#endif /* __EXECSNOOP_H */


### PR DESCRIPTION
Hi, I've made version of `execsnoop` using libbpf, but currently it lacks few essential parts (printing `args` and relative timestamps). I just wanted to ask few questions before implementing them.

To implement argument printing I need hash table (or some balanced tree) and wanted to ask if it would be okay if I add some library ([like this one](https://github.com/attractivechaos/klib/blob/master/khash.h)). Or maybe it would be better to use `hsearch` from glibc. Or, as another variant, implement it in CPP and use STL. To be honest, I would prefer to add header only library, since `hsearch` lacks some features  and CPP version will require libstd on host machine, library in the same time could be reused by other tools.

Also, it seems, there is a possibility of **memory leak** in current (python) `execsnoop` implementation. Basically, it receives arguments from [kprobe](https://github.com/iovisor/bcc/blob/master/tools/execsnoop.py#L277) and saves them in memory, but removes them only when receives event from [kretprobe](https://github.com/iovisor/bcc/blob/master/tools/execsnoop.py#L305). So, if event from kretprobe would be lost, it will never remove stored arguments from memory and over time such arguments could pile up. But since events are rarely lost and to be perceivable amount of lost events should be huge I don't think that's an issue. So, I wanted to ask if that's important, in that case I could add periodic GC to my implementation.
