### PR TITLE
fix llvm 11 compilation issues

### DIFF
--- a/src/cc/frontends/b/codegen_llvm.h
+++ b/src/cc/frontends/b/codegen_llvm.h
@@ -27,8 +27,10 @@
 
 namespace llvm {
 class AllocaInst;
+template<typename T> class ArrayRef;
 class BasicBlock;
 class BranchInst;
+class CallInst;
 class Constant;
 class Instruction;
 class IRBuilderBase;
@@ -104,6 +106,8 @@ class CodegenLLVM : public Visitor {
   StatusTuple lookup_struct_type(StructDeclStmtNode *decl, llvm::StructType **stype) const;
   StatusTuple lookup_struct_type(VariableDeclStmtNode *n, llvm::StructType **stype,
                                  StructDeclStmtNode **decl = nullptr) const;
+  llvm::CallInst *createCall(llvm::Value *Callee,
+                             llvm::ArrayRef<llvm::Value *> Args);
 
   template <typename... Args> void emit(const char *fmt, Args&&... params);
   void emit(const char *s);


### PR DESCRIPTION
The llvm CreateCall used in bcc is deprecated in llvm 11:
  https://reviews.llvm.org/D76269
The llvm CreateMemCpy is changed in llvm 11 as well:
  https://reviews.llvm.org/D71473

This caused bcc compilation error.

  /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc: In member function
     ‘ebpf::StatusTuple ebpf::cc::CodegenLLVM::emit_log(ebpf::cc::Method CallExprNode*)’:
  /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc:691:39: error: no matching function for call to
     ‘llvm::IRBuilder<>::CreateCall(llvm::Value*&, std::vector<llvm::Value*, std::allocator<llvm::Value*> >&)’
     expr_ = B.CreateCall(printk_fn, args);
                                       ^
  ...

  /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc: In member function
     ‘virtual ebpf::StatusTuple ebpf::cc::CodegenLLVM::visit_string_exp_node(ebpf::cc::StringExprNode*)’:
  /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc:440:55: error: no matching function for call to
     ‘llvm::IRBuilder<>::CreateMemCpy(llvm:Value*&, int, llvm::Value*&, int, std::__cxx11::basic_string<char>::size_type)’
   B.CreateMemCpy(ptr, 1, global, 1, n->val_.size() + 1);
                                                       ^
  ...

This patch fixed the compilation issue.