### PR TITLE
use bpf_probe_read_kernel for implicit kernel mem read on s390

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -90,6 +90,7 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   std::vector<clang::ParmVarDecl *> fn_args_;
   std::set<clang::Expr *> visited_;
   std::string current_fn_;
+  bool has_overlap_kuaddr_;
 };
 
 // Do a depth-first search to rewrite all pointers that need to be probed
@@ -129,6 +130,7 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   std::list<int> ptregs_returned_;
   const clang::Stmt *addrof_stmt_;
   bool is_addrof_;
+  bool has_overlap_kuaddr_;
 };
 
 // A helper class to the frontend action, walks the decls


### PR DESCRIPTION
Commit f579bf8d60c8 ("bpf: use bpf_probe_read in implicitly
generated kernel mem read") unconditionally use bpf_probe_read()
for implicit kernel memory read in bpf programs.

This won't work for s390 with recent kernels since s390 has
overlap user/kernel addresses and bpf_probe_read() is not
available any more.

This patch partially reverted Commit f579bf8d60c8 such
that for s390, bpf_probe_read_kernel() will be used
while other architectures bpf_probe_read() is used.

Signed-off-by: Yonghong Song <yhs@fb.com>