### PR TITLE
libbpf-tools: make some minor refactoring

### DIFF
--- a/libbpf-tools/biolatency.bpf.c
+++ b/libbpf-tools/biolatency.bpf.c
@@ -7,13 +7,13 @@
 #include "biolatency.h"
 #include "bits.bpf.h"
 
-#define MAX_ENTRIES 10240
+#define MAX_ENTRIES	10240
 
-const volatile char targ_disk[DISK_NAME_LEN] = {};
 const volatile bool targ_per_disk = false;
 const volatile bool targ_per_flag = false;
 const volatile bool targ_queued = false;
 const volatile bool targ_ms = false;
+const volatile dev_t targ_dev = -1;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -33,41 +33,32 @@ struct {
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } hists SEC(".maps");
 
-static __always_inline bool disk_filtered(const char *disk)
-{
-	int i;
-
-	for (i = 0; targ_disk[i] != '\0' && i < DISK_NAME_LEN; i++) {
-		if (disk[i] != targ_disk[i])
-			return false;
-	}
-	return true;
-}
-
 static __always_inline
 int trace_rq_start(struct request *rq)
 {
 	u64 ts = bpf_ktime_get_ns();
-	char disk[DISK_NAME_LEN];
 
-	bpf_probe_read_kernel_str(&disk, sizeof(disk), rq->rq_disk->disk_name);
-	if (!disk_filtered(disk))
-		return 0;
+	if (targ_dev != -1) {
+		struct gendisk *disk = BPF_CORE_READ(rq, rq_disk);
+		dev_t dev;
 
+		dev = disk ? MKDEV(BPF_CORE_READ(disk, major),
+				BPF_CORE_READ(disk, first_minor)) : 0;
+		if (targ_dev != dev)
+			return 0;
+	}
 	bpf_map_update_elem(&start, &rq, &ts, 0);
 	return 0;
 }
 
 SEC("tp_btf/block_rq_insert")
-int BPF_PROG(tp_btf__block_rq_insert, struct request_queue *q,
-	     struct request *rq)
+int BPF_PROG(block_rq_insert, struct request_queue *q, struct request *rq)
 {
 	return trace_rq_start(rq);
 }
 
 SEC("tp_btf/block_rq_issue")
