### PR TITLE
fix LSM_PROBE return value

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -1029,11 +1029,13 @@ __attribute__((always_inline))                                  \
 static int ____##name(unsigned long long *ctx, ##args);         \
 int name(unsigned long long *ctx)                               \
 {                                                               \
+        int __ret;                                              \
+                                                                \
         _Pragma("GCC diagnostic push")                          \
         _Pragma("GCC diagnostic ignored \"-Wint-conversion\"")  \
-        ____##name(___bpf_ctx_cast(args));                      \
+        __ret = ____##name(___bpf_ctx_cast(args));              \
         _Pragma("GCC diagnostic pop")                           \
-        return 0;                                               \
+        return __ret;                                           \
 }                                                               \
 static int ____##name(unsigned long long *ctx, ##args)
 


### PR DESCRIPTION
Fix issue #2976.
The LSM_PROBE program return value is fixed with value 0.
This is not correct. The return value is meaningful for
LSM_PROBE programs. Return proper value provided by the
bpf program itself.

Signed-off-by: Yonghong Song <yhs@fb.com>