### PR TITLE
Fix runqslower to indicate that the latency param is in microseconds.

### DIFF
--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -50,7 +50,7 @@ parser = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
     epilog=examples)
 parser.add_argument("min_us", nargs="?", default='10000',
-    help="minimum run queue latecy to trace, in ms (default 10000)")
+    help="minimum run queue latency to trace, in us (default 10000)")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
 


### PR DESCRIPTION
This is a minor fix... I was using `runqslower` when I noticed that the help text indicated that the latency parameter was in milliseconds, when it's actually in microseconds. This change fixes that, and I also fixed a typo in that line while I was there.
