### PR TITLE
Add install steps for Alpine Linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,7 @@
   - [RHEL](#rhel---binary)
   - [Amazon Linux 1](#Amazon-Linux-1---Binary)
   - [Amazon Linux 2](#Amazon-Linux-2---Binary)
+  - [Alpine](#alpine---binary)
 * [Source](#source)
   - [Debian](#debian---source)
   - [Ubuntu](#ubuntu---source)
@@ -17,6 +18,7 @@
   - [openSUSE](#opensuse---source)
   - [Centos](#centos---source)
   - [Amazon Linux](#amazon-linux---source)
+  - [Alpine](#alpine---source)
 * [Older Instructions](#older-instructions)
 
 ## Kernel Configuration
@@ -231,6 +233,36 @@ Use case 1. Install BCC for your AMI's default kernel (no reboot required):
 sudo amazon-linux-extras enable BCC
 sudo yum install kernel-devel-$(uname -r)
 sudo yum install bcc
+```
+
+## Alpine - Binary
+
+As of Alpine 3.11, bcc binaries are available in the community repository:
+
+```
+sudo apk add bcc-tools bcc-doc
+```
+
+The tools are installed in `/usr/share/bcc/tools`.
+
+**Python Compatibility**
+
+The binary packages include bindings for Python 3 only. The Python-based tools assume that a `python` binary is available at `/usr/bin/python`, but that may not be true on recent versions of Alpine. If you encounter errors like `<tool-name>: not found`, you can try creating a symlink to the Python 3.x binary like so:
+
+```
+sudo ln -s $(which python3) /usr/bin/python
+```
+
+**Containers**
+
+Alpine Linux is often used as a base system for containers. `bcc` can be used in such an environment by launching the container in privileged mode with kernel modules available through bind mounts:
+
+```
+sudo docker run --rm -it --privileged \
+  -v /lib/modules:/lib/modules:ro \
+  -v /sys:/sys:ro \
+  -v /usr/src:/usr/src:ro \
+  alpine:3.12
 ```
 
 # Source
@@ -546,6 +578,35 @@ sudo mount -t debugfs debugfs /sys/kernel/debug
 ```
 
 ### Test
+```
+sudo /usr/share/bcc/tools/execsnoop
+```
+
+## Alpine - Source
+
+### Install packages required for building
+
+```
+sudo apk add tar git build-base iperf linux-headers llvm10-dev llvm10-static \
+  clang-dev clang-static cmake python3 flex-dev bison luajit-dev elfutils-dev \
+  zlib-dev
+```
+
+### Build bcc
+
+```
+git clone https://github.com/iovisor/bcc.git
+mkdir bcc/build; cd bcc/build
+# python2 can be substituted here, depending on your environment
+cmake -DPYTHON_CMD=python3 ..
+make && sudo make install
+
+# Optional, but needed if you don't have /usr/bin/python on your system
+ln -s $(which python3) /usr/bin/python
+```
+
+### Test
+
 ```
 sudo /usr/share/bcc/tools/execsnoop
 ```


### PR DESCRIPTION
Recent changes in Alpine have made it possible to build bcc without ugly patches, so it seems like a good time to add the instructions here. I'm hopeful that the Python 3 caveats can be removed soon and that the tools will work out of the box on more systems. It should be fairly easy to get up and running, though.