### PR TITLE
libbpf-tools: refactor, move public methods to trace_helpers.c

### DIFF
--- a/libbpf-tools/cpudist.c
+++ b/libbpf-tools/cpudist.c
@@ -6,7 +6,6 @@
 #include <argp.h>
 #include <signal.h>
 #include <stdio.h>
-#include <sys/resource.h>
 #include <unistd.h>
 #include <time.h>
 #include <bpf/libbpf.h>
@@ -122,21 +121,11 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 }
 
 int libbpf_print_fn(enum libbpf_print_level level,
-		const char *format, va_list args)
+		    const char *format, va_list args)
 {
 	if (level == LIBBPF_DEBUG && !env.verbose)
 		return 0;
 	return vfprintf(stderr, format, args);
-}
-
-static int bump_memlock_rlimit(void)
-{
-	struct rlimit rlim_new = {
-		.rlim_cur	= RLIM_INFINITY,
-		.rlim_max	= RLIM_INFINITY,
-	};
-
-	return setrlimit(RLIMIT_MEMLOCK, &rlim_new);
 }
 
 static int get_pid_max(void)

--- a/libbpf-tools/drsnoop.c
+++ b/libbpf-tools/drsnoop.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/resource.h>
 #include <unistd.h>
 #include <time.h>
 #include <bpf/libbpf.h>
@@ -98,21 +97,11 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 }
 
 int libbpf_print_fn(enum libbpf_print_level level,
-            const char *format, va_list args)
+		    const char *format, va_list args)
 {
 	if (level == LIBBPF_DEBUG && !env.verbose)
 		return 0;
 	return vfprintf(stderr, format, args);
-}
-
-static int bump_memlock_rlimit(void)
-{
-	struct rlimit rlim_new = {
-		.rlim_cur	= RLIM_INFINITY,
-		.rlim_max	= RLIM_INFINITY,
-	};
-
-	return setrlimit(RLIMIT_MEMLOCK, &rlim_new);
 }
 
 void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
@@ -150,7 +139,7 @@ int main(int argc, char **argv)
 	struct ksyms *ksyms = NULL;
 	const struct ksym *ksym;
 	struct drsnoop_bpf *obj;
-	time_t start_time;
+	__u64 time_end = 0;
 	int err;
 
 	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
@@ -207,7 +196,7 @@ int main(int argc, char **argv)
 	else
 		printf("... Hit Ctrl-C to end.\n");
 	printf("%-8s %-16s %-6s %8s %5s",
-	        "TIME", "COMM", "TID", "LAT(ms)", "PAGES");
+		"TIME", "COMM", "TID", "LAT(ms)", "PAGES");
 	if (env.extended)
 		printf(" %8s", "FREE(KB)");
 	printf("\n");
@@ -223,13 +212,18 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	start_time = time(NULL);
-	while (!env.duration || time(NULL) - start_time < env.duration) {
-		if ((err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS)) < 0) {
-			printf("error polling perf buffer: %d\n", err);
+	/* setup duration */
+	if (env.duration)
+		time_end = get_ktime_ns() + env.duration * NSEC_PER_SEC;
+
+	/* main: poll */
+	while (1) {
+		if ((err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS)) < 0)
 			break;
-		}
+		if (env.duration && get_ktime_ns() > time_end)
+			goto cleanup;
 	}
+	printf("error polling perf buffer: %d\n", err);
 
 cleanup:
 	perf_buffer__free(pb);

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -4,7 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/resource.h>
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
@@ -12,9 +11,9 @@
 #include <bpf/bpf.h>
 #include "execsnoop.h"
 #include "execsnoop.skel.h"
+#include "trace_helpers.h"
 
 #define PERF_BUFFER_PAGES   64
-#define NSEC_PER_SEC 1000000000L
 #define NSEC_PRECISION (NSEC_PER_SEC / 1000)
 #define MAX_ARGS_KEY 259
 
@@ -128,18 +127,8 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	return 0;
 }
 
-static int bump_memlock_rlimit(void)
-{
-	struct rlimit rlim_new = {
-		.rlim_cur	= RLIM_INFINITY,
-		.rlim_max	= RLIM_INFINITY,
-	};
-
-	return setrlimit(RLIMIT_MEMLOCK, &rlim_new);
-}
-
 int libbpf_print_fn(enum libbpf_print_level level,
-            const char *format, va_list args)
+		    const char *format, va_list args)
 {
 	if (level == LIBBPF_DEBUG && !env.verbose)
 		return 0;

--- a/libbpf-tools/execsnoop.h
+++ b/libbpf-tools/execsnoop.h
@@ -13,6 +13,7 @@
 #define LAST_ARG (FULL_MAX_ARGS_ARR - ARGSIZE)
 
 struct event {
+	char comm[TASK_COMM_LEN];
 	pid_t pid;
 	pid_t tgid;
 	pid_t ppid;
@@ -20,7 +21,6 @@ struct event {
 	int retval;
 	int args_count;
 	unsigned int args_size;
-	char comm[TASK_COMM_LEN];
 	char args[FULL_MAX_ARGS_ARR];
 };
 

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -7,13 +7,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/resource.h>
 #include <unistd.h>
 #include <time.h>
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
 #include "filelife.h"
 #include "filelife.skel.h"
+#include "trace_helpers.h"
 
 #define PERF_BUFFER_PAGES	16
 #define PERF_POLL_TIMEOUT_MS	100
@@ -64,21 +64,11 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 }
 
 int libbpf_print_fn(enum libbpf_print_level level,
-		const char *format, va_list args)
+		    const char *format, va_list args)
 {
 	if (level == LIBBPF_DEBUG && !env.verbose)
 		return 0;
 	return vfprintf(stderr, format, args);
-}
-
-static int bump_memlock_rlimit(void)
-{
-	struct rlimit rlim_new = {
-		.rlim_cur	= RLIM_INFINITY,
-		.rlim_max	= RLIM_INFINITY,
-	};
-
-	return setrlimit(RLIMIT_MEMLOCK, &rlim_new);
 }
 
 void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)

