### PR TITLE
libbpf-tools: remove unnecessary header include from syscount.bpf.c

### DIFF
--- a/libbpf-tools/syscount.bpf.c
+++ b/libbpf-tools/syscount.bpf.c
@@ -6,7 +6,6 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_core_read.h>
-#include <string.h>
 #include "syscount.h"
 
 const volatile bool count_by_process = false;


### PR DESCRIPTION
It causes build failure on my system due to trying to include GCC-specific
header. It doesn't seem to be necessary, though, so remove it.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>