### PR TITLE
libbpibbpf-tools: fix tcpconnect types usage

### DIFF
--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -242,8 +242,8 @@ static void print_count_ipv6(int map_fd)
 	}
 
 	for (__u32 i = 0; i < n; i++) {
-		memcpy(src.s6_addr, &keys[i].saddr, sizeof(src.s6_addr));
-		memcpy(dst.s6_addr, &keys[i].daddr, sizeof(src.s6_addr));
+		memcpy(src.s6_addr, keys[i].saddr, sizeof(src.s6_addr));
+		memcpy(dst.s6_addr, keys[i].daddr, sizeof(src.s6_addr));
 
 		printf("%-25s %-25s %-20d %-10llu\n",
 		       inet_ntop(AF_INET6, &src, s, sizeof(s)),
@@ -289,8 +289,8 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 		s.x4.s_addr = event->saddr_v4;
 		d.x4.s_addr = event->daddr_v4;
 	} else if (event->af == AF_INET6) {
-		memcpy(&s.x6.s6_addr, &event->saddr_v6, sizeof(s.x6.s6_addr));
-		memcpy(&d.x6.s6_addr, &event->daddr_v6, sizeof(d.x6.s6_addr));
+		memcpy(&s.x6.s6_addr, event->saddr_v6, sizeof(s.x6.s6_addr));
+		memcpy(&d.x6.s6_addr, event->daddr_v6, sizeof(d.x6.s6_addr));
 	} else {
 		warn("broken event: event->af=%d", event->af);
 		return;

--- a/libbpf-tools/tcpconnect.h
+++ b/libbpf-tools/tcpconnect.h
@@ -18,19 +18,19 @@ struct ipv4_flow_key {
 };
 
 struct ipv6_flow_key {
-	unsigned __int128 saddr;
-	unsigned __int128 daddr;
+	__u8 saddr[16];
+	__u8 daddr[16];
 	__u16 dport;
 };
 
 struct event {
 	union {
 		__u32 saddr_v4;
-		unsigned __int128 saddr_v6;
+		__u8 saddr_v6[16];
 	};
 	union {
 		__u32 daddr_v4;
-		unsigned __int128 daddr_v6;
+		__u8 daddr_v6[16];
 	};
 	char task[TASK_COMM_LEN];
 	__u64 ts_us;


### PR DESCRIPTION
The __int128 is not defined for 32-bit platforms, see [1], so replace it by
a portable array of __u8.

The usage of this type came from the original tcpconnect.py, and __int128 is
still used in most (if not all) original BCC tools to store IPv6 addresses.

[1] https://github.com/iovisor/bcc/issues/3044

Signed-off-by: Anton Protopopov <a.s.protopopov@gmail.com>