### PR TITLE
Update installation instructions for Arch Linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 * [Packages](#packages)
   - [Ubuntu](#ubuntu---binary)
   - [Fedora](#fedora---binary)
-  - [Arch](#arch---aur)
+  - [Arch](#arch---binary)
   - [Gentoo](#gentoo---portage)
   - [openSUSE](#opensuse---binary)
   - [RHEL](#rhel---binary)
@@ -160,15 +160,12 @@ echo -e '[iovisor]\nbaseurl=https://repo.iovisor.org/yum/main/f27/$basearch\nena
 sudo dnf install bcc-tools kernel-devel-$(uname -r) kernel-headers-$(uname -r)
 ```
 
-## Arch - AUR
+## Arch - Binary
 
-Upgrade the kernel to minimum 4.3.1-1 first; the ```CONFIG_BPF_SYSCALL=y``` configuration was not added until [this kernel release](https://bugs.archlinux.org/task/47008).
-
-Install these packages using any AUR helper such as [pacaur](https://aur.archlinux.org/packages/pacaur), [yaourt](https://aur.archlinux.org/packages/yaourt), [cower](https://aur.archlinux.org/packages/cower), etc.:
+bcc is available in the standard Arch repos, so it can be installed with the `pacman` command:
 ```
-bcc bcc-tools python-bcc
+# pacman -S bcc bcc-tools python-bcc
 ```
-All build and install dependencies are listed [in the PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=bcc) and should install automatically.
 
 ## Gentoo - Portage
 


### PR DESCRIPTION
`bcc`, `bcc-tools`, and `python-bcc` were recently moved from the AUR to the official Arch repositories, so the installation instructions need to be updated.

I also removed the note about upgrading to kernel 4.3.1-1. The `linux-lts` package was upgraded from 4.1.21 to 4.4.7 by [this commit](https://github.com/archlinux/svntogit-packages/commit/20d5e134c5154161886d4f049811c9b30cd6544b#diff-3e341d2d9c67be01819b25b25d5e53ea3cdf3a38d28846cda85a195eb9b7203a) in April 2016. Considering that `linux-lts` trails behind the other Arch kernel packages (`linux`, `linux-zen`, `linux-hardened`), I think that any Arch installation that is still in use can be assumed to be on a kernel later than 4.3.1