### PR TITLE
libbpf-tools: initialize global structs in runqlen and softirqs

### DIFF
--- a/libbpf-tools/runqlen.bpf.c
+++ b/libbpf-tools/runqlen.bpf.c
@@ -8,7 +8,7 @@
 
 const volatile bool targ_per_cpu = false;
 
-struct hist hists[MAX_CPU_NR];
+struct hist hists[MAX_CPU_NR] = {};
 
 SEC("perf_event")
 int do_sample(struct bpf_perf_event_data *ctx)

--- a/libbpf-tools/softirqs.bpf.c
+++ b/libbpf-tools/softirqs.bpf.c
@@ -17,8 +17,8 @@ struct {
 	__type(value, u64);
 } start SEC(".maps");
 
-__u64 counts[NR_SOFTIRQS];
-struct hist hists[NR_SOFTIRQS];
+__u64 counts[NR_SOFTIRQS] = {};
+struct hist hists[NR_SOFTIRQS] = {};
 
 SEC("tp_btf/softirq_entry")
 int BPF_PROG(softirq_entry, unsigned int vec_nr)


### PR DESCRIPTION
Hello,

when building libbpf-tools with make I got the following error for runqlen:

```
  BPF      runqlen.bpf.o
  GEN-SKEL runqlen.skel.h
libbpf: invalid relo for 'hists' in special section 0xfff2; forgot to initialize global var?..
Error: failed to open BPF object file: Relocation failed
make: *** [Makefile:77: .output/runqlen.skel.h] Error 255
make: *** Deleting file '.output/runqlen.skel.h'
```

softirqs failed with similar errors:
```
  BPF      softirqs.bpf.o
  GEN-SKEL softirqs.skel.h
libbpf: invalid relo for 'counts' in special section 0xfff2; forgot to initialize global var?..
Error: failed to open BPF object file: Relocation failed
make: *** [Makefile:77: .output/softirqs.skel.h] Error 255
make: *** Deleting file '.output/softirqs.skel.h'
```

I've managed to fix the errors by initializing the global variables, similarly to how vfsstat.bpf.c does. After compiling. I ran the programs and everything seems to work.

Regards,
Juraj