### PR TITLE
http-parse-complete.py toHex funtion has error

### DIFF
--- a/examples/networking/http_filter/http-parse-complete.py
+++ b/examples/networking/http_filter/http-parse-complete.py
@@ -34,7 +34,7 @@ MAX_AGE_SECONDS = 30       # max age entry in bpf_sessions map
 def toHex(s):
     lst = ""
     for ch in s:
-        hv = hex(ch).replace('0x', '')
+        hv = hex(ord(ch)).replace('0x', '')
         if len(hv) == 1:
             hv = '0' + hv
         lst = lst + hv


### PR DESCRIPTION
resolves #2848 
problem
-----------
http-parse-complete.py error out on my debian 10.3 machine.
with error log 
```
 ##dev@debian:~/git/bcc/examples/networking/http_filter$ sudo python http-parse-complete.py -i wlp3s0
binding socket to 'wlp3s0'
Traceback (most recent call last):
  File "http-parse-complete.py", line 191, in <module>
    ip_src = int(toHex(ip_src_str), 16)
  File "http-parse-complete.py", line 37, in toHex
    hv = hex(ch).replace('0x', '')
TypeError: hex() argument can't be converted to hex
```
root cause
-------------

in line
```
hv = hex(ch).replace('0x', '')
```
hex as per [python documetation](https://docs.python.org/3/library/functions.html#hex)
first argument is expeted of type int
but ch is of type str
so we can use ord() to convert it appropriately.
