### PR TITLE
docs: Add missing code block closure

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -445,6 +445,7 @@ BPF_ITER(task)
   ... task->pid, task->tgid, task->comm, ...
   return 0;
 }
+```
 
 BPF iterators are introduced in 5.8 kernel for task, task_file, bpf_map, netlink_sock and ipv6_route . In 5.9, support is added to tcp/udp sockets and bpf map element (hashmap, arraymap and sk_local_storage_map) traversal.
 


### PR DESCRIPTION
https://github.com/iovisor/bcc/commit/5fe35766ac0e2860c7e6c1694a2338365e9497a6 missed a code closure and now the reference guide doesn't render well.