### PR TITLE
silence a python travis-ci warning

### DIFF
--- a/tools/biolatpcts.py
+++ b/tools/biolatpcts.py
@@ -120,7 +120,8 @@ elif args.which == 'after-rq-alloc':
 elif args.which == 'on-device':
     start_time_field = 'io_start_time_ns'
 else:
-    die()
+    print("Invalid latency measurement {}".format(args.which))
+    exit()
 
 bpf_source = bpf_source.replace('__START_TIME_FIELD__', start_time_field)
 bpf_source = bpf_source.replace('__MAJOR__', str(major))


### PR DESCRIPTION
The travis-ci flags a python warning:
```
  $ flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
  ./tools/biolatpcts.py:123:5: F821 undefined name 'die'
      die()
      ^
  1     F821 undefined name 'die'
```
Let us fix it with proper error message and then exit().

Signed-off-by: Yonghong Song <yhs@fb.com>