### PR TITLE
Implement ISRA detection in the C++ API

### DIFF
--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -40,6 +40,22 @@ struct open_probe_t {
   std::vector<std::pair<int, int>>* per_cpu_fd;
 };
 
+// Helper class to detect isra renaming.
+class Isra {
+ public:
+  Isra() = default;
+  Isra(const Isra& other) = delete;
+
+  // Initialize the internal symbol list.
+  void init(std::istream& in);
+
+  // Try to find a string; returns nullptr if no match was found.
+  const std::string* find(const std::string& symbol);
+
+ private:
+  std::vector<std::string> syms_;
+};
+
 class USDT;
 
 class BPF {
@@ -297,6 +313,10 @@ class BPF {
 
   void init_fail_reset();
 
+  // Find the .isra. version of a symbol from isras_, returns nullptr if no
+  // symbol could be found.
+  const std::string* find_isra(const std::string& symbol);
+
   int flag_;
 
   void *bsymcache_;
@@ -317,6 +337,9 @@ class BPF {
   std::map<std::string, BPFPerfBuffer*> perf_buffers_;
   std::map<std::string, BPFPerfEventArray*> perf_event_arrays_;
   std::map<std::pair<uint32_t, uint32_t>, open_probe_t> perf_events_;
+
+  bool have_isra_{false};  // have we initialized isra_?
+  Isra isra_;              // the isra map
 };
 
 class USDT {

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_LIBBCC_SOURCES
 	test_bpf_table.cc
 	test_cg_storage.cc
 	test_hash_table.cc
+	test_isra.cc
 	test_map_in_map.cc
 	test_perf_event.cc
 	test_pinned_table.cc

--- a/tests/cc/test_isra.cc
+++ b/tests/cc/test_isra.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 Evan Klitzke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+
+#include "BPF.h"
+#include "catch.hpp"
+
+TEST_CASE("test isra", "find") {
+  const std::string kallsyms = R"(
+0000000000000000 A fixed_percpu_data
+0000000000000000 A __per_cpu_start
+0000000000000000 A cpu_debug_store
+0000000000000000 A irq_stack_backing_store
+0000000000000000 A cpu_tss_rw
+0000000000000000 A gdt_page
+0000000000000000 A gdt_page.isra.0
+0000000000000000 t _rs_collect_tx_data.constprop.0.isra.0	[iwlmvm]
+0000000000000000 t sof_suspend.isra.0	[snd_sof]
+0000000000000000 t sof_suspend.isra.0.cold	[snd_sof]
+0000000000000000 t sof_resume.isra.0	[snd_sof]
+0000000000000000 t sof_resume.isra.0.cold	[snd_sof]
+0000000000000000 t skl_free.isra.0	[snd_soc_skl]
+0000000000000000 t skl_decoupled_trigger.isra.0	[snd_soc_skl]
+0000000000000000 t skl_setup_out_format.isra.0	[snd_soc_skl]
+0000000000000000 t skl_set_base_module_format.isra.0	[snd_soc_skl]
+0000000000000000 t skl_get_mconfig_cap_cpr.isra.0	[snd_soc_skl]
+0000000000000000 t skl_get_mconfig_pb_cpr.isra.0	[snd_soc_skl]
+0000000000000000 t skl_tplg_fill_dma_id.isra.0	[snd_soc_skl]
+0000000000000000 t skl_tplg_set_module_bind_params.isra.0	[snd_soc_skl]
+0000000000000000 t fuse_fh_to_parent	[fuse]
+0000000000000000 t fuse_show_options	[fuse]
+)";
+
+  ebpf::Isra isra;
+  std::istringstream in(kallsyms);
+  isra.init(in);
+
+  // This should be null because it's not a symbol of type "t"
+  REQUIRE(isra.find("gdt_page.isra.0") == nullptr);
+
+  // This should be null because it's not an isra symbol
+  REQUIRE(isra.find("fuse_show_options") == nullptr);
+
+  // This should be null because it's not an isra symbol
+  const std::string *p = isra.find("skl_free");
+  REQUIRE(p != nullptr);
+  REQUIRE(*p == "skl_free.isra.0");
+
+  // We should get the first lexicographical match for this one
+  p = isra.find("sof_suspend");
+  REQUIRE(p != nullptr);
+  REQUIRE(*p == "sof_suspend.isra.0");
+
+  // It needs to be a real match, not a partial match
+  REQUIRE(isra.find("sof_") == nullptr);
+}


### PR DESCRIPTION
This change attempts to handles kprobe whose names are mangled by GCC ISRA as described in #1754 

With this change if bcc fails to load a kprobe, it builds a sorted vector of all the .isra. symbols from `/proc/kallsyms`. If a .isra version of a symbol can be found in this vector, that symbol name is used instead. On my Linux desktop there are 810 such symbols (total string size 22 KB). I've written a new test case, and it should be fine if `/proc/kallsyms` isn't available. I didn't implement this in the Python API since I only use the C++ API, but it's probably easy to implement the exact same technique in Python (the Python `bisect` module implements the same functionality as `std::lower_bound`).

As mentioned [here](https://github.com/iovisor/bcc/issues/1754#issuecomment-471868602) GCC might change the function signature of functions optimized this way, so it might  be problematic to do things like inspect function arguments in this case.

One other question is whether this should be opt-in instead. Right now I'm just doing it automatically, but I could see if some people find this to be confusing.