### PR TITLE
fix: encode path to bytes in python3

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -278,7 +278,7 @@ class BPF(object):
         else:
             for path in os.environ["PATH"].split(os.pathsep):
                 path = path.strip('"')
-                exe_file = os.path.join(path, bin_path)
+                exe_file = os.path.join(path.encode(), bin_path)
                 if is_exe(exe_file):
                     return exe_file
         return None


### PR DESCRIPTION
Python 3 will complain about mixing strings and bytes in `os.path.join`

```sh
$ python3
Python 3.8.2 (default, Apr 27 2020, 15:53:34)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from bcc import BPF
>>> BPF.find_exe(b"bash")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 281, in find_exe
    exe_file = os.path.join(path, bin_path)
  File "/usr/lib/python3.8/posixpath.py", line 90, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib/python3.8/genericpath.py", line 155, in _check_arg_types
    raise TypeError("Can't mix strings and bytes in path components") from None
TypeError: Can't mix strings and bytes in path components
```

Adding `encode()` should work with both Python 2 and 3

```sh
$ python2
Python 2.7.18rc1 (default, Apr  7 2020, 12:05:55)
[GCC 9.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> [p.encode() for p in os.environ["PATH"].split(os.pathsep)]
['/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin', '/usr/games', '/usr/local/games', '/snap/bin']
```

```sh
$ python3
Python 3.8.2 (default, Apr 27 2020, 15:53:34)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> [p.encode() for p in os.environ["PATH"].split(os.pathsep)]
[b'/usr/local/sbin', b'/usr/local/bin', b'/usr/sbin', b'/usr/bin', b'/sbin', b'/bin', b'/usr/games', b'/usr/local/games', b'/snap/bin']
```