### PR TITLE
libbpf-tools: add numamove

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -9,6 +9,7 @@
 /execsnoop
 /filelife
 /hardirqs
+/numamove
 /opensnoop
 /readahead
 /runqlat

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -20,6 +20,7 @@ APPS = \
 	execsnoop \
 	filelife \
 	hardirqs \
+	numamove \
 	opensnoop \
 	readahead \
 	runqlat \

--- a/libbpf-tools/numamove.bpf.c
+++ b/libbpf-tools/numamove.bpf.c
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Wenbo Zhang
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, u32);
+	__type(value, u64);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} start SEC(".maps");
+
+__u64 latency = 0;
+__u64 num = 0;
+
+SEC("fentry/migrate_misplaced_page")
+int BPF_PROG(migrate_misplaced_page)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+	u64 ts = bpf_ktime_get_ns();
+
+	bpf_map_update_elem(&start, &pid, &ts, 0);
+	return 0;
+}
+
+SEC("fexit/migrate_misplaced_page")
+int BPF_PROG(migrate_misplaced_page_exit)
+{
+	u32 pid = bpf_get_current_pid_tgid();
+	u64 *tsp, ts = bpf_ktime_get_ns();
+	s64 delta;
+
+	tsp = bpf_map_lookup_elem(&start, &pid);
+	if (!tsp)
+		return 0;
+	delta = (s64)(ts - *tsp);
+	if (delta < 0)
+		goto cleanup;
+	__sync_fetch_and_add(&latency, delta / 1000000U);
+	__sync_fetch_and_add(&num, 1);
+
+cleanup:
+	bpf_map_delete_elem(&start, &pid);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/numamove.c
+++ b/libbpf-tools/numamove.c
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2020 Wenbo Zhang
+//
+// Based on numamove(8) from from BPF-Perf-Tools-Book by Brendan Gregg.
+// 8-Jun-2020   Wenbo Zhang   Created this.
+#include <argp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <time.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "numamove.skel.h"
+#include "trace_helpers.h"
+
+static struct env {
+	bool verbose;
+} env;
+
+static volatile bool exiting;
+
+const char *argp_program_version = "numamove 0.1";
+const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char argp_program_doc[] =
+"Show page migrations of type NUMA misplaced per second.\n"
+"\n"
+"USAGE: numamove [--help]\n"
+"\n"
+"EXAMPLES:\n"
+"    numamove              # Show page migrations' count and latency";
+
+static const struct argp_option opts[] = {
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	switch (key) {
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'h':
+		argp_usage(state);
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+int libbpf_print_fn(enum libbpf_print_level level,
+		    const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_handler(int sig)
+{
+	exiting = true;
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct numamove_bpf *obj;
+	struct tm *tm;
+	char ts[32];
+	time_t t;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	err = bump_memlock_rlimit();
+	if (err) {
+		fprintf(stderr, "failed to increase rlimit: %d\n", err);
+		return 1;
+	}
+
+	obj = numamove_bpf__open_and_load();
+	if (!obj) {
+		fprintf(stderr, "failed to open and/or load BPF object\n");
+		return 1;
+	}
+
+	err = numamove_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+
+	signal(SIGINT, sig_handler);
+
+	printf("%-10s %18s %18s\n", "TIME", "NUMA_migrations",
+		"NUMA_migrations_ms");
+	while (!exiting) {
+		sleep(1);
+		time(&t);
+		tm = localtime(&t);
+		strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+		printf("%-10s %18lld %18lld\n", ts,
+			__atomic_exchange_n(&obj->bss->num, 0,
+					__ATOMIC_RELAXED),
+			__atomic_exchange_n(&obj->bss->latency, 0,
+					__ATOMIC_RELAXED));
+	}
+
+cleanup:
+	numamove_bpf__destroy(obj);
+	return err != 0;
+}


### PR DESCRIPTION
With test workloads, the output looks as below:

```
TIME          NUMA_migrations NUMA_migrations_ms
02:54:41                31576                  0
02:54:42                31705                  0
02:54:43                31450                  3
02:54:44                31572                  0
02:54:45                30984                  0
02:54:46                31543                  0
02:54:47                31686                  1
02:54:48                31593                  0
02:54:49                31530                  4
02:54:50                31322                 11
02:54:51                31710                  0
02:54:52                31675                  0
02:54:53                31622                  2
02:54:54                31630                  4
```


Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>