### PR TITLE
dbstat: fix overflowing timestamp

### DIFF
--- a/tools/dbstat.py
+++ b/tools/dbstat.py
@@ -39,7 +39,7 @@ parser.add_argument("-m", "--threshold", type=int, default=0,
     help="trace queries slower than this threshold (ms)")
 parser.add_argument("-u", "--microseconds", action="store_true",
     help="display query latencies in microseconds (default: milliseconds)")
-parser.add_argument("-i", "--interval", type=int, default=99999999999,
+parser.add_argument("-i", "--interval", type=int, default=99999999,
     help="print summary at this interval (seconds)")
 args = parser.parse_args()
 

--- a/tools/klockstat.py
+++ b/tools/klockstat.py
@@ -61,7 +61,7 @@ time_group.add_argument("-d", "--duration", type=int,
     help="total duration of trace in seconds")
 time_group.add_argument("-i", "--interval", type=int,
     help="print summary at this interval (seconds)")
-parser.add_argument("-n", "--locks", type=int, default=999999999,
+parser.add_argument("-n", "--locks", type=int, default=99999999,
     help="print given number of locks")
 parser.add_argument("-s", "--stacks", type=int, default=1,
     help="print given number of stack entries")
@@ -452,7 +452,7 @@ print("Tracing lock events... Hit Ctrl-C to end.")
 exiting = 0 if args.interval else 1
 exiting = 1 if args.duration else 0
 
-seconds = 999999999
+seconds = 99999999
 if args.interval:
     seconds = args.interval
 if args.duration:


### PR DESCRIPTION
The current default value of interval (99999999999) in dbstat is too
high to be used in the sleep() function in python 3. I couldn't find a
authoritative source on the issue, but it seems the max value is
2^63/10^9 (9223372036). Anyway, 99999999 is the de facto standard for
a very big number here, so just use that. It's over 3 years, that
should be enough.

For consistency, I also change a couple of value in klockstat even
though they didn't overflow.

It fixes the following error:
$ dbstat mysql
Tracing database queries for pids  slower than 0 ms...
Traceback (most recent call last):
  File "./dbstat", line 112, in <module>
    sleep(args.interval)
OverflowError: timestamp too large to convert to C _PyTime_t