### PR TITLE
cachetop: Change the default sort order to Descending

### DIFF
--- a/tools/cachetop.py
+++ b/tools/cachetop.py
@@ -136,7 +136,7 @@ def handle_loop(stdscr, args):
     stdscr.nodelay(1)
     # set default sorting field
     sort_field = FIELDS.index(DEFAULT_FIELD)
-    sort_reverse = False
+    sort_reverse = True
 
     # load BPF program
     bpf_text = """


### PR DESCRIPTION
currently with ascending sort the useful information
is commonly beyond the bottom of the terminal window
and it is necessary to reverse the sort manually every execution.

Signed-off-by: Mark Kogan <mkogan@redhat.com>