### PR TITLE
opensnoop: fix --cgroupmap with kfunc

### DIFF
--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -177,6 +177,12 @@ KRETFUNC_PROBE(do_sys_open, int dfd, const char *filename, int flags, int mode, 
     PID_TID_FILTER
     UID_FILTER
     FLAGS_FILTER
+#if CGROUPSET
+    u64 cgroupid = bpf_get_current_cgroup_id();
+    if (cgroupset.lookup(&cgroupid) == NULL) {
+      return 0;
+    }
+#endif
 
     struct data_t data = {};
     bpf_get_current_comm(&data.comm, sizeof(data.comm));


### PR DESCRIPTION
Commit c347fe6c9f75 ("Support kfunc in opensnoop.py") introduces an
alternative probe on do_sys_open() with kfuncs instead of kprobes. This
new implementation is used if the kernel supports it. But it removed the
--cgroupmap filter added in commit b2aa29fa3269 ("tools: cgroup
filtering in execsnoop/opensnoop").

This patch adds the --cgroupmap filter in the kfunc implementation.

-----

Note: I didn't test it yet; I will need to get a newer kernel first, see https://github.com/iovisor/bcc/pull/2726#issuecomment-601095997.

/cc @olsajiri 