### PR TITLE
USDT: make path failure message more explicit

### DIFF
--- a/examples/usdt_sample/usdt_sample.md
+++ b/examples/usdt_sample/usdt_sample.md
@@ -93,6 +93,11 @@ input
 	4          arg2 = pf_6
 	4          arg2 = pf_23
 	5          arg2 = pf_24
+
+Should that command fail with the error message "HINT: Binary path usdt_sample_lib1 should be absolute", try instead:
+
+sudo python tools/argdist.py -p 47575 -i 5 -C 'u:ABSOLUTE-PATH-TO-BCC-REPO/bcc/examples/usdt_sample/build/usdt_sample_lib1/libusdt_sample_lib1.so:operation_start():char*:arg2#input' -z 32
+
 ```
 
 Use latency.py to trace the operation latencies:

--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -420,10 +420,10 @@ void *bcc_usdt_new_frompid(int pid, const char *path) {
   } else {
     struct stat buffer;
     if (strlen(path) >= 1 && path[0] != '/') {
-      fprintf(stderr, "HINT: Binary path should be absolute.\n\n");
+      fprintf(stderr, "HINT: Binary path %s should be absolute.\n\n", path);
       return nullptr;
     } else if (stat(path, &buffer) == -1) {
-      fprintf(stderr, "HINT: Specified binary doesn't exist.\n\n");
+      fprintf(stderr, "HINT: Specified binary %s doesn't exist.\n\n", path);
       return nullptr;
     }
     ctx = new USDT::Context(pid, path);


### PR DESCRIPTION
Make it clear which file the USDT runtime files to find and suggest a
fix.