### PR TITLE
usdt: Add helpers to set semaphore values

### DIFF
--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -70,9 +70,12 @@ int bcc_usdt_get_argument(void *usdt, const char *provider_name,
                           struct bcc_usdt_argument *argument);
 
 int bcc_usdt_enable_probe(void *, const char *, const char *);
+int bcc_usdt_addsem_probe(void *, const char *, const char *, int16_t);
 #define BCC_USDT_HAS_FULLY_SPECIFIED_PROBE
 int bcc_usdt_enable_fully_specified_probe(void *, const char *, const char *,
                                           const char *);
+int bcc_usdt_addsem_fully_specified_probe(void *, const char *, const char *,
+                                          const char *, int16_t);
 const char *bcc_usdt_genargs(void **ctx_array, int len);
 const char *bcc_usdt_get_probe_argctype(
   void *ctx, const char* probe_name, const int arg_index

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -262,6 +262,8 @@ class Context {
 
   void add_probe(const char *binpath, const struct bcc_elf_usdt *probe);
   std::string resolve_bin_path(const std::string &bin_path);
+  Probe *get_checked(const std::string &provider_name,
+                     const std::string &probe_name);
 
 private:
   uint8_t mod_match_inode_only_;
@@ -285,6 +287,9 @@ public:
   bool enable_probe(const std::string &probe_name, const std::string &fn_name);
   bool enable_probe(const std::string &provider_name,
                     const std::string &probe_name, const std::string &fn_name);
+  bool addsem_probe(const std::string &provider_name,
+                    const std::string &probe_name, const std::string &fn_name,
+                    int16_t val);
 
   typedef void (*each_cb)(struct bcc_usdt *);
   void each(each_cb callback);


### PR DESCRIPTION
While debugging a high memory consumption issue in bpftrace, I noticed
that a USDT::Context object can take ~10M per instance [0]. Along with
the new --usdt-file-activation feature in bpftrace
( https://github.com/iovisor/bpftrace/pull/1317 ), bpftrace can
potentially hold onto many dozens of USDT:Context instances, causing
memory issues.

While reducing the amount of memory USDT::Context uses is one option,
we can potentially side step it by allowing the usdt semaphore count to
be set independently. Before, the only way to increment the count (by 1)
is to call bcc_usdt_enable*(). bcc_usdt_enable*() has checks that limit
it to a single increment per context. The only way to decrement the
count is by calling bcc_usdt_close() which naturally only allows for
one decrement.

With independent semaphore helpers, we can avoid holding onto a
USDT::Context instance for the lifetime of the tracing session. We can
simply:

1. create a USDT::Context
2. increment the semaphore count for the probe we care about
3. destroy the USDT::Context
4. repeat 1-3 for all probes we want to attach to
5. do our tracing
6. create a USDT::Context for the probe we care about
7. decrement the semaphore count
8. destroy the USDT::Context
9. repeat 6-8 for all the probes we're attached to

This approach also has the benefit of 1 USDT::Context instance being
alive at a time which can help keep memory high watermark low.

[0]: Through gdb single stepping and /proc/pid/status. Exact process is
not described here b/c memory usage probably varies based on tracee
binary.