### PR TITLE
Forbid trampolines for archs other than x86_64

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -22,6 +22,7 @@ import re
 import struct
 import errno
 import sys
+import platform
 
 from .libbcc import lib, bcc_symbol, bcc_symbol_option, bcc_stacktrace_build_id, _SYM_CB_TYPE
 from .table import Table, PerfEventArray, RingBuf, BPF_MAP_TYPE_QUEUE, BPF_MAP_TYPE_STACK
@@ -895,6 +896,9 @@ class BPF(object):
 
     @staticmethod
     def support_kfunc():
+        # there's no trampoline support for other than x86_64 arch
+        if platform.machine() != 'x86_64':
+            return False;
         if not lib.bpf_has_kernel_btf():
             return False;
         # kernel symbol "bpf_trampoline_link_prog" indicates kfunc support


### PR DESCRIPTION
The trampoline support check in bcc does not work properly,
so the feature is detected even on architectures that do not
support it - all archs other than x86_64.

We are checking for bpf_trampoline_link_prog to exist in
kernel, which works fine on x86_64 to check if the feature
is supported, but it's global function, so it exists also
in other archs even when the feature is not supported
so it returns True also on other archs.

Adding explicit x86_64 check to support_kfunc function.