### PR TITLE
libbpf-tools: add CO-RE cpudist

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -1,4 +1,5 @@
 /.output
+/cpudist
 /drsnoop
 /execsnoop
 /filelife

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -10,6 +10,7 @@ CFLAGS := -g -O2 -Wall
 ARCH := $(shell uname -m | sed 's/x86_64/x86/')
 
 APPS = \
+	cpudist \
 	drsnoop \
 	execsnoop \
 	filelife \

--- a/libbpf-tools/cpudist.bpf.c
+++ b/libbpf-tools/cpudist.bpf.c
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenbo Zhang
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+#include "cpudist.h"
+
+#define TASK_RUNNING 0
+
+const volatile bool targ_per_process = false;
+const volatile bool targ_per_thread = false;
+const volatile bool targ_offcpu = false;
+const volatile bool targ_ms = false;
+const volatile pid_t targ_tgid = -1;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u32);
+	__type(value, u64);
+} start SEC(".maps");
+
+static struct hist initial_hist;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u32);
+	__type(value, struct hist);
+} hists SEC(".maps");
+
+static __always_inline u64 log2(u32 v)
+{
+	u32 shift, r;
+
+	r = (v > 0xFFFF) << 4; v >>= r;
+	shift = (v > 0xFF) << 3; v >>= shift; r |= shift;
+	shift = (v > 0xF) << 2; v >>= shift; r |= shift;
+	shift = (v > 0x3) << 1; v >>= shift; r |= shift;
+	r |= (v >> 1);
+
+	return r;
+}
+
+static __always_inline u64 log2l(u64 v)
+{
+	u32 hi = v >> 32;
+
+	if (hi)
+		return log2(hi) + 32;
+	else
+		return log2(v);
+}
+
+static __always_inline void store_start(u32 tgid, u32 pid, u64 ts)
+{
+	if (targ_tgid != -1 && targ_tgid != tgid)
+		return;
+	bpf_map_update_elem(&start, &pid, &ts, 0);
+}
+
+static __always_inline void update_hist(struct task_struct *task,
+					u32 tgid, u32 pid, u64 ts)
+{
+	u64 delta, *tsp, slot;
+	struct hist *histp;
+	u32 id;
+
+	if (targ_tgid != -1 && targ_tgid != tgid)
+		return;
+
+	tsp = bpf_map_lookup_elem(&start, &pid);
+	if (!tsp || ts < *tsp)
+		return;
+
+	if (targ_per_process)
+		id = tgid;
+	else if (targ_per_thread)
+		id = pid;
+	else
+		id = -1;
+	histp = bpf_map_lookup_elem(&hists, &id);
+	if (!histp) {
+		bpf_map_update_elem(&hists, &id, &initial_hist, 0);
+		histp = bpf_map_lookup_elem(&hists, &id);
+		if (!histp)
+			return;
+		BPF_CORE_READ_STR_INTO(&histp->comm, task, comm);
+	}
+	delta = ts - *tsp;
+	if (targ_ms)
+		delta /= 1000000;
+	else
+		delta /= 1000;
+	slot = log2l(delta);
+	if (slot >= MAX_SLOTS)
+		slot = MAX_SLOTS - 1;
+	__sync_fetch_and_add(&histp->slots[slot], 1);
+}
+
+SEC("kprobe/finish_task_switch")
+int BPF_KPROBE(kprobe__finish_task_switch, struct task_struct *prev)
+{
+	u32 prev_tgid = BPF_CORE_READ(prev, tgid);
+	u32 prev_pid = BPF_CORE_READ(prev, pid);
+	u64 id = bpf_get_current_pid_tgid();
+	u32 tgid = id >> 32, pid = id;
+	u64 ts = bpf_ktime_get_ns();
+
+	if (targ_offcpu) {
+		store_start(prev_tgid, prev_pid, ts);
+		update_hist((void*)bpf_get_current_task(), tgid, pid, ts);
+	} else {
+		if (BPF_CORE_READ(prev, state) == TASK_RUNNING)
+			update_hist(prev, prev_tgid, prev_pid, ts);
+		store_start(tgid, pid, ts);
+	}
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/cpudist.c
+++ b/libbpf-tools/cpudist.c
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2020 Wenbo Zhang
+//
+// Based on cpudist(8) from BCC by Brendan Gregg & Dina Goldshtein.
+// 8-May-2020   Wenbo Zhang   Created this.
+#include <argp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <sys/resource.h>
+#include <unistd.h>
+#include <time.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "cpudist.h"
+#include "cpudist.skel.h"
+#include "trace_helpers.h"
+
+static struct env {
+	time_t interval;
+	pid_t pid;
+	int times;
+	bool offcpu;
+	bool timestamp;
+	bool per_process;
+	bool per_thread;
+	bool milliseconds;
+	bool verbose;
+} env = {
+	.interval = 99999999,
+	.pid = -1,
+	.times = 99999999,
+};
+
+static volatile bool exiting;
+
+const char *argp_program_version = "cpudist 0.1";
+const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char argp_program_doc[] =
+"Summarize on-CPU time per task as a histogram.\n"
+"\n"
+"USAGE: cpudist [-h] [-O] [-T] [-m] [-P] [-L] [-p PID] [interval] [count]\n"
+"\n"
+"EXAMPLES:\n"
+"    cpudist              # summarize on-CPU time as a histogram"
+"    cpudist -O           # summarize off-CPU time as a histogram"
+"    cpudist 1 10         # print 1 second summaries, 10 times"
+"    cpudist -mT 1        # 1s summaries, milliseconds, and timestamps"
+"    cpudist -P           # show each PID separately"
+"    cpudist -p 185       # trace PID 185 only";
+
+static const struct argp_option opts[] = {
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{ "offcpu", 'O', NULL, 0, "Measure off-CPU time" },
+	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
+	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
+	{ "pids", 'P', NULL, 0, "Print a histogram per process ID" },
+	{ "tids", 'L', NULL, 0, "Print a histogram per thread ID" },
+	{ "pid", 'p', "PID", 0, "Trace this PID only" },
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	static int pos_args;
+
+	switch (key) {
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'h':
+		argp_usage(state);
+		break;
+	case 'm':
+		env.milliseconds = true;
+		break;
+	case 'p':
+		errno = 0;
+		env.pid = strtol(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "invalid PID: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 'O':
+		env.offcpu = true;
+		break;
+	case 'P':
+		env.per_process = true;
+		break;
+	case 'L':
+		env.per_thread = true;
+		break;
+	case 'T':
+		env.timestamp = true;
+		break;
+	case ARGP_KEY_ARG:
+		errno = 0;
+		if (pos_args == 0) {
+			env.interval = strtol(arg, NULL, 10);
+			if (errno) {
+				fprintf(stderr, "invalid internal\n");
+				argp_usage(state);
+			}
+		} else if (pos_args == 1) {
+			env.times = strtol(arg, NULL, 10);
+			if (errno) {
+				fprintf(stderr, "invalid times\n");
+				argp_usage(state);
+			}
+		} else {
+			fprintf(stderr,
+				"unrecognized positional argument: %s\n", arg);
+			argp_usage(state);
+		}
+		pos_args++;
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+int libbpf_print_fn(enum libbpf_print_level level,
+		const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static int bump_memlock_rlimit(void)
+{
+	struct rlimit rlim_new = {
+		.rlim_cur	= RLIM_INFINITY,
+		.rlim_max	= RLIM_INFINITY,
+	};
+
+	return setrlimit(RLIMIT_MEMLOCK, &rlim_new);
+}
+
+static int get_pid_max(void)
+{
+	int pid_max;
+	FILE *f;
+
+	f = fopen("/proc/sys/kernel/pid_max", "r");
+	if (!f)
+		return -1;
+	if (fscanf(f, "%d\n", &pid_max) != 1)
+		pid_max = -1;
+	fclose(f);
+	return pid_max;
+}
+
+static void sig_handler(int sig)
+{
+	exiting = true;
+}
+
+static int print_log2_hists(int fd)
+{
+	char *units = env.milliseconds ? "msecs" : "usecs";
+	__u32 lookup_key = -2, next_key;
+	struct hist hist;
+	int err;
+
+	while (!bpf_map_get_next_key(fd, &lookup_key, &next_key)) {
+		err = bpf_map_lookup_elem(fd, &next_key, &hist);
+		if (err < 0) {
+			fprintf(stderr, "failed to lookup hist: %d\n", err);
+			return -1;
+		}
+		if (env.per_process)
+			printf("\npid = %d %s\n", next_key, hist.comm);
+		if (env.per_thread)
+			printf("\ntid = %d %s\n", next_key, hist.comm);
+		print_log2_hist(hist.slots, MAX_SLOTS, units);
+		lookup_key = next_key;
+	}
+
+	lookup_key = -2;
+	while (!bpf_map_get_next_key(fd, &lookup_key, &next_key)) {
+		err = bpf_map_delete_elem(fd, &next_key);
+		if (err < 0) {
+			fprintf(stderr, "failed to cleanup hist : %d\n", err);
+			return -1;
+		}
+		lookup_key = next_key;
+	}
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct cpudist_bpf *obj;
+	int pid_max, fd, err;
+	struct tm *tm;
+	char ts[32];
+	time_t t;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	err = bump_memlock_rlimit();
+	if (err) {
+		fprintf(stderr, "failed to increase rlimit: %d\n", err);
+		return 1;
+	}
+
+	obj = cpudist_bpf__open();
+	if (!obj) {
+		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		return 1;
+	}
+
+	/* initialize global data (filtering options) */
+	obj->rodata->targ_per_process = env.per_process;
+	obj->rodata->targ_per_thread = env.per_thread;
+	obj->rodata->targ_ms = env.milliseconds;
+	obj->rodata->targ_offcpu = env.offcpu;
+	obj->rodata->targ_tgid = env.pid;
+
+	pid_max = get_pid_max();
+	if (pid_max < 0) {
+		fprintf(stderr, "failed to get pid_max\n");
+		return 1;
+	}
+
+	bpf_map__resize(obj->maps.start, pid_max);
+	if (!env.per_process && !env.per_thread)
+		bpf_map__resize(obj->maps.hists, 1);
+	else
+		bpf_map__resize(obj->maps.hists, pid_max);
+
+	err = cpudist_bpf__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF object: %d\n", err);
+		goto cleanup;
+	}
+
+	err = cpudist_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+
+	fd = bpf_map__fd(obj->maps.hists);
+
+	signal(SIGINT, sig_handler);
+
+	printf("Tracing %s-CPU time... Hit Ctrl-C to end.\n", env.offcpu ? "off" : "on");
+
+	/* main: poll */
+	while (1) {
+		sleep(env.interval);
+		printf("\n");
+
+		if (env.timestamp) {
+			time(&t);
+			tm = localtime(&t);
+			strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+			printf("%-8s\n", ts);
+		}
+
+		err = print_log2_hists(fd);
+		if (err)
+			break;
+
+		if (exiting || --env.times == 0)
+			break;
+	}
+
+cleanup:
+	cpudist_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/libbpf-tools/cpudist.h
+++ b/libbpf-tools/cpudist.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __CPUDIST_H
+#define __CPUDIST_H
+
+#define TASK_COMM_LEN	16
+#define MAX_SLOTS	36
+
+struct hist {
+	__u32 slots[MAX_SLOTS];
+	char comm[TASK_COMM_LEN];
+};
+
+#endif // __CPUDIST_H

--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -150,3 +150,65 @@ const struct ksym *ksyms__get_symbol(const struct ksyms *ksyms,
 
 	return NULL;
 }
+
+#define min(x, y) ({				 \
+	typeof(x) _min1 = (x);			 \
+	typeof(y) _min2 = (y);			 \
+	(void) (&_min1 == &_min2);		 \
+	_min1 < _min2 ? _min1 : _min2; })
+
+static void print_stars(unsigned int val, unsigned int val_max, int width)
+{
+	int num_stars, num_spaces, i;
+	bool need_plus;
+
+	num_stars = min(val, val_max) * width / val_max;
+	num_spaces = width - num_stars;
+	need_plus = val > val_max;
+
+	for (i = 0; i < num_stars; i++)
+		printf("*");
+	for (i = 0; i < num_spaces; i++)
+		printf(" ");
+	if (need_plus)
+		printf("+");
+}
+
+void print_log2_hist(unsigned int *vals, int vals_size, char *val_type)
+{
+	int stars_max = 40, idx_max = -1;
+	unsigned int val, val_max = 0;
+	unsigned long long low, high;
+	int stars, width, i;
+
+	for (i = 0; i < vals_size; i++) {
+		val = vals[i];
+		if (val > 0)
+			idx_max = i;
+		if (val > val_max)
+			val_max = val;
+	}
+
+	if (idx_max < 0)
+		return;
+
+	printf("%*s%-*s : count    distribution\n", idx_max <= 32 ? 5 : 15, "",
+		idx_max <= 32 ? 19 : 29, val_type);
+
+	if (idx_max <= 32)
+		stars = stars_max;
+	else
+		stars = stars_max / 2;
+
+	for (i = 0; i <= idx_max; i++) {
+		low = (1ULL << (i + 1)) >> 1;
+		high = (1ULL << (i + 1)) - 1;
+		if (low == high)
+			low -= 1;
+		val = vals[i];
+		width = idx_max <= 32 ? 10 : 20;
+		printf("%*lld -> %-*lld : %-8d |", width, low, width, high, val);
+		print_stars(val, val_max, stars);
+		printf("|\n");
+	}
+}

--- a/libbpf-tools/trace_helpers.h
+++ b/libbpf-tools/trace_helpers.h
@@ -16,4 +16,6 @@ const struct ksym *ksyms__map_addr(const struct ksyms *ksyms,
 const struct ksym *ksyms__get_symbol(const struct ksyms *ksyms,
 				     const char *name);
 
+void print_log2_hist(unsigned int *vals, int vals_size, char *val_type);
+
 #endif /* __TRACE_HELPERS_H */


### PR DESCRIPTION
- Implement cpudist, which is consistent with https://github.com/iovisor/bcc/blob/master/tools/cpudist_example.txt
- Add a new helper `print_log2_hist` in `trace_helpers`
- Add a general dictionary (based on the glibc's binary search tree) in `trace_helpers`
- Add a bpf helper `bpf_log(l)` in `helpers.h`
- Add  `-Wno-unused-result` to CFLAGS to ignore warnings caused by `asprintf`.

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>