### PR TITLE
add test_lpm_trie.py test

### DIFF
--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -85,3 +85,5 @@ add_test(NAME py_test_free_bcc_memory WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_D
   COMMAND ${TEST_WRAPPER} py_test_free_bcc_memory sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_free_bcc_memory.py)
 add_test(NAME py_test_rlimit WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_test_rlimit sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_rlimit.py)
+add_test(NAME py_test_lpm_trie WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_test_lpm_trie sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_lpm_trie.py)


### PR DESCRIPTION
test_lpm_trie.py has been in the repo for quite some time,
but is not included in the unit test.

The issue https://github.com/iovisor/bcc/issues/2860
exposed an issue involved in using together with BTF,
which requires the key type to be a structure.

Let add it as a unit test so we can be sure
lpm_trie map is supported properly by bcc.

Signed-off-by: Yonghong Song <yhs@fb.com>