### PR TITLE
Fix KFUNC_PROBE return value

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -1012,7 +1012,7 @@ int raw_tracepoint__##event(struct bpf_raw_tracepoint_args *ctx)
 #define BPF_PROG(name, args...)                                 \
 int name(unsigned long long *ctx);                              \
 __attribute__((always_inline))                                  \
-static void ____##name(unsigned long long *ctx, ##args);        \
+static int ____##name(unsigned long long *ctx, ##args);         \
 int name(unsigned long long *ctx)                               \
 {                                                               \
         _Pragma("GCC diagnostic push")                          \
@@ -1021,7 +1021,7 @@ int name(unsigned long long *ctx)                               \
         _Pragma("GCC diagnostic pop")                           \
         return 0;                                               \
 }                                                               \
-static void ____##name(unsigned long long *ctx, ##args)
+static int ____##name(unsigned long long *ctx, ##args)
 
 #define KFUNC_PROBE(event, args...) \
         BPF_PROG(kfunc__ ## event, args)

--- a/tools/klockstat.py
+++ b/tools/klockstat.py
@@ -352,17 +352,17 @@ int mutex_lock_enter(struct pt_regs *ctx)
 program_kfunc = """
 KFUNC_PROBE(mutex_unlock, void *lock)
 {
-    do_mutex_unlock_enter();
+    return do_mutex_unlock_enter();
 }
 
 KRETFUNC_PROBE(mutex_lock, void *lock, int ret)
 {
-    do_mutex_lock_return();
+    return do_mutex_lock_return();
 }
 
 KFUNC_PROBE(mutex_lock, void *lock)
 {
-    do_mutex_lock_enter(ctx, 3);
+    return do_mutex_lock_enter(ctx, 3);
 }
 
 """

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -197,6 +197,8 @@ KRETFUNC_PROBE(do_sys_open, int dfd, const char __user *filename, int flags, int
     data.ret   = ret;
 
     events.perf_submit(ctx, &data, sizeof(data));
+
+    return 0:
 }
 """
 


### PR DESCRIPTION
The KFUNC_PROBE macro is using "void" as return type, this is causing problems
in some tools that have a filtering enable that returns 0.

Reproducer: (Notice that it requires BTF support)

```
$ python opensnoop.py --pid 5
/virtual/main.c:33:21: error: void function '____kretfunc__do_sys_open' should not return a value [-Wreturn-type]
    if (pid != 5) { return 0; }
                    ^      ~
1 error generated.
...
```
Signed-off-by: Mauricio Vásquez <mauricio@kinvolk.io>

FIxes changes made in https://github.com/iovisor/bcc/pull/2726.