### PR TITLE
slabratetop: Add memcg_cache_params struct def

### DIFF
--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -62,7 +62,13 @@ def signal_ignore(signal, frame):
 bpf_text = """
 #include <uapi/linux/ptrace.h>
 #include <linux/mm.h>
-#include <linux/slab.h>
+
+// memcg_cache_params is a part of kmem_cache, but is not publicly exposed in
+// kernel versions 5.4 to 5.8.  Define an empty struct for it here to allow the
+// bpf program to compile.  It has been completely removed in kernel version
+// 5.9, but it does not hurt to have it here for versions 5.4 to 5.8.
+struct memcg_cache_params {};
+
 #ifdef CONFIG_SLUB
 #include <linux/slub_def.h>
 #else


### PR DESCRIPTION
The following kernel commit moves struct memcg_cache_params from
 include/linux/slab.h to mm/slab.h.

    commit 9adeaa226988b97bc15928e12f40a9863134467c
    Author: Waiman Long <longman@redhat.com>
    Date:   Mon Sep 23 15:33:49 2019 -0700

        mm, slab: move memcg_cache_params structure to mm/slab.h

        The memcg_cache_params structure is only embedded into the kmem_cache of
        slab and slub allocators as defined in slab_def.h and slub_def.h and used
        internally by mm code.  There is no needed to expose it in a public
        header.  So move it from include/linux/slab.h to mm/slab.h.  It is just a
        refactoring patch with no code change.

        ...

The commit is in kernel v5.4, causing a compiler error when including
slub_def.h or slab_def.h in slabratetop's bpf program.

Add an empty definition of the struct in slabratetop's bpf
program so it will compile with kernel version >= v5.4.
The actual struct definition is not required for slabratetop's bpf program.

Tested with kernel v5.8.8 and v5.3.7.

Fixes: https://github.com/iovisor/bcc/issues/2955

Signed-off-by: Daniel Rank dwrank@gmail.com