### PR TITLE
bcc: Use bpf_probe_read_user in tools and provide backward compatibility

### DIFF
--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -556,7 +556,7 @@ int count(struct pt_regs *ctx) {
     struct key_t key = {};
     u64 zero = 0, *val;
 
-    bpf_probe_read(&key.c, sizeof(key.c), (void *)PT_REGS_PARM1(ctx));
+    bpf_probe_read_user(&key.c, sizeof(key.c), (void *)PT_REGS_PARM1(ctx));
     // could also use `counts.increment(key)`
     val = counts.lookup_or_try_init(&key, &zero);
     if (val) {
@@ -620,7 +620,7 @@ int do_trace(struct pt_regs *ctx) {
     uint64_t addr;
     char path[128]={0};
     bpf_usdt_readarg(6, ctx, &addr);
-    bpf_probe_read(&path, sizeof(path), (void *)addr);
+    bpf_probe_read_user(&path, sizeof(path), (void *)addr);
     bpf_trace_printk("path:%s\\n", path);
     return 0;
 };
@@ -640,7 +640,7 @@ b = BPF(text=bpf_text, usdt_contexts=[u])
 Things to learn:
 
 1. ```bpf_usdt_readarg(6, ctx, &addr)```: Read the address of argument 6 from the USDT probe into ```addr```.
-1. ```bpf_probe_read(&path, sizeof(path), (void *)addr)```: Now the string ```addr``` points to into our ```path``` variable.
+1. ```bpf_probe_read_user(&path, sizeof(path), (void *)addr)```: Now the string ```addr``` points to into our ```path``` variable.
 1. ```u = USDT(pid=int(pid))```: Initialize USDT tracing for the given PID.
 1. ```u.enable_probe(probe="http__server__request", fn_name="do_trace")```: Attach our ```do_trace()``` BPF C function to the Node.js ```http__server__request``` USDT probe.
 1. ```b = BPF(text=bpf_text, usdt_contexts=[u])```: Need to pass in our USDT object, ```u```, to BPF object creation.

--- a/examples/cpp/RecordMySQLQuery.cc
+++ b/examples/cpp/RecordMySQLQuery.cc
@@ -34,7 +34,7 @@ int probe_mysql_query(struct pt_regs *ctx, void* thd, char* query, size_t len) {
     key.ts = bpf_ktime_get_ns();
     key.pid = bpf_get_current_pid_tgid();
 
-    bpf_probe_read_str(&key.query, sizeof(key.query), query);
+    bpf_probe_read_user_str(&key.query, sizeof(key.query), query);
 
     int one = 1;
     queries.update(&key, &one);

--- a/examples/lua/bashreadline.c
+++ b/examples/lua/bashreadline.c
@@ -15,7 +15,8 @@ int printret(struct pt_regs *ctx)
           return 0;
         pid = bpf_get_current_pid_tgid();
         data.pid = pid;
-        bpf_probe_read(&data.str, sizeof(data.str), (void *)PT_REGS_RC(ctx));
+        bpf_probe_read_user(&data.str, sizeof(data.str),
+                            (void *)PT_REGS_RC(ctx));
         events.perf_submit(ctx, &data, sizeof(data));
         return 0;
 };

--- a/examples/lua/strlen_count.lua
+++ b/examples/lua/strlen_count.lua
@@ -26,7 +26,7 @@ int printarg(struct pt_regs *ctx) {
   if (pid != PID)
     return 0;
   char str[128] = {};
-  bpf_probe_read(&str, sizeof(str), (void *)PT_REGS_PARM1(ctx));
+  bpf_probe_read_user(&str, sizeof(str), (void *)PT_REGS_PARM1(ctx));
   bpf_trace_printk("strlen(\"%s\")\n", &str);
   return 0;
 };

--- a/examples/lua/usdt_ruby.lua
+++ b/examples/lua/usdt_ruby.lua
@@ -22,7 +22,7 @@ int trace_method(struct pt_regs *ctx) {
   bpf_usdt_readarg(2, ctx, &addr);
 
   char fn_name[128] = {};
-  bpf_probe_read(&fn_name, sizeof(fn_name), (void *)addr);
+  bpf_probe_read_user(&fn_name, sizeof(fn_name), (void *)addr);
 
   bpf_trace_printk("%s(...)\n", fn_name);
   return 0;

--- a/examples/tracing/mysqld_query.py
+++ b/examples/tracing/mysqld_query.py
@@ -34,7 +34,7 @@ int do_trace(struct pt_regs *ctx) {
      * see: https://dev.mysql.com/doc/refman/5.7/en/dba-dtrace-ref-query.html
      */
     bpf_usdt_readarg(1, ctx, &addr);
-    bpf_probe_read(&query, sizeof(query), (void *)addr);
+    bpf_probe_read_user(&query, sizeof(query), (void *)addr);
     bpf_trace_printk("%s\\n", query);
     return 0;
 };

--- a/examples/tracing/nodejs_http_server.py
+++ b/examples/tracing/nodejs_http_server.py
@@ -26,7 +26,7 @@ int do_trace(struct pt_regs *ctx) {
     uint64_t addr;
     char path[128]={0};
     bpf_usdt_readarg(6, ctx, &addr);
-    bpf_probe_read(&path, sizeof(path), (void *)addr);
+    bpf_probe_read_user(&path, sizeof(path), (void *)addr);
     bpf_trace_printk("path:%s\\n", path);
     return 0;
 };

--- a/examples/tracing/strlen_count.py
+++ b/examples/tracing/strlen_count.py
@@ -31,7 +31,7 @@ int count(struct pt_regs *ctx) {
     struct key_t key = {};
     u64 zero = 0, *val;
 
-    bpf_probe_read(&key.c, sizeof(key.c), (void *)PT_REGS_PARM1(ctx));
+    bpf_probe_read_user(&key.c, sizeof(key.c), (void *)PT_REGS_PARM1(ctx));
     // could also use `counts.increment(key)`
     val = counts.lookup_or_try_init(&key, &zero);
     if (val) {

--- a/examples/tracing/strlen_snoop.py
+++ b/examples/tracing/strlen_snoop.py
@@ -34,7 +34,7 @@ int printarg(struct pt_regs *ctx) {
         return 0;
 
     char str[80] = {};
-    bpf_probe_read(&str, sizeof(str), (void *)PT_REGS_PARM1(ctx));
+    bpf_probe_read_user(&str, sizeof(str), (void *)PT_REGS_PARM1(ctx));
     bpf_trace_printk("%s\\n", &str);
 
     return 0;

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -602,6 +602,7 @@ static long long (*bpf_tcp_gen_syncookie)(struct bpf_sock *sk, void *ip,
 static int (*bpf_skb_output)(void *ctx, void *map, __u64 flags, void *data,
                              __u64 size) =
   (void *)BPF_FUNC_skb_output;
+
 static int (*bpf_probe_read_user)(void *dst, __u32 size,
                                   const void *unsafe_ptr) =
   (void *)BPF_FUNC_probe_read_user;
@@ -887,8 +888,8 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #if defined(__TARGET_ARCH_x86)
 #define bpf_target_x86
 #define bpf_target_defined
-#elif defined(__TARGET_ARCH_s930x)
-#define bpf_target_s930x
+#elif defined(__TARGET_ARCH_s390x)
+#define bpf_target_s390x
 #define bpf_target_defined
 #elif defined(__TARGET_ARCH_arm64)
 #define bpf_target_arm64
@@ -905,7 +906,7 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #if defined(__x86_64__)
 #define bpf_target_x86
 #elif defined(__s390x__)
-#define bpf_target_s930x
+#define bpf_target_s390x
 #elif defined(__aarch64__)
 #define bpf_target_arm64
 #elif defined(__powerpc__)
@@ -923,7 +924,7 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #define PT_REGS_RC(ctx)		((ctx)->gpr[3])
 #define PT_REGS_IP(ctx)		((ctx)->nip)
 #define PT_REGS_SP(ctx)		((ctx)->gpr[1])
-#elif defined(bpf_target_s930x)
+#elif defined(bpf_target_s390x)
 #define PT_REGS_PARM1(x) ((x)->gprs[2])
 #define PT_REGS_PARM2(x) ((x)->gprs[3])
 #define PT_REGS_PARM3(x) ((x)->gprs[4])

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -726,7 +726,7 @@ void BTypeVisitor::rewriteFuncParam(FunctionDecl *D) {
     // it in case of "syscall__" for other architectures.
     if (strncmp(D->getName().str().c_str(), "syscall__", 9) == 0 ||
         strncmp(D->getName().str().c_str(), "kprobe____x64_sys_", 18) == 0) {
-      preamble += "#ifdef CONFIG_ARCH_HAS_SYSCALL_WRAPPER\n";
+      preamble += "#if defined(CONFIG_ARCH_HAS_SYSCALL_WRAPPER) && !defined(__s390x__)\n";
       genParamIndirectAssign(D, preamble, calling_conv_regs);
       preamble += "\n#else\n";
       genParamDirectAssign(D, preamble, calling_conv_regs);

--- a/tools/bashreadline.py
+++ b/tools/bashreadline.py
@@ -52,7 +52,7 @@ int printret(struct pt_regs *ctx) {
         return 0;
     pid = bpf_get_current_pid_tgid();
     data.pid = pid;
-    bpf_probe_read(&data.str, sizeof(data.str), (void *)PT_REGS_RC(ctx));
+    bpf_probe_read_user(&data.str, sizeof(data.str), (void *)PT_REGS_RC(ctx));
 
     bpf_get_current_comm(&comm, sizeof(comm));
     if (comm[0] == 'b' && comm[1] == 'a' && comm[2] == 's' && comm[3] == 'h' && comm[4] == 0 ) {

--- a/tools/biosnoop.lua
+++ b/tools/biosnoop.lua
@@ -84,7 +84,8 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
     valp = infobyreq.lookup(&req);
     if (valp == 0) {
         data.len = req->__data_len;
-        strcpy(data.name,"?");
+        data.name[0] = '?';
+        data.name[1] = 0;
     } else {
         data.pid = valp->pid;
         data.len = req->__data_len;

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -108,7 +108,8 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
     valp = infobyreq.lookup(&req);
     if (valp == 0) {
         data.len = req->__data_len;
-        strcpy(data.name, "?");
+        data.name[0] = '?';
+        data.name[1] = 0;
     } else {
         if (##QUEUE##) {
             data.qdelta = *tsp - valp->ts;

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -127,12 +127,12 @@ Trace only packets with enum_server_command == COM_QUERY
     tmp.timestamp = bpf_ktime_get_ns();
 
 #if defined(MYSQL56)
-    bpf_probe_read(&tmp.query, sizeof(tmp.query), (void*) PT_REGS_PARM3(ctx));
+    bpf_probe_read_user(&tmp.query, sizeof(tmp.query), (void*) PT_REGS_PARM3(ctx));
 #elif defined(MYSQL57)
     void* st = (void*) PT_REGS_PARM2(ctx);
     char* query;
-    bpf_probe_read(&query, sizeof(query), st);
-    bpf_probe_read(&tmp.query, sizeof(tmp.query), query);
+    bpf_probe_read_user(&query, sizeof(query), st);
+    bpf_probe_read_user(&tmp.query, sizeof(tmp.query), query);
 #else //USDT
     bpf_usdt_readarg(1, ctx, &tmp.query);
 #endif
@@ -157,7 +157,13 @@ int query_end(struct pt_regs *ctx) {
         data.pid = pid >> 32;   // only process id
         data.timestamp = tempp->timestamp;
         data.duration = delta;
+#if defined(MYSQL56) || defined(MYSQL57)
+	// We already copied string to the bpf stack. Hence use bpf_probe_read()
         bpf_probe_read(&data.query, sizeof(data.query), tempp->query);
+#else
+	// USDT - we didnt copy string to the bpf stack before.
+        bpf_probe_read_user(&data.query, sizeof(data.query), tempp->query);
+#endif
         events.perf_submit(ctx, &data, sizeof(data));
 #ifdef THRESHOLD
     }

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -120,7 +120,7 @@ BPF_PERF_OUTPUT(events);
 
 static int __submit_arg(struct pt_regs *ctx, void *ptr, struct data_t *data)
 {
-    bpf_probe_read(data->argv, sizeof(data->argv), ptr);
+    bpf_probe_read_user(data->argv, sizeof(data->argv), ptr);
     events.perf_submit(ctx, data, sizeof(struct data_t));
     return 1;
 }
@@ -128,7 +128,7 @@ static int __submit_arg(struct pt_regs *ctx, void *ptr, struct data_t *data)
 static int submit_arg(struct pt_regs *ctx, void *ptr, struct data_t *data)
 {
     const char *argp = NULL;
-    bpf_probe_read(&argp, sizeof(argp), ptr);
+    bpf_probe_read_user(&argp, sizeof(argp), ptr);
     if (argp) {
         return __submit_arg(ctx, (void *)(argp), data);
     }

--- a/tools/funcslower.py
+++ b/tools/funcslower.py
@@ -82,7 +82,11 @@ struct entry_t {
     u64 id;
     u64 start_ns;
 #ifdef GRAB_ARGS
+#ifndef __s390x__
     u64 args[6];
+#else
+    u64 args[5];
+#endif
 #endif
 };
 
@@ -94,7 +98,11 @@ struct data_t {
     u64 retval;
     char comm[TASK_COMM_LEN];
 #ifdef GRAB_ARGS
+#ifndef __s390x__
     u64 args[6];
+#else
+    u64 args[5];
+#endif
 #endif
 #ifdef USER_STACKS
     int user_stack_id;
@@ -130,7 +138,9 @@ static int trace_entry(struct pt_regs *ctx, int id)
     entry.args[2] = PT_REGS_PARM3(ctx);
     entry.args[3] = PT_REGS_PARM4(ctx);
     entry.args[4] = PT_REGS_PARM5(ctx);
+#ifndef __s390x__
     entry.args[5] = PT_REGS_PARM6(ctx);
+#endif
 #endif
 
     entryinfo.update(&tgid_pid, &entry);

--- a/tools/gethostlatency.py
+++ b/tools/gethostlatency.py
@@ -64,7 +64,7 @@ int do_entry(struct pt_regs *ctx) {
     u32 pid = bpf_get_current_pid_tgid();
 
     if (bpf_get_current_comm(&val.comm, sizeof(val.comm)) == 0) {
-        bpf_probe_read(&val.host, sizeof(val.host),
+        bpf_probe_read_user(&val.host, sizeof(val.host),
                        (void *)PT_REGS_PARM1(ctx));
         val.pid = bpf_get_current_pid_tgid();
         val.ts = bpf_ktime_get_ns();

--- a/tools/lib/ucalls.py
+++ b/tools/lib/ucalls.py
@@ -158,9 +158,9 @@ int trace_entry(struct pt_regs *ctx) {
 #endif
     READ_CLASS
     READ_METHOD
-    bpf_probe_read(&data.method.clazz, sizeof(data.method.clazz),
+    bpf_probe_read_user(&data.method.clazz, sizeof(data.method.clazz),
                    (void *)clazz);
-    bpf_probe_read(&data.method.method, sizeof(data.method.method),
+    bpf_probe_read_user(&data.method.method, sizeof(data.method.method),
                    (void *)method);
 #ifndef LATENCY
     valp = counts.lookup_or_try_init(&data.method, &val);
@@ -182,9 +182,9 @@ int trace_return(struct pt_regs *ctx) {
     data.pid = bpf_get_current_pid_tgid();
     READ_CLASS
     READ_METHOD
-    bpf_probe_read(&data.method.clazz, sizeof(data.method.clazz),
+    bpf_probe_read_user(&data.method.clazz, sizeof(data.method.clazz),
                    (void *)clazz);
-    bpf_probe_read(&data.method.method, sizeof(data.method.method),
+    bpf_probe_read_user(&data.method.method, sizeof(data.method.method),
                    (void *)method);
     entry_timestamp = entry.lookup(&data);
     if (!entry_timestamp) {

--- a/tools/lib/uflow.py
+++ b/tools/lib/uflow.py
@@ -81,8 +81,8 @@ int NAME(struct pt_regs *ctx) {
 
     READ_CLASS
     READ_METHOD
-    bpf_probe_read(&data.clazz, sizeof(data.clazz), (void *)clazz);
-    bpf_probe_read(&data.method, sizeof(data.method), (void *)method);
+    bpf_probe_read_user(&data.clazz, sizeof(data.clazz), (void *)clazz);
+    bpf_probe_read_user(&data.method, sizeof(data.method), (void *)method);
 
     FILTER_CLASS
     FILTER_METHOD

--- a/tools/lib/ugc.py
+++ b/tools/lib/ugc.py
@@ -140,8 +140,8 @@ if language == "java":
     u64 manager = 0, pool = 0;
     bpf_usdt_readarg(1, ctx, &manager);        // ptr to manager name
     bpf_usdt_readarg(3, ctx, &pool);           // ptr to pool name
-    bpf_probe_read(&event.string1, sizeof(event.string1), (void *)manager);
-    bpf_probe_read(&event.string2, sizeof(event.string2), (void *)pool);
+    bpf_probe_read_user(&event.string1, sizeof(event.string1), (void *)manager);
+    bpf_probe_read_user(&event.string2, sizeof(event.string2), (void *)pool);
     """
 
     def formatter(e):

--- a/tools/lib/uobjnew.py
+++ b/tools/lib/uobjnew.py
@@ -98,7 +98,7 @@ int alloc_entry(struct pt_regs *ctx) {
     u64 classptr = 0, size = 0;
     bpf_usdt_readarg(2, ctx, &classptr);
     bpf_usdt_readarg(4, ctx, &size);
-    bpf_probe_read(&key.name, sizeof(key.name), (void *)classptr);
+    bpf_probe_read_user(&key.name, sizeof(key.name), (void *)classptr);
     valp = allocs.lookup_or_try_init(&key, &zero);
     if (valp) {
         valp->total_size += size;
@@ -132,7 +132,7 @@ int object_alloc_entry(struct pt_regs *ctx) {
     struct val_t *valp, zero = {};
     u64 classptr = 0;
     bpf_usdt_readarg(1, ctx, &classptr);
-    bpf_probe_read(&key.name, sizeof(key.name), (void *)classptr);
+    bpf_probe_read_user(&key.name, sizeof(key.name), (void *)classptr);
     valp = allocs.lookup_or_try_init(&key, &zero);
     if (valp) {
         valp->num_allocs += 1;  // We don't know the size, unfortunately

--- a/tools/lib/uthreads.py
+++ b/tools/lib/uthreads.py
@@ -80,7 +80,7 @@ int %s(struct pt_regs *ctx) {
     bpf_usdt_readarg(1, ctx, &nameptr);
     bpf_usdt_readarg(3, ctx, &id);
     bpf_usdt_readarg(4, ctx, &native_id);
-    bpf_probe_read(&te.name, sizeof(te.name), (void *)nameptr);
+    bpf_probe_read_user(&te.name, sizeof(te.name), (void *)nameptr);
     te.runtime_id = id;
     te.native_id = native_id;
     __builtin_memcpy(&te.type, type, sizeof(te.type));

--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -109,22 +109,22 @@ int syscall__mount(struct pt_regs *ctx, char __user *source,
 
     event.type = EVENT_MOUNT_SOURCE;
     __builtin_memset(event.str, 0, sizeof(event.str));
-    bpf_probe_read(event.str, sizeof(event.str), source);
+    bpf_probe_read_user(event.str, sizeof(event.str), source);
     events.perf_submit(ctx, &event, sizeof(event));
 
     event.type = EVENT_MOUNT_TARGET;
     __builtin_memset(event.str, 0, sizeof(event.str));
-    bpf_probe_read(event.str, sizeof(event.str), target);
+    bpf_probe_read_user(event.str, sizeof(event.str), target);
     events.perf_submit(ctx, &event, sizeof(event));
 
     event.type = EVENT_MOUNT_TYPE;
     __builtin_memset(event.str, 0, sizeof(event.str));
-    bpf_probe_read(event.str, sizeof(event.str), type);
+    bpf_probe_read_user(event.str, sizeof(event.str), type);
     events.perf_submit(ctx, &event, sizeof(event));
 
     event.type = EVENT_MOUNT_DATA;
     __builtin_memset(event.str, 0, sizeof(event.str));
-    bpf_probe_read(event.str, sizeof(event.str), data);
+    bpf_probe_read_user(event.str, sizeof(event.str), data);
     events.perf_submit(ctx, &event, sizeof(event));
 
     return 0;
@@ -164,7 +164,7 @@ int syscall__umount(struct pt_regs *ctx, char __user *target, int flags)
 
     event.type = EVENT_UMOUNT_TARGET;
     __builtin_memset(event.str, 0, sizeof(event.str));
-    bpf_probe_read(event.str, sizeof(event.str), target);
+    bpf_probe_read_user(event.str, sizeof(event.str), target);
     events.perf_submit(ctx, &event, sizeof(event));
 
     return 0;

--- a/tools/mysqld_qslower.py
+++ b/tools/mysqld_qslower.py
@@ -81,7 +81,7 @@ int do_done(struct pt_regs *ctx) {
     if (delta >= """ + str(min_ns) + """) {
         // populate and emit data struct
         struct data_t data = {.pid = pid, .ts = sp->ts, .delta = delta};
-        bpf_probe_read(&data.query, sizeof(data.query), (void *)sp->query);
+        bpf_probe_read_user(&data.query, sizeof(data.query), (void *)sp->query);
         events.perf_submit(ctx, &data, sizeof(data));
     }
 

--- a/tools/sslsniff.py
+++ b/tools/sslsniff.py
@@ -72,7 +72,7 @@ int probe_SSL_write(struct pt_regs *ctx, void *ssl, void *buf, int num) {
         bpf_get_current_comm(&__data.comm, sizeof(__data.comm));
 
         if ( buf != 0) {
-                bpf_probe_read(&__data.v0, sizeof(__data.v0), buf);
+                bpf_probe_read_user(&__data.v0, sizeof(__data.v0), buf);
         }
 
         perf_SSL_write.perf_submit(ctx, &__data, sizeof(__data));
@@ -108,7 +108,7 @@ int probe_SSL_read_exit(struct pt_regs *ctx, void *ssl, void *buf, int num) {
         bpf_get_current_comm(&__data.comm, sizeof(__data.comm));
 
         if (bufp != 0) {
-                bpf_probe_read(&__data.v0, sizeof(__data.v0), (char *)*bufp);
+                bpf_probe_read_user(&__data.v0, sizeof(__data.v0), (char *)*bufp);
         }
 
         bufs.delete(&pid);

--- a/tools/statsnoop.py
+++ b/tools/statsnoop.py
@@ -84,7 +84,7 @@ int trace_return(struct pt_regs *ctx)
     }
 
     struct data_t data = {.pid = pid};
-    bpf_probe_read(&data.fname, sizeof(data.fname), (void *)valp->fname);
+    bpf_probe_read_user(&data.fname, sizeof(data.fname), (void *)valp->fname);
     bpf_get_current_comm(&data.comm, sizeof(data.comm));
     data.ts_ns = bpf_ktime_get_ns();
     data.ret = PT_REGS_RC(ctx);

--- a/tools/ttysnoop.py
+++ b/tools/ttysnoop.py
@@ -80,7 +80,7 @@ int kprobe__tty_write(struct pt_regs *ctx, struct file *file,
     // bpf_probe_read() can only use a fixed size, so truncate to count
     // in user space:
     struct data_t data = {};
-    bpf_probe_read(&data.buf, BUFSIZE, (void *)buf);
+    bpf_probe_read_user(&data.buf, BUFSIZE, (void *)buf);
     if (count > BUFSIZE)
         data.count = BUFSIZE;
     else


### PR DESCRIPTION
Hi @yonghong-song, @brendangregg, @4ast, all

[RFC 0/1] Support bpf_probe_read_user in bcc tools

bcc tracks the function arg pointers and then converts the pointer
deferences (both user and kernel pointer) into the bpf_probe_read().
However this is not valid for architecture which has overlapping address
space. To overcome this issue, the bpf_probe_read_{user/kernel} variant
was introduced.

Few Feasible solution for separation of user probe read and the kernel
probe read:

Approach 1 (temporary approach):
1. Explicitly use bpf_probe_read_user() for copying the user-space var
into the ebpf stack. Like kernel/bpf/samples/.
-  Make changes in the tools and examples.
- For backward compatibility, when kernel version < 5.5, convert
  bpf_probe_read_user call to bpf_probe_read(). Atleast the tools are
  valid for architecture which supports it.

Approach 2
2. Mark certain pointer as user and then track it while visiting AST
nodes in cases like return, callexp, binop, assignment etc.. I am yet
to try this and see how this can be performed

Let me know, your suggestions for approach 1, approach 2 or any other good approaches. Thank you

The first approach rfc is added below.

Best Regards
Sumanth
