### PR TITLE
tools: fix alignment of ipv6_key_t in tcptop

### DIFF
--- a/tools/tcptop.py
+++ b/tools/tcptop.py
@@ -88,11 +88,12 @@ BPF_HASH(ipv4_send_bytes, struct ipv4_key_t);
 BPF_HASH(ipv4_recv_bytes, struct ipv4_key_t);
 
 struct ipv6_key_t {
-    u32 pid;
     unsigned __int128 saddr;
     unsigned __int128 daddr;
+    u32 pid;
     u16 lport;
     u16 dport;
+    u64 __pad__;
 };
 BPF_HASH(ipv6_send_bytes, struct ipv6_key_t);
 BPF_HASH(ipv6_recv_bytes, struct ipv6_key_t);


### PR DESCRIPTION
Fixes the following error on aarch64:

bpf: Failed to load program: Permission denied
; struct sock *sk = ctx->regs[0]; int copied = ctx->regs[1];
0: (79) r8 = *(u64 *)(r1 +8)
...
; struct ipv6_key_t ipv6_key = {.pid = pid};
79: (63) *(u32 *)(r10 -48) = r7
; struct ipv6_key_t ipv6_key = {.pid = pid};
80: (7b) *(u64 *)(r10 +8) = r9
invalid stack off=8 size=8
processed 96 insns (limit 1000000) max_states_per_insn 0 total_states 7 peak_states 7 mark_read 4