### PR TITLE
Add killsnoop arg for filtering on signal

### DIFF
--- a/man/man8/killsnoop.8
+++ b/man/man8/killsnoop.8
@@ -28,6 +28,9 @@ Only print failed kill() syscalls.
 .TP
 \-p PID
 Trace this process ID only (filtered in-kernel).
+.TP
+\-s SIGNAL
+Trace this signal only (filtered in-kernel).
 .SH EXAMPLES
 .TP
 Trace all kill() syscalls:
@@ -41,6 +44,10 @@ Trace only kill() syscalls that failed:
 Trace PID 181 only:
 #
 .B killsnoop \-p 181
+.TP
+Trace signal 9 only:
+#
+.B killsnoop \-s 9
 .SH FIELDS
 .TP
 TIME

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -23,7 +23,7 @@ examples = """examples:
     ./killsnoop           # trace all kill() signals
     ./killsnoop -x        # only show failed kills
     ./killsnoop -p 181    # only trace PID 181
-    ./killsnoop -s 13     # only trace signal 13
+    ./killsnoop -s 9      # only trace signal 9
 """
 parser = argparse.ArgumentParser(
     description="Trace signals issued by the kill() syscall",

--- a/tools/killsnoop_example.txt
+++ b/tools/killsnoop_example.txt
@@ -29,6 +29,7 @@ optional arguments:
   -p PID, --pid PID  trace this PID only
 
 examples:
-    ./killsnoop           # trace all kill() signals
-    ./killsnoop -x        # only show failed kills
-    ./killsnoop -p 181    # only trace PID 181
+    ./killsnoop               # trace all kill() signals
+    ./killsnoop -x            # only show failed kills
+    ./killsnoop -p 181        # only trace PID 181
+    ./killsnoop -s 9          # only trace signal 9

--- a/tools/killsnoop_example.txt
+++ b/tools/killsnoop_example.txt
@@ -29,7 +29,7 @@ optional arguments:
   -p PID, --pid PID  trace this PID only
 
 examples:
-    ./killsnoop               # trace all kill() signals
-    ./killsnoop -x            # only show failed kills
-    ./killsnoop -p 181        # only trace PID 181
-    ./killsnoop -s 9          # only trace signal 9
+    ./killsnoop           # trace all kill() signals
+    ./killsnoop -x        # only show failed kills
+    ./killsnoop -p 181    # only trace PID 181
+    ./killsnoop -s 9      # only trace signal 9


### PR DESCRIPTION
I was recently using killsnoop to troubleshoot some weird signal behaviour and found that I had to run killsnoop over long periods of time in order to catch the behaviour. A problem I ran into was that filtering for signals I was looking for vs all other signals getting sent around in the system required either logging everything to a file and parsing from there, or running a forked version of killsnoop to filter on the signal.

This PR includes a change to allow optional filtering of the signal that is passed to kill() to help reduce noise in cases like this.

I haven't updated the examples as I'm not sure if this will be considered useful, but happy to do so if this gets the green light.