### PR TITLE
add attribute readers to class USDT (C++ API)

### DIFF
--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -330,6 +330,12 @@ class USDT {
   USDT(const USDT& usdt);
   USDT(USDT&& usdt) noexcept;
 
+  const std::string &binary_path() const { return binary_path_; }
+  pid_t pid() const { return pid_; }
+  const std::string &provider() const { return provider_; }
+  const std::string &name() const { return name_; }
+  const std::string &probe_func() const { return probe_func_; }
+
   StatusTuple init();
 
   bool operator==(const USDT& other) const;

--- a/tests/cc/test_usdt_probes.cc
+++ b/tests/cc/test_usdt_probes.cc
@@ -62,6 +62,16 @@ TEST_CASE("test finding a probe in our own process", "[usdt]") {
   }
 }
 
+TEST_CASE("test probe's attributes with C++ API", "[usdt]") {
+    const ebpf::USDT u("/proc/self/exe", "libbcc_test", "sample_probe_1", "on_event");
+
+    REQUIRE(u.binary_path() == "/proc/self/exe");
+    REQUIRE(u.pid() == -1);
+    REQUIRE(u.provider() == "libbcc_test");
+    REQUIRE(u.name() == "sample_probe_1");
+    REQUIRE(u.probe_func() == "on_event");
+}
+
 TEST_CASE("test fine a probe in our own binary with C++ API", "[usdt]") {
     ebpf::BPF bpf;
     ebpf::USDT u("/proc/self/exe", "libbcc_test", "sample_probe_1", "on_event");


### PR DESCRIPTION
I need to access attributes for `class USDT`, and it's natural to provide them.