### PR TITLE
libbpf-tools: CO-RE opensnoop minor improvements

### DIFF
--- a/libbpf-tools/opensnoop.bpf.c
+++ b/libbpf-tools/opensnoop.bpf.c
@@ -10,7 +10,7 @@
 const volatile __u64 min_us = 0;
 const volatile pid_t targ_pid = 0;
 const volatile pid_t targ_tgid = 0;
-const volatile pid_t targ_uid = 0;
+const volatile uid_t targ_uid = 0;
 const volatile bool targ_failed = false;
 
 struct {
@@ -26,6 +26,10 @@ struct {
 	__uint(value_size, sizeof(u32));
 } events SEC(".maps");
 
+static __always_inline bool valid_uid(uid_t uid) {
+	return uid != INVALID_UID;
+}
+
 static __always_inline
 int trace_filtered(u32 tgid, u32 pid)
 {
@@ -36,8 +40,8 @@ int trace_filtered(u32 tgid, u32 pid)
 		return 1;
 	if (targ_pid && targ_pid != pid)
 		return 1;
-	if (targ_uid) {
-		uid = bpf_get_current_uid_gid();
+	if (valid_uid(targ_uid)) {
+		uid = (u32)bpf_get_current_uid_gid();
 		if (targ_uid != uid) {
 			return 1;
 		}

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -39,7 +39,9 @@ static struct env {
 	bool extended;
 	bool failed;
 	char *name;
-} env = {};
+} env = {
+	.uid = INVALID_UID
+};
 
 const char *argp_program_version = "opensnoop 0.1";
 const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
@@ -79,7 +81,7 @@ static const struct argp_option opts[] = {
 static error_t parse_arg(int key, char *arg, struct argp_state *state)
 {
 	static int pos_args;
-	int pid, uid, duration;
+	long int pid, uid, duration;
 
 	switch (key) {
 	case 'e':
@@ -134,7 +136,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 'u':
 		errno = 0;
 		uid = strtol(arg, NULL, 10);
-		if (errno || uid <= 0) {
+		if (errno || uid < 0 || uid >= INVALID_UID) {
 			fprintf(stderr, "Invalid UID %s\n", arg);
 			argp_usage(state);
 		}

--- a/libbpf-tools/opensnoop.h
+++ b/libbpf-tools/opensnoop.h
@@ -4,6 +4,7 @@
 
 #define TASK_COMM_LEN 16
 #define NAME_MAX 255
+#define INVALID_UID ((uid_t)-1)
 
 struct args_t {
 	const char *fname;


### PR DESCRIPTION
 * allow passing `0` as valid uid
 * fix type of `targ_uid`

Also wanted to say, that there is another way to implement UID filtering, that will support `0` UID. According to [kernel source][uid_valid] there is only one invalid UID, it is `(uint)-1` which should be `UINT_MAX`. So instead of adding another variable, like I did, it possible to check if `targ_uid` is `UINT_MAX` (or `-1`), but I don't think we should be stingy on variables in this case.

[uid_valid]: https://github.com/torvalds/linux/blob/master/include/linux/uidgid.h#L113