### PR TITLE
libbpf-tools: fix tcpconnlat types usage

### DIFF
--- a/libbpf-tools/tcpconnlat.c
+++ b/libbpf-tools/tcpconnlat.c
@@ -115,8 +115,8 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 		s.x4.s_addr = e->saddr_v4;
 		d.x4.s_addr = e->daddr_v4;
 	} else if (e->af == AF_INET6) {
-		memcpy(&s.x6.s6_addr, &e->saddr_v6, sizeof(s.x6.s6_addr));
-		memcpy(&d.x6.s6_addr, &e->daddr_v6, sizeof(d.x6.s6_addr));
+		memcpy(&s.x6.s6_addr, e->saddr_v6, sizeof(s.x6.s6_addr));
+		memcpy(&d.x6.s6_addr, e->daddr_v6, sizeof(d.x6.s6_addr));
 	} else {
 		fprintf(stderr, "broken event: event->af=%d", e->af);
 		return;

--- a/libbpf-tools/tcpconnlat.h
+++ b/libbpf-tools/tcpconnlat.h
@@ -6,11 +6,11 @@
 struct event {
 	union {
 		__u32 saddr_v4;
-		unsigned __int128 saddr_v6;
+		__u8 saddr_v6[16];
 	};
 	union {
 		__u32 daddr_v4;
-		unsigned __int128 daddr_v6;
+		__u8 daddr_v6[16];
 	};
 	char comm[TASK_COMM_LEN];
 	__u64 delta_us;


### PR DESCRIPTION
As https://github.com/iovisor/bcc/pull/3051  and https://github.com/iovisor/bcc/issues/3044  mentioned 

> The __int128 is not defined for 32-bit platforms, see [1], so replace it bya portable array of __u8.

so fix this as @aspsk did.

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>