### PR TITLE
Fix symbol resolution via symfs

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -562,6 +562,10 @@ static char *find_debug_via_symfs(Elf *e, const char* path) {
 
   check_build_id = find_buildid(e, buildid);
 
+  int ns_prefix_length = 0;
+  sscanf(path, "/proc/%*u/root/%n", &ns_prefix_length);
+  path += ns_prefix_length;
+
   snprintf(fullpath, sizeof(fullpath), "%s/%s", symfs, path);
   if (access(fullpath, F_OK) == -1)
     goto out;


### PR DESCRIPTION
Paths that are passed to find_debug_via_symfs often start with /proc/PID/root/
prefix which is followed by actual path. This breaks symfs symbol resoultion.
Symfs directory usually does not contain proc subdirectory and subdirectories
for each pid.

Here are examples of stack traces I got when tracing dlopen on Android before:
```
7acc558ef8 dlopen+0 (/system/lib64/libdl.so)
7a2222f988 EglThreadState::GetProcAddress(char const*)+64 (/vendor/lib64/egl/libGLESv2_adreno.so)
7ac8e3ecbc eglGetProcAddress+540 (/system/lib64/libEGL.so)
7acb824a58 GrGLMakeAssembledGLESInterface(void*, void (* ()(void, char const*))())+8136 (/system/lib64/libhwui.so)
7acb83a9b0 GrGLCreateNativeInterface()+48 (/system/lib64/libhwui.so)
7acb63443c 0x7acb63443c ([unknown])
7acb9cd33c 0x7acb9cd33c ([unknown])
7acb9cdd70 0x7acb9cdd70 ([unknown])
7acb9c7f20 0x7acb9c7f20 ([unknown])
7acb9cbcc8 0x7acb9cbcc8 ([unknown])
7acb98348c 0x7acb98348c ([unknown])
7acb65da30 0x7acb65da30 ([unknown])
7aca096b84 android::Thread::_threadLoop(void*)+284 (/system/lib64/libutils.so)
7acc2c6288 __pthread_start(void*)+40 (/system/lib64/libc.so)
7acc266500 __start_thread+72 (/system/lib64/libc.so)
```

and after:
```
7acc558ef8 dlopen+0 (/system/lib64/libdl.so)
7a23a2d988 EglThreadState::GetProcAddress(char const*)+64 (/vendor/lib64/egl/libGLESv2_adreno.so)
7ac8e3ecbc eglGetProcAddress+540 (/system/lib64/libEGL.so)
7acb824a58 0x7acb824a58 ([unknown])
7acb83a9b0 GrGLCreateNativeInterface()+48 (/system/lib64/libhwui.so)
7acb63443c android::uirenderer::debug::GlesDriver::getSkiaInterface()+20 (/system/lib64/libhwui.so)
7acb9cd33c android::uirenderer::renderthread::EglManager::initialize()+700 (/system/lib64/libhwui.so)
7acb9cdd70 android::uirenderer::renderthread::EglManager::createSurface(ANativeWindow*, bool)+48 (/system/lib64/libhwui.so)
7acb9c7f20 android::uirenderer::skiapipeline::SkiaOpenGLPipeline::setSurface(android::Surface*, android::uirenderer::renderthread::SwapBehavior, android::uirenderer::renderthread::ColorMode)+88 (/system/lib64/libhwui.so)
7acb9cbcc8 android::uirenderer::renderthread::CanvasContext::setSurface(android::sp<android::Surface>&&)+88 (/system/lib64/libhwui.so)
7acb98348c android::uirenderer::WorkQueue::process()+172 (/system/lib64/libhwui.so)
7acb65da30 0x7acb65da30 ([unknown])
7aca096b84 android::Thread::_threadLoop(void*)+284 (/system/lib64/libutils.so)
7acc2c6288 __pthread_start(void*)+40 (/system/lib64/libc.so)
7acc266500 __start_thread+72 (/system/lib64/libc.so)
```