### PR TITLE
tools: tcptracer: fix alignement in tcp_ipv6_event_t

### DIFF
--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -73,12 +73,12 @@ struct tcp_ipv6_event_t {
     u32 type;
     u32 pid;
     char comm[TASK_COMM_LEN];
-    u8 ip;
     unsigned __int128 saddr;
     unsigned __int128 daddr;
     u16 sport;
     u16 dport;
     u32 netns;
+    u8 ip;
 };
 BPF_PERF_OUTPUT(tcp_ipv6_event);
 


### PR DESCRIPTION
On IPv6, tcptracer ports always appears as zeros:

Tracing TCP established connections. Ctrl-C to end.
T  PID    COMM             IP SADDR            DADDR            SPORT  DPORT
X  7055   nc               4  127.0.0.1        127.0.0.1        49476  9999
C  7074   nc               4  127.0.0.1        127.0.0.1        49478  9999
X  7074   nc               4  127.0.0.1        127.0.0.1        49478  9999
C  7085   nc               6  [::]             [0:0:0:1::]      0      0
X  7085   nc               6  [::]             [0:0:0:1::]      0      0
C  7086   nc               6  [::]             [0:0:0:1::]      0      0

This seems related to alignment issue wrt to the __int128 type in
tcp_ipv6_event_t structure. Moving the u8 field ip to the end of the
structure fixes the issue.

Fixes #2781