### PR TITLE
Add missing LSM probe cleanup

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1472,6 +1472,8 @@ class BPF(object):
             self.detach_kfunc(k)
         for k, v in list(self.kfunc_exit_fds.items()):
             self.detach_kretfunc(k)
+        for k, v in list(self.lsm_fds.items()):
+            self.detach_lsm(k)
 
         # Clean up opened perf ring buffer and perf events
         table_keys = list(self.tables.keys())


### PR DESCRIPTION
I neglected to add cleanup logic for LSM probes in #2979. This patch fixes the mistake.