### PR TITLE
Add example for new helper bpf_get_ns_current_pid_tgid() to documentation.

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -31,6 +31,7 @@ This guide is incomplete. If something feels missing, check the bcc and kernel s
         - [9. bpf_get_prandom_u32()](#9-bpf_get_prandom_u32)
         - [10. bpf_probe_read_user()](#10-bpf_probe_read_user)
         - [11. bpf_probe_read_user_str()](#11-bpf_probe_read_user_str)
+        - [12. bpf_get_ns_current_pid_tgid()](#4-bpf_get_ns_current_pid_tgid)
     - [Debugging](#debugging)
         - [1. bpf_override_return()](#1-bpf_override_return)
     - [Output](#output)
@@ -574,6 +575,24 @@ This copies a `NULL` terminated string from user address space to the BPF stack,
 Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=bpf_probe_read_user_str+path%3Aexamples&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=bpf_probe_read_user_str+path%3Atools&type=Code)
+  
+
+### 12. bpf_get_ns_current_pid_tgid()
+
+Syntax: ```u32 bpf_get_ns_current_pid_tgid(u64 dev, u64 ino, struct bpf_pidns_info* nsdata, u32 size)```
+
+Values for *pid* and *tgid* as seen from the current *namespace* will be returned in *nsdata*.
+
+Return 0 on success, or one of the following in case of failure:
+ 
+- **-EINVAL** if dev and inum supplied don't match dev_t and inode number with nsfs of current task, or if dev conversion to dev_t lost high bits.
+
+- **-ENOENT** if pidns does not exists for the current task.
+
+Examples in situ:
+[search /examples](https://github.com/iovisor/bcc/search?q=bpf_get_ns_current_pid_tgid+path%3Aexamples&type=Code),
+[search /tools](https://github.com/iovisor/bcc/search?q=bpf_get_ns_current_pid_tgid+path%3Atools&type=Code)
+
 
 ## Debugging
 

--- a/examples/tracing/hello_perf_output_using_ns.py
+++ b/examples/tracing/hello_perf_output_using_ns.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+# Carlos Neira <cneirabustos@gmail.com>
+# This is a Hello World example that uses BPF_PERF_OUTPUT.
+# in this example bpf_get_ns_current_pid_tgid(), this helper
+# works inside pid namespaces.
+# bpf_get_current_pid_tgid() only returns the host pid outside any
+# namespace and this will not work when the script is run inside a pid namespace.
+
+from bcc import BPF
+from bcc.utils import printb
+import sys, os
+from stat import *
+
+# define BPF program
+prog = """
+#include <linux/sched.h>
+
+// define output data structure in C
+struct data_t {
+    u32 pid;
+    u64 ts;
+    char comm[TASK_COMM_LEN];
+};
+BPF_PERF_OUTPUT(events);
+
+int hello(struct pt_regs *ctx) {
+    struct data_t data = {};
+    struct bpf_pidns_info ns = {};
+
+    if(bpf_get_ns_current_pid_tgid(DEV, INO, &ns, sizeof(struct bpf_pidns_info)))
+	return 0;
+    data.pid = ns.pid;
+    data.ts = bpf_ktime_get_ns();
+    bpf_get_current_comm(&data.comm, sizeof(data.comm));
+
+    events.perf_submit(ctx, &data, sizeof(data));
+
+    return 0;
+}
+"""
+
+devinfo = os.stat("/proc/self/ns/pid")
+for r in (("DEV", str(devinfo.st_dev)), ("INO", str(devinfo.st_ino))):
+    prog = prog.replace(*r)
+
+# load BPF program
+b = BPF(text=prog)
+b.attach_kprobe(event=b.get_syscall_fnname("clone"), fn_name="hello")
+
+# header
+print("%-18s %-16s %-6s %s" % ("TIME(s)", "COMM", "PID", "MESSAGE"))
+
+# process event
+start = 0
+
+
+def print_event(cpu, data, size):
+    global start
+    event = b["events"].event(data)
+    if start == 0:
+        start = event.ts
+    time_s = (float(event.ts - start)) / 1000000000
+    printb(
+        b"%-18.9f %-16s %-6d %s"
+        % (time_s, event.comm, event.pid, b"Hello, perf_output!")
+    )
+
+
+# loop with callback to print_event
+b["events"].open_perf_buffer(print_event)
+while 1:
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()


### PR DESCRIPTION
This PR completes the work done for [PID filtering issues when running bpf script inside container ](https://github.com/iovisor/bcc/issues/1329).

- Added  bpf_get_ns_current_pid_tgid helper to developer reference documentation. 
- Added example cloning hello_perfoutput.py as hello_perfoutput_using_ns.py replacing  bpf_get_current_pid_tgid() with the new helper  bpf_get_ns_current_pid_tgid().