### PR TITLE
set larger range to get probes evnet for test_usdt2.py

### DIFF
--- a/tests/python/test_usdt2.py
+++ b/tests/python/test_usdt2.py
@@ -149,7 +149,7 @@ int do_trace3(struct pt_regs *ctx) {
         b["event6"].open_perf_buffer(print_event6)
 
         # three iterations to make sure we get some probes and have time to process them
-        for i in range(3):
+        for i in range(5):
             b.perf_buffer_poll()
 
         # note that event1 and event4 do not really fire, so their state should be 0


### PR DESCRIPTION

I test test_usdt2.py on aarch64 with kernel-5.9-rc5,
gcc-9.2.1 and glibc2.30.
with the current range of 3, always get failure:
======================================================================
FAIL: test_attach1 (__main__.TestUDST)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_usdt2.py", line 170, in test_attach1
    self.assertTrue(self.evt_st_6 == 1)
AssertionError: False is not true

----------------------------------------------------------------------
Ran 1 test in 1.068s

FAILED (failures=1)

Signed-off-by: Chunmei Xu <xuchunmei@linux.alibaba.com>