### PR TITLE
valloc and pvalloc is deprecated in bionic on Android

### DIFF
--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -434,9 +434,9 @@ if not kernel_trace:
         attach_probes("calloc")
         attach_probes("realloc")
         attach_probes("posix_memalign")
-        attach_probes("valloc")
+        attach_probes("valloc", can_fail=True) # failed on Android, is deprecated in libc.so from bionic directory
         attach_probes("memalign")
-        attach_probes("pvalloc")
+        attach_probes("pvalloc", can_fail=True) # failed on Android, is deprecated in libc.so from bionic directory
         attach_probes("aligned_alloc", can_fail=True)  # added in C11
         bpf.attach_uprobe(name=obj, sym="free", fn_name="free_enter",
                                   pid=pid)


### PR DESCRIPTION
memleak -p PID will failed on Android
https://android.googlesource.com/platform/bionic/+/master/libc/bionic/malloc_common.cpp#196