### PR TITLE
add -fPIC to compile examples/cpp and tests/cc

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -6,6 +6,9 @@ include_directories(${CMAKE_SOURCE_DIR}/src/cc)
 include_directories(${CMAKE_SOURCE_DIR}/src/cc/api)
 include_directories(${CMAKE_SOURCE_DIR}/src/cc/libbpf/include/uapi)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+
 option(INSTALL_CPP_EXAMPLES "Install C++ examples. Those binaries are statically linked and can take plenty of disk space" OFF)
 
 add_executable(HelloWorld HelloWorld.cc)

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -11,8 +11,8 @@ target_link_libraries(test_static bcc-static)
 
 add_test(NAME c_test_static COMMAND ${TEST_WRAPPER} c_test_static sudo ${CMAKE_CURRENT_BINARY_DIR}/test_static)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-result")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result -fPIC")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-result -fPIC")
 
 if(ENABLE_USDT)
 set(TEST_LIBBCC_SOURCES


### PR DESCRIPTION
I use clang-8.0.1 and gcc-8.3.1 to compile bcc-0.12.0,
without -fPIC, will get errors like this:
/usr/bin/ld: CMakeFiles/test_libbcc.dir/test_libbcc.cc.o: relocation
R_X86_64_32S against symbol `_ZTVN5Catch21LegacyReporterAdapterE' can
not be used when making a PIE object; recompile with -fPIC
/usr/bin/ld: CMakeFiles/test_libbcc.dir/test_c_api.cc.o: relocation
R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE
object; recompile with -fPIC
/usr/bin/ld: CMakeFiles/CGroupTest.dir/CGroupTest.cc.o: relocation
R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE
object; recompile with -fPIC

Signed-off-by: Chunmei Xu <xuchunmei@linux.alibaba.com>