### PR TITLE
doc: Update INSTALL.md to automatically detect version selection in Ubuntu

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,16 +95,15 @@ echo "deb https://repo.iovisor.org/apt/$(lsb_release -cs) $(lsb_release -cs) mai
 sudo apt-get update
 sudo apt-get install bcc-tools libbcc-examples linux-headers-$(uname -r)
 ```
-(replace `xenial` with `artful` or `bionic` as appropriate). Tools will be installed under /usr/share/bcc/tools.
+Tools will be installed under /usr/share/bcc/tools.
 
 **Upstream Nightly Packages**
 
 ```bash
-echo "deb [trusted=yes] https://repo.iovisor.org/apt/xenial xenial-nightly main" | sudo tee /etc/apt/sources.list.d/iovisor.list
+echo "deb [trusted=yes] https://repo.iovisor.org/apt/$(lsb_release -cs) $(lsb_release -cs)-nightly main" | sudo tee /etc/apt/sources.list.d/iovisor.list
 sudo apt-get update
 sudo apt-get install bcc-tools libbcc-examples linux-headers-$(uname -r)
 ```
-(replace `xenial` with `artful` or `bionic` as appropriate)
 
 ## Fedora - Binary
 


### PR DESCRIPTION
Updated to auto-select the version when installing a package on Ubuntu, similar to #2057. I also removed it because the caution to fix it to fit the version is no longer needed.