### PR TITLE
Fix KBUILD_MODNAME errors on newer kernels

### DIFF
--- a/examples/networking/xdp/xdp_drop_count.py
+++ b/examples/networking/xdp/xdp_drop_count.py
@@ -52,7 +52,6 @@ else:
 
 # load BPF program
 b = BPF(text = """
-#define KBUILD_MODNAME "foo"
 #include <uapi/linux/bpf.h>
 #include <linux/in.h>
 #include <linux/if_ether.h>

--- a/examples/networking/xdp/xdp_macswap_count.py
+++ b/examples/networking/xdp/xdp_macswap_count.py
@@ -50,7 +50,6 @@ else:
 
 # load BPF program
 b = BPF(text = """
-#define KBUILD_MODNAME "foo"
 #include <uapi/linux/bpf.h>
 #include <linux/in.h>
 #include <linux/if_ether.h>

--- a/examples/networking/xdp/xdp_redirect_cpu.py
+++ b/examples/networking/xdp/xdp_redirect_cpu.py
@@ -30,7 +30,6 @@ if (cpu_id > max_cpu):
 
 # load BPF program
 b = BPF(text = """
-#define KBUILD_MODNAME "foo"
 #include <uapi/linux/bpf.h>
 #include <linux/in.h>
 #include <linux/if_ether.h>

--- a/examples/networking/xdp/xdp_redirect_map.py
+++ b/examples/networking/xdp/xdp_redirect_map.py
@@ -29,7 +29,6 @@ out_idx = ip.link_lookup(ifname=out_if)[0]
 
 # load BPF program
 b = BPF(text = """
-#define KBUILD_MODNAME "foo"
 #include <uapi/linux/bpf.h>
 #include <linux/in.h>
 #include <linux/if_ether.h>

--- a/examples/tracing/nflatency.py
+++ b/examples/tracing/nflatency.py
@@ -12,7 +12,6 @@ import time
 from bcc import BPF
 
 BPF_SRC = """
-#define KBUILD_MODNAME "bpf_hook_nflatency"
 #include <linux/ip.h>
 #include <linux/ipv6.h>
 #include <linux/tcp.h>

--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -101,6 +101,7 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
   cflags->push_back("-D__HAVE_BUILTIN_BSWAP16__");
   cflags->push_back("-D__HAVE_BUILTIN_BSWAP32__");
   cflags->push_back("-D__HAVE_BUILTIN_BSWAP64__");
+  cflags->push_back("-DKBUILD_MODNAME=\"bcc\"");
 
   // If ARCH env variable is set, pass this along.
   if (archenv)

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -78,7 +78,6 @@ int count_foo(struct pt_regs *ctx, unsigned long a, unsigned long b) {
 
     def test_probe_read3(self):
         text = """
-#define KBUILD_MODNAME "foo"
 #include <net/tcp.h>
 #define _(P) ({typeof(P) val = 0; bpf_probe_read_kernel(&val, sizeof(val), &P); val;})
 int count_tcp(struct pt_regs *ctx, struct sk_buff *skb) {
@@ -90,7 +89,6 @@ int count_tcp(struct pt_regs *ctx, struct sk_buff *skb) {
 
     def test_probe_read4(self):
         text = """
-#define KBUILD_MODNAME "foo"
 #include <net/tcp.h>
 #define _(P) ({typeof(P) val = 0; bpf_probe_read_kernel(&val, sizeof(val), &P); val;})
 int test(struct pt_regs *ctx, struct sk_buff *skb) {
@@ -102,7 +100,6 @@ int test(struct pt_regs *ctx, struct sk_buff *skb) {
 
     def test_probe_read_whitelist1(self):
         text = """
-#define KBUILD_MODNAME "foo"
 #include <net/tcp.h>
 int count_tcp(struct pt_regs *ctx, struct sk_buff *skb) {
     // The below define is in net/tcp.h:
@@ -120,7 +117,6 @@ int count_tcp(struct pt_regs *ctx, struct sk_buff *skb) {
 
     def test_probe_read_whitelist2(self):
         text = """
-#define KBUILD_MODNAME "foo"
 #include <net/tcp.h>
 int count_tcp(struct pt_regs *ctx, struct sk_buff *skb) {
     // The below define is in net/tcp.h:
@@ -1084,7 +1080,6 @@ int test(struct __sk_buff *ctx) {
 
     def test_probe_read_return(self):
         text = """
-#define KBUILD_MODNAME "foo"
 #include <uapi/linux/ptrace.h>
 #include <linux/tcp.h>
 static inline unsigned char *my_skb_transport_header(struct sk_buff *skb) {
@@ -1100,7 +1095,6 @@ int test(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
 
     def test_probe_read_multiple_return(self):
         text = """
-#define KBUILD_MODNAME "foo"
 #include <uapi/linux/ptrace.h>
 #include <linux/tcp.h>
 static inline u64 error_function() {
@@ -1121,7 +1115,6 @@ int test(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
 
     def test_probe_read_return_expr(self):
         text = """
-#define KBUILD_MODNAME "foo"
 #include <uapi/linux/ptrace.h>
 #include <linux/tcp.h>
 static inline unsigned char *my_skb_transport_header(struct sk_buff *skb) {
@@ -1137,7 +1130,6 @@ int test(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb) {
 
     def test_probe_read_return_call(self):
         text = """
-#define KBUILD_MODNAME "foo"
 #include <uapi/linux/ptrace.h>
 #include <linux/tcp.h>
 static inline struct tcphdr *my_skb_transport_header(struct sk_buff *skb) {

--- a/tools/tcplife.lua
+++ b/tools/tcplife.lua
@@ -25,7 +25,6 @@ uint16_t ntohs(uint16_t netshort);
 
 local program = [[
 #include <uapi/linux/ptrace.h>
-#define KBUILD_MODNAME "foo"
 #include <linux/tcp.h>
 #include <net/sock.h>
 #include <bcc/proto.h>

--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -66,7 +66,6 @@ debug = 0
 # define BPF program
 bpf_text = """
 #include <uapi/linux/ptrace.h>
-#define KBUILD_MODNAME "foo"
 #include <linux/tcp.h>
 #include <net/sock.h>
 #include <bcc/proto.h>

--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -61,7 +61,6 @@ debug = 0
 # define BPF program
 bpf_header = """
 #include <uapi/linux/ptrace.h>
-#define KBUILD_MODNAME "foo"
 #include <linux/tcp.h>
 #include <net/sock.h>
 #include <bcc/proto.h>


### PR DESCRIPTION
On newer kernels, networking tools fail with `include/net/flow_offload.h:304:4: error: use of undeclared identifier 'KBUILD_MODNAME'`.

This patch adds a default compiler flag to define `KBUILD_MODNAME`, similar to https://github.com/iovisor/bpftrace/pull/716.