### PR TITLE
Fixes a problem when LLVM_DEFINITIONS contains a definition with an `=`

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -12,7 +12,11 @@ include_directories(${LIBELF_INCLUDE_DIRS})
 # todo: if check for kernel version
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libbpf/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libbpf/include/uapi)
-add_definitions(${LLVM_DEFINITIONS})
+
+# add_definitions has a problem parsing "-D_GLIBCXX_USE_CXX11_ABI=0", this is safer
+separate_arguments(LLVM_DEFINITIONS)
+add_compile_options(${LLVM_DEFINITIONS})
+
 configure_file(libbcc.pc.in libbcc.pc @ONLY)
 configure_file(bcc_version.h.in bcc_version.h @ONLY)
 


### PR DESCRIPTION
add_definitions seems to be trying to misparsing the arguments in LLVM_DEFINITIONS in any of them has an equal sign in. I ran into the problem with `-D_GLIBCXX_USE_CXX11_ABI=0`.
separate_arguments turns LLVM_DEFINITIONS into a cmake list and add_compile_options adds the items in the list to the compiler options without trying to do any additional parsing. This fixed my build problem.