### PR TITLE
[C++] add BPF::enable_usdt(void) and disble_usdt(void) to handle all the USDT at once

### DIFF
--- a/examples/cpp/FollyRequestContextSwitch.cc
+++ b/examples/cpp/FollyRequestContextSwitch.cc
@@ -98,7 +98,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  auto attach_res = bpf->attach_usdt();
+  auto attach_res = bpf->attach_usdt_all();
   if (attach_res.code() != 0) {
     std::cerr << attach_res.msg() << std::endl;
     return 1;
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
 
   shutdown_handler = [&](int s) {
     std::cerr << "Terminating..." << std::endl;
-    bpf->detach_usdt();
+    bpf->detach_usdt_all();
     delete bpf;
     exit(0);
   };

--- a/examples/cpp/FollyRequestContextSwitch.cc
+++ b/examples/cpp/FollyRequestContextSwitch.cc
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
 
   shutdown_handler = [&](int s) {
     std::cerr << "Terminating..." << std::endl;
-    bpf->detach_usdt(u);
+    bpf->detach_usdt();
     delete bpf;
     exit(0);
   };

--- a/examples/cpp/FollyRequestContextSwitch.cc
+++ b/examples/cpp/FollyRequestContextSwitch.cc
@@ -98,7 +98,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  auto attach_res = bpf->attach_usdt(u);
+  auto attach_res = bpf->attach_usdt();
   if (attach_res.code() != 0) {
     std::cerr << attach_res.msg() << std::endl;
     return 1;

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -490,36 +490,51 @@ StatusTuple BPF::detach_uprobe(const std::string& binary_path,
   return StatusTuple::OK();
 }
 
+StatusTuple BPF::detach_usdt_without_validation(const USDT& u, pid_t pid) {
+  auto& probe = *static_cast<::USDT::Probe*>(u.probe_.get());
+  bool failed = false;
+  std::string err_msg;
+  for (const auto& loc : probe.locations_) {
+    auto res = detach_uprobe(loc.bin_path_, std::string(), loc.address_,
+                             BPF_PROBE_ENTRY, pid);
+    if (!res.ok()) {
+      failed = true;
+      err_msg += "USDT " + u.print_name() + " at " + loc.bin_path_ +
+                  " address " + std::to_string(loc.address_);
+      err_msg += ": " + res.msg() + "\n";
+    }
+  }
+
+  if (!probe.disable()) {
+    failed = true;
+    err_msg += "Unable to disable USDT " + u.print_name();
+  }
+
+  if (failed)
+    return StatusTuple(-1, err_msg);
+  else
+    return StatusTuple::OK();
+}
+
 StatusTuple BPF::detach_usdt(const USDT& usdt, pid_t pid) {
   for (const auto& u : usdt_) {
     if (u == usdt) {
-      auto& probe = *static_cast<::USDT::Probe*>(u.probe_.get());
-      bool failed = false;
-      std::string err_msg;
-      for (const auto& loc : probe.locations_) {
-        auto res = detach_uprobe(loc.bin_path_, std::string(), loc.address_,
-                                 BPF_PROBE_ENTRY, pid);
-        if (res.code() != 0) {
-          failed = true;
-          err_msg += "USDT " + u.print_name() + " at " + loc.bin_path_ +
-                     " address " + std::to_string(loc.address_);
-          err_msg += ": " + res.msg() + "\n";
-        }
-      }
-
-      if (!probe.disable()) {
-        failed = true;
-        err_msg += "Unable to disable USDT " + u.print_name();
-      }
-
-      if (failed)
-        return StatusTuple(-1, err_msg);
-      else
-        return StatusTuple::OK();
+      return detach_usdt_without_validation(u, pid);
     }
   }
 
   return StatusTuple(-1, "USDT %s not found", usdt.print_name().c_str());
+}
+
+StatusTuple BPF::detach_usdt() {
+  for (const auto& u : usdt_) {
+    auto ret = detach_usdt_without_validation(u, -1);
+    if (!ret.ok()) {
+      return ret;
+    }
+  }
+
+  return StatusTuple::OK();
 }
 
 StatusTuple BPF::detach_tracepoint(const std::string& tracepoint) {

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -307,7 +307,7 @@ StatusTuple BPF::attach_usdt(const USDT& usdt, pid_t pid) {
   return StatusTuple(-1, "USDT %s not found", usdt.print_name().c_str());
 }
 
-StatusTuple BPF::attach_usdt() {
+StatusTuple BPF::attach_usdt_all() {
   for (const auto& u : usdt_) {
     auto res = attach_usdt_without_validation(u, -1);
     if (!res.ok()) {
@@ -526,7 +526,7 @@ StatusTuple BPF::detach_usdt(const USDT& usdt, pid_t pid) {
   return StatusTuple(-1, "USDT %s not found", usdt.print_name().c_str());
 }
 
-StatusTuple BPF::detach_usdt() {
+StatusTuple BPF::detach_usdt_all() {
   for (const auto& u : usdt_) {
     auto ret = detach_usdt_without_validation(u, -1);
     if (!ret.ok()) {

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -264,45 +264,60 @@ StatusTuple BPF::attach_uprobe(const std::string& binary_path,
   return StatusTuple::OK();
 }
 
+StatusTuple BPF::attach_usdt_without_validation(const USDT& u, pid_t pid) {
+  auto& probe = *static_cast<::USDT::Probe*>(u.probe_.get());
+  if (!probe.enable(u.probe_func_))
+    return StatusTuple(-1, "Unable to enable USDT %s" + u.print_name());
+
+  bool failed = false;
+  std::string err_msg;
+  int cnt = 0;
+  for (const auto& loc : probe.locations_) {
+    auto res = attach_uprobe(loc.bin_path_, std::string(), u.probe_func_,
+                              loc.address_, BPF_PROBE_ENTRY, pid);
+    if (!res.ok()) {
+      failed = true;
+      err_msg += "USDT " + u.print_name() + " at " + loc.bin_path_ +
+                  " address " + std::to_string(loc.address_);
+      err_msg += ": " + res.msg() + "\n";
+      break;
+    }
+    cnt++;
+  }
+  if (failed) {
+    for (int i = 0; i < cnt; i++) {
+      auto res = detach_uprobe(probe.locations_[i].bin_path_, std::string(),
+                               probe.locations_[i].address_, BPF_PROBE_ENTRY, pid);
+      if (!res.ok())
+        err_msg += "During clean up: " + res.msg() + "\n";
+    }
+    return StatusTuple(-1, err_msg);
+  } else {
+    return StatusTuple::OK();
+  }
+}
+
 StatusTuple BPF::attach_usdt(const USDT& usdt, pid_t pid) {
   for (const auto& u : usdt_) {
     if (u == usdt) {
-      auto& probe = *static_cast<::USDT::Probe*>(u.probe_.get());
-      if (!probe.enable(u.probe_func_))
-        return StatusTuple(-1, "Unable to enable USDT " + u.print_name());
-
-      bool failed = false;
-      std::string err_msg;
-      int cnt = 0;
-      for (const auto& loc : probe.locations_) {
-        auto res = attach_uprobe(loc.bin_path_, std::string(), u.probe_func_,
-                                 loc.address_, BPF_PROBE_ENTRY, pid);
-        if (res.code() != 0) {
-          failed = true;
-          err_msg += "USDT " + u.print_name() + " at " + loc.bin_path_ +
-                     " address " + std::to_string(loc.address_);
-          err_msg += ": " + res.msg() + "\n";
-          break;
-        }
-        cnt++;
-      }
-      if (failed) {
-        for (int i = 0; i < cnt; i++) {
-          auto res =
-              detach_uprobe(probe.locations_[i].bin_path_, std::string(),
-                            probe.locations_[i].address_, BPF_PROBE_ENTRY, pid);
-          if (res.code() != 0)
-            err_msg += "During clean up: " + res.msg() + "\n";
-        }
-        return StatusTuple(-1, err_msg);
-      } else {
-        return StatusTuple::OK();
-      }
+      return attach_usdt_without_validation(u, pid);
     }
   }
 
   return StatusTuple(-1, "USDT %s not found", usdt.print_name().c_str());
 }
+
+StatusTuple BPF::attach_usdt() {
+  for (const auto& u : usdt_) {
+    auto res = attach_usdt_without_validation(u, -1);
+    if (!res.ok()) {
+      return res;
+    }
+  }
+
+  return StatusTuple::OK();
+}
+
 
 StatusTuple BPF::attach_tracepoint(const std::string& tracepoint,
                                    const std::string& probe_func) {

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -87,6 +87,7 @@ class BPF {
   StatusTuple attach_usdt(const USDT& usdt, pid_t pid = -1);
   StatusTuple attach_usdt();
   StatusTuple detach_usdt(const USDT& usdt, pid_t pid = -1);
+  StatusTuple detach_usdt();
 
   StatusTuple attach_tracepoint(const std::string& tracepoint,
                                 const std::string& probe_func);
@@ -250,6 +251,7 @@ class BPF {
                                bpf_probe_attach_type type, pid_t pid);
 
   StatusTuple attach_usdt_without_validation(const USDT& usdt, pid_t pid);
+  StatusTuple detach_usdt_without_validation(const USDT& usdt, pid_t pid);
 
   StatusTuple detach_kprobe_event(const std::string& event, open_probe_t& attr);
   StatusTuple detach_uprobe_event(const std::string& event, open_probe_t& attr);

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -85,9 +85,9 @@ class BPF {
                             pid_t pid = -1,
                             uint64_t symbol_offset = 0);
   StatusTuple attach_usdt(const USDT& usdt, pid_t pid = -1);
-  StatusTuple attach_usdt();
+  StatusTuple attach_usdt_all();
   StatusTuple detach_usdt(const USDT& usdt, pid_t pid = -1);
-  StatusTuple detach_usdt();
+  StatusTuple detach_usdt_all();
 
   StatusTuple attach_tracepoint(const std::string& tracepoint,
                                 const std::string& probe_func);

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -85,6 +85,7 @@ class BPF {
                             pid_t pid = -1,
                             uint64_t symbol_offset = 0);
   StatusTuple attach_usdt(const USDT& usdt, pid_t pid = -1);
+  StatusTuple attach_usdt();
   StatusTuple detach_usdt(const USDT& usdt, pid_t pid = -1);
 
   StatusTuple attach_tracepoint(const std::string& tracepoint,
@@ -247,6 +248,8 @@ class BPF {
                                bpf_probe_attach_type type);
   std::string get_uprobe_event(const std::string& binary_path, uint64_t offset,
                                bpf_probe_attach_type type, pid_t pid);
+
+  StatusTuple attach_usdt_without_validation(const USDT& usdt, pid_t pid);
 
   StatusTuple detach_kprobe_event(const std::string& event, open_probe_t& attr);
   StatusTuple detach_uprobe_event(const std::string& event, open_probe_t& attr);

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -83,10 +83,10 @@ TEST_CASE("test fine probes in our own binary with C++ API", "[usdt]") {
     auto res = bpf.init("int on_event() { return 0; }", {}, {u});
     REQUIRE(res.ok());
 
-    res = bpf.attach_usdt();
+    res = bpf.attach_usdt_all();
     REQUIRE(res.ok());
 
-    res = bpf.detach_usdt();
+    res = bpf.detach_usdt_all();
     REQUIRE(res.ok());
 }
 

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -76,6 +76,20 @@ TEST_CASE("test fine a probe in our own binary with C++ API", "[usdt]") {
     REQUIRE(res.code() == 0);
 }
 
+TEST_CASE("test fine probes in our own binary with C++ API", "[usdt]") {
+    ebpf::BPF bpf;
+    ebpf::USDT u("/proc/self/exe", "libbcc_test", "sample_probe_1", "on_event");
+
+    auto res = bpf.init("int on_event() { return 0; }", {}, {u});
+    REQUIRE(res.ok());
+
+    res = bpf.attach_usdt();
+    REQUIRE(res.ok());
+
+    res = bpf.detach_all();
+    REQUIRE(res.ok());
+}
+
 TEST_CASE("test fine a probe in our Process with C++ API", "[usdt]") {
     ebpf::BPF bpf;
     ebpf::USDT u(::getpid(), "libbcc_test", "sample_probe_1", "on_event");

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -86,7 +86,7 @@ TEST_CASE("test fine probes in our own binary with C++ API", "[usdt]") {
     res = bpf.attach_usdt();
     REQUIRE(res.ok());
 
-    res = bpf.detach_all();
+    res = bpf.detach_usdt();
     REQUIRE(res.ok());
 }
 


### PR DESCRIPTION
It's bothering to write a loop such as:

```c++
  for (auto &probe : probes) {
    ret = bpf->attach_usdt(probe);
    if (!ret.ok()) {
      std::cerr << "attach_usdt: " << ret.msg() << std::endl;
      return EXIT_FAILURE;
    }
  }
```

So I think it makes sense when the BPF.h provides a way to enable/disable all the USDTs at once.