### PR TITLE
Introducing Queue/Stack helpers and clang frontend

### DIFF
--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -176,6 +176,14 @@ class BPF {
     return BPFPercpuCgStorageTable<ValueType>({});
   }
 
+  template <class ValueType>
+  BPFQueueStackTable<ValueType> get_queuestack_table(const std::string& name) {
+    TableStorage::iterator it;
+    if (bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
+      return BPFQueueStackTable<ValueType>(it->second);
+    return BPFQueueStackTable<ValueType>({});
+  }
+
   void* get_bsymcache(void) {
     if (bsymcache_ == NULL) {
       bsymcache_ = bcc_buildsymcache_new();

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -1036,7 +1036,16 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           } else if (memb_name == "get_local_storage") {
             prefix = "bpf_get_local_storage";
             suffix = ")";
-          } else {
+          } else if (memb_name == "push") {
+            prefix = "bpf_map_push_elem";
+            suffix = ")";
+          } else if (memb_name == "pop") {
+            prefix = "bpf_map_pop_elem";
+            suffix = ")";
+          } else if (memb_name == "peek") {
+            prefix = "bpf_map_peek_elem";
+            suffix = ")";
+           } else {
             error(GET_BEGINLOC(Call), "invalid bpf_table operation %0") << memb_name;
             return false;
           }
@@ -1419,6 +1428,12 @@ bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
       table.leaf_size = 0;
     } else if (section_attr == "maps/perf_array") {
       map_type = BPF_MAP_TYPE_PERF_EVENT_ARRAY;
+    } else if (section_attr == "maps/queue") {
+      table.key_size = 0;
+      map_type = BPF_MAP_TYPE_QUEUE;
+    } else if (section_attr == "maps/stack") {
+      table.key_size = 0;
+      map_type = BPF_MAP_TYPE_STACK;
     } else if (section_attr == "maps/cgroup_array") {
       map_type = BPF_MAP_TYPE_CGROUP_ARRAY;
     } else if (section_attr == "maps/stacktrace") {

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -322,6 +322,11 @@ int bpf_delete_elem(int fd, void *key)
   return bpf_map_delete_elem(fd, key);
 }
 
+int bpf_lookup_and_delete(int fd, void *key, void *value)
+{
+  return bpf_map_lookup_and_delete_elem(fd, key, value);
+}
+
 int bpf_get_first_key(int fd, void *key, size_t key_size)
 {
   int i, res;

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -44,6 +44,7 @@ int bpf_lookup_elem(int fd, void *key, void *value);
 int bpf_delete_elem(int fd, void *key);
 int bpf_get_first_key(int fd, void *key, size_t key_size);
 int bpf_get_next_key(int fd, void *key, void *next_key);
+int bpf_lookup_and_delete(int fd, void *key, void *value);
 
 /*
  * Load a BPF program, and return the FD of the loaded program.

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TEST_LIBBCC_SOURCES
 	test_perf_event.cc
 	test_pinned_table.cc
 	test_prog_table.cc
+	test_queuestack_table.cc
 	test_shared_table.cc
 	test_sk_storage.cc
 	test_sock_table.cc

--- a/tests/cc/test_queuestack_table.cc
+++ b/tests/cc/test_queuestack_table.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020 Politecnico di Torino
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BPF.h"
+#include "catch.hpp"
+#include <iostream>
+#include <linux/version.h>
+
+//Queue/Stack types are available only from 5.0.0
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+TEST_CASE("queue table", "[queue_table]") {
+  const std::string BPF_PROGRAM = R"(
+    BPF_QUEUE(myqueue, int, 30);
+  )";
+
+  ebpf::BPF bpf;
+  ebpf::StatusTuple res(0);
+  res = bpf.init(BPF_PROGRAM);
+  REQUIRE(res.code() == 0);
+
+  ebpf::BPFQueueStackTable<int> t = bpf.get_queuestack_table<int>("myqueue");
+
+  SECTION("standard methods") {
+    int i, val;
+    std::string value;
+
+    // insert elements
+    for (i=0; i<30; i++) {
+      res = t.push_value(i);
+      REQUIRE(res.code() == 0);
+    }
+
+    // checking head (peek)
+    res = t.get_head(val);
+    REQUIRE(res.code() == 0);
+    REQUIRE(val == 0);
+
+    // retrieve elements
+    for (i=0; i<30; i++) {
+      res = t.pop_value(val);
+      REQUIRE(res.code() == 0);
+      REQUIRE(val == i);
+    }
+    // get non existing element
+    res = t.pop_value(val);
+    REQUIRE(res.code() != 0);
+  }
+}
+
+TEST_CASE("stack table", "[stack_table]") {
+  const std::string BPF_PROGRAM = R"(
+    BPF_STACK(mystack, int, 30);
+  )";
+
+  ebpf::BPF bpf;
+  ebpf::StatusTuple res(0);
+  res = bpf.init(BPF_PROGRAM);
+  REQUIRE(res.code() == 0);
+
+  ebpf::BPFQueueStackTable<int> t = bpf.get_queuestack_table<int>("mystack");
+
+  SECTION("standard methods") {
+    int i, val;
+    std::string value;
+
+    // insert elements
+    for (i=0; i<30; i++) {
+      res = t.push_value(i);
+      REQUIRE(res.code() == 0);
+    }
+
+    // checking head (peek)
+    res = t.get_head(val);
+    REQUIRE(res.code() == 0);
+    REQUIRE(val == 29);
+
+    // retrieve elements
+    for (i=0; i<30; i++) {
+      res = t.pop_value(val);
+      REQUIRE(res.code() == 0);
+      REQUIRE( val == (30 - 1 - i));
+    }
+    // get non existing element
+    res = t.pop_value(val);
+    REQUIRE(res.code() != 0);
+  }
+}
+#endif


### PR DESCRIPTION
This PR aims to introduce helpers to declare Queue/Stack maps. I have supported also
the creation of shared/public/pinned ones, as for the "traditional" tables.
In clang frontend I have added both declaration of maps type/queue, type/stack and all the operations
supported so far by these new maps (push/pop/peek).

Possible declarations introduced:

* BPF_QUEUESTACK(<"queue"/"stack">, <name>, <leaf_type>, <max_entries>, \<flags>)
* BPF_QUEUESTACK_SHARED(...)
* BPF_QUEUESTACK_PINNED(...)
* BPF_QUEUESTACK_PUBLIC(...)
* BPF_QUEUE(\<name>, <leaf_type>, <max_entries>)
* BPF_QUEUE(\<name>, <leaf_type>, <max_entries>, \<flags>)
* BPF_STACK(\<name>, <leaf_type>, <max_entries>)
* BPF_STACK(\<name>, <leaf_type>, <max_entries>, \<flags>)

Signed-off-by: Simone Magnani <simonemagnani.96@gmail.com>
Co-authored-by: Sebastiano Miano <sebastiano.miano@polito.it>