### PR TITLE
libbpf-tools: determine target host architecture

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -7,6 +7,7 @@ LIBBPF_SRC := $(abspath ../src/cc/libbpf/src)
 LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
 INCLUDES := -I$(OUTPUT)
 CFLAGS := -g -O2 -Wall
+ARCH := $(shell uname -m | sed 's/x86_64/x86/')
 
 APPS = drsnoop opensnoop runqslower
 
@@ -47,8 +48,8 @@ $(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT)
 
 $(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) vmlinux.h | $(OUTPUT)
 	$(call msg,BPF,$@)
-	$(Q)$(CLANG) -g -O2 -target bpf $(INCLUDES)			      \
-		 -c $(filter %.c,$^) -o $@ &&				      \
+	$(Q)$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH)		      \
+		     $(INCLUDES) -c $(filter %.c,$^) -o $@ &&		      \
 	$(LLVM_STRIP) -g $@
 
 # Build libbpf.a


### PR DESCRIPTION
BPF code is compiled with -target bpf, but for PT_REGS_PARM macro (and by
induction for BPF_KPROBE/BPF_KRETPROBE macros as well), it's important to know
what's the target host original architecture was, to use correct definition of
struct pt_regs. Determine that based on output of `uname -m` (taking into
account that both x86_64 and x86 are defined as x86 internally for kernel).

Reported-by: Wenbo Zhang <ethercflow@gmail.com>
Signed-off-by: Andrii Nakryiko <andriin@fb.com>