### PR TITLE
Support Debug symbols lookup in namespace of process

### DIFF
--- a/src/cc/common.cc
+++ b/src/cc/common.cc
@@ -60,7 +60,8 @@ std::string get_pid_exe(pid_t pid) {
   if (res >= static_cast<int>(sizeof(exe_path)))
     res = sizeof(exe_path) - 1;
   exe_path[res] = '\0';
-  return std::string(exe_path);
+
+  return tfm::format("/proc/%d/root%s", pid, exe_path);
 }
 
 enum class field_kind_t {


### PR DESCRIPTION
Debugging container with something like bpftrace can lead to missing userspace symbols because debuginfo files are looked up in the namespace of current process only.
This PR changes debuginfo file lookup to try the process namespace first.