### PR TITLE
isotack tool proposal

### DIFF
--- a/tools/iostack.py
+++ b/tools/iostack.py
@@ -151,8 +151,8 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
             print("    %s" % b.sym(addr, k.tgid_pid).decode('utf-8', 'replace'))
 
         if k.tgid_pid != 0xffffffff:
-            print("    %s [%d]" % (k.comm_name.decode('utf-8', 'replace'),
+            print("        %s [%d]" % (k.comm_name.decode('utf-8', 'replace'),
                                    k.tgid_pid))
         else:
-            print("    %s" % (k.comm_name.decode('utf-8', 'replace')))
+            print("        %s" % (k.comm_name.decode('utf-8', 'replace')))
         print("        %d\n" % v.value)

--- a/tools/iostack.py
+++ b/tools/iostack.py
@@ -32,7 +32,6 @@ BPF_STACK_TRACE(stack_traces, 16384);
 int _generic_make_request(struct pt_regs *ctx, struct bio *bio) {
     struct disk_data_t data = {};
     int dir = op_is_write((bio)->bi_opf & REQ_OP_MASK) ? WRITE : READ;
-    
     u32 bi_size = bio->bi_iter.bi_size;
     
     struct gendisk *bio_disk = bio->bi_disk;
@@ -125,7 +124,7 @@ duration = int(args.duration)
 
 # header
 if not args.folded:
-    print("Tracing total io sizes (bytes) to block devices", end="")
+    print("Tracing io (bytes) to block devices", end="")
     if duration < 99999999:
         print(" for %d secs." % duration)
     else:

--- a/tools/iostack.py
+++ b/tools/iostack.py
@@ -31,6 +31,7 @@ int _generic_make_request(struct pt_regs *ctx, struct bio *bio) {
 #ifdef KERNEL_STACK
     data.kernel_stack_id = stack_traces.get_stackid(ctx, 0);
 #endif
+
 #ifdef USER_STACK
     data.user_stack_id = stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
     data.tgid_pid = bpf_get_current_pid_tgid();
@@ -132,7 +133,7 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
         # print folded stack output
         user_stack = list(user_stack)
         kernel_stack = list(kernel_stack)
-        line = [b.sym(addr, k.tgid).decode('utf-8', 'replace') for addr in
+        line = [b.sym(addr, k.tgid_pid).decode('utf-8', 'replace') for addr in
                 reversed(user_stack)] + \
                (do_delimiter and ["-"] or []) + \
                [b.ksym(addr).decode('utf-8', 'replace') for addr in

--- a/tools/iostack.py
+++ b/tools/iostack.py
@@ -152,5 +152,5 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
             print("    --")
         for addr in user_stack:
             print("    %s" % b.sym(addr, k.tgid_pid).decode('utf-8', 'replace'))
-        print("    %s [%d]" % (k.comm_name).decode('utf-8', 'replace'))
+        print("    %s" % (k.comm_name.decode('utf-8', 'replace')))
         print("        %d\n" % v.value)

--- a/tools/iostack.py
+++ b/tools/iostack.py
@@ -31,7 +31,8 @@ BPF_STACK_TRACE(stack_traces, 16384);
 
 int _generic_make_request(struct pt_regs *ctx, struct bio *bio) {
     struct disk_data_t data = {};
-    int dir = (bio)->bi_opf & REQ_OP_MASK;
+    int dir = op_is_write((bio)->bi_opf & REQ_OP_MASK) ? WRITE : READ;
+    
     u32 bi_size = bio->bi_iter.bi_size;
     
     struct gendisk *bio_disk = bio->bi_disk;
@@ -76,7 +77,7 @@ examples = """examples:
     ./iostack -U        # include user stacks
     ./iostack -K -f     # Output in folded format for flame graphs
     ./iostack -P        # Display stacks separately for each process
-    ./iostack -io r -K  # Trace only reads
+    ./iostack -K -io r  # Trace only reads
         """
 parser = argparse.ArgumentParser(
     description="Count events and their stack traces",

--- a/tools/iostack.py
+++ b/tools/iostack.py
@@ -45,7 +45,7 @@ int _generic_make_request(struct pt_regs *ctx, struct bio *bio) {
     data.user_stack_id = stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
 #endif
 
-#ifdef PERPID
+#ifdef PER_PID
     data.tgid_pid = bpf_get_current_pid_tgid() >> 32;
 #else 
     data.tgid_pid = 0xffffffff;

--- a/tools/iostack.py
+++ b/tools/iostack.py
@@ -1,0 +1,191 @@
+from bcc import BPF
+from time import sleep
+import argparse
+import signal
+import errno
+from sys import stderr
+
+# define BPF program
+bpf_text = """
+#include <linux/blkdev.h>
+#include <linux/blk_types.h>
+
+// define output data structure in C
+struct data_t {
+    char disk_name[DISK_NAME_LEN];
+    int kernel_stack_id;
+    int user_stack_id;
+    u64 tgid_pid;
+};
+BPF_PERF_OUTPUT(events);
+
+BPF_HASH(counts, struct data_t);
+BPF_STACK_TRACE(stack_traces, 16384);
+
+int _generic_make_request(struct pt_regs *ctx, struct bio *bio) {
+    struct data_t data = {};
+
+    struct gendisk *bio_disk = bio->bi_disk;
+        bpf_probe_read_kernel(&data.disk_name, sizeof(data.disk_name),
+                       bio_disk->disk_name);
+    data.kernel_stack_id = stack_traces.get_stackid(ctx, 0);
+#ifdef USER_STACKS
+    data.user_stack_id = stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
+    data.tgid_pid = bpf_get_current_pid_tgid();
+#endif
+    counts.increment(data);
+    
+    events.perf_submit(ctx, &data, sizeof(data));
+    return 0;
+}
+"""
+
+examples = """examples:
+    ./stackcount submit_bio         # count kernel stack traces for submit_bio
+    ./stackcount -d ip_output       # include a user/kernel stack delimiter
+    ./stackcount -s ip_output       # show symbol offsets
+    ./stackcount -sv ip_output      # show offsets and raw addresses (verbose)
+    ./stackcount 'tcp_send*'        # count stacks for funcs matching tcp_send*
+    ./stackcount -r '^tcp_send.*'   # same as above, using regular expressions
+    ./stackcount -Ti 5 ip_output    # output every 5 seconds, with timestamps
+    ./stackcount -p 185 ip_output   # count ip_output stacks for PID 185 only
+    ./stackcount -c 1 put_prev_entity   # count put_prev_entity stacks for CPU 1 only
+    ./stackcount -p 185 c:malloc    # count stacks for malloc in PID 185
+    ./stackcount t:sched:sched_fork # count stacks for sched_fork tracepoint
+    ./stackcount -p 185 u:node:*    # count stacks for all USDT probes in node
+    ./stackcount -K t:sched:sched_switch   # kernel stacks only
+    ./stackcount -U t:sched:sched_switch   # user stacks only
+        """
+parser = argparse.ArgumentParser(
+    description="Count events and their stack traces",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("-p", "--pid", type=int,
+                    help="trace this PID only")
+parser.add_argument("-c", "--cpu", type=int,
+                    help="trace this CPU only")
+parser.add_argument("-i", "--interval",
+                    help="summary interval, seconds")
+parser.add_argument("-D", "--duration",
+                    help="total duration of trace, seconds")
+parser.add_argument("-T", "--timestamp", action="store_true",
+                    help="include timestamp on output")
+parser.add_argument("-r", "--regexp", action="store_true",
+                    help="use regular expressions. Default is \"*\" wildcards only.")
+parser.add_argument("-s", "--offset", action="store_true",
+                    help="show address offsets")
+parser.add_argument("-P", "--perpid", action="store_true",
+                    help="display stacks separately for each process")
+parser.add_argument("-K", "--kernel-stacks",
+                    action="store_true", help="kernel stack only", default=True)
+parser.add_argument("-U", "--user-stacks",
+                    action="store_true", help="user stack only", default=False)
+parser.add_argument("-v", "--verbose", action="store_true",
+                    help="show raw addresses")
+parser.add_argument("-f", "--folded", action="store_true",
+                    help="output folded format")
+parser.add_argument("--debug", action="store_true",
+                    help="print BPF program before starting (for debugging purposes)")
+
+args = parser.parse_args()
+
+folded = True
+need_delimiter = True
+user_stack = False
+kernel_stack = True
+if user_stack:
+    bpf_text = "#define USER_STACKS\n" + bpf_text
+if kernel_stack:
+    bpf_text = "#define KERNEL_STACKS\n" + bpf_text
+
+# load BPF program
+b = BPF(text=bpf_text)
+b.attach_kprobe(event="generic_make_request", fn_name="_generic_make_request")
+matched = b.num_open_kprobes()
+if matched == 0:
+    print("error: 0 functions traced. Exiting.", file=stderr)
+    exit(1)
+
+# signal handler
+def signal_ignore(signal, frame):
+    print()
+
+try:
+    sleep(99999999)
+except KeyboardInterrupt:
+    # as cleanup can take many seconds, trap Ctrl-C:
+    signal.signal(signal.SIGINT, signal_ignore)
+
+
+# print folded stack output
+def print_folded_stack(disk_name, kernel_stack, user_stack=[],
+                       need_delimiter=False):
+    user_stack = list(user_stack)
+    kernel_stack = list(kernel_stack)
+    line = [b.sym(addr, k.tgid_pid).decode('utf-8', 'replace') for addr in
+            reversed(user_stack)] + \
+           (need_delimiter and ["-"] or []) + \
+           [b.ksym(addr).decode('utf-8', 'replace') for addr in
+            reversed(kernel_stack)] + \
+           [disk_name.decode('utf-8', 'replace')]
+    print("%s %d" % (";".join(line), v.value))
+
+counts = b.get_table("counts")
+stack_traces = b.get_table("stack_traces")
+
+for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
+    # disk_name = k.disk_name
+    #
+    # user_stack = [] if k.user_stack_id < 0 else \
+    #     stack_traces.walk(k.user_stack_id)
+    #
+    # kernel_stack = [] if k.kernel_stack_id < 0 else \
+    #     stack_traces.walk(k.kernel_stack_id)
+    #
+    # if folded:
+    #     print_folded_stack(disk_name, kernel_stack, user_stack, need_delimiter)
+    # else:
+    #
+    #     print("disk %s" % k.disk_name.decode('utf-8'))
+    #     for addr in kernel_stack:
+    #         print("    %s" % b.ksym(addr).decode('utf-8'))
+    #     if need_delimiter:
+    #         print("    --")
+    #     for addr in user_stack:
+    #         print("    %s" % b.sym(addr, k.tgid_pid))
+    #
+    user_stack = []
+
+    if args.user_stacks and k.user_stack_id > 0:
+        user_stack = stack_traces.walk(k.user_stack_id)
+
+    kernel_stack = []
+    if args.kernel_stacks and k.kernel_stack_id > 0:
+        kernel_tmp = stack_traces.walk(k.kernel_stack_id)
+
+        # fix kernel stack
+        for addr in kernel_tmp:
+            kernel_stack.append(addr)
+
+    do_delimiter = user_stack and kernel_stack
+
+    if args.folded:
+        # print folded stack output
+        user_stack = list(user_stack)
+        kernel_stack = list(kernel_stack)
+        line = [b.sym(addr, k.tgid).decode('utf-8', 'replace') for addr in
+                reversed(user_stack)] + \
+               (do_delimiter and ["-"] or []) + \
+               [b.ksym(addr).decode('utf-8', 'replace') for addr in
+                reversed(kernel_stack)] + \
+               [k.disk_name.decode('utf-8', 'replace')]
+        print("%s %d" % (";".join(line), v.value))
+    else:
+        print("disk %s" % k.disk_name.decode('utf-8', 'replace'))
+        # print default multi-line stack output.
+        for addr in kernel_stack:
+            print("    %s" % b.ksym(addr).decode('utf-8', 'replace'))
+        for addr in user_stack:
+            print("    %s" % b.sym(addr, k.tgid_pid).decode('utf-8', 'replace'))
+
+        print("        %d\n" % v.value)

--- a/tools/iostack.py
+++ b/tools/iostack.py
@@ -1,8 +1,9 @@
+#!/usr/bin/python
+
 from bcc import BPF
 from time import sleep
 import argparse
 import signal
-import errno
 from sys import stderr
 
 # define BPF program
@@ -17,7 +18,6 @@ struct data_t {
     int user_stack_id;
     u64 tgid_pid;
 };
-BPF_PERF_OUTPUT(events);
 
 BPF_HASH(counts, struct data_t);
 BPF_STACK_TRACE(stack_traces, 16384);
@@ -26,16 +26,18 @@ int _generic_make_request(struct pt_regs *ctx, struct bio *bio) {
     struct data_t data = {};
 
     struct gendisk *bio_disk = bio->bi_disk;
-        bpf_probe_read_kernel(&data.disk_name, sizeof(data.disk_name),
+    bpf_probe_read_kernel(&data.disk_name, sizeof(data.disk_name),
                        bio_disk->disk_name);
+#ifdef KERNEL_STACK
     data.kernel_stack_id = stack_traces.get_stackid(ctx, 0);
-#ifdef USER_STACKS
+#endif
+#ifdef USER_STACK
     data.user_stack_id = stack_traces.get_stackid(ctx, BPF_F_USER_STACK);
     data.tgid_pid = bpf_get_current_pid_tgid();
 #endif
-    counts.increment(data);
-    
-    events.perf_submit(ctx, &data, sizeof(data));
+
+    counts.increment(data, bio->bi_iter.bi_size);
+
     return 0;
 }
 """
@@ -62,26 +64,14 @@ parser = argparse.ArgumentParser(
     epilog=examples)
 parser.add_argument("-p", "--pid", type=int,
                     help="trace this PID only")
-parser.add_argument("-c", "--cpu", type=int,
-                    help="trace this CPU only")
 parser.add_argument("-i", "--interval",
                     help="summary interval, seconds")
 parser.add_argument("-D", "--duration",
                     help="total duration of trace, seconds")
-parser.add_argument("-T", "--timestamp", action="store_true",
-                    help="include timestamp on output")
-parser.add_argument("-r", "--regexp", action="store_true",
-                    help="use regular expressions. Default is \"*\" wildcards only.")
-parser.add_argument("-s", "--offset", action="store_true",
-                    help="show address offsets")
-parser.add_argument("-P", "--perpid", action="store_true",
-                    help="display stacks separately for each process")
-parser.add_argument("-K", "--kernel-stacks",
-                    action="store_true", help="kernel stack only", default=True)
-parser.add_argument("-U", "--user-stacks",
-                    action="store_true", help="user stack only", default=False)
-parser.add_argument("-v", "--verbose", action="store_true",
-                    help="show raw addresses")
+parser.add_argument("-K", "--kernel-stack",
+                    action="store_true", help="kernel stack only")
+parser.add_argument("-U", "--user-stack",
+                    action="store_true", help="user stack only")
 parser.add_argument("-f", "--folded", action="store_true",
                     help="output folded format")
 parser.add_argument("--debug", action="store_true",
@@ -90,13 +80,11 @@ parser.add_argument("--debug", action="store_true",
 args = parser.parse_args()
 
 folded = True
-need_delimiter = True
-user_stack = False
-kernel_stack = True
-if user_stack:
-    bpf_text = "#define USER_STACKS\n" + bpf_text
-if kernel_stack:
-    bpf_text = "#define KERNEL_STACKS\n" + bpf_text
+
+if args.user_stack:
+    bpf_text = "#define USER_STACK\n" + bpf_text
+if args.kernel_stack:
+    bpf_text = "#define KERNEL_STACK\n" + bpf_text
 
 # load BPF program
 b = BPF(text=bpf_text)
@@ -106,66 +94,37 @@ if matched == 0:
     print("error: 0 functions traced. Exiting.", file=stderr)
     exit(1)
 
+duration = int(args.duration)
+# header
+if not args.folded:
+    print("Tracing total io sizes (bytes) of %s by %s stack", end="")
+    if duration < 99999999:
+        print(" for %d secs." % duration)
+    else:
+        print("... Hit Ctrl-C to end.")
+
 # signal handler
 def signal_ignore(signal, frame):
     print()
 
 try:
-    sleep(99999999)
+    sleep(duration)
 except KeyboardInterrupt:
     # as cleanup can take many seconds, trap Ctrl-C:
     signal.signal(signal.SIGINT, signal_ignore)
-
-
-# print folded stack output
-def print_folded_stack(disk_name, kernel_stack, user_stack=[],
-                       need_delimiter=False):
-    user_stack = list(user_stack)
-    kernel_stack = list(kernel_stack)
-    line = [b.sym(addr, k.tgid_pid).decode('utf-8', 'replace') for addr in
-            reversed(user_stack)] + \
-           (need_delimiter and ["-"] or []) + \
-           [b.ksym(addr).decode('utf-8', 'replace') for addr in
-            reversed(kernel_stack)] + \
-           [disk_name.decode('utf-8', 'replace')]
-    print("%s %d" % (";".join(line), v.value))
 
 counts = b.get_table("counts")
 stack_traces = b.get_table("stack_traces")
 
 for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
-    # disk_name = k.disk_name
-    #
-    # user_stack = [] if k.user_stack_id < 0 else \
-    #     stack_traces.walk(k.user_stack_id)
-    #
-    # kernel_stack = [] if k.kernel_stack_id < 0 else \
-    #     stack_traces.walk(k.kernel_stack_id)
-    #
-    # if folded:
-    #     print_folded_stack(disk_name, kernel_stack, user_stack, need_delimiter)
-    # else:
-    #
-    #     print("disk %s" % k.disk_name.decode('utf-8'))
-    #     for addr in kernel_stack:
-    #         print("    %s" % b.ksym(addr).decode('utf-8'))
-    #     if need_delimiter:
-    #         print("    --")
-    #     for addr in user_stack:
-    #         print("    %s" % b.sym(addr, k.tgid_pid))
-    #
     user_stack = []
 
-    if args.user_stacks and k.user_stack_id > 0:
+    if args.user_stack and k.user_stack_id > 0:
         user_stack = stack_traces.walk(k.user_stack_id)
 
     kernel_stack = []
-    if args.kernel_stacks and k.kernel_stack_id > 0:
-        kernel_tmp = stack_traces.walk(k.kernel_stack_id)
-
-        # fix kernel stack
-        for addr in kernel_tmp:
-            kernel_stack.append(addr)
+    if args.kernel_stack and k.kernel_stack_id > 0:
+        kernel_stack = stack_traces.walk(k.kernel_stack_id)
 
     do_delimiter = user_stack and kernel_stack
 
@@ -185,6 +144,8 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
         # print default multi-line stack output.
         for addr in kernel_stack:
             print("    %s" % b.ksym(addr).decode('utf-8', 'replace'))
+        if do_delimiter:
+            print("    --")
         for addr in user_stack:
             print("    %s" % b.sym(addr, k.tgid_pid).decode('utf-8', 'replace'))
 

--- a/tools/iostack.py
+++ b/tools/iostack.py
@@ -79,7 +79,7 @@ examples = """examples:
     ./iostack -K -io r  # Trace only reads
         """
 parser = argparse.ArgumentParser(
-    description="Count events and their stack traces",
+    description="Count io sizes and their stack traces to block devices",
     formatter_class=argparse.RawDescriptionHelpFormatter,
     epilog=examples)
 

--- a/tools/iostack.py
+++ b/tools/iostack.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 from bcc import BPF
 from time import sleep
 import argparse

--- a/tools/iostack_example.txt
+++ b/tools/iostack_example.txt
@@ -1,0 +1,583 @@
+Demonstrations of iostack, the Linux eBPF/bcc version.
+
+
+This program traces io to block devices counts their sizes with their entire
+stack trace, summarized in-kernel for efficiency. For example, total io
+issued to all  block devices:
+# ./iostack.py
+Tracing io (bytes) to block devices... Hit Ctrl-C to end.
+^Cdisk sdc
+        md1_raid1
+        R: 0, W: 1024
+
+disk sdb
+        md1_raid1
+        R: 0, W: 1024
+
+disk sdd
+        md1_raid1
+        R: 0, W: 1024
+
+disk sdb
+        mdadm
+        R: 24576, W: 0
+
+disk sdd
+        systemd-udevd
+        R: 380928, W: 0
+
+disk dm-0
+        kworker/u8:2
+        R: 0, W: 581632
+
+disk sda
+        kworker/u8:2
+        R: 0, W: 581632
+
+disk sdc
+        systemd-udevd
+        R: 1048576, W: 0
+
+disk sdb
+        systemd-udevd
+        R: 1794048, W: 0
+
+disk md1
+        systemd-udevd
+        R: 3223552, W: 0
+
+disk sdc
+        fio
+        R: 0, W: 838860800
+
+disk md1
+        fio
+        R: 0, W: 838860800
+
+disk sdb
+        fio
+        R: 0, W: 838860800
+
+disk sdd
+        fio
+        R: 0, W: 838860800
+
+This showed the io byte counts to all the devices while the main workload was
+performed by fio with 16 KiB random write in 8 io threads with iodepth 32 to
+Linux mdraid level=1 created over 3 devices. The total io size of each device in raid
+equals to the size of io issued to the raid since it is level 1. Also, some udev
+activity could be seen here.
+
+Now adding -K option to see the kernel stack traces (i.e. datapath here) for each
+block device:
+# ./iostack.py -K
+Tracing io (bytes) to block devices... Hit Ctrl-C to end.
+^Cdisk sdc
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 1024
+
+disk sde
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 1024
+
+disk sdd
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 1024
+
+disk sdb
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 1024
+
+//// udev ios are removed for short
+
+disk sde
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 407093248, W: 416231424
+
+disk sdb
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 407719936, W: 415830016
+
+disk sdd
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 407404544, W: 416198656
+
+disk sdc
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 407535616, W: 416112640
+
+disk md5
+    generic_make_request
+    blkdev_direct_IO
+    generic_file_direct_write
+    __generic_file_write_iter
+    blkdev_write_iter
+    aio_write
+    io_submit_one
+    __x64_sys_io_submit
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        fio
+        R: 0, W: 838860800
+The example is more complex. It shows the same fio pattern with 16 KiB
+random write in 8 io threads with iodepth 32. But this time it is Linux mdraid
+level 5 so we can see that read and write io size counts are different on raid
+block devicesand underlying devices due to RMW for parity updates. And we can
+distinguish that io to raid block device are submitted from fio whereas to
+underlying devices they come from mdraid threads.
+
+One can add -U flag to add user-level traces, but usually, there are a lot of
+"[unknown]" there. Since in most cases applications are compiled without frame pointers.
+"It's a common compiler optimization, but it breaks frame pointer-based stack
+walkers. Similar broken stacks will be seen by other profilers and debuggers
+that use frame pointers. Hopefully your application preserves them so that
+the user-level stack trace is visible. So how does one get frame pointers, if
+your application doesn't have them to start with? For the current bcc (until
+it supports other stack walkers), you need to be running an application binaries
+that preserves frame pointers, eg, using gcc's -fno-omit-frame-pointer. That's
+about all I'll say here: this is a big topic that is not bcc/BPF specific." (Brendan Gregg)
+
+In the next example, I add -P flag to trace io per process and run fio with numjobs=2,
+also limit the duration of tracing by 10 sec with -D 10 flag.
+
+# ./iostack.py -K -P -D 10
+Tracing io (bytes) to block devices for 10 secs.
+disk sdd
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5 [29410]
+        R: 0, W: 1024
+
+disk sde
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5 [29410]
+        R: 0, W: 1024
+
+disk sdb
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5 [29410]
+        R: 0, W: 1024
+
+disk sdc
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5 [29410]
+        R: 0, W: 1024
+
+disk sdb
+    generic_make_request
+    __blkdev_direct_IO_simple
+    generic_file_read_iter
+    new_sync_read
+    vfs_read
+    ksys_read
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        mdadm [29632]
+        R: 4096, W: 0
+
+disk sdb
+    generic_make_request
+    __blkdev_direct_IO_simple
+    generic_file_read_iter
+    new_sync_read
+    vfs_read
+    ksys_read
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        mdadm [29626]
+        R: 4096, W: 0
+
+disk sdb
+    generic_make_request
+    __blkdev_direct_IO_simple
+    generic_file_read_iter
+    new_sync_read
+    vfs_read
+    ksys_read
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        mdadm [29620]
+        R: 4096, W: 0
+
+disk sdb
+    generic_make_request
+    __blkdev_direct_IO_simple
+    generic_file_read_iter
+    new_sync_read
+    vfs_read
+    ksys_read
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        mdadm [29630]
+        R: 4096, W: 0
+
+disk sdb
+    generic_make_request
+    __blkdev_direct_IO_simple
+    generic_file_read_iter
+    new_sync_read
+    vfs_read
+    ksys_read
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        mdadm [29628]
+        R: 4096, W: 0
+
+disk sdb
+    generic_make_request
+    __blkdev_direct_IO_simple
+    generic_file_read_iter
+    new_sync_read
+    vfs_read
+    ksys_read
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        mdadm [29624]
+        R: 4096, W: 0
+
+disk sdb
+    generic_make_request
+    __blkdev_direct_IO_simple
+    generic_file_read_iter
+    new_sync_read
+    vfs_read
+    ksys_read
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        mdadm [29636]
+        R: 4096, W: 0
+
+disk sdb
+    generic_make_request
+    __blkdev_direct_IO_simple
+    generic_file_read_iter
+    new_sync_read
+    vfs_read
+    ksys_read
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        mdadm [29634]
+        R: 4096, W: 0
+
+//// udev is removed from output
+
+disk md5
+    generic_make_request
+    blkdev_direct_IO
+    generic_file_direct_write
+    __generic_file_write_iter
+    blkdev_write_iter
+    aio_write
+    io_submit_one
+    __x64_sys_io_submit
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        fio [29622]
+        R: 0, W: 104857600
+
+disk md5
+    generic_make_request
+    blkdev_direct_IO
+    generic_file_direct_write
+    __generic_file_write_iter
+    blkdev_write_iter
+    aio_write
+    io_submit_one
+    __x64_sys_io_submit
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        fio [29621]
+        R: 0, W: 104857600
+
+disk sdd
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5 [29410]
+        R: 98938880, W: 103481344
+
+disk sdb
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5 [29410]
+        R: 99295232, W: 103256064
+
+disk sdc
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5 [29410]
+        R: 99438592, W: 103170048
+
+disk sde
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5 [29410]
+        R: 99168256, W: 103473152
+We can see both fio threads PID submitting io to mdraid block device whereas
+io to underlying devices are still comes from mdraid threads.
+
+
+We can define which types of io (reads, writes, or both) should be counted by
+using the flag -io with possible values of "r", "w" or "rw" which is the default.
+It could be useful for researching the SSD endurance and counting
+drive writes per day (DWPD).
+
+# ./iostack.py -K -D 86400 -io w
+Tracing io (bytes) to block devices for 86400 secs.
+^Cdisk sde
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 1024
+
+disk sdc
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 1024
+
+disk sdb
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 1024
+
+disk sdd
+    generic_make_request
+    md_update_sb.part.0
+    md_check_recovery
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 1024
+
+disk sdc
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 103280640
+
+disk sdb
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 103350272
+
+disk sde
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 103460864
+
+disk sdd
+    generic_make_request
+    ops_run_io
+    handle_stripe
+    handle_active_stripes.constprop.0
+    raid5d
+    md_thread
+    kthread
+    ret_from_fork
+        md5_raid5
+        R: 0, W: 103546880
+
+disk md5
+    generic_make_request
+    blkdev_direct_IO
+    generic_file_direct_write
+    __generic_file_write_iter
+    blkdev_write_iter
+    aio_write
+    io_submit_one
+    __x64_sys_io_submit
+    do_syscall_64
+    entry_SYSCALL_64_after_hwframe
+        fio
+        R: 0, W: 209715200
+In this example I Ctrl+C earlier than a day run.
+
+The -f option will emit folded output, which can be used as input to other
+tools including flame graphs. In this example, I run tracing of fio randwrite
+workload run to multiple files of mounted xfs created over lvm on raid5:
+
+# ./iostack.py -K -f > stack
+^C
+I found the most informative flame graph created in reverse order since this way we
+summarize io per device and see the datapath from processes.
+# flamegraph.pl --reverse stack  --countname "bytes" > out.svg
+
+In other cases, it may be  useful to see from the processes perspective
+# flamegraph.pl stack  --countname "bytes" > out.svg
+
+Flame graphs visualize stack traces. For information about them and links
+to open source software, see http://www.brendangregg.com/flamegraphs.html .
+This folded output can be piped directly into flamegraph.pl (the Perl version).
+
+
+USAGE message:
+
+# ./iostack.py -h
+usage: iostack.py [-h] [-D DURATION] [-K] [-U] [-f] [-P] [-io {r,w,rw}]
+
+Count io sizes and their stack traces to block devices
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -D DURATION, --duration DURATION
+                        total duration of trace, seconds
+  -K, --kernel-stack    kernel stack only
+  -U, --user-stack      user stack only
+  -f, --folded          output folded format
+  -P, --perpid          display stacks separately for each process
+  -io {r,w,rw}, --iodir {r,w,rw}
+                        io dir to trace
+
+examples:
+    ./iostack           # count bytes read or written by processes for all devices
+    ./iostack -D 5      # trace only for 5 seconds
+    ./iostack -K        # include kernel stacks
+    ./iostack -U        # include user stacks
+    ./iostack -K -f     # Output in folded format for flame graphs
+    ./iostack -P        # Display stacks separately for each process
+    ./iostack -K -io r  # Trace only reads


### PR DESCRIPTION
Hi everyone, I am new to bcc. Recently I used it to create a tool like other bcc/tools, that helps me analyze the performance, load balancing, and datapath within our custom SW raid system. And I think of maybe merging my work into main bcc tree. Since it may be useful for anyone who analyzes io subsystems: raids, VM, individual devices. This tool is different from other like disksnoop, stackcount and bitesize (most similar ones) because it focuses on the block devices, rather than processes, store stack traces to analyze the hottest datapathes, count total io sizes to measure device endurance and io balancing. For me initially, it started as a tool to investigate RAID read-modify-write parity updates costs.

Besides this tool works on the most generic kernel block layer function `generic_make_request` not the blk_account_io_start or _done or similar so that it makes it possible to track io to any kind of block devices: bio- based, single queue req-based, mq.

Additionally, I implemented io size counting in thread-safe manner so we do not lose any io information with multithreaded workloads. I performed testing by fio and Linux mdraid, lvm xfs, and different types of block devices and queue types: null_blk with different queue_mode parameter, SSD, NVMe drives.
Also, flamegraphs are beautiful and informative for analysis with this tool.

Please let me know if it is not "on the level" to be in iovisor tools and what possible improvements should I do.
