### PR TITLE
memleak: Add workaround to alleviate misjudgments when free is missing

### DIFF
--- a/man/man8/memleak.8
+++ b/man/man8/memleak.8
@@ -3,8 +3,8 @@
 memleak \- Print a summary of outstanding allocations and their call stacks to detect memory leaks. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B memleak [-h] [-p PID] [-t] [-a] [-o OLDER] [-c COMMAND] [--combined-only]
-[-s SAMPLE_RATE] [-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE] [-O OBJ] [INTERVAL]
-[COUNT]
+[--wa-missing-free] [-s SAMPLE_RATE] [-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE]
+[-O OBJ] [INTERVAL] [COUNT]
 .SH DESCRIPTION
 memleak traces and matches memory allocation and deallocation requests, and
 collects call stacks for each allocation. memleak can then print a summary
@@ -52,6 +52,9 @@ Run the specified command and trace its allocations only. This traces libc alloc
 Use statistics precalculated in kernel space. Amount of data to be pulled from
 kernel significantly decreases, at the cost of losing capabilities of time-based
 false positives filtering (\-o).
+.TP
+\-\-wa-missing-free
+Make up the action of free to alleviate misjudgments when free is missing.
 .TP
 \-s SAMPLE_RATE
 Record roughly every SAMPLE_RATE-th allocation to reduce overhead.
@@ -108,6 +111,9 @@ also reduce overhead by capturing only allocations of specific sizes.
 Additionally, option \-\-combined-only saves processing time by reusing already
 calculated allocation statistics from kernel. It's faster, but lacks information
 about particular allocations.
+
+Also, option \-\-wa-missing-free makes memleak more accuracy in the complicated
+environment.
 
 To determine the rate at which your application is calling malloc/free, or the
 rate at which your kernel is calling kmalloc/kfree, place a probe with perf and

--- a/tools/memleak_example.txt
+++ b/tools/memleak_example.txt
@@ -146,13 +146,33 @@ Note that even though the application leaks 16 bytes of memory every second,
 the report (printed every 5 seconds) doesn't "see" all the allocations because
 of the sampling rate applied. 
 
+Profiling in memory part is hard to be accurate because of BPF infrastructure.
+memleak keeps misjudging memory leak on the complicated environment which has
+the action of free in hard/soft irq.
+Add workaround to alleviate misjudgments when free is missing:
+
+# ./memleak --wa-missing-free
+Attaching to kernel allocators, Ctrl+C to quit.
+...
+        248 bytes in 4 allocations from stack
+                 bpf_prog_load [kernel]
+                 sys_bpf [kernel]
+
+        328 bytes in 1 allocations from stack
+                 perf_mmap [kernel]
+                 mmap_region [kernel]
+                 do_mmap [kernel]
+                 vm_mmap_pgoff [kernel]
+                 sys_mmap_pgoff [kernel]
+                 sys_mmap [kernel]
+
 
 USAGE message:
 
 # ./memleak -h
 usage: memleak.py [-h] [-p PID] [-t] [-a] [-o OLDER] [-c COMMAND]
-                  [--combined-only] [-s SAMPLE_RATE] [-T TOP] [-z MIN_SIZE]
-                  [-Z MAX_SIZE] [-O OBJ]
+                  [--combined-only] [--wa-missing-free] [-s SAMPLE_RATE]
+                  [-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE] [-O OBJ]
                   [interval] [count]
 
 Trace outstanding memory allocations that weren't freed.
@@ -177,6 +197,8 @@ optional arguments:
   -c COMMAND, --command COMMAND
                         execute and trace the specified command
   --combined-only       show combined allocation statistics only
+  --wa-missing-free     Workaround to alleviate misjudgments when free is
+                        missing
   -s SAMPLE_RATE, --sample-rate SAMPLE_RATE
                         sample every N-th allocation to decrease the overhead
   -T TOP, --top TOP     display only this many top allocating stacks (by size)


### PR DESCRIPTION
Profiling in memory part is hard to be accurate because of BPF infrastructure.
memleak keeps misjudging memory leak on the complicated environment which has
the action of free in hard/soft irq.

For example, in my misjudged case:

640 bytes in 10 allocations from stack
--
__kmalloc+0x178 [kernel]
__kmalloc+0x178 [kernel]
xhci_urb_enqueue+0x140 [kernel]
usb_hcd_submit_urb+0x5e0 [kernel]

This result looks like kernel doesn't free urb_priv. However, it's not true.
The reason for this leak is because xhci hw irq interrupts during the BPF program.
BPF program is not finished on that CPU, and xhci_irq() will call xhci_urb_free_priv()
before the end. But the kernel doesn't permit this isr to go into BPF program again.
Because BPF infrastructure(trace_call_bpf) denied this action.
So we miss this free action and cause memory leak misjudgment.

Side-effect:
- Increase overhead for each memory allocation.
- A higher chance to be interrupted at the allocation part causes ignore more allocations.

This workaround doesn't solve all misjudgments, the improvement in BPF infrastructure
is the only solution.