### PR TITLE
adjust layout string in JIT with llvm11 128bit spec support

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -446,10 +446,18 @@ int BPFModule::finalize() {
       *sections_p;
 
   mod->setTargetTriple("bpf-pc-linux");
+#if LLVM_MAJOR_VERSION >= 11
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  mod->setDataLayout("e-m:e-p:64:64-i64:64-i128:128-n32:64-S128");
+#else
+  mod->setDataLayout("E-m:e-p:64:64-i64:64-i128:128-n32:64-S128");
+#endif
+#else
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   mod->setDataLayout("e-m:e-p:64:64-i64:64-n32:64-S128");
 #else
   mod->setDataLayout("E-m:e-p:64:64-i64:64-n32:64-S128");
+#endif
 #endif
   sections_p = rw_engine_enabled_ ? &sections_ : &tmp_sections;
 


### PR DESCRIPTION
To fix the issue (https://github.com/iovisor/bcc/issues/2827)
which exposed a problem with aarch64 frontend and bpf backend
regarding __int128 type, the following llvm patch
   https://reviews.llvm.org/D76587
landed to explicitly support i128 type in bpf layout spec.

Adjust the layout string in bpf_module JIT compilation
accordingly.

Signed-off-by: Yonghong Song <yhs@fb.com>