### PR TITLE
Add .lazy_symbolize field to bcc_symbol_option

### DIFF
--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -173,6 +173,7 @@ class bcc_symbol_option(ct.Structure):
     _fields_ = [
             ('use_debug_file', ct.c_int),
             ('check_debug_file_crc', ct.c_int),
+            ('lazy_symbolize', ct.c_int),
             ('use_symbol_type', ct.c_uint),
         ]
 

--- a/src/python/bcc/perf.py
+++ b/src/python/bcc/perf.py
@@ -27,15 +27,19 @@ class Perf(object):
                         ('read_format', ct.c_ulong),
                         ('flags', ct.c_ulong),
                         ('wakeup_events', ct.c_uint),
-                        ('IGNORE3', ct.c_uint),
-                        ('IGNORE4', ct.c_ulong),
-                        ('IGNORE5', ct.c_ulong),
-                        ('IGNORE6', ct.c_ulong),
-                        ('IGNORE7', ct.c_uint),
-                        ('IGNORE8', ct.c_int),
-                        ('IGNORE9', ct.c_ulong),
-                        ('IGNORE10', ct.c_uint),
-                        ('IGNORE11', ct.c_uint)
+                        ('IGNORE3', ct.c_uint),  # bp_type
+                        ('IGNORE4', ct.c_ulong),  # bp_addr
+                        ('IGNORE5', ct.c_ulong),  # bp_len
+                        ('IGNORE6', ct.c_ulong),  # branch_sample_type
+                        ('IGNORE7', ct.c_ulong),  # sample_regs_user
+                        ('IGNORE8', ct.c_uint),  # sample_stack_user
+                        ('IGNORE9', ct.c_int),  # clockid
+                        ('IGNORE10', ct.c_ulong),  # sample_regs_intr
+                        ('IGNORE11', ct.c_uint),  # aux_watermark
+                        ('IGNORE12', ct.c_uint16),  # sample_max_stack
+                        ('IGNORE13', ct.c_uint16),  # __reserved_2
+                        ('IGNORE14', ct.c_uint),  # aux_sample_size
+                        ('IGNORE15', ct.c_uint),  # __reserved_3
                 ]
 
         # x86 specific, from arch/x86/include/generated/uapi/asm/unistd_64.h


### PR DESCRIPTION
`bcc.libbcc.bcc_symbol_option` class defined at `libbcc.py` is different from the structure defined at `bcc_syms.h`

The former lacks of `.lazy_symbolize` field. So, the field is added to the class.

And also `perf_event_attr` defined at `perf.py` is different from the structure defined at `vmlinux.h`

So, missing fields are added to the class.
