### PR TITLE
fix: avoid -Wsign-compare warnings

### DIFF
--- a/src/cc/frontends/b/lexer.h
+++ b/src/cc/frontends/b/lexer.h
@@ -51,7 +51,7 @@ class Lexer : public yyFlexLexer {
   }
   std::string text(const position& begin, const position& end) const {
     std::string result;
-    for (size_t i = begin.line; i <= end.line; ++i) {
+    for (auto i = begin.line; i <= end.line; ++i) {
       if (i == begin.line && i == end.line) {
         result += lines_.at(i - 1).substr(begin.column - 1, end.column - begin.column);
       } else if (i == begin.line && i < end.line) {


### PR DESCRIPTION
There are warnings in lexer.h:

> .../iovisor/bcc/src/cc/frontends/b/lexer.h:54:35: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘const counter_type’ {aka ‘const int’} [-Wsign-compare]
   54 |     for (size_t i = begin.line; i <= end.line; ++i)
