### PR TITLE
Do not prepend /proc multiple times in bcc_resolve_symname

### DIFF
--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -730,7 +730,7 @@ int bcc_resolve_symname(const char *module, const char *symname,
   }
   if (sym->module == NULL)
     return -1;
-  if (pid != 0 && pid != -1) {
+  if (pid != 0 && pid != -1 && strstr(sym->module, "/proc") != sym->module){
     char *temp = (char*)sym->module;
     sym->module = strdup(tfm::format("/proc/%d/root%s", pid, sym->module).c_str());
     free(temp);

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -362,5 +362,11 @@ TEST_CASE("test probing running Ruby process in namespaces",
 
     res = bpf.detach_usdt(u, ruby_pid);
     REQUIRE(res.code() == 0);
+
+    struct bcc_symbol sym;
+    std::string pid_root= "/proc/" + std::to_string(ruby_pid) + "/root/";
+    std::string module = pid_root + "usr/local/bin/ruby";
+    REQUIRE(bcc_resolve_symname(module.c_str(), "rb_gc_mark", 0x0, ruby_pid, nullptr, &sym) == 0);
+    REQUIRE(std::string(sym.module).find(pid_root, 1) == std::string::npos);
   }
 }


### PR DESCRIPTION
Like in https://github.com/iovisor/bcc/commit/5ce16e478a98442b7687e9f5139c1cdb27051ce6 we need to not prepend /proc/PID/root multiple times.

This is because for containerized processes, paths like:

`/proc/2593844/root/proc/2593844/root/usr/local/bin/memcached`

May be invalid if process in in a different PID namespace.