### PR TITLE
tools: fix a python 3 map issue in dbstat and dbslower

### DIFF
--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -194,7 +194,7 @@ else:
             args.pids = map(int, subprocess.check_output(
                                             "pidof postgres".split()).split())
 
-    usdts = map(lambda pid: USDT(pid=pid), args.pids)
+    usdts = list(map(lambda pid: USDT(pid=pid), args.pids))
     for usdt in usdts:
         usdt.enable_probe("query__start", "query_start")
         usdt.enable_probe("query__done", "query_end")

--- a/tools/dbstat.py
+++ b/tools/dbstat.py
@@ -83,7 +83,7 @@ program = program.replace("SCALE", str(1000 if args.microseconds else 1000000))
 program = program.replace("FILTER", "" if args.threshold == 0 else
         "if (delta / 1000000 < %d) { return 0; }" % args.threshold)
 
-usdts = map(lambda pid: USDT(pid=pid), args.pids)
+usdts = list(map(lambda pid: USDT(pid=pid), args.pids))
 for usdt in usdts:
     usdt.enable_probe("query__start", "probe_start")
     usdt.enable_probe("query__done", "probe_end")


### PR DESCRIPTION
In python 3, map returns an iterator and not a list anymore. This
patch cast the map into a list. It fixes the following error:

$ /usr/share/bcc/tools/dbstat mysql
Traceback (most recent call last):
  File "/usr/share/bcc/tools/dbstat", line 95, in <module>
    bpf = BPF(text=program, usdt_contexts=usdts)
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 339, in __init__
    ctx_array = (ct.c_void_p * len(usdt_contexts))()
TypeError: object of type 'map' has no len()