### PR TITLE
libbpf-tools: add CO-RE biostacks

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -2,6 +2,7 @@
 /biolatency
 /biopattern
 /biosnoop
+/biostacks
 /bitesize
 /cpudist
 /drsnoop

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -13,6 +13,7 @@ APPS = \
 	biolatency \
 	biopattern \
 	biosnoop \
+	biostacks \
 	bitesize \
 	cpudist \
 	drsnoop \

--- a/libbpf-tools/biostacks.bpf.c
+++ b/libbpf-tools/biostacks.bpf.c
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenbo Zhang
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+#include "biostacks.h"
+#include "bits.bpf.h"
+
+#define MAX_ENTRIES 10240
+
+const volatile char targ_disk[DISK_NAME_LEN] = {};
+const volatile bool targ_ms = false;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct request *);
+	__type(value, u64);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} start SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, u64);
+	__type(value, struct rqinfo);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} rqinfos SEC(".maps");
+
+static __always_inline bool disk_filtered(const char *disk)
+{
+	int i;
+
+	for (i = 0; targ_disk[i] != '\0' && i < DISK_NAME_LEN; i++) {
+		if (disk[i] != targ_disk[i])
+			return false;
+	}
+	return true;
+}
+
+static __always_inline
+int trace_start(struct rqinfo *rqinfo, void *ctx, struct request *rq,
+		u32 pid, u64 ts)
+{
+	rqinfo->pid = pid;
+	rqinfo->kern_stack_size = bpf_get_stack(ctx, rqinfo->kern_stack,
+					sizeof(rqinfo->kern_stack), 0);
+	rqinfo->start_ts = ts;
+	bpf_get_current_comm(&rqinfo->comm, sizeof(rqinfo->comm));
+	bpf_map_update_elem(&start, &rq, &ts, 0);
+	bpf_map_update_elem(&rqinfos, &ts, rqinfo, 0);
+	return 0;
+}
+
+SEC("fentry/blk_account_io_start")
+int BPF_PROG(fentry__blk_account_io_start, struct request *rq)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+	u64 ts = bpf_ktime_get_ns();
+	struct rqinfo rqinfo = {};
+
+	bpf_probe_read_kernel_str(&rqinfo.disk, sizeof(rqinfo.disk),
+				rq->rq_disk->disk_name);
+	if (!disk_filtered(rqinfo.disk))
+		return 0;
+	return trace_start(&rqinfo, ctx, rq, pid, ts);
+}
+
+SEC("kprobe/blk_account_io_merge_bio")
+int BPF_KPROBE(kprobe__blk_account_io_merge_bio, struct request *rq)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+	u64 *tsp, ts = bpf_ktime_get_ns();
+	struct rqinfo rqinfo = {};
+
+	BPF_CORE_READ_STR_INTO(&rqinfo, rq, rq_disk, disk_name);
+	tsp = bpf_map_lookup_elem(&start, &rq);
+	if (tsp) {
+		bpf_map_delete_elem(&rqinfos, tsp);
+	} else {
+		if (!disk_filtered(rqinfo.disk))
+			return 0;
+	}
+	return trace_start(&rqinfo, ctx, rq, pid, ts);
+}
+
+SEC("fentry/blk_account_io_done")
+int BPF_PROG(fentry__blk_account_io_done, struct request *rq)
+{
+	u64 slot, *tsp, ts = bpf_ktime_get_ns();
+	struct rqinfo *rqinfop;
+	s64 delta;
+
+	tsp = bpf_map_lookup_elem(&start, &rq);
+	if (!tsp)
+		return 0;
+	rqinfop = bpf_map_lookup_elem(&rqinfos, tsp);
+	if (!rqinfop)
+		goto cleanup;
+	delta = (s64)(ts - rqinfop->start_ts);
+	if (delta < 0) {
+		bpf_map_delete_elem(&rqinfos, tsp);
+		goto cleanup;
+	}
+	if (targ_ms)
+		delta /= 1000000;
+	else
+		delta /= 1000;
+	slot = log2l(delta);
+	if (slot >= MAX_SLOTS)
+		slot = MAX_SLOTS - 1;
+	__sync_fetch_and_add(&rqinfop->slots[slot], 1);
+
+cleanup:
+	bpf_map_delete_elem(&start, &rq);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/biostacks.c
+++ b/libbpf-tools/biostacks.c
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2020 Wenbo Zhang
+//
+// Based on biostacks(8) from BPF-Perf-Tools-Book by Brendan Gregg.
+// 10-Aug-2020   Wenbo Zhang   Created this.
+#include <argp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "biostacks.h"
+#include "biostacks.skel.h"
+#include "trace_helpers.h"
+
+static struct env {
+	char *disk;
+	int disk_len;
+	int duration;
+	bool milliseconds;
+	bool verbose;
+} env = {
+	.duration = -1,
+};
+
+const char *argp_program_version = "biostacks 0.1";
+const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char argp_program_doc[] =
+"Tracing block I/O with init stacks.\n"
+"\n"
+"USAGE: biostacks [-h]\n"
+"\n"
+"EXAMPLES:\n"
+"    biostacks              # trace block I/O with init stacks.\n"
+"    biolatency -d sdc      # trace sdc only\n";
+
+static const struct argp_option opts[] = {
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{ "disk",  'd', "DISK",  0, "Trace this disk only" },
+	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	static int pos_args;
+
+	switch (key) {
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'h':
+		argp_usage(state);
+		break;
+	case 'd':
+		env.disk = arg;
+		env.disk_len = strlen(arg) + 1;
+		if (env.disk_len > DISK_NAME_LEN) {
+			fprintf(stderr, "invaild disk name: too long\n");
+			argp_usage(state);
+		}
+		break;
+	case 'm':
+		env.milliseconds = true;
+		break;
+	case ARGP_KEY_ARG:
+		if (pos_args++) {
+			fprintf(stderr,
+				"unrecognized positional argument: %s\n", arg);
+			argp_usage(state);
+		}
+		errno = 0;
+		env.duration = strtoll(arg, NULL, 10);
+		if (errno || env.duration <= 0) {
+			fprintf(stderr, "invalid delay (in us): %s\n", arg);
+			argp_usage(state);
+		}
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+int libbpf_print_fn(enum libbpf_print_level level,
+		const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_handler(int sig)
+{
+}
+
+static int print_map(struct ksyms *ksyms, int fd)
+{
+	char *units = env.milliseconds ? "msecs" : "usecs";
+	__u64 lookup_key = -1, next_key;
+	const struct ksym *ksym;
+	int num_stack, i, err;
+	struct rqinfo rqinfo;
+
+	while (!bpf_map_get_next_key(fd, &lookup_key, &next_key)) {
+		err = bpf_map_lookup_elem(fd, &next_key, &rqinfo);
+		if (err < 0) {
+			fprintf(stderr, "failed to lookup hist: %d\n", err);
+			return -1;
+		}
+		printf("%-14.14s %-6d %-7s\n",
+			rqinfo.comm, rqinfo.pid, rqinfo.disk);
+		num_stack = rqinfo.kern_stack_size /
+			sizeof(rqinfo.kern_stack[0]);
+		for (i = 0; i < num_stack; i++) {
+			ksym = ksyms__map_addr(ksyms, rqinfo.kern_stack[i]);
+			printf("%s\n", ksym->name);
+		}
+		print_log2_hist(rqinfo.slots, MAX_SLOTS, units);
+		printf("\n");
+		lookup_key = next_key;
+	}
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct ksyms *ksyms = NULL;
+	struct biostacks_bpf *obj;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	err = bump_memlock_rlimit();
+	if (err) {
+		fprintf(stderr, "failed to increase rlimit: %d\n", err);
+		return 1;
+	}
+
+	obj = biostacks_bpf__open();
+	if (!obj) {
+		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		return 1;
+	}
+
+	/* initialize global data (filtering options) */
+	if (env.disk)
+		strncpy((char*)obj->rodata->targ_disk, env.disk, env.disk_len);
+	obj->rodata->targ_ms = env.milliseconds;
+
+	err = biostacks_bpf__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF object: %d\n", err);
+		goto cleanup;
+	}
+
+	obj->links.fentry__blk_account_io_start =
+		bpf_program__attach(obj->progs.fentry__blk_account_io_start);
+	err = libbpf_get_error(obj->links.fentry__blk_account_io_start);
+	if (err) {
+		fprintf(stderr, "failed to attach blk_account_io_start: %s\n",
+			strerror(err));
+		goto cleanup;
+	}
+	ksyms = ksyms__load();
+	if (!ksyms) {
+		fprintf(stderr, "failed to load kallsyms\n");
+		goto cleanup;
+	}
+	if (ksyms__get_symbol(ksyms, "blk_account_io_merge_bio")) {
+		obj->links.kprobe__blk_account_io_merge_bio =
+			bpf_program__attach(obj->
+					progs.kprobe__blk_account_io_merge_bio);
+		err = libbpf_get_error(obj->
+				links.kprobe__blk_account_io_merge_bio);
+		if (err) {
+			fprintf(stderr, "failed to attach "
+				"blk_account_io_merge_bio: %s\n",
+				strerror(err));
+			goto cleanup;
+		}
+	}
+	obj->links.fentry__blk_account_io_done =
+		bpf_program__attach(obj->progs.fentry__blk_account_io_done);
+	err = libbpf_get_error(obj->links.fentry__blk_account_io_done);
+	if (err) {
+		fprintf(stderr, "failed to attach blk_account_io_done: %s\n",
+			strerror(err));
+		goto cleanup;
+	}
+
+	signal(SIGINT, sig_handler);
+
+	printf("Tracing block I/O with init stacks. Hit Ctrl-C to end.\n");
+	sleep(env.duration);
+	print_map(ksyms, bpf_map__fd(obj->maps.rqinfos));
+
+cleanup:
+	biostacks_bpf__destroy(obj);
+	ksyms__free(ksyms);
+
+	return err != 0;
+}

--- a/libbpf-tools/biostacks.h
+++ b/libbpf-tools/biostacks.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __BIOSTACKS_H
+#define __BIOSTACKS_H
+
+#define DISK_NAME_LEN	32
+#define TASK_COMM_LEN	16
+#define MAX_SLOTS	20
+#define MAX_STACK	20
+
+struct rqinfo {
+	__u32 pid;
+	int kern_stack_size;
+	__u64 start_ts;
+	__u64 kern_stack[MAX_STACK];
+	__u32 slots[MAX_SLOTS];
+	char comm[TASK_COMM_LEN];
+	char disk[DISK_NAME_LEN];
+};
+
+#endif /* __BIOSTACKS_H */


### PR DESCRIPTION
```sh
etcd           5170   sda
bpf_prog_13cb591a4e5b16a5_fentry__blk_account_io_start
bpf_prog_13cb591a4e5b16a5_fentry__blk_account_io_start
bpf_trampoline_38122
blk_account_io_start
generic_make_request
submit_bio
ext4_io_submit
ext4_writepages
do_writepages
__filemap_fdatawrite_range
file_write_and_wait_range
ext4_sync_file
vfs_fsync_range
do_fsync
__x64_sys_fdatasync
do_syscall_64
entry_SYSCALL_64_after_hwframe
     usecs               : count    distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 1        |****************************************|

```

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>