### PR TITLE
tools/capable: fix compilation error

### DIFF
--- a/tools/capable.py
+++ b/tools/capable.py
@@ -193,7 +193,7 @@ int kprobe__cap_capable(struct pt_regs *ctx, const struct cred *cred,
     struct repeat_t repeat = {0,};
     repeat.cap = cap;
 #if CGROUPSET
-    repeat.cgroupid = bpf_get_current_cgroup_id(),
+    repeat.cgroupid = bpf_get_current_cgroup_id();
 #else
     repeat.tgid = tgid;
 #endif


### PR DESCRIPTION
9d7feeed87c5 ("tools: add option --unique to capable.py") introduced a
compilation error when the --unique flag is passed.

Signed-off-by: Mauricio Vásquez <mauricio@kinvolk.io>