### PR TITLE
Adding support to load lsm programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,14 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/src)
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
+# It's possible to use other kernel headers with
+# KERNEL_INCLUDE_DIRS build variable, like:
+#  $ cd <kernel-dir>
+#  $ make INSTALL_HDR_PATH=/tmp/headers headers_install
+#  $ cd <bcc-dir>
+#  $ cmake -DKERNEL_INCLUDE_DIRS=/tmp/headers/include/ ...
+include_directories(${KERNEL_INCLUDE_DIRS})
+
 include(cmake/GetGitRevisionDescription.cmake)
 include(cmake/version.cmake)
 include(CMakeDependentOption)

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -1029,6 +1029,9 @@ static int ____##name(unsigned long long *ctx, ##args)
 #define KRETFUNC_PROBE(event, args...) \
         BPF_PROG(kretfunc__ ## event, args)
 
+#define LSM_PROBE(event, args...) \
+        BPF_PROG(lsm__ ## event, args)
+
 #define TP_DATA_LOC_READ_CONST(dst, field, length)                        \
         do {                                                              \
             unsigned short __offset = args->data_loc_##field & 0xFFFF;    \

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -564,9 +564,13 @@ int bcc_prog_load_xattr(struct bpf_load_program_attr *attr, int prog_len,
     } else if (strncmp(attr->name, "kretfunc__", 10) == 0) {
       name_offset = 10;
       expected_attach_type = BPF_TRACE_FEXIT;
+    } else if (strncmp(attr->name, "lsm__", 5) == 0) {
+      name_offset = 5;
+      expected_attach_type = BPF_LSM_MAC;
     }
 
-    if (attr->prog_type == BPF_PROG_TYPE_TRACING) {
+    if (attr->prog_type == BPF_PROG_TYPE_TRACING ||
+        attr->prog_type == BPF_PROG_TYPE_LSM) {
       attr->attach_btf_id = libbpf_find_vmlinux_btf_id(attr->name + name_offset,
                                                        expected_attach_type);
       attr->expected_attach_type = expected_attach_type;

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -157,6 +157,7 @@ class BPF(object):
     RAW_TRACEPOINT = 17
     CGROUP_SOCK_ADDR = 18
     TRACING = 26
+    LSM = 29
 
     # from xdp_action uapi/linux/bpf.h
     XDP_ABORTED = 0

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -323,6 +323,18 @@ int kprobe__blk_update_request(struct pt_regs *ctx, struct request *req) {
     return 0;
 }""")
 
+    @skipUnless(kernel_version_ge(5,7), "requires kernel >= 5.7")
+    def test_lsm_probe(self):
+        b = BPF(text="""
+LSM_PROBE(bpf, int cmd, union bpf_attr *uattr, unsigned int size) {
+    return 0;
+}""")
+        # depending on CONFIG_BPF_LSM being compiled in
+        try:
+            b.load_func("lsm__bpf", BPF.LSM)
+        except:
+            pass
+
     def test_probe_read_helper(self):
         b = BPF(text="""
 #include <linux/fs.h>


### PR DESCRIPTION
Adding the 'lsm__' prefix check for loaded program
and set BPF_LSM_MAC as expected_attach_type if the 
program name matches.

This way we can load LSM programs via bcc interface.

The program attach can be done by existing kfunc API:
  bpf_attach_kfunc
  bpf_detach_kfunc

It will be used in upcomming bpftrace change that
adds lsm probes.
