### PR TITLE
 libbpf-tools: fix tcpconnect compile errors

### DIFF
--- a/libbpf-tools/maps.bpf.h
+++ b/libbpf-tools/maps.bpf.h
@@ -4,7 +4,7 @@
 #define __MAPS_BPF_H
 
 #include <bpf/bpf_helpers.h>
-#include <errno.h>
+#include <asm-generic/errno.h>
 
 static __always_inline void *
 bpf_map_lookup_or_try_init(void *map, const void *key, const void *init)

--- a/libbpf-tools/tcpconnect.bpf.c
+++ b/libbpf-tools/tcpconnect.bpf.c
@@ -11,11 +11,11 @@
 #include "maps.bpf.h"
 #include "tcpconnect.h"
 
-const volatile bool do_count;
-const volatile int filter_ports_len;
-const volatile int filter_ports[MAX_PORTS];
-const volatile pid_t filter_pid;
+SEC(".rodata") int filter_ports[MAX_PORTS];
+const volatile int filter_ports_len = 0;
 const volatile uid_t filter_uid = -1;
+const volatile pid_t filter_pid = 0;
+const volatile bool do_count = 0;
 
 /* Define here, because there are conflicts with include files */
 #define AF_INET		2

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -338,7 +338,7 @@ static void print_events(int perf_map_fd)
 	print_events_header();
 	while (hang_on) {
 		err = perf_buffer__poll(pb, 100);
-		if (err < 0) {
+		if (err < 0 && errno != EINTR) {
 			warn("Error polling perf buffer: %d\n", err);
 			goto cleanup;
 		}


### PR DESCRIPTION
On ubuntu 18.04, I got several compile errors, so I did this fix up.

1.  Use `asm-generic/error.h` instead of `error.h` to fix error:
> /usr/include/linux/errno.h:1:10: fatal error: 'asm/errno.h' file not found

2. Initial global vals to fix errors, eg:
> libbpf: invalid relo for 'filter_ports_len' in special section 0xfff2; forgot to initialize global var?..
> Error: failed to open BPF object file: 0
> Makefile:66: recipe for target '.output/tcpconnect.skel.h' failed

3. Ignore `EINTR` error info, eg: after `Ctrl-C` I got
> Error polling perf buffer: -4

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>