-int BPF_PROG(tp_btf__block_rq_issue, struct request_queue *q,
-	     struct request *rq)
+int BPF_PROG(block_rq_issue, struct request_queue *q, struct request *rq)
 {
 	if (targ_queued && BPF_CORE_READ(q, elevator))
 		return 0;
@@ -75,8 +66,8 @@ int BPF_PROG(tp_btf__block_rq_issue, struct request_queue *q,
 }
 
 SEC("tp_btf/block_rq_complete")
-int BPF_PROG(tp_btf__block_rq_complete, struct request *rq, int error,
-	     unsigned int nr_bytes)
+int BPF_PROG(block_rq_complete, struct request *rq, int error,
+	unsigned int nr_bytes)
 {
 	u64 slot, *tsp, ts = bpf_ktime_get_ns();
 	struct hist_key hkey = {};
@@ -90,9 +81,12 @@ int BPF_PROG(tp_btf__block_rq_complete, struct request *rq, int error,
 	if (delta < 0)
 		goto cleanup;
 
-	if (targ_per_disk)
-		bpf_probe_read_kernel_str(&hkey.disk, sizeof(hkey.disk),
-					rq->rq_disk->disk_name);
+	if (targ_per_disk) {
+		struct gendisk *disk = BPF_CORE_READ(rq, rq_disk);
+
+		hkey.dev = disk ? MKDEV(BPF_CORE_READ(disk, major),
+					BPF_CORE_READ(disk, first_minor)) : 0;
+	}
 	if (targ_per_flag)
 		hkey.cmd_flags = rq->cmd_flags;
 
@@ -105,9 +99,9 @@ int BPF_PROG(tp_btf__block_rq_complete, struct request *rq, int error,
 	}
 
 	if (targ_ms)
-		delta /= 1000000;
+		delta /= 1000000U;
 	else
-		delta /= 1000;
+		delta /= 1000U;
 	slot = log2l(delta);
 	if (slot >= MAX_SLOTS)
 		slot = MAX_SLOTS - 1;

--- a/libbpf-tools/biolatency.h
+++ b/libbpf-tools/biolatency.h
@@ -5,9 +5,14 @@
 #define DISK_NAME_LEN	32
 #define MAX_SLOTS	27
 
+#define MINORBITS	20
+#define MINORMASK	((1U << MINORBITS) - 1)
+
+#define MKDEV(ma, mi)	(((ma) << MINORBITS) | (mi))
+
 struct hist_key {
-	char disk[DISK_NAME_LEN];
 	__u32 cmd_flags;
+	__u32 dev;
 };
 
 struct hist {

--- a/libbpf-tools/biopattern.bpf.c
+++ b/libbpf-tools/biopattern.bpf.c
@@ -17,7 +17,7 @@ struct {
 } counters SEC(".maps");
 
 SEC("tracepoint/block/block_rq_complete")
-int tp__block__block_rq_complete(struct trace_event_raw_block_rq_complete *ctx)
+int handle__block_rq_complete(struct trace_event_raw_block_rq_complete *ctx)
 {
 	sector_t *last_sectorp,  sector = ctx->sector;
 	struct counter *counterp, zero = {};

--- a/libbpf-tools/biopattern.h
+++ b/libbpf-tools/biopattern.h
@@ -1,5 +1,8 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 #ifndef __BIOPATTERN_H
 #define __BIOPATTERN_H
+
+#define DISK_NAME_LEN	32
 
 struct counter {
 	__u64 last_sector;

--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -6,10 +6,10 @@
 #include <bpf/bpf_tracing.h>
 #include "biosnoop.h"
 
-#define MAX_ENTRIES 10240
+#define MAX_ENTRIES	10240
 
-const volatile char targ_disk[DISK_NAME_LEN] = {};
 const volatile bool targ_queued = false;
+const volatile dev_t targ_dev = -1;
 
 struct piddata {
 	char comm[TASK_COMM_LEN];
@@ -27,6 +27,7 @@ struct {
 struct stage {
 	u64 insert;
 	u64 issue;
+	dev_t dev;
 };
 
 struct {
@@ -55,26 +56,15 @@ int trace_pid(struct request *rq)
 }
 
 SEC("fentry/blk_account_io_start")
-int BPF_PROG(fentry__blk_account_io_start, struct request *rq)
+int BPF_PROG(blk_account_io_start, struct request *rq)
 {
 	return trace_pid(rq);
 }
 
 SEC("kprobe/blk_account_io_merge_bio")
-int BPF_KPROBE(kprobe__blk_account_io_merge_bio, struct request *rq)
+int BPF_KPROBE(blk_account_io_merge_bio, struct request *rq)
 {
 	return trace_pid(rq);
-}
-
-static __always_inline bool disk_filtered(const char *disk)
-{
-	int i;
-
-	for (i = 0; targ_disk[i] != '\0' && i < DISK_NAME_LEN; i++) {
-		if (disk[i] != targ_disk[i])
-			return false;
-	}
-	return true;
 }
 
 static __always_inline
@@ -82,16 +72,15 @@ int trace_rq_start(struct request *rq, bool insert)
 {
 	struct stage *stagep, stage = {};
 	u64 ts = bpf_ktime_get_ns();
-	char disk[DISK_NAME_LEN];
 
 	stagep = bpf_map_lookup_elem(&start, &rq);
 	if (!stagep) {
-		bpf_probe_read_kernel_str(&disk, sizeof(disk),
-					rq->rq_disk->disk_name);
-		if (!disk_filtered(disk)) {
-			bpf_map_delete_elem(&infobyreq, &rq);
+		struct gendisk *disk = BPF_CORE_READ(rq, rq_disk);
+
+		stage.dev = disk ? MKDEV(BPF_CORE_READ(disk, major),
+				BPF_CORE_READ(disk, first_minor)) : 0;
+		if (targ_dev != -1 && targ_dev != stage.dev)
 			return 0;
-		}
 		stagep = &stage;
 	}
 	if (insert)
@@ -104,21 +93,19 @@ int trace_rq_start(struct request *rq, bool insert)
 }
 
 SEC("tp_btf/block_rq_insert")
-int BPF_PROG(tp_btf__block_rq_insert, struct request_queue *q,
-	     struct request *rq)
+int BPF_PROG(block_rq_insert, struct request_queue *q, struct request *rq)
 {
 	return trace_rq_start(rq, true);
 }
 
 SEC("tp_btf/block_rq_issue")
-int BPF_PROG(tp_btf__block_rq_issue, struct request_queue *q,
-	     struct request *rq)
+int BPF_PROG(block_rq_issue, struct request_queue *q, struct request *rq)
 {
 	return trace_rq_start(rq, false);
 }
 
 SEC("tp_btf/block_rq_complete")
-int BPF_PROG(tp_btf__block_rq_complete, struct request *rq, int error,
+int BPF_PROG(block_rq_complete, struct request *rq, int error,
 	     unsigned int nr_bytes)
 {
 	u64 slot, ts = bpf_ktime_get_ns();
@@ -152,8 +139,7 @@ int BPF_PROG(tp_btf__block_rq_complete, struct request *rq, int error,
 	event.sector = rq->__sector;
 	event.len = rq->__data_len;
 	event.cmd_flags = rq->cmd_flags;
-	bpf_probe_read_kernel_str(&event.disk, sizeof(event.disk),
-				rq->rq_disk->disk_name);
+	event.dev = stagep->dev;
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event,
 			sizeof(event));
 

--- a/libbpf-tools/biosnoop.h
+++ b/libbpf-tools/biosnoop.h
@@ -1,9 +1,15 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 #ifndef __BIOSNOOP_H
 #define __BIOSNOOP_H
 
 #define DISK_NAME_LEN	32
 #define TASK_COMM_LEN	16
 #define RWBS_LEN	8
+
+#define MINORBITS	20
+#define MINORMASK	((1U << MINORBITS) - 1)
+
+#define MKDEV(ma, mi)	(((ma) << MINORBITS) | (mi))
 
 struct event {
 	char comm[TASK_COMM_LEN];
@@ -14,7 +20,7 @@ struct event {
 	__u32 len;
 	__u32 pid;
 	__u32 cmd_flags;
-	char disk[DISK_NAME_LEN];
+	__u32 dev;
 };
 
 #endif /* __BIOSNOOP_H */

--- a/libbpf-tools/biostacks.bpf.c
+++ b/libbpf-tools/biostacks.bpf.c
@@ -99,9 +99,9 @@ int BPF_PROG(blk_account_io_done, struct request *rq)
 	if (!histp)
 		goto cleanup;
 	if (targ_ms)
-		delta /= 1000000;
+		delta /= 1000000U;
 	else
-		delta /= 1000;
+		delta /= 1000U;
 	slot = log2l(delta);
 	if (slot >= MAX_SLOTS)
 		slot = MAX_SLOTS - 1;

--- a/libbpf-tools/biostacks.c
+++ b/libbpf-tools/biostacks.c
@@ -23,11 +23,11 @@ static struct env {
 };
 
 const char *argp_program_version = "biostacks 0.1";
-const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Tracing block I/O with init stacks.\n"
 "\n"
-"USAGE: biostacks [--help] [-d disk] [duration]\n"
+"USAGE: biostacks [--help] [-d disk] [-m] [duration]\n"
 "\n"
 "EXAMPLES:\n"
 "    biostacks              # trace block I/O with init stacks.\n"
@@ -48,9 +48,6 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	switch (key) {
 	case 'v':
 		env.verbose = true;
-		break;
-	case 'h':
-		argp_usage(state);
 		break;
 	case 'd':
 		env.disk = arg;
@@ -96,7 +93,7 @@ static void sig_handler(int sig)
 static
 void print_map(struct ksyms *ksyms, struct partitions *partitions, int fd)
 {
-	char *units = env.milliseconds ? "msecs" : "usecs";
+	const char *units = env.milliseconds ? "msecs" : "usecs";
 	struct rqinfo lookup_key = {}, next_key;
 	const struct partition *partition;
 	const struct ksym *ksym;
@@ -168,7 +165,7 @@ int main(int argc, char **argv)
 	if (env.disk) {
 		partition = partitions__get_by_name(partitions, env.disk);
 		if (!partition) {
-			fprintf(stderr, "invaild partition name: not exit\n");
+			fprintf(stderr, "invaild partition name: not exist\n");
 			goto cleanup;
 		}
 		obj->rodata->targ_dev = partition->dev;

--- a/libbpf-tools/biostacks.h
+++ b/libbpf-tools/biostacks.h
@@ -10,7 +10,7 @@
 #define MINORBITS	20
 #define MINORMASK	((1U << MINORBITS) - 1)
 
-#define MKDEV(ma,mi)	(((ma) << MINORBITS) | (mi))
+#define MKDEV(ma, mi)	(((ma) << MINORBITS) | (mi))
 
 struct rqinfo {
 	__u32 pid;

--- a/libbpf-tools/bitesize.h
+++ b/libbpf-tools/bitesize.h
@@ -1,8 +1,15 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 #ifndef __BITESIZE_H
 #define __BITESIZE_H
 
 #define TASK_COMM_LEN	16
+#define DISK_NAME_LEN	32
 #define MAX_SLOTS	20
+
+#define MINORBITS	20
+#define MINORMASK	((1U << MINORBITS) - 1)
+
+#define MKDEV(ma, mi)	(((ma) << MINORBITS) | (mi))
 
 struct hist_key {
 	char comm[TASK_COMM_LEN];

--- a/libbpf-tools/cpudist.bpf.c
+++ b/libbpf-tools/cpudist.bpf.c
@@ -7,7 +7,7 @@
 #include "cpudist.h"
 #include "bits.bpf.h"
 
-#define TASK_RUNNING 0
+#define TASK_RUNNING	0
 
 const volatile bool targ_per_process = false;
 const volatile bool targ_per_thread = false;
@@ -76,7 +76,7 @@ static __always_inline void update_hist(struct task_struct *task,
 }
 
 SEC("kprobe/finish_task_switch")
-int BPF_KPROBE(kprobe__finish_task_switch, struct task_struct *prev)
+int BPF_KPROBE(finish_task_switch, struct task_struct *prev)
 {
 	u32 prev_tgid = BPF_CORE_READ(prev, tgid);
 	u32 prev_pid = BPF_CORE_READ(prev, pid);

--- a/libbpf-tools/cpudist.c
+++ b/libbpf-tools/cpudist.c
@@ -33,11 +33,11 @@ static struct env {
 static volatile bool exiting;
 
 const char *argp_program_version = "cpudist 0.1";
-const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Summarize on-CPU time per task as a histogram.\n"
 "\n"
-"USAGE: cpudist [-h] [-O] [-T] [-m] [-P] [-L] [-p PID] [interval] [count]\n"
+"USAGE: cpudist [--help] [-O] [-T] [-m] [-P] [-L] [-p PID] [interval] [count]\n"
 "\n"
 "EXAMPLES:\n"
 "    cpudist              # summarize on-CPU time as a histogram"
@@ -48,7 +48,6 @@ const char argp_program_doc[] =
 "    cpudist -p 185       # trace PID 185 only";
 
 static const struct argp_option opts[] = {
-	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{ "offcpu", 'O', NULL, 0, "Measure off-CPU time" },
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
 	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
@@ -66,9 +65,6 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	switch (key) {
 	case 'v':
 		env.verbose = true;
-		break;
-	case 'h':
-		argp_usage(state);
 		break;
 	case 'm':
 		env.milliseconds = true;

--- a/libbpf-tools/drsnoop.c
+++ b/libbpf-tools/drsnoop.c
@@ -27,7 +27,7 @@ static struct env {
 } env = { };
 
 const char *argp_program_version = "drsnoop 0.1";
-const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Trace direct reclaim latency.\n"
 "\n"
@@ -115,7 +115,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	tm = localtime(&t);
 	strftime(ts, sizeof(ts), "%H:%M:%S", tm);
 	printf("%-8s %-16s %-6d %8.3f %5lld",
-	       ts, e->task, e->pid, (double)e->delta_ns / 1000000,
+	       ts, e->task, e->pid, e->delta_ns / 1000000.0,
 	       e->nr_reclaimed);
 	if (env.extended)
 		printf(" %8llu", e->nr_free_pages * page_size / 1024);

--- a/libbpf-tools/drsnoop.h
+++ b/libbpf-tools/drsnoop.h
@@ -2,7 +2,7 @@
 #ifndef __DRSNOOP_H
 #define __DRSNOOP_H
 
-#define TASK_COMM_LEN 16
+#define TASK_COMM_LEN	16
 
 struct event {
 	char task[TASK_COMM_LEN];

--- a/libbpf-tools/drsnoop_example.txt
+++ b/libbpf-tools/drsnoop_example.txt
@@ -68,4 +68,4 @@ EXAMPLES:
       --usage                Give a short usage message
   -V, --version              Print program version
 
-Report bugs to <ethercflow@gmail.com>.
+Report bugs to <bpf@vger.kernel.org>.

--- a/libbpf-tools/execsnoop.bpf.c
+++ b/libbpf-tools/execsnoop.bpf.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>

--- a/libbpf-tools/filelife.bpf.c
+++ b/libbpf-tools/filelife.bpf.c
@@ -37,20 +37,20 @@ probe_create(struct inode *dir, struct dentry *dentry)
 }
 
 SEC("kprobe/vfs_create")
-int BPF_KPROBE(kprobe__vfs_create, struct inode *dir, struct dentry *dentry)
+int BPF_KPROBE(vfs_create, struct inode *dir, struct dentry *dentry)
 {
 	return probe_create(dir, dentry);
 }
 
 SEC("kprobe/security_inode_create")
-int BPF_KPROBE(kprobe__security_inode_create, struct inode *dir,
+int BPF_KPROBE(security_inode_create, struct inode *dir,
 	     struct dentry *dentry)
 {
 	return probe_create(dir, dentry);
 }
 
 SEC("kprobe/vfs_unlink")
-int BPF_KPROBE(kprobe__vfs_unlink, struct inode *dir, struct dentry *dentry)
+int BPF_KPROBE(vfs_unlink, struct inode *dir, struct dentry *dentry)
 {
 	u64 id = bpf_get_current_pid_tgid();
 	struct event event = {};

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -24,11 +24,11 @@ static struct env {
 } env = { };
 
 const char *argp_program_version = "filelife 0.1";
-const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Trace the lifespan of short-lived files.\n"
 "\n"
-"USAGE: filelife [-p PID]\n"
+"USAGE: filelife  [--help] [-p PID]\n"
 "\n"
 "EXAMPLES:\n"
 "    filelife         # trace all events\n"

--- a/libbpf-tools/filelife.h
+++ b/libbpf-tools/filelife.h
@@ -2,8 +2,8 @@
 #ifndef __FILELIFE_H
 #define __FILELIFE_H
 
-#define DNAME_INLINE_LEN 32
-#define TASK_COMM_LEN    16
+#define DNAME_INLINE_LEN	32
+#define TASK_COMM_LEN		16
 
 struct event {
 	char file[DNAME_INLINE_LEN];

--- a/libbpf-tools/numamove.c
+++ b/libbpf-tools/numamove.c
@@ -20,7 +20,7 @@ static struct env {
 static volatile bool exiting;
 
 const char *argp_program_version = "numamove 0.1";
-const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Show page migrations of type NUMA misplaced per second.\n"
 "\n"
@@ -30,7 +30,7 @@ const char argp_program_doc[] =
 "    numamove              # Show page migrations' count and latency";
 
 static const struct argp_option opts[] = {
-	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
 	{},
 };
 
@@ -39,9 +39,6 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	switch (key) {
 	case 'v':
 		env.verbose = true;
-		break;
-	case 'h':
-		argp_usage(state);
 		break;
 	default:
 		return ARGP_ERR_UNKNOWN;

--- a/libbpf-tools/readahead.bpf.c
+++ b/libbpf-tools/readahead.bpf.c
@@ -6,7 +6,7 @@
 #include "readahead.h"
 #include "bits.bpf.h"
 
-#define MAX_ENTRIES 10240
+#define MAX_ENTRIES	10240
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -27,7 +27,7 @@ struct {
 static struct hist hist;
 
 SEC("fentry/__do_page_cache_readahead")
-int BPF_PROG(fentry__do_page_cache_readahead)
+int BPF_PROG(do_page_cache_readahead)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	u64 one = 1;
@@ -37,7 +37,7 @@ int BPF_PROG(fentry__do_page_cache_readahead)
 }
 
 SEC("fexit/__page_cache_alloc")
-int BPF_PROG(fexit__page_cache_alloc, gfp_t gfp, struct page *ret)
+int BPF_PROG(page_cache_alloc_ret, gfp_t gfp, struct page *ret)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	u64 ts;
@@ -54,7 +54,7 @@ int BPF_PROG(fexit__page_cache_alloc, gfp_t gfp, struct page *ret)
 }
 
 SEC("fexit/__do_page_cache_readahead")
-int BPF_PROG(fexit__do_page_cache_readahead)
+int BPF_PROG(do_page_cache_readahead_ret)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 
@@ -63,7 +63,7 @@ int BPF_PROG(fexit__do_page_cache_readahead)
 }
 
 SEC("fentry/mark_page_accessed")
-int BPF_PROG(fentry__mark_page_accessed, struct page *page)
+int BPF_PROG(mark_page_accessed, struct page *page)
 {
 	u64 *tsp, slot, ts = bpf_ktime_get_ns();
 	s64 delta;
@@ -74,7 +74,7 @@ int BPF_PROG(fentry__mark_page_accessed, struct page *page)
 	delta = (s64)(ts - *tsp);
 	if (delta < 0)
 		goto update_and_cleanup;
-	slot = log2l(delta / 1000000);
+	slot = log2l(delta / 1000000U);
 	if (slot >= MAX_SLOTS)
 		slot = MAX_SLOTS - 1;
 	__sync_fetch_and_add(&hist.slots[slot], 1);

--- a/libbpf-tools/readahead.c
+++ b/libbpf-tools/readahead.c
@@ -23,18 +23,17 @@ static struct env {
 static volatile bool exiting;
 
 const char *argp_program_version = "readahead 0.1";
-const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Show fs automatic read-ahead usage.\n"
 "\n"
-"USAGE: readahead [-d DURATION]\n"
+"USAGE: readahead [--help] [-d DURATION]\n"
 "\n"
 "EXAMPLES:\n"
 "    readahead              # summarize on-CPU time as a histogram"
 "    readahead -d 10        # trace for 10 seconds only\n";
 
 static const struct argp_option opts[] = {
-	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{ "duration", 'd', "DURATION", 0, "Duration to trace"},
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
 	{},
@@ -53,9 +52,6 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			fprintf(stderr, "Invalid duration: %s\n", arg);
 			argp_usage(state);
 		}
-		break;
-	case 'h':
-		argp_usage(state);
 		break;
 	default:
 		return ARGP_ERR_UNKNOWN;

--- a/libbpf-tools/readahead.h
+++ b/libbpf-tools/readahead.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 #ifndef __READAHEAD_H
 #define __READAHEAD_H
 

--- a/libbpf-tools/runqslower.bpf.c
+++ b/libbpf-tools/runqslower.bpf.c
@@ -4,7 +4,7 @@
 #include <bpf/bpf_helpers.h>
 #include "runqslower.h"
 
-#define TASK_RUNNING 0
+#define TASK_RUNNING	0
 
 const volatile __u64 min_us = 0;
 const volatile pid_t targ_pid = 0;

--- a/libbpf-tools/tcpconnect.bpf.c
+++ b/libbpf-tools/tcpconnect.bpf.c
@@ -192,25 +192,25 @@ end:
 }
 
 SEC("kprobe/tcp_v4_connect")
-int BPF_KPROBE(kprobe__tcp_v4_connect, struct sock *sk)
+int BPF_KPROBE(tcp_v4_connect, struct sock *sk)
 {
 	return enter_tcp_connect(ctx, sk);
 }
 
 SEC("kretprobe/tcp_v4_connect")
-int BPF_KRETPROBE(kretprobe__tcp_v4_connect, int ret)
+int BPF_KRETPROBE(tcp_v4_connect_ret, int ret)
 {
 	return exit_tcp_connect(ctx, ret, 4);
 }
 
 SEC("kprobe/tcp_v6_connect")
-int BPF_KPROBE(kprobe__tcp_v6_connect, struct sock *sk)
+int BPF_KPROBE(tcp_v6_connect, struct sock *sk)
 {
 	return enter_tcp_connect(ctx, sk);
 }
 
 SEC("kretprobe/tcp_v6_connect")
-int BPF_KRETPROBE(kretprobe__tcp_v6_connect, int ret)
+int BPF_KRETPROBE(tcp_v6_connect_ret, int ret)
 {
 	return exit_tcp_connect(ctx, ret, 6);
 }

--- a/libbpf-tools/tcpconnlat.bpf.c
+++ b/libbpf-tools/tcpconnlat.bpf.c
@@ -47,19 +47,19 @@ static __always_inline int trace_connect(struct sock *sk)
 }
 
 SEC("fentry/tcp_v4_connect")
-int BPF_PROG(fentry__tcp_v4_connect, struct sock *sk)
+int BPF_PROG(tcp_v4_connect, struct sock *sk)
 {
 	return trace_connect(sk);
 }
 
 SEC("kprobe/tcp_v6_connect")
-int BPF_KPROBE(kprobe__tcp_v6_connect, struct sock *sk)
+int BPF_KPROBE(tcp_v6_connect, struct sock *sk)
 {
 	return trace_connect(sk);
 }
 
 SEC("fentry/tcp_rcv_state_process")
-int BPF_PROG(fentry__tcp_rcv_state_process, struct sock *sk)
+int BPF_PROG(tcp_rcv_state_process, struct sock *sk)
 {
 	struct piddata *piddatap;
 	struct event event = {};
@@ -78,7 +78,7 @@ int BPF_PROG(fentry__tcp_rcv_state_process, struct sock *sk)
 	if (delta < 0)
 		goto cleanup;
 
-	event.delta_us = delta / 1000;
+	event.delta_us = delta / 1000U;
 	if (targ_min_us && event.delta_us < targ_min_us)
 		goto cleanup;
 	__builtin_memcpy(&event.comm, piddatap->comm,

--- a/libbpf-tools/tcpconnlat.c
+++ b/libbpf-tools/tcpconnlat.c
@@ -25,11 +25,11 @@ static struct env {
 } env;
 
 const char *argp_program_version = "tcpconnlat 0.1";
-const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "\nTrace TCP connects and show connection latency.\n"
 "\n"
-"USAGE: tcpconnlat [-h] [-t] [-p PID]\n"
+"USAGE: tcpconnlat [--help] [-t] [-p PID]\n"
 "\n"
 "EXAMPLES:\n"
 "    tcpconnlat              # summarize on-CPU time as a histogram"
@@ -39,7 +39,6 @@ const char argp_program_doc[] =
 "    tcpconnlat -p 185       # trace PID 185 only";
 
 static const struct argp_option opts[] = {
-	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{ "timestamp", 't', NULL, 0, "Include timestamp on output" },
 	{ "pid", 'p', "PID", 0, "Trace this PID only" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
@@ -53,9 +52,6 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	switch (key) {
 	case 'v':
 		env.verbose = true;
-		break;
-	case 'h':
-		argp_usage(state);
 		break;
 	case 'p':
 		errno = 0;

--- a/libbpf-tools/tcpconnlat.h
+++ b/libbpf-tools/tcpconnlat.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
 #ifndef __TCPCONNLAT_H
 #define __TCPCONNLAT_H
 

--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -1,4 +1,8 @@
 /* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+// Copyright (c) 2020 Wenbo Zhang
+//
+// Based on ksyms improvements from Andrii Nakryiko, add more helpers.
+// 28-Feb-2020   Wenbo Zhang   Created this.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -18,7 +22,7 @@
 #define MINORBITS	20
 #define MINORMASK	((1U << MINORBITS) - 1)
 
-#define MKDEV(ma,mi)	(((ma) << MINORBITS) | (mi))
+#define MKDEV(ma, mi)	(((ma) << MINORBITS) | (mi))
 
 struct ksyms {
 	struct ksym *syms;

--- a/libbpf-tools/vfsstat.bpf.c
+++ b/libbpf-tools/vfsstat.bpf.c
@@ -16,31 +16,31 @@ static __always_inline int inc_stats(int key)
 }
 
 SEC("kprobe/vfs_read")
-int BPF_KPROBE(kprobe__vfs_read)
+int BPF_KPROBE(vfs_read)
 {
 	return inc_stats(S_READ);
 }
 
 SEC("kprobe/vfs_write")
-int BPF_KPROBE(kprobe__vfs_write)
+int BPF_KPROBE(vfs_write)
 {
 	return inc_stats(S_WRITE);
 }
 
 SEC("kprobe/vfs_fsync")
-int BPF_KPROBE(kprobe__vfs_fsync)
+int BPF_KPROBE(vfs_fsync)
 {
 	return inc_stats(S_FSYNC);
 }
 
 SEC("kprobe/vfs_open")
-int BPF_KPROBE(kprobe__vfs_open)
+int BPF_KPROBE(vfs_open)
 {
 	return inc_stats(S_OPEN);
 }
 
 SEC("kprobe/vfs_create")
-int BPF_KPROBE(kprobe__vfs_create)
+int BPF_KPROBE(vfs_create)
 {
 	return inc_stats(S_CREATE);
 }

--- a/libbpf-tools/xfsslower.bpf.c
+++ b/libbpf-tools/xfsslower.bpf.c
@@ -6,7 +6,7 @@
 #include <bpf/bpf_tracing.h>
 #include "xfsslower.h"
 
-#define NULL    0
+#define NULL	0
 
 const volatile pid_t targ_tgid = 0;
 const volatile __u64 min_lat = 0;
@@ -53,7 +53,7 @@ probe_entry(struct file *fp, loff_t s, loff_t e)
 }
 
 SEC("kprobe/xfs_file_read_iter")
-int BPF_KPROBE(kprobe__xfs_file_read_iter, struct kiocb *iocb)
+int BPF_KPROBE(xfs_file_read_iter, struct kiocb *iocb)
 {
 	struct file *fp = BPF_CORE_READ(iocb, ki_filp);
 	loff_t start = BPF_CORE_READ(iocb, ki_pos);
@@ -62,7 +62,7 @@ int BPF_KPROBE(kprobe__xfs_file_read_iter, struct kiocb *iocb)
 }
 
 SEC("kprobe/xfs_file_write_iter")
-int BPF_KPROBE(kprobe__xfs_file_write_iter, struct kiocb *iocb)
+int BPF_KPROBE(xfs_file_write_iter, struct kiocb *iocb)
 {
 	struct file *fp = BPF_CORE_READ(iocb, ki_filp);
 	loff_t start = BPF_CORE_READ(iocb, ki_pos);
@@ -71,13 +71,13 @@ int BPF_KPROBE(kprobe__xfs_file_write_iter, struct kiocb *iocb)
 }
 
 SEC("kprobe/xfs_file_open")
-int BPF_KPROBE(kprobe__xfs_file_open, struct inode *inode, struct file *file)
+int BPF_KPROBE(xfs_file_open, struct inode *inode, struct file *file)
 {
 	return probe_entry(file, 0, 0);
 }
 
 SEC("kprobe/xfs_file_fsync")
-int BPF_KPROBE(kprobe__xfs_file_fsync, struct file *file, loff_t start,
+int BPF_KPROBE(xfs_file_fsync, struct file *file, loff_t start,
 	       loff_t end)
 {
 	return probe_entry(file, start, end);
@@ -134,25 +134,25 @@ probe_exit(struct pt_regs *ctx, char type, ssize_t size)
 }
 
 SEC("kretprobe/xfs_file_read_iter")
-int BPF_KRETPROBE(kretprobe__xfs_file_read_iters, ssize_t ret)
+int BPF_KRETPROBE(xfs_file_read_iters_ret, ssize_t ret)
 {
 	return probe_exit(ctx, TRACE_READ, ret);
 }
 
 SEC("kretprobe/xfs_file_write_iter")
-int BPF_KRETPROBE(kretprobe__xfs_file_write_iter, ssize_t ret)
+int BPF_KRETPROBE(xfs_file_write_iter_ret, ssize_t ret)
 {
 	return probe_exit(ctx, TRACE_WRITE, ret);
 }
 
 SEC("kretprobe/xfs_file_open")
-int BPF_KRETPROBE(kretprobe__xfs_file_open)
+int BPF_KRETPROBE(xfs_file_open_ret)
 {
 	return probe_exit(ctx, TRACE_OPEN, 0);
 }
 
 SEC("kretprobe/xfs_file_fsync")
-int BPF_KRETPROBE(kretprobe__xfs_file_sync)
+int BPF_KRETPROBE(xfs_file_sync_ret)
 {
 	return probe_exit(ctx, TRACE_FSYNC, 0);
 }

--- a/libbpf-tools/xfsslower.c
+++ b/libbpf-tools/xfsslower.c
@@ -33,7 +33,7 @@ static struct env {
 };
 
 const char *argp_program_version = "xfsslower 0.1";
-const char *argp_program_bug_address = "<ethercflow@gmail.com>";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Trace common XFS file operations slower than a threshold.\n"
 "\n"
@@ -48,7 +48,6 @@ const char argp_program_doc[] =
 static const struct argp_option opts[] = {
 	{ "csv", 'c', NULL, 0, "Output as csv" },
 	{ "duration", 'd', "DURATION", 0, "Total duration of trace in seconds" },
-	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help"},
 	{ "pid", 'p', "PID", 0, "Process PID to trace" },
 	{ "min", 'm', "MIN", 0, "Min latency of trace in ms (default 10)" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
@@ -64,9 +63,6 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	switch (key) {
 	case 'v':
 		env.verbose = true;
-		break;
-	case 'h':
-		argp_usage(state);
 		break;
 	case 'c':
 		env.csv = true;

--- a/libbpf-tools/xfsslower.h
+++ b/libbpf-tools/xfsslower.h
@@ -2,8 +2,8 @@
 #ifndef __XFSSLOWER_H
 #define __XFSSLOWER_H
 
-#define DNAME_INLINE_LEN 32
-#define TASK_COMM_LEN    16
+#define DNAME_INLINE_LEN	32
+#define TASK_COMM_LEN		16
 
 #define TRACE_READ   'R'
 #define TRACE_WRITE  'W'


### PR DESCRIPTION
- Unify the filtering of blk tools
- Remove the meaningless function name prefix 
- Fix several incorrect parameter description
- Fix sth like: `char*` -> `const char *`, `(double)val * n` -> `var * n.0`
- Supplement the missing license or copyright 

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>