### PR TITLE
tool: trace process termination by default

### DIFF
--- a/man/man8/exitsnoop.8
+++ b/man/man8/exitsnoop.8
@@ -2,7 +2,7 @@
 .SH NAME
 exitsnoop \- Trace all process termination (exit, fatal signal). Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B exitsnoop [\-h] [\-t] [\-\-utc] [\-x] [\-p PID] [\-\-label LABEL]
+.B exitsnoop [\-h] [\-t] [\-\-utc] [\-x] [\-p PID] [\-\-label LABEL] [\-\-per\-thread]
 .SH DESCRIPTION
 exitsnoop traces process termination, showing the command name and reason for
 termination, either an exit or a fatal signal.
@@ -35,6 +35,9 @@ Trace this process ID only (filtered in-kernel).
 .TP
 \-\-label LABEL
 Label each line with LABEL (default 'exit') in first column (2nd if timestamp is present).
+.TP
+\-\-per\-thread
+Trace per thread termination
 .SH EXAMPLES
 .TP
 Trace all process termination
@@ -56,6 +59,10 @@ Trace PID 181 only:
 Label each output line with 'EXIT':
 #
 .B exitsnoop \-\-label EXIT
+.TP
+Trace per thread termination
+#
+.B exitsnoop \-\-per\-thread
 .SH FIELDS
 .TP
 TIME-TZ

--- a/tools/exitsnoop_example.txt
+++ b/tools/exitsnoop_example.txt
@@ -67,7 +67,7 @@ TIME-UTC     LABEL PCOMM            PID    PPID   TID    AGE(s)  EXIT_CODE
 USAGE message:
 
 # ./exitsnoop.py -h
-usage: exitsnoop.py [-h] [-t] [--utc] [-p PID] [--label LABEL] [-x]
+usage: exitsnoop.py [-h] [-t] [--utc] [-p PID] [--label LABEL] [-x] [--per-thread]
 
 Trace all process termination (exit, fatal signal)
 
@@ -78,6 +78,7 @@ optional arguments:
   -p PID, --pid PID  trace this PID only
   --label LABEL      label each line
   -x, --failed       trace only fails, exclude exit(0)
+  --per-thread       trace per thread termination
 
 examples:
     exitsnoop                # trace all process termination
@@ -86,6 +87,7 @@ examples:
     exitsnoop --utc          # include timestamps (UTC)
     exitsnoop -p 181         # only trace PID 181
     exitsnoop --label=exit   # label each output line with 'exit'
+    exitsnoop --per-thread   # trace per thread termination
 
 Exit status:
 


### PR DESCRIPTION
`sched_process_exit` tracepoint is called when thread terminates.
So exitsnoop shows line per each thread termination if the process
is multi-thread process. This is not useful when people wants to
know why process terminates, not thread.

So this changes exitsnoop default behavior which traces process termination
instead of thread termination. And add `--per-thread` option which behaves
as original exitsnoop implementation.

### Motivation

I suppose `exitsnoop` should check both PID and TID as default behavior because its documentations says **Trace all process termination** but current implementation **traces all thread termination**. However I'm not sure that there is no problem to change default behavior for backward compatibility.
