### PR TITLE
libbpf-tools: add CO-RE readahead

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -8,6 +8,7 @@
 /execsnoop
 /filelife
 /opensnoop
+/readahead
 /runqslower
 /syscount
 /tcpconnect

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -19,6 +19,7 @@ APPS = \
 	execsnoop \
 	filelife \
 	opensnoop \
+	readahead \
 	runqslower \
 	syscount \
 	tcpconnect \

--- a/libbpf-tools/readahead.bpf.c
+++ b/libbpf-tools/readahead.bpf.c
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenbo Zhang
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "readahead.h"
+#include "bits.bpf.h"
+
+#define MAX_ENTRIES 10240
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} in_readahead SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct page *);
+	__type(value, u64);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} birth SEC(".maps");
+
+static struct hist hist;
+
+SEC("fentry/__do_page_cache_readahead")
+int BPF_PROG(fentry__do_page_cache_readahead)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+	u64 one = 1;
+
+	bpf_map_update_elem(&in_readahead, &pid, &one, 0);
+	return 0;
+}
+
+SEC("fexit/__page_cache_alloc")
+int BPF_PROG(fexit__page_cache_alloc, gfp_t gfp, struct page *ret)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+	u64 ts;
+
+	if (!bpf_map_lookup_elem(&in_readahead, &pid))
+		return 0;
+
+	ts = bpf_ktime_get_ns();
+	bpf_map_update_elem(&birth, &ret, &ts, 0);
+	__sync_fetch_and_add(&hist.unused, 1);
+	__sync_fetch_and_add(&hist.total, 1);
+
+	return 0;
+}
+
+SEC("fexit/__do_page_cache_readahead")
+int BPF_PROG(fexit__do_page_cache_readahead)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+
+	bpf_map_delete_elem(&in_readahead, &pid);
+	return 0;
+}
+
+SEC("fentry/mark_page_accessed")
+int BPF_PROG(fentry__mark_page_accessed, struct page *page)
+{
+	u64 *tsp, slot, ts = bpf_ktime_get_ns();
+	s64 delta;
+
+	tsp = bpf_map_lookup_elem(&birth, &page);
+	if (!tsp)
+		return 0;
+	delta = (s64)(ts - *tsp);
+	if (delta < 0)
+		goto update_and_cleanup;
+	slot = log2l(delta / 1000000);
+	if (slot >= MAX_SLOTS)
+		slot = MAX_SLOTS - 1;
+	__sync_fetch_and_add(&hist.slots[slot], 1);
+
+update_and_cleanup:
+	__sync_fetch_and_add(&hist.unused, -1);
+	bpf_map_delete_elem(&birth, &page);
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/readahead.c
+++ b/libbpf-tools/readahead.c
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2020 Wenbo Zhang
+//
+// Based on readahead(8) from from BPF-Perf-Tools-Book by Brendan Gregg.
+// 8-Jun-2020   Wenbo Zhang   Created this.
+#include <argp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "readahead.h"
+#include "readahead.skel.h"
+#include "trace_helpers.h"
+
+static struct env {
+	int duration;
+	bool verbose;
+} env = {
+	.duration = -1
+};
+
+static volatile bool exiting;
+
+const char *argp_program_version = "readahead 0.1";
+const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char argp_program_doc[] =
+"Show fs automatic read-ahead usage.\n"
+"\n"
+"USAGE: readahead [-d DURATION]\n"
+"\n"
+"EXAMPLES:\n"
+"    readahead              # summarize on-CPU time as a histogram"
+"    readahead -d 10        # trace for 10 seconds only\n";
+
+static const struct argp_option opts[] = {
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{ "duration", 'd', "DURATION", 0, "Duration to trace"},
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	switch (key) {
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'd':
+		errno = 0;
+		env.duration = strtol(arg, NULL, 10);
+		if (errno || env.duration <= 0) {
+			fprintf(stderr, "Invalid duration: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 'h':
+		argp_usage(state);
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+int libbpf_print_fn(enum libbpf_print_level level,
+		    const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_handler(int sig)
+{
+	exiting = true;
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct readahead_bpf *obj;
+	struct hist *histp;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	err = bump_memlock_rlimit();
+	if (err) {
+		fprintf(stderr, "failed to increase rlimit: %d\n", err);
+		return 1;
+	}
+
+	obj = readahead_bpf__open_and_load();
+	if (!obj) {
+		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		return 1;
+	}
+
+	err = readahead_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+
+	signal(SIGINT, sig_handler);
+
+	printf("Tracing fs read-ahead ... Hit Ctrl-C to end.\n");
+
+	sleep(env.duration);
+	printf("\n");
+
+	histp = &obj->bss->hist;
+
+	printf("Readahead unused/total pages: %d/%d\n",
+		histp->unused, histp->total);
+	print_log2_hist(histp->slots, MAX_SLOTS, "msecs");
+
+cleanup:
+	readahead_bpf__destroy(obj);
+	return err != 0;
+}

--- a/libbpf-tools/readahead.h
+++ b/libbpf-tools/readahead.h
@@ -1,0 +1,12 @@
+#ifndef __READAHEAD_H
+#define __READAHEAD_H
+
+#define MAX_SLOTS	20
+
+struct hist {
+	__u32 unused;
+	__u32 total;
+	__u32 slots[MAX_SLOTS];
+};
+
+#endif /* __READAHEAD_H */


### PR DESCRIPTION
The output looks like:

```sh
Tracing fs read-ahead ... Hit Ctrl-C to end.
^C
Readahead unsued/total pages: 96/473288
     msecs               : count    distribution
         0 -> 1          : 473191   |****************************************|
         2 -> 3          : 1        |                                        |
```



Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>