### PR TITLE
Fix github actions tests

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,19 +1,19 @@
-# Using ubuntu 19.04 for newer `unshare` command used in tests
-FROM ubuntu:19.04
+FROM ubuntu:18.04
 
 ARG LLVM_VERSION="8"
 ENV LLVM_VERSION=$LLVM_VERSION
 
 RUN apt-get update && apt-get install -y curl gnupg &&\
     llvmRepository="\n\
-deb http://apt.llvm.org/disco/ llvm-toolchain-disco main\n\
-deb-src http://apt.llvm.org/disco/ llvm-toolchain-disco main\n\
-deb http://apt.llvm.org/disco/ llvm-toolchain-disco-${LLVM_VERSION} main\n\
-deb-src http://apt.llvm.org/disco/ llvm-toolchain-disco-${LLVM_VERSION} main\n" &&\
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main\n\
+deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main\n\
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM_VERSION} main\n\
+deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM_VERSION} main\n" &&\
     echo $llvmRepository >> /etc/apt/sources.list && \
     curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
 RUN apt-get update && apt-get install -y \
+      util-linux \
       bison \
       binutils-dev \
       cmake \


### PR DESCRIPTION
Github actions are failing because the docker image used for testing is based
in Ubuntu 19.04 that is EOL now. This commit downgrades the version used for
testing to 18.04 that is LTS. It also installs the "util-linux" package that
includes the "unshare" command.
