### PR TITLE
usdt: Have Context::addsem_probe() nop if pid not specified

### DIFF
--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -359,8 +359,12 @@ bool Context::addsem_probe(const std::string &provider_name,
                            int16_t val) {
   Probe *found_probe = get_checked(provider_name, probe_name);
 
-  if (found_probe != nullptr)
-    return found_probe->add_to_semaphore(val);
+  if (found_probe != nullptr) {
+    if (found_probe->need_enable())
+      return found_probe->add_to_semaphore(val);
+
+    return true;
+  }
 
   return false;
 }


### PR DESCRIPTION
This makes bcc_usdt_addsem*() more consistent with the bcc_usdt_enable*()
interface where if a USDT::Context was not constructed with a pid the
semaphore enablement nops.