### PR TITLE
Extend PerfType members

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -109,6 +109,10 @@ class PerfType:
     # From perf_type_id in uapi/linux/perf_event.h
     HARDWARE = 0
     SOFTWARE = 1
+    TRACEPOINT = 2
+    HW_CACHE = 3
+    RAW = 4
+    BREAKPOINT = 5
 
 class PerfHWConfig:
     # From perf_hw_id in uapi/linux/perf_event.h


### PR DESCRIPTION
You can use

    b.attach_perf_event(ev_type=PerfType.RAW, ...)

to attach perf raw event for profiling.

Signed-off-by: Edward Wu <edwardwu@realtek.com>