### PR TITLE
Fix tcpdrop v6 source (remote) and dest (local) address

### DIFF
--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -128,10 +128,12 @@ int trace_tcp_drop(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
         struct ipv6_data_t data6 = {};
         data6.pid = pid;
         data6.ip = 6;
+        // The remote address (skc_v6_daddr) was the source
         bpf_probe_read_kernel(&data6.saddr, sizeof(data6.saddr),
-            sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
-        bpf_probe_read_kernel(&data6.daddr, sizeof(data6.daddr),
             sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+        // The local address (skc_v6_rcv_saddr) was the destination
+        bpf_probe_read_kernel(&data6.daddr, sizeof(data6.daddr),
+            sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
         data6.dport = dport;
         data6.sport = sport;
         data6.state = state;


### PR DESCRIPTION
For v6 connections, tcpdrop.py would report the source and destination addresses swapped - tcp_drop() covers the input path, where the source of the received packet is the daddr stored in the socket.  The destination of the received packet is the local address. This commit swaps them to be correct and leaves a comment since it is not obvious (they can be removed).

