### PR TITLE
offwaketime: Add support for --state

### DIFF
--- a/man/man8/offwaketime.8
+++ b/man/man8/offwaketime.8
@@ -2,7 +2,7 @@
 .SH NAME
 offwaketime \- Summarize blocked time by off-CPU stack + waker stack. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B offwaketime [\-h] [\-p PID | \-t TID | \-u | \-k] [\-U | \-K] [\-f] [\-\-stack-storage-size STACK_STORAGE_SIZE] [\-m MIN_BLOCK_TIME] [\-M MAX_BLOCK_TIME] [duration]
+.B offwaketime [\-h] [\-p PID | \-t TID | \-u | \-k] [\-U | \-K] [\-f] [\-\-stack-storage-size STACK_STORAGE_SIZE] [\-m MIN_BLOCK_TIME] [\-M MAX_BLOCK_TIME] [\-\-state STATE] [duration]
 .SH DESCRIPTION
 This program shows kernel stack traces and task names that were blocked and
 "off-CPU", along with the stack traces and task names for the threads that woke
@@ -64,6 +64,10 @@ The amount of time in microseconds over which we store traces (default 1)
 .TP
 \-M MAX_BLOCK_TIME
 The amount of time in microseconds under which we store traces (default U64_MAX)
+.TP
+\-\-state
+Filter on this thread state bitmask (eg, 2 == TASK_UNINTERRUPTIBLE).
+See include/linux/sched.h for states.
 .SH EXAMPLES
 .TP
 Trace all thread blocking events, and summarize (in-kernel) by user and kernel off-CPU stack trace, waker stack traces, task names, and total blocked time:

--- a/tools/offwaketime_example.txt
+++ b/tools/offwaketime_example.txt
@@ -307,7 +307,7 @@ USAGE message:
 # ./offwaketime -h
 usage: offwaketime [-h] [-p PID | -t TID | -u | -k] [-U | -K] [-d] [-f]
                    [--stack-storage-size STACK_STORAGE_SIZE]
-                   [-m MIN_BLOCK_TIME] [-M MAX_BLOCK_TIME]
+                   [-m MIN_BLOCK_TIME] [-M MAX_BLOCK_TIME] [--state STATE]
                    [duration]
 
 Summarize blocked time by kernel stack trace + waker stack
@@ -340,6 +340,8 @@ optional arguments:
   -M MAX_BLOCK_TIME, --max-block-time MAX_BLOCK_TIME
                         the amount of time in microseconds under which we
                         store traces (default U64_MAX)
+  --state STATE         filter on this thread state bitmask (eg, 2 ==
+                        TASK_UNINTERRUPTIBLE) see include/linux/sched.h
 
 examples:
     ./offwaketime             # trace off-CPU + waker stack time until Ctrl-C


### PR DESCRIPTION
Since offwaketime is really an amalgamation of offcputime and wakeuptime
there is no reason why it shouldn't support the --state argument of the
former.