### PR TITLE
Docker: add kmod dependency to docker container

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -19,5 +19,5 @@ COPY --from=builder /root/bcc/*.deb /root/bcc/
 
 RUN \
   apt-get update -y && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y python python3 binutils libelf1 && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y python python3 binutils libelf1 kmod && \
   dpkg -i /root/bcc/*.deb


### PR DESCRIPTION
modprobe and rmmod are used to load the kheaders module as a last option
when kernel headers are not found. The modprobe command is missing in the
docker image and scroipts are failing:

$ /usr/share/bcc/tools/execsnoop --mntnsmap /sys/fs/bpf/mnt_ns_set
sh: 1: modprobe: not found
Unable to find kernel headers. Try rebuilding kernel with CONFIG_IKHEADERS=m (module)
...

Signed-off-by: Mauricio Vásquez <mauricio@kinvolk.io>