--- a/libbpf-tools/filelife.h
+++ b/libbpf-tools/filelife.h
@@ -6,10 +6,10 @@
 #define TASK_COMM_LEN    16
 
 struct event {
-	__u64 delta_ns;
-	pid_t tgid;
 	char file[DNAME_INLINE_LEN];
 	char task[TASK_COMM_LEN];
+	__u64 delta_ns;
+	pid_t tgid;
 };
 
 #endif /* __FILELIFE_H */

--- a/libbpf-tools/runqslower.c
+++ b/libbpf-tools/runqslower.c
@@ -7,12 +7,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/resource.h>
 #include <time.h>
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
 #include "runqslower.h"
 #include "runqslower.skel.h"
+#include "trace_helpers.h"
 
 struct env {
 	pid_t pid;
@@ -97,16 +97,6 @@ int libbpf_print_fn(enum libbpf_print_level level,
 	if (level == LIBBPF_DEBUG && !env.verbose)
 		return 0;
 	return vfprintf(stderr, format, args);
-}
-
-static int bump_memlock_rlimit(void)
-{
-	struct rlimit rlim_new = {
-		.rlim_cur	= RLIM_INFINITY,
-		.rlim_max	= RLIM_INFINITY,
-	};
-
-	return setrlimit(RLIMIT_MEMLOCK, &rlim_new);
 }
 
 void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)

--- a/libbpf-tools/syscount.c
+++ b/libbpf-tools/syscount.c
@@ -2,7 +2,6 @@
 // Copyright (c) 2020 Anton Protopopov
 //
 // Based on syscount(8) from BCC by Sasha Goldshtein
-#include <sys/resource.h>
 #include <unistd.h>
 #include <signal.h>
 #include <fcntl.h>
@@ -13,6 +12,7 @@
 #include "syscount.skel.h"
 #include "errno_helpers.h"
 #include "syscall_helpers.h"
+#include "trace_helpers.h"
 
 /* This structure extends data_t by adding a key item which should be sorted
  * together with the count and total_ns fields */
@@ -93,22 +93,12 @@ static int get_int(const char *arg, int *ret, int min, int max)
 }
 
 static int libbpf_print_fn(enum libbpf_print_level level,
-		const char *format, va_list args)
+			   const char *format, va_list args)
 {
 	if (level == LIBBPF_DEBUG && !env.verbose)
 		return 0;
 
 	return vfprintf(stderr, format, args);
-}
-
-static int bump_memlock_rlimit(void)
-{
-	struct rlimit rlim_new = {
-		.rlim_cur	= RLIM_INFINITY,
-		.rlim_max	= RLIM_INFINITY,
-	};
-
-	return setrlimit(RLIMIT_MEMLOCK, &rlim_new);
 }
 
 static int compar_count(const void *dx, const void *dy)

--- a/libbpf-tools/trace_helpers.h
+++ b/libbpf-tools/trace_helpers.h
@@ -2,6 +2,8 @@
 #ifndef __TRACE_HELPERS_H
 #define __TRACE_HELPERS_H
 
+#define NSEC_PER_SEC		1000000000ULL
+
 struct ksym {
 	const char *name;
 	unsigned long addr;
@@ -17,5 +19,8 @@ const struct ksym *ksyms__get_symbol(const struct ksyms *ksyms,
 				     const char *name);
 
 void print_log2_hist(unsigned int *vals, int vals_size, char *val_type);
+
+unsigned long long get_ktime_ns(void);
+int bump_memlock_rlimit(void);
 
 #endif /* __TRACE_HELPERS_H */

--- a/libbpf-tools/vfsstat.c
+++ b/libbpf-tools/vfsstat.c
@@ -2,13 +2,13 @@
 // Copyright (c) 2020 Anton Protopopov
 //
 // Based on vfsstat(8) from BCC by Brendan Gregg
-#include <sys/resource.h>
 #include <argp.h>
 #include <unistd.h>
 #include <time.h>
 #include <bpf/bpf.h>
 #include "vfsstat.h"
 #include "vfsstat.skel.h"
+#include "trace_helpers.h"
 
 const char *argp_program_version = "vfsstat 0.1";
 const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
@@ -74,21 +74,11 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 }
 
 static int libbpf_print_fn(enum libbpf_print_level level,
-		const char *format, va_list args)
+			   const char *format, va_list args)
 {
 	if (level == LIBBPF_DEBUG && !env.verbose)
 		return 0;
 	return vfprintf(stderr, format, args);
-}
-
-static int bump_memlock_rlimit(void)
-{
-	struct rlimit rlim_new = {
-		.rlim_cur	= RLIM_INFINITY,
-		.rlim_max	= RLIM_INFINITY,
-	};
-
-	return setrlimit(RLIMIT_MEMLOCK, &rlim_new);
 }
 
 static const char *strftime_now(char *s, size_t max, const char *format)


### PR DESCRIPTION
- extract `bump_memlock_rlimit` and put into `trace_helpers.c`
- extract `get_ktime_ns` and put into `trace_helpers.c`
- Resort struct's fields by alignment size instead of field size

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>