### PR TITLE
Fix KFUNC_PROBE calls in vfs_stat.py by adding a return value

### DIFF
--- a/tools/vfsstat.py
+++ b/tools/vfsstat.py
@@ -66,11 +66,11 @@ void do_create(struct pt_regs *ctx) { stats_increment(S_CREATE); }
 """
 
 bpf_text_kfunc = """
-KFUNC_PROBE(vfs_read, int unused)   { stats_increment(S_READ); }
-KFUNC_PROBE(vfs_write, int unused)  { stats_increment(S_WRITE); }
-KFUNC_PROBE(vfs_fsync, int unused)  { stats_increment(S_FSYNC); }
-KFUNC_PROBE(vfs_open, int unused)   { stats_increment(S_OPEN); }
-KFUNC_PROBE(vfs_create, int unused) { stats_increment(S_CREATE); }
+KFUNC_PROBE(vfs_read, int unused)   { stats_increment(S_READ); return 0; }
+KFUNC_PROBE(vfs_write, int unused)  { stats_increment(S_WRITE); return 0;  }
+KFUNC_PROBE(vfs_fsync, int unused)  { stats_increment(S_FSYNC); return 0;  }
+KFUNC_PROBE(vfs_open, int unused)   { stats_increment(S_OPEN); return 0;  }
+KFUNC_PROBE(vfs_create, int unused) { stats_increment(S_CREATE); return 0;  }
 """
 
 is_support_kfunc = BPF.support_kfunc()

--- a/tools/vfsstat.py
+++ b/tools/vfsstat.py
@@ -67,10 +67,10 @@ void do_create(struct pt_regs *ctx) { stats_increment(S_CREATE); }
 
 bpf_text_kfunc = """
 KFUNC_PROBE(vfs_read, int unused)   { stats_increment(S_READ); return 0; }
-KFUNC_PROBE(vfs_write, int unused)  { stats_increment(S_WRITE); return 0;  }
-KFUNC_PROBE(vfs_fsync, int unused)  { stats_increment(S_FSYNC); return 0;  }
-KFUNC_PROBE(vfs_open, int unused)   { stats_increment(S_OPEN); return 0;  }
-KFUNC_PROBE(vfs_create, int unused) { stats_increment(S_CREATE); return 0;  }
+KFUNC_PROBE(vfs_write, int unused)  { stats_increment(S_WRITE); return 0; }
+KFUNC_PROBE(vfs_fsync, int unused)  { stats_increment(S_FSYNC); return 0; }
+KFUNC_PROBE(vfs_open, int unused)   { stats_increment(S_OPEN); return 0; }
+KFUNC_PROBE(vfs_create, int unused) { stats_increment(S_CREATE); return 0; }
 """
 
 is_support_kfunc = BPF.support_kfunc()


### PR DESCRIPTION
After #2978, `vfsstat.py` causes verifier to complain due to missing return values from `KFUNC_PROBE`s. This pull request adds explicit return values to these BPF programs.