### PR TITLE
libbpf-tools: add CO-RE biolatency

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -1,4 +1,5 @@
 /.output
+/biolatency
 /bitesize
 /cpudist
 /drsnoop

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -10,6 +10,7 @@ CFLAGS := -g -O2 -Wall
 ARCH := $(shell uname -m | sed 's/x86_64/x86/')
 
 APPS = \
+	biolatency \
 	bitesize \
 	cpudist \
 	drsnoop \

--- a/libbpf-tools/biolatency.bpf.c
+++ b/libbpf-tools/biolatency.bpf.c
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenbo Zhang
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+#include "biolatency.h"
+#include "bits.bpf.h"
+
+#define MAX_ENTRIES 10240
+
+const volatile char targ_disk[DISK_NAME_LEN] = {};
+const volatile bool targ_per_disk = false;
+const volatile bool targ_per_flag = false;
+const volatile bool targ_queued = false;
+const volatile bool targ_ms = false;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct request *);
+	__type(value, u64);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} start SEC(".maps");
+
+static struct hist initial_hist;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct hist_key);
+	__type(value, struct hist);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} hists SEC(".maps");
+
+static __always_inline bool disk_filtered(const char *disk)
+{
+	int i;
+
+	for (i = 0; targ_disk[i] != '\0' && i < DISK_NAME_LEN; i++) {
+		if (disk[i] != targ_disk[i])
+			return false;
+	}
+	return true;
+}
+
+static __always_inline
+int trace_rq_start(struct request *rq)
+{
+	u64 ts = bpf_ktime_get_ns();
+	char disk[DISK_NAME_LEN];
+
+	bpf_probe_read_kernel_str(&disk, sizeof(disk), rq->rq_disk->disk_name);
+	if (!disk_filtered(disk))
+		return 0;
+
+	bpf_map_update_elem(&start, &rq, &ts, 0);
+	return 0;
+}
+
+SEC("tp_btf/block_rq_insert")
+int BPF_PROG(tp_btf__block_rq_insert, struct request_queue *q,
+	     struct request *rq)
+{
+	return trace_rq_start(rq);
+}
+
+SEC("tp_btf/block_rq_issue")
+int BPF_PROG(tp_btf__block_rq_issue, struct request_queue *q,
+	     struct request *rq)
+{
+	if (targ_queued && BPF_CORE_READ(q, elevator))
+		return 0;
+	return trace_rq_start(rq);
+}
+
+SEC("tp_btf/block_rq_complete")
+int BPF_PROG(tp_btf__block_rq_complete, struct request *rq, int error,
+	     unsigned int nr_bytes)
+{
+	u64 slot, *tsp, ts = bpf_ktime_get_ns();
+	struct hist_key hkey = {};
+	struct hist *histp;
+	s64 delta;
+
+	tsp = bpf_map_lookup_elem(&start, &rq);
+	if (!tsp)
+		return 0;
+	delta = (s64)(ts - *tsp);
+	if (delta < 0)
+		goto cleanup;
+
+	if (targ_per_disk)
+		bpf_probe_read_kernel_str(&hkey.disk, sizeof(hkey.disk),
+					rq->rq_disk->disk_name);
+	if (targ_per_flag)
+		hkey.cmd_flags = rq->cmd_flags;
+
+	histp = bpf_map_lookup_elem(&hists, &hkey);
+	if (!histp) {
+		bpf_map_update_elem(&hists, &hkey, &initial_hist, 0);
+		histp = bpf_map_lookup_elem(&hists, &hkey);
+		if (!histp)
+			goto cleanup;
+	}
+
+	if (targ_ms)
+		delta /= 1000000;
+	else
+		delta /= 1000;
+	slot = log2l(delta);
+	if (slot >= MAX_SLOTS)
+		slot = MAX_SLOTS - 1;
+	__sync_fetch_and_add(&histp->slots[slot], 1);
+
+cleanup:
+	bpf_map_delete_elem(&start, &rq);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/biolatency.c
+++ b/libbpf-tools/biolatency.c
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2020 Wenbo Zhang
+//
+// Based on biolatency(8) from BCC by Brendan Gregg.
+// 15-Jun-2020   Wenbo Zhang   Created this.
+#include <argp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <time.h>
+#include <bpf/libbpf.h>
+#include <sys/resource.h>
+#include <bpf/bpf.h>
+#include "blk_types.h"
+#include "biolatency.h"
+#include "biolatency.skel.h"
+#include "trace_helpers.h"
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
+
+static struct env {
+	char *disk;
+	int disk_len;
+	time_t interval;
+	int times;
+	bool timestamp;
+	bool queued;
+	bool per_disk;
+	bool per_flag;
+	bool milliseconds;
+	bool verbose;
+} env = {
+	.interval = 99999999,
+	.times = 99999999,
+};
+
+static volatile bool exiting;
+
+const char *argp_program_version = "biolatency 0.1";
+const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char argp_program_doc[] =
+	"Summarize block device I/O latency as a histogram.\n"
+	"\n"
+	"USAGE: biolatency [-h] [-T] [-m] [-Q] [-D] [-F] [-d] [interval] [count]\n"
+	"\n"
+	"EXAMPLES:\n"
+	"    biolatency              # summarize block I/O latency as a histogram\n"
+	"    biolatency 1 10         # print 1 second summaries, 10 times\n"
+	"    biolatency -mT 1        # 1s summaries, milliseconds, and timestamps\n"
+	"    biolatency -Q           # include OS queued time in I/O time\n"
+	"    biolatency -D           # show each disk device separately\n"
+	"    biolatency -F           # show I/O flags separately\n"
+	"    biolatency -d sdc       # Trace sdc only\n";
+
+static const struct argp_option opts[] = {
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
+	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
+	{ "queued", 'Q', NULL, 0, "Include OS queued time in I/O time" },
+	{ "disk", 'D', NULL, 0, "Print a histogram per disk device" },
+	{ "flag", 'F', NULL, 0, "Print a histogram per set of I/O flags" },
+	{ "disk",  'd', "DISK",  0, "Trace this disk only" },
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	static int pos_args;
+
+	switch (key) {
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'h':
+		argp_usage(state);
+		break;
+	case 'm':
+		env.milliseconds = true;
+		break;
+	case 'Q':
+		env.queued = true;
+		break;
+	case 'D':
+		env.per_disk = true;
+		break;
+	case 'F':
+		env.per_flag = true;
+		break;
+	case 'd':
+		env.disk = arg;
+		env.disk_len = strlen(arg) + 1;
+		if (env.disk_len > DISK_NAME_LEN) {
+			fprintf(stderr, "invaild disk name: too long\n");
+			argp_usage(state);
+		}
+		break;
+	case ARGP_KEY_ARG:
+		errno = 0;
+		if (pos_args == 0) {
+			env.interval = strtol(arg, NULL, 10);
+			if (errno) {
+				fprintf(stderr, "invalid internal\n");
+				argp_usage(state);
+			}
+		} else if (pos_args == 1) {
+			env.times = strtol(arg, NULL, 10);
+			if (errno) {
+				fprintf(stderr, "invalid times\n");
+				argp_usage(state);
+			}
+		} else {
+			fprintf(stderr,
+				"unrecognized positional argument: %s\n", arg);
+			argp_usage(state);
+		}
+		pos_args++;
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+int libbpf_print_fn(enum libbpf_print_level level,
+		const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_handler(int sig)
+{
+	exiting = true;
+}
+
+static void print_cmd_flags(int cmd_flags)
+{
+	static struct { int bit; const char *str; } flags[] = {
+		{ REQ_NOWAIT, "NoWait-" },
+		{ REQ_BACKGROUND, "Background-" },
+		{ REQ_RAHEAD, "ReadAhead-" },
+		{ REQ_PREFLUSH, "PreFlush-" },
+		{ REQ_FUA, "FUA-" },
+		{ REQ_INTEGRITY, "Integrity-" },
+		{ REQ_IDLE, "Idle-" },
+		{ REQ_NOMERGE, "NoMerge-" },
+		{ REQ_PRIO, "Priority-" },
+		{ REQ_META, "Metadata-" },
+		{ REQ_SYNC, "Sync-" },
+	};
+	static const char *ops[] = {
+		[REQ_OP_READ] = "Read",
+		[REQ_OP_WRITE] = "Write",
+		[REQ_OP_FLUSH] = "Flush",
+		[REQ_OP_DISCARD] = "Discard",
+		[REQ_OP_SECURE_ERASE] = "SecureErase",
+		[REQ_OP_ZONE_RESET] = "ZoneReset",
+		[REQ_OP_WRITE_SAME] = "WriteSame",
+		[REQ_OP_ZONE_RESET_ALL] = "ZoneResetAll",
+		[REQ_OP_WRITE_ZEROES] = "WriteZeroes",
+		[REQ_OP_ZONE_OPEN] = "ZoneOpen",
+		[REQ_OP_ZONE_CLOSE] = "ZoneClose",
+		[REQ_OP_ZONE_FINISH] = "ZoneFinish",
+		[REQ_OP_SCSI_IN] = "SCSIIn",
+		[REQ_OP_SCSI_OUT] = "SCSIOut",
+		[REQ_OP_DRV_IN] = "DrvIn",
+		[REQ_OP_DRV_OUT] = "DrvOut",
+	};
+	int i;
+
+	printf("flags = ");
+
+	for (i = 0; i < ARRAY_SIZE(flags); i++) {
+		if (cmd_flags & flags[i].bit)
+			printf("%s", flags[i].str);
+	}
+
+	if ((cmd_flags & REQ_OP_MASK) < ARRAY_SIZE(ops))
+		printf("%s", ops[cmd_flags & REQ_OP_MASK]);
+	else
+		printf("Unknown");
+}
+
+static int print_log2_hists(int fd)
+{
+	struct hist_key lookup_key = { .cmd_flags = -1 }, next_key;
+	char *units = env.milliseconds ? "msecs" : "usecs";
+	struct hist hist;
+	int err;
+
+	while (!bpf_map_get_next_key(fd, &lookup_key, &next_key)) {
+		err = bpf_map_lookup_elem(fd, &next_key, &hist);
+		if (err < 0) {
+			fprintf(stderr, "failed to lookup hist: %d\n", err);
+			return -1;
+		}
+		if (env.per_disk)
+			printf("\ndisk = %s\t", next_key.disk[0] != '\0' ?
+				next_key.disk : "unnamed");
+		if (env.per_flag)
+			print_cmd_flags(next_key.cmd_flags);
+		printf("\n");
+		print_log2_hist(hist.slots, MAX_SLOTS, units);
+		lookup_key = next_key;
+	}
+
+	lookup_key.cmd_flags = -1;
+	while (!bpf_map_get_next_key(fd, &lookup_key, &next_key)) {
+		err = bpf_map_delete_elem(fd, &next_key);
+		if (err < 0) {
+			fprintf(stderr, "failed to cleanup hist : %d\n", err);
+			return -1;
+		}
+		lookup_key = next_key;
+	}
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct biolatency_bpf *obj;
+	struct tm *tm;
+	char ts[32];
+	time_t t;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	err = bump_memlock_rlimit();
+	if (err) {
+		fprintf(stderr, "failed to increase rlimit: %d\n", err);
+		return 1;
+	}
+
+	obj = biolatency_bpf__open();
+	if (!obj) {
+		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		return 1;
+	}
+
+	/* initialize global data (filtering options) */
+	if (env.disk)
+		strncpy((char*)obj->rodata->targ_disk, env.disk, env.disk_len);
+	obj->rodata->targ_per_disk = env.per_disk;
+	obj->rodata->targ_per_flag = env.per_flag;
+	obj->rodata->targ_ms = env.milliseconds;
+	obj->rodata->targ_queued = env.queued;
+
+	err = biolatency_bpf__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF object: %d\n", err);
+		goto cleanup;
+	}
+
+	if (env.queued) {
+		obj->links.tp_btf__block_rq_insert =
+			bpf_program__attach(obj->progs.tp_btf__block_rq_insert);
+		err = libbpf_get_error(obj->links.tp_btf__block_rq_insert);
+		if (err) {
+			fprintf(stderr, "failed to attach: %s\n", strerror(-err));
+			goto cleanup;
+		}
+	}
+	obj->links.tp_btf__block_rq_issue =
+		bpf_program__attach(obj->progs.tp_btf__block_rq_issue);
+	err = libbpf_get_error(obj->links.tp_btf__block_rq_issue);
+	if (err) {
+		fprintf(stderr, "failed to attach: %s\n", strerror(-err));
+		goto cleanup;
+	}
+	obj->links.tp_btf__block_rq_complete =
+		bpf_program__attach(obj->progs.tp_btf__block_rq_complete);
+	err = libbpf_get_error(obj->links.tp_btf__block_rq_complete);
+	if (err) {
+		fprintf(stderr, "failed to attach: %s\n", strerror(-err));
+		goto cleanup;
+	}
+
+	signal(SIGINT, sig_handler);
+
+	printf("Tracing block device I/O... Hit Ctrl-C to end.\n");
+
+	/* main: poll */
+	while (1) {
+		sleep(env.interval);
+		printf("\n");
+
+		if (env.timestamp) {
+			time(&t);
+			tm = localtime(&t);
+			strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+			printf("%-8s\n", ts);
+		}
+
+		err = print_log2_hists(bpf_map__fd(obj->maps.hists));
+		if (err)
+			break;
+
+		if (exiting || --env.times == 0)
+			break;
+	}
+
+cleanup:
+	biolatency_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/libbpf-tools/biolatency.h
+++ b/libbpf-tools/biolatency.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __BIOLATENCY_H
+#define __BIOLATENCY_H
+
+#define DISK_NAME_LEN	32
+#define MAX_SLOTS	27
+
+struct hist_key {
+	char disk[DISK_NAME_LEN];
+	__u32 cmd_flags;
+};
+
+struct hist {
+	__u32 slots[MAX_SLOTS];
+};
+
+#endif /* __BIOLATENCY_H */

--- a/libbpf-tools/blk_types.h
+++ b/libbpf-tools/blk_types.h
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __BLK_TYPES_H
+#define __BLK_TYPES_H
+
+/* From include/linux/blk_types.h */
+
+/*
+ * Operations and flags common to the bio and request structures.
+ * We use 8 bits for encoding the operation, and the remaining 24 for flags.
+ *
+ * The least significant bit of the operation number indicates the data
+ * transfer direction:
+ *
+ *   - if the least significant bit is set transfers are TO the device
+ *   - if the least significant bit is not set transfers are FROM the device
+ *
+ * If a operation does not transfer data the least significant bit has no
+ * meaning.
+ */
+#define REQ_OP_BITS	8
+#define REQ_OP_MASK	((1 << REQ_OP_BITS) - 1)
+#define REQ_FLAG_BITS	24
+
+enum req_opf {
+	/* read sectors from the device */
+	REQ_OP_READ		= 0,
+	/* write sectors to the device */
+	REQ_OP_WRITE		= 1,
+	/* flush the volatile write cache */
+	REQ_OP_FLUSH		= 2,
+	/* discard sectors */
+	REQ_OP_DISCARD		= 3,
+	/* securely erase sectors */
+	REQ_OP_SECURE_ERASE	= 5,
+	/* reset a zone write pointer */
+	REQ_OP_ZONE_RESET	= 6,
+	/* write the same sector many times */
+	REQ_OP_WRITE_SAME	= 7,
+	/* reset all the zone present on the device */
+	REQ_OP_ZONE_RESET_ALL	= 8,
+	/* write the zero filled sector many times */
+	REQ_OP_WRITE_ZEROES	= 9,
+	/* Open a zone */
+	REQ_OP_ZONE_OPEN	= 10,
+	/* Close a zone */
+	REQ_OP_ZONE_CLOSE	= 11,
+	/* Transition a zone to full */
+	REQ_OP_ZONE_FINISH	= 12,
+
+	/* SCSI passthrough using struct scsi_request */
+	REQ_OP_SCSI_IN		= 32,
+	REQ_OP_SCSI_OUT		= 33,
+	/* Driver private requests */
+	REQ_OP_DRV_IN		= 34,
+	REQ_OP_DRV_OUT		= 35,
+
+	REQ_OP_LAST,
+};
+
+enum req_flag_bits {
+	__REQ_FAILFAST_DEV =	/* no driver retries of device errors */
+		REQ_OP_BITS,
+	__REQ_FAILFAST_TRANSPORT, /* no driver retries of transport errors */
+	__REQ_FAILFAST_DRIVER,	/* no driver retries of driver errors */
+	__REQ_SYNC,		/* request is sync (sync write or read) */
+	__REQ_META,		/* metadata io request */
+	__REQ_PRIO,		/* boost priority in cfq */
+	__REQ_NOMERGE,		/* don't touch this for merging */
+	__REQ_IDLE,		/* anticipate more IO after this one */
+	__REQ_INTEGRITY,	/* I/O includes block integrity payload */
+	__REQ_FUA,		/* forced unit access */
+	__REQ_PREFLUSH,		/* request for cache flush */
+	__REQ_RAHEAD,		/* read ahead, can fail anytime */
+	__REQ_BACKGROUND,	/* background IO */
+	__REQ_NOWAIT,           /* Don't wait if request will block */
+	__REQ_NOWAIT_INLINE,	/* Return would-block error inline */
+	/*
+	 * When a shared kthread needs to issue a bio for a cgroup, doing
+	 * so synchronously can lead to priority inversions as the kthread
+	 * can be trapped waiting for that cgroup.  CGROUP_PUNT flag makes
+	 * submit_bio() punt the actual issuing to a dedicated per-blkcg
+	 * work item to avoid such priority inversions.
+	 */
+	__REQ_CGROUP_PUNT,
+
+	/* command specific flags for REQ_OP_WRITE_ZEROES: */
+	__REQ_NOUNMAP,		/* do not free blocks when zeroing */
+
+	__REQ_HIPRI,
+
+	/* for driver use */
+	__REQ_DRV,
+	__REQ_SWAP,		/* swapping request. */
+	__REQ_NR_BITS,		/* stops here */
+};
+
+#define REQ_FAILFAST_DEV	(1ULL << __REQ_FAILFAST_DEV)
+#define REQ_FAILFAST_TRANSPORT	(1ULL << __REQ_FAILFAST_TRANSPORT)
+#define REQ_FAILFAST_DRIVER	(1ULL << __REQ_FAILFAST_DRIVER)
+#define REQ_SYNC		(1ULL << __REQ_SYNC)
+#define REQ_META		(1ULL << __REQ_META)
+#define REQ_PRIO		(1ULL << __REQ_PRIO)
+#define REQ_NOMERGE		(1ULL << __REQ_NOMERGE)
+#define REQ_IDLE		(1ULL << __REQ_IDLE)
+#define REQ_INTEGRITY		(1ULL << __REQ_INTEGRITY)
+#define REQ_FUA			(1ULL << __REQ_FUA)
+#define REQ_PREFLUSH		(1ULL << __REQ_PREFLUSH)
+#define REQ_RAHEAD		(1ULL << __REQ_RAHEAD)
+#define REQ_BACKGROUND		(1ULL << __REQ_BACKGROUND)
+#define REQ_NOWAIT		(1ULL << __REQ_NOWAIT)
+#define REQ_NOWAIT_INLINE	(1ULL << __REQ_NOWAIT_INLINE)
+#define REQ_CGROUP_PUNT		(1ULL << __REQ_CGROUP_PUNT)
+
+#define REQ_NOUNMAP		(1ULL << __REQ_NOUNMAP)
+#define REQ_HIPRI		(1ULL << __REQ_HIPRI)
+
+#define REQ_DRV			(1ULL << __REQ_DRV)
+#define REQ_SWAP		(1ULL << __REQ_SWAP)
+
+#define REQ_FAILFAST_MASK \
+	(REQ_FAILFAST_DEV | REQ_FAILFAST_TRANSPORT | REQ_FAILFAST_DRIVER)
+
+#define REQ_NOMERGE_FLAGS \
+	(REQ_NOMERGE | REQ_PREFLUSH | REQ_FUA)
+
+#endif /* __BLK_TYPES_H */


### PR DESCRIPTION
- implement [biolatency](https://github.com/iovisor/bcc/blob/master/tools/biolatency.py) with `BTF_PROG_TYPE_TRACING` instead of `kprobes`
- extract string filter to `bits.bpf.h`
- modify makefile to add *bpf.h as *.bpf.o's dep for re-build detection

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>