### PR TITLE
libbpf-tools: small clean ups across all tools

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -1,3 +1,4 @@
 /.output
-/runqslower
 /drsnoop
+/opensnoop
+/runqslower

--- a/libbpf-tools/drsnoop.bpf.c
+++ b/libbpf-tools/drsnoop.bpf.c
@@ -4,9 +4,6 @@
 #include <bpf/bpf_helpers.h>
 #include "drsnoop.h"
 
-#define BPF_F_INDEX_MASK		0xffffffffULL
-#define BPF_F_CURRENT_CPU		BPF_F_INDEX_MASK
-
 const volatile pid_t targ_pid = 0;
 const volatile pid_t targ_tgid = 0;
 const volatile __u64 vm_zone_stat_kaddr = 0;

--- a/libbpf-tools/opensnoop.bpf.c
+++ b/libbpf-tools/opensnoop.bpf.c
@@ -7,9 +7,6 @@
 
 #define TASK_RUNNING 0
 
-#define BPF_F_INDEX_MASK		0xffffffffULL
-#define BPF_F_CURRENT_CPU		BPF_F_INDEX_MASK
-
 const volatile __u64 min_us = 0;
 const volatile pid_t targ_pid = 0;
 const volatile pid_t targ_tgid = 0;

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
 	struct perf_buffer_opts pb_opts;
 	struct perf_buffer *pb = NULL;
 	struct opensnoop_bpf *obj;
-	__u64 time_end;
+	__u64 time_end = 0;
 	int err;
 
 	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);

--- a/libbpf-tools/runqslower.bpf.c
+++ b/libbpf-tools/runqslower.bpf.c
@@ -6,9 +6,6 @@
 
 #define TASK_RUNNING 0
 
-#define BPF_F_INDEX_MASK		0xffffffffULL
-#define BPF_F_CURRENT_CPU		BPF_F_INDEX_MASK
-
 const volatile __u64 min_us = 0;
 const volatile pid_t targ_pid = 0;
 const volatile pid_t targ_tgid = 0;


### PR DESCRIPTION
Remove BPF_F_CURRENT_CPU definitions, which are now provided by vmlinux.h
after 1aae4bdd7879 ("bpf: Switch BPF UAPI #define constants used from BPF
program side to enums") commit in kernel.

Fix potential uninitialized read warning in opensnoop.

Also add opensnoop to .gitignore.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>