### PR TITLE
Introduce task detector

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -8,3 +8,4 @@
 /syscount
 /vfsstat
 /xfsslower
+/task_detector

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -19,6 +19,7 @@ APPS = \
 	syscount \
 	vfsstat \
 	xfsslower \
+	task_detector \
 	#
 
 COMMON_OBJ = \

--- a/libbpf-tools/task_detector.bpf.c
+++ b/libbpf-tools/task_detector.bpf.c
@@ -1,7 +1,5 @@
 // SPDX-Licence-Identifier: GPL-2.0
-// Copyright (c) 2020 Wenhao Qu
-//
-// Based on task_detector by Yun Wang
+// Copyright (c) 2020 Alibaba Cloud
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 #include "task_detector.h"

--- a/libbpf-tools/task_detector.bpf.c
+++ b/libbpf-tools/task_detector.bpf.c
@@ -1,0 +1,266 @@
+// SPDX-Licence-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenhao Qu
+//
+// Based on task_detector by Yun Wang
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include "task_detector.h"
+
+#define DEBUG_ON 0
+#define TASK_RUNNING 0x0000
+#define TASK_REPORT_MAX 0x0100
+
+struct{
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct user_info);
+} user_info_maps SEC(".maps");
+
+struct{
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, NR_ENTRY_MAX);
+	__type(key, int);
+	__type(value, struct trace_info);
+} trace_info_maps SEC(".maps");
+
+struct{
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, NR_ENTRY_MAX);
+	__type(key, struct si_key);
+	__type(value, u64);
+} syscall_info_maps SEC(".maps");
+
+struct{
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, int);
+} start_maps SEC(".maps");
+
+struct{
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, int);
+} end_maps SEC(".maps");
+
+struct{
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, int);
+} trace_on_maps SEC(".maps");
+
+static inline void *get_user_info(void)
+{
+	int key = 0;
+
+	return bpf_map_lookup_elem(&user_info_maps, &key);
+}
+
+static inline void set_trace_on(int cpu)
+{
+	int key = 0;
+	int *trace_on = bpf_map_lookup_elem(&trace_on_maps, &key);
+
+	if (trace_on)
+		*trace_on = cpu + 1;
+}
+
+static inline void set_trace_off(void)
+{
+	int key = 0;
+	int *trace_on = bpf_map_lookup_elem(&trace_on_maps, &key);
+
+	if (trace_on)
+		*trace_on = 0;
+}
+
+static inline int should_trace(int cpu)
+{
+	int key = 0;
+	int *trace_on = bpf_map_lookup_elem(&trace_on_maps, &key);
+
+	return (trace_on && *trace_on == cpu + 1);
+}
+
+static inline void *get_trace(int key)
+{
+	return bpf_map_lookup_elem(&trace_info_maps, &key);
+}
+
+static inline void add_trace(struct trace_info ti)
+{
+	int orig_end, key = 0;
+	struct trace_info *tip;
+	int *start, *end;
+
+	start = bpf_map_lookup_elem(&start_maps, &key);
+	end = bpf_map_lookup_elem(&end_maps, &key);
+
+	if (!start || !end)
+		return;
+
+	orig_end = *end;
+	*end = (*end + 1);
+
+	if (*end == NR_ENTRY_MAX)
+		*end = 0;
+
+	if (*end == *start)
+		return;
+
+	//tip = get_trace(orig_end);
+	//if (!tip) {
+	//	*end = orig_end;
+	//	return;
+	//}
+
+	//memcpy(tip, &ti, sizeof(ti));
+	ti.ts = bpf_ktime_get_ns();
+
+	if (ti.type == TYPE_SYSCALL_ENTER ||
+	    ti.type == TYPE_SYSCALL_EXIT ||
+	    ti.type == TYPE_WAIT ||
+	    ti.type == TYPE_DEQUEUE)
+		bpf_get_current_comm(&ti.comm, sizeof(ti.comm));
+	bpf_map_update_elem(&trace_info_maps, &orig_end, &ti, 0);
+}
+
+SEC("tp_btf/sched_process_exit")
+int handle__sched_process_exit(u64 *ctx)
+{
+	struct task_struct *p = (void *)ctx[0];
+	struct user_info *ui = get_user_info();
+
+	if (ui && ui->pid && ui->pid == p->pid)
+		ui->exit = 1;
+
+	return 0;
+}
+
+SEC("tp_btf/sched_migrate_task")
+int handle__sched_migrate_task(u64 *ctx)
+{
+	struct task_struct *p = (void *) ctx[0];
+	int dest_cpu = (int) ctx[1];
+	struct trace_info ti = {
+		.cpu = dest_cpu,
+		.pid = p->pid,
+		.type = TYPE_MIGRATE,
+	};
+	struct user_info *ui = get_user_info();
+
+	if (!ui || !ui->pid || ui->pid != p->pid)
+		return 0;
+
+	set_trace_on(dest_cpu);
+
+	add_trace(ti);
+
+	return 0;
+}
+
+SEC("tp_btf/sched_wakeup")
+int handle__sched_wakeup(u64 *ctx)
+{
+	struct task_struct *p = (void *) ctx[0];
+	//int target_cpu = task_cpu(p);
+	struct trace_info ti = {
+		.cpu = p->wake_cpu,
+		.pid = p->pid,
+		.type = TYPE_ENQUEUE,
+	};
+	struct user_info *ui = get_user_info();
+
+	if (!ui || !ui->pid || ui->pid != p->pid)
+		return 0;
+
+	set_trace_on(p->wake_cpu);
+
+	add_trace(ti);
+
+	return 0;
+}
+
+SEC("tp_btf/sched_switch")
+int handle__sched_switch(u64 *ctx)
+{
+	struct task_struct *prev = (void *) ctx[1];
+	struct task_struct *next = (void *) ctx[2];
+	struct trace_info ti = {
+		.cpu = bpf_get_smp_processor_id(),
+	}, *tip;
+	struct user_info *ui = get_user_info();
+
+	if (!ui || !ui->pid)
+		return 0;
+
+	if (!should_trace(ti.cpu)) {
+		if (ui->pid != prev->pid &&
+		    ui->pid != next->pid)
+			return 0;
+
+		set_trace_on(ti.cpu);
+
+		ti.pid = ui->pid;
+		ti.type = TYPE_MIGRATE;
+		add_trace(ti);
+	}
+
+	if (prev->state != TASK_RUNNING &&
+	    prev->state != TASK_REPORT_MAX) {
+		if (ui->pid == prev->pid)
+			set_trace_off();
+		ti.type = TYPE_DEQUEUE;
+	} else
+		ti.type = TYPE_WAIT;
+	ti.pid = prev->pid;
+	add_trace(ti);
+
+	if (!should_trace(ti.cpu))
+		return 0;
+
+	ti.type = TYPE_EXECUTE;
+	ti.pid = next->pid,
+	add_trace(ti);
+
+	return 0;
+}
+
+SEC("tracepoint/raw_syscalls/sys_enter")
+int bpf_trace_sys_enter(struct trace_event_raw_sys_enter *args)
+{
+	struct trace_info ti = {
+		.cpu = bpf_get_smp_processor_id(),
+		.pid = bpf_get_current_pid_tgid(),
+		.type = TYPE_SYSCALL_ENTER,
+		.syscall = args->id,
+	}, *tip;
+	struct user_info *ui = get_user_info();
+
+	if (args->id && ui && ui->trace_syscall && should_trace(ti.cpu))
+		add_trace(ti);
+
+	return 0;
+}
+
+SEC("tracepoint/raw_syscalls/sys_exit")
+int bpf_trace_sys_exit(struct trace_event_raw_sys_exit *args)
+{
+	struct trace_info ti = {
+		.cpu = bpf_get_smp_processor_id(),
+		.pid = bpf_get_current_pid_tgid(),
+		.type = TYPE_SYSCALL_EXIT,
+		.syscall = args->id,
+	}, *tip;
+	struct user_info *ui = get_user_info();
+
+	if (args->id && ui && ui->trace_syscall && should_trace(ti.cpu))
+		add_trace(ti);
+
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/libbpf-tools/task_detector.c
+++ b/libbpf-tools/task_detector.c
@@ -1,7 +1,12 @@
 // SPDX-Licence-Identifier: GPL-2.0
-// Copyright (c) 2020 Wenhao Qu
+// Copyright (c) 2020 Alibaba Cloud
 //
-// Based on task_detector by Yun Wang
+// Based on task_detector by Michael Wang
+// Created by Wenhao Qu
+//
+// Maintainers:
+// Michael Wang <yun.wang@linux.alibaba.com>
+// Wenhao Qu <quxi.qwh@alibaba-inc.com>
 #include <argp.h>
 #include <stdio.h>
 #include <signal.h>
@@ -24,15 +29,15 @@
 #include "task_detector.skel.h"
 
 const char *argp_program_version = "task_detector 0.1";
-const char *argp_program_bug_address = "<yun.wang@xxxxxxxxxxxxxxxxx>";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 static const char argp_program_doc[] =
 "Trace the related schedule events of a specified task.\n"
 "\n"
 "USAGE: task_detector -p PID [-s]\n"
 "\n"
 "EXAMPLES:\n"
-"    runqslower -p 49870       	# trace pid 49870\n"
-"    runqslower -p 49870 -s    	# trace pid 49870 and system call\n";
+"    task_detector -p 49870       	# trace pid 49870\n"
+"    task_detector -p 49870 -s    	# trace pid 49870 and system call\n";
 
 static const struct argp_option opts[] = {
 	{ "pid", 'p', "PID", 0, "Process PID to trace"},

--- a/libbpf-tools/task_detector.c
+++ b/libbpf-tools/task_detector.c
@@ -1,0 +1,371 @@
+// SPDX-Licence-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenhao Qu
+//
+// Based on task_detector by Yun Wang
+#include <argp.h>
+#include <stdio.h>
+#include <signal.h>
+#include <sched.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <locale.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <dirent.h>
+#include <bpf/bpf.h>
+#include "errno_helpers.h"
+#include "trace_helpers.h"
+#include "syscall_helpers.h"
+#include "task_detector.h"
+#include "task_detector.skel.h"
+
+const char *argp_program_version = "task_detector 0.1";
+const char *argp_program_bug_address = "<yun.wang@xxxxxxxxxxxxxxxxx>";
+static const char argp_program_doc[] =
+"Trace the related schedule events of a specified task.\n"
+"\n"
+"USAGE: task_detector -p PID [-s]\n"
+"\n"
+"EXAMPLES:\n"
+"    runqslower -p 49870       	# trace pid 49870\n"
+"    runqslower -p 49870 -s    	# trace pid 49870 and system call\n";
+
+static const struct argp_option opts[] = {
+	{ "pid", 'p', "PID", 0, "Process PID to trace"},
+	{ "syscall", 's', NULL, 0, "Trace SYSCALL Info"},
+	{},
+};
+
+static struct env {
+	int ui_map_fd;
+	int ti_map_fd;
+	int si_map_fd;
+	int start_map_fd;
+	int end_map_fd;
+	bool exiting;
+	int nr_cpus;
+	int trace_syscall;
+	int target;
+} env = {
+	.exiting = false,
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	int pid;
+	switch (key) {
+	case 'p':
+		if(arg == NULL) {
+			fprintf(stderr, "PID is required\n");
+			argp_usage(state);
+		} else {
+			pid = strtol(arg, NULL, 10);
+			if (pid <= 0) {
+				fprintf(stderr, "Invalid PID: %s\n", arg);
+				argp_usage(state);
+			}
+			env.target = pid;
+		}
+		break;
+	case 's':
+		env.trace_syscall = 1;
+		break;
+	case ARGP_KEY_END:
+		if (!env.target) {
+			fprintf(stderr, "No target PID\n");
+			argp_usage(state);
+		}
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+
+static inline int get_comm(int pid, char comm[])
+{
+	int fd, ret = 1;
+	char path_buf[512];
+
+	comm[0] = '\0';
+
+	if (!pid) {
+		strcpy(comm, "IDLE");
+		return 0;
+	}
+
+	snprintf(path_buf, sizeof(path_buf), "/proc/%d/comm", pid);
+	fd = open(path_buf, O_RDONLY);
+	if (fd) {
+		int cnt;
+
+		cnt = read(fd, comm, 16);
+		if (cnt > 0) {
+			comm[cnt - 1] = '\0';
+			ret = 0;
+		}
+	}
+	close(fd);
+	return ret;
+}
+
+static inline int time_to_str(u64 ns, char *buf, size_t len)
+{
+	u64 us = ns / 1000;
+	u64 ms = us / 1000;
+	u64 s = ms / 1000;
+
+	if (s > 10)
+		snprintf(buf, len, "%llus", s);
+	else if (ms > 10)
+		snprintf(buf, len, "%llums", ms);
+	else if (us > 10)
+		snprintf(buf, len, "%lluus", us);
+	else
+		snprintf(buf, len, "%lluns", ns);
+
+	return (s || ms > 10);
+}
+
+static inline void pr_ti(struct trace_info *ti, char *opt, char *delay)
+{
+	char comm[16];
+
+	if (get_comm(ti->pid, comm))
+		memcpy(comm, ti->comm, sizeof(comm));
+
+	printf("%-27lluCPU=%-7dPID=%-7dCOMM=%-20s%-37s%-17s\n",
+				ti->ts, ti->cpu, ti->pid, comm, opt,
+				delay ? delay : "");
+}
+
+static int print_trace_info(int start, int end)
+{
+	int key;
+	char d_str[16];
+	char comm_buf[2*TASK_COMM_LEN];
+	static u64 w_start, p_start;
+	static struct trace_info ti_last;
+
+	for (key = start; key != end; key = (key + 1) % NR_ENTRY_MAX) {
+		char func[80];
+		struct trace_info ti;
+		struct si_key sik;
+		u64 siv;
+
+		if (bpf_map_lookup_elem(env.ti_map_fd, &key, &ti))
+			continue;
+
+		time_to_str(ti.ts - ti_last.ts, d_str, sizeof(d_str));
+
+		switch (ti.type) {
+		case TYPE_MIGRATE:
+			w_start = p_start = ti.ts;
+			pr_ti(&ti, "MIGRATE", NULL);
+			break;
+		case TYPE_ENQUEUE:
+			w_start = p_start = ti.ts;
+			printf("----------------------------\n");
+			pr_ti(&ti, "ENQUEUE", NULL);
+			break;
+		case TYPE_WAIT:
+			if (ti.pid == env.target) {
+				w_start = ti.ts;
+				pr_ti(&ti, "WAIT AFTER EXECUTED", d_str);
+			} else {
+				time_to_str(ti.ts - p_start,
+						d_str, sizeof(d_str));
+				pr_ti(&ti, "PREEMPTED", d_str);
+			}
+			break;
+		case TYPE_EXECUTE:
+			if (ti.pid == env.target) {
+				time_to_str(ti.ts - w_start,
+						d_str, sizeof(d_str));
+				pr_ti(&ti, "EXECUTE AFTER WAITED", d_str);
+			} else {
+				p_start = ti.ts;
+				pr_ti(&ti, "PREEMPT", NULL);
+			}
+			break;
+		case TYPE_DEQUEUE:
+			if (ti.pid == env.target)
+				pr_ti(&ti, "DEQUEUE AFTER EXECUTED", d_str);
+			else {
+				time_to_str(ti.ts - p_start,
+						d_str, sizeof(d_str));
+				pr_ti(&ti, "DEQUEUE AFTER PREEMPTED", d_str);
+			}
+			break;
+		case TYPE_SYSCALL_ENTER:
+			siv = ti.ts;
+			sik.cpu = ti.cpu;
+			sik.pid = ti.pid;
+			sik.syscall = ti.syscall;
+			bpf_map_update_elem(env.si_map_fd, &sik, &siv, BPF_ANY);
+			syscall_name(ti.syscall, comm_buf, sizeof(comm_buf));
+			snprintf(func, sizeof(func), "SC [%d:%s] ENTER",
+					ti.syscall, comm_buf);
+			pr_ti(&ti, func, NULL);
+			break;
+		case TYPE_SYSCALL_EXIT:
+			sik.cpu = ti.cpu;
+			sik.pid = ti.pid;
+			sik.syscall = ti.syscall;
+			if (bpf_map_lookup_elem(env.si_map_fd, &sik, &siv))
+				break;
+			time_to_str(ti.ts - siv, d_str, sizeof(d_str));
+			bpf_map_delete_elem(env.si_map_fd, &sik);
+			syscall_name(ti.syscall, comm_buf, sizeof(comm_buf));
+			snprintf(func, sizeof(func), "SC [%d:%s] TAKE %s TO EXIT",
+					ti.syscall, comm_buf, d_str);
+			pr_ti(&ti, func, NULL);
+			break;
+		default:
+			break;
+		}
+
+		memcpy(&ti_last, &ti, sizeof(ti));
+	}
+
+	return end;
+}
+
+static int setup_user_info(int pid)
+{
+	int key = 0;
+	DIR *dir;
+	char buf[256];
+	struct user_info ui;
+	snprintf(buf, sizeof(buf), "/proc/%d", pid);
+	dir = opendir(buf);
+	if (!dir) {
+		printf("Open %s failed: %s\n", buf, strerror(errno));
+		return -1;
+	}
+	memset(&ui, 0, sizeof(ui));
+	ui.pid = pid;
+	ui.trace_syscall = env.trace_syscall;
+	bpf_map_update_elem(env.ui_map_fd, &key, &ui, BPF_ANY);
+
+	closedir(dir);
+
+	return 0;
+}
+
+static void int_exit(int sig)
+{
+	env.exiting = true;
+}
+
+int main(int argc, char **argv)
+{
+	struct task_detector_bpf *obj;
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	init_syscall_names();
+	
+	/* Check cpu number */
+	env.nr_cpus = sysconf(_SC_NPROCESSORS_CONF);
+	if (env.nr_cpus > NR_CPU_MAX) {
+		printf("Support Maximum %d cpus\n", NR_CPU_MAX);
+		goto freename;
+	}
+	
+	/* Increase rlimit */
+	err = bump_memlock_rlimit();
+	if (err) {
+		fprintf(stderr, "failed to increase rlimit: %d\n", err);
+		goto freename;
+	}
+	
+	/* Open bpf object */
+	obj = task_detector_bpf__open();
+	if(!obj){
+		fprintf(stderr, "failed to open and/or load BPF object\n");
+		goto freename;
+	}
+
+	/* Load bpf program */
+	err = task_detector_bpf__load(obj);
+	if(err){
+		fprintf(stderr, "failed to load BPF object: %d\n", err);
+		goto cleanup;
+	}
+	
+	/* Attach bpf program */
+	err = task_detector_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+
+	/* Setup global map fd */
+	env.ui_map_fd = bpf_map__fd(obj->maps.user_info_maps);
+	env.ti_map_fd = bpf_map__fd(obj->maps.trace_info_maps);
+	env.si_map_fd = bpf_map__fd(obj->maps.syscall_info_maps);
+	env.start_map_fd = bpf_map__fd(obj->maps.start_maps);
+	env.end_map_fd = bpf_map__fd(obj->maps.end_maps);
+
+	/* Setip user info */
+	if (setup_user_info(env.target)) {
+		printf("Illegal Target %d\n", env.target);
+		goto cleanup;
+	}
+	
+	signal(SIGINT, int_exit);
+	signal(SIGTERM, int_exit);
+
+	printf("Start tracing schedule events ");
+	if (env.trace_syscall)
+		printf("(include SYSCALL)");
+	printf("\nTarget task pid %d\n", env.target);
+	
+	/* main: print trace info */
+	while (1) {
+		if (env.exiting)
+			goto cleanup;
+		int key = 0, start = 0, end = 0;
+		struct user_info ui = {
+			.exit = 0,
+		};
+
+		bpf_map_lookup_elem(env.ui_map_fd, &key, &ui);
+		if (ui.exit) {
+			printf("Target \"%d\" Destroyed\n", env.target);
+			goto cleanup;
+		}
+
+		bpf_map_lookup_elem(env.start_map_fd, &key, &start);
+		bpf_map_lookup_elem(env.end_map_fd, &key, &end);
+		if (start == end) {
+			sleep(1);
+			continue;
+		}
+
+		start = print_trace_info(start, end);
+
+		bpf_map_update_elem(env.start_map_fd, &key, &start, BPF_ANY);
+	}
+
+cleanup:
+	task_detector_bpf__destroy(obj);
+freename:
+	free_syscall_names();
+	return err != 0;
+}

--- a/libbpf-tools/task_detector.h
+++ b/libbpf-tools/task_detector.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenhao Qu
+//
+// Based on task_detector by Yun Wang
+#ifndef TASK_DETECTOR_H
+#define TASK_DETECTOR_H
+
+#define NR_ENTRY_MAX		10000
+#define NR_CPU_MAX		512
+#define TASK_COMM_LEN		16
+
+typedef unsigned long long u64;
+typedef int pid_t;
+
+enum {
+	TYPE_MIGRATE,
+	TYPE_ENQUEUE,
+	TYPE_WAIT,
+	TYPE_EXECUTE,
+	TYPE_DEQUEUE,
+	TYPE_SYSCALL_ENTER,
+	TYPE_SYSCALL_EXIT,
+};
+
+struct user_info {
+	pid_t pid;
+	int exit;
+	int trace_syscall;
+};
+
+struct trace_info {
+	int type;
+	int cpu;
+	int syscall;
+	pid_t pid;
+	u64 ts;
+	char comm[16];
+};
+
+struct si_key {
+	int cpu;
+	int syscall;
+	pid_t pid;
+};
+#endif /* __TASK_DETECTOR_H */

--- a/libbpf-tools/task_detector.h
+++ b/libbpf-tools/task_detector.h
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
-// Copyright (c) 2020 Wenhao Qu
-//
-// Based on task_detector by Yun Wang
+// Copyright (c) 2020 Alibaba Cloud
 #ifndef TASK_DETECTOR_H
 #define TASK_DETECTOR_H
 

--- a/libbpf-tools/task_detector.md
+++ b/libbpf-tools/task_detector.md
@@ -1,0 +1,46 @@
+Task Detector
+------
+
+This is a tool to trace the related schedule events of a specified task, eg the migration, sched in/out, wakeup and sleep/block.
+
+The event was translated into sentence to be more readable, by execute command 'task_detector -p 24104' we continually tracing the schedule events related to 'top' like:
+
+```Shell
+# task_detector -p 24104
+Start tracing schedule events 
+Target task pid 24104
+----------------------------
+102770938643193            CPU=1      PID=24104  COMM=top                 ENQUEUE                                               
+102770938684071            CPU=1      PID=0      COMM=IDLE                PREEMPTED                            40us             
+102770938684854            CPU=1      PID=24104  COMM=top                 EXECUTE AFTER WAITED                 41us             
+102770949149591            CPU=1      PID=24104  COMM=top                 WAIT AFTER EXECUTED                  10464us          
+102770949149957            CPU=1      PID=24190  COMM=kworker/1:5-mm_     PREEMPT                                               
+102770949153368            CPU=1      PID=24190  COMM=kworker/1:5-mm_     DEQUEUE AFTER PREEMPTED              3411ns           
+102770949153470            CPU=1      PID=24104  COMM=top                 EXECUTE AFTER WAITED                 3879ns           
+102770949277377            CPU=1      PID=24104  COMM=top                 DEQUEUE AFTER EXECUTED               123us    
+----------------------------
+```
+
+This could be helpful on debugging the competition on CPU resource, to find out who has stolen the CPU and how much it stolen.
+
+It can also tracing the syscall by append options -s.
+
+```Shell
+Start tracing schedule events (include SYSCALL)
+Target task pid 24104
+----------------------------
+104043332442246            CPU=2      PID=24104  COMM=top                 ENQUEUE                                               
+104043332475329            CPU=2      PID=0      COMM=IDLE                PREEMPTED                            33us             
+104043332476101            CPU=2      PID=24104  COMM=top                 EXECUTE AFTER WAITED                 33us             
+104043332525807            CPU=2      PID=24104  COMM=top                 SC [257:openat] ENTER                                 
+104043332570577            CPU=2      PID=24104  COMM=top                 SC [257:openat] TAKE 44us TO EXIT                     
+104043332577193            CPU=2      PID=24104  COMM=top                 SC [5:fstat] ENTER                                    
+104043332582304            CPU=2      PID=24104  COMM=top                 SC [5:fstat] TAKE 5111ns TO EXIT                      
+104043332599968            CPU=2      PID=24104  COMM=top                 SC [3:close] ENTER                                    
+104043332602472            CPU=2      PID=24104  COMM=top                 SC [3:close] TAKE 2504ns TO EXIT                      
+104043332618210            CPU=2      PID=24104  COMM=top                 SC [8:lseek] ENTER                                    
+104043332624106            CPU=2      PID=24104  COMM=top                 SC [8:lseek] TAKE 5896ns TO EXIT                      
+104043332716699            CPU=2      PID=24104  COMM=top                 SC [257:openat] ENTER                                 
+104043332744398            CPU=2      PID=24104  COMM=top                 SC [257:openat] TAKE 27us TO EXIT                    
+...
+``` 


### PR DESCRIPTION
The task detector is first introduced on Mail-Archive by Michael Wang, which could trace the related schedule events of a specified task and be helpful on debugging the competition on CPU resource.

As Andrii suggested, now we have rewrite this tool based on libbpf and CO-RE.

We open this pull request to merge this task detector tool into BCC tools.