### PR TITLE
uprobe: Add ref_cnt_offset arg to bpf_attach_uprobe

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -225,7 +225,8 @@ StatusTuple BPF::attach_uprobe(const std::string& binary_path,
                                const std::string& probe_func,
                                uint64_t symbol_addr,
                                bpf_probe_attach_type attach_type, pid_t pid,
-                               uint64_t symbol_offset) {
+                               uint64_t symbol_offset,
+                               uint32_t ref_ctr_offset) {
 
   if (symbol_addr != 0 && symbol_offset != 0)
     return StatusTuple(-1,
@@ -245,7 +246,8 @@ StatusTuple BPF::attach_uprobe(const std::string& binary_path,
   TRY2(load_func(probe_func, BPF_PROG_TYPE_KPROBE, probe_fd));
 
   int res_fd = bpf_attach_uprobe(probe_fd, attach_type, probe_event.c_str(),
-                                 binary_path.c_str(), offset, pid);
+                                 binary_path.c_str(), offset, pid,
+                                 ref_ctr_offset);
 
   if (res_fd < 0) {
     TRY2(unload_func(probe_func));

--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -20,9 +20,12 @@
 #include <cstdio>
 #include <cstring>
 #include <exception>
+#include <fcntl.h>
 #include <iostream>
 #include <memory>
 #include <sstream>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <utility>
 #include <vector>
 
@@ -38,6 +41,37 @@
 #include "usdt.h"
 
 #include "BPF.h"
+
+namespace {
+/*
+ * Kernels ~4.20 and later support specifying the ref_ctr_offset as an argument
+ * to attaching a uprobe, which negates the need to seek to this memory offset
+ * in userspace to manage semaphores, as the kernel will do it for us.  This
+ * helper function checks if this support is available by reading the uprobe
+ * format for this value, added in a6ca88b241d5e929e6e60b12ad8cd288f0ffa
+*/
+bool uprobe_ref_ctr_supported() {
+  const char *ref_ctr_pmu_path =
+      "/sys/bus/event_source/devices/uprobe/format/ref_ctr_offset";
+  const char *ref_ctr_pmu_expected = "config:32-63\0";
+  char ref_ctr_pmu_fmt[64];  // in Linux source this buffer is compared vs
+                             // PAGE_SIZE, but 64 is probably ample
+  int fd = open(ref_ctr_pmu_path, O_RDONLY);
+  if (fd < 0)
+    return false;
+
+  int ret = read(fd, ref_ctr_pmu_fmt, sizeof(ref_ctr_pmu_fmt));
+  close(fd);
+  if (ret < 0) {
+    return false;
+  }
+  if (strncmp(ref_ctr_pmu_expected, ref_ctr_pmu_fmt,
+              strlen(ref_ctr_pmu_expected)) == 0) {
+    return true;
+  }
+  return false;
+}
+} // namespace
 
 namespace ebpf {
 
@@ -268,7 +302,7 @@ StatusTuple BPF::attach_uprobe(const std::string& binary_path,
 
 StatusTuple BPF::attach_usdt_without_validation(const USDT& u, pid_t pid) {
   auto& probe = *static_cast<::USDT::Probe*>(u.probe_.get());
-  if (!probe.enable(u.probe_func_))
+  if (!uprobe_ref_ctr_supported() && !probe.enable(u.probe_func_))
     return StatusTuple(-1, "Unable to enable USDT %s" + u.print_name());
 
   bool failed = false;
@@ -276,7 +310,8 @@ StatusTuple BPF::attach_usdt_without_validation(const USDT& u, pid_t pid) {
   int cnt = 0;
   for (const auto& loc : probe.locations_) {
     auto res = attach_uprobe(loc.bin_path_, std::string(), u.probe_func_,
-                              loc.address_, BPF_PROBE_ENTRY, pid);
+                             loc.address_, BPF_PROBE_ENTRY, pid, 0,
+                             probe.semaphore_offset());
     if (!res.ok()) {
       failed = true;
       err_msg += "USDT " + u.print_name() + " at " + loc.bin_path_ +
@@ -507,7 +542,7 @@ StatusTuple BPF::detach_usdt_without_validation(const USDT& u, pid_t pid) {
     }
   }
 
-  if (!probe.disable()) {
+  if (!uprobe_ref_ctr_supported() && !probe.disable()) {
     failed = true;
     err_msg += "Unable to disable USDT " + u.print_name();
   }

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -78,7 +78,8 @@ class BPF {
                             uint64_t symbol_addr = 0,
                             bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY,
                             pid_t pid = -1,
-                            uint64_t symbol_offset = 0);
+                            uint64_t symbol_offset = 0,
+                            uint32_t ref_ctr_offset = 0);
   StatusTuple detach_uprobe(const std::string& binary_path,
                             const std::string& symbol, uint64_t symbol_addr = 0,
                             bpf_probe_attach_type attach_type = BPF_PROBE_ENTRY,

--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -26,11 +26,15 @@ extern "C" {
 struct bcc_elf_usdt {
   uint64_t pc;
   uint64_t base_addr;
+  // Virtual address semaphore is found at
   uint64_t semaphore;
 
   const char *provider;
   const char *name;
   const char *arg_fmt;
+
+  // Offset from start of file where the semaphore is at
+  uint64_t semaphore_offset;
 };
 
 // Binary module path, bcc_elf_usdt struct, payload

--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -30,9 +30,12 @@ struct bcc_usdt {
     const char *provider;
     const char *name;
     const char *bin_path;
+    // Virtual address semaphore is found at
     uint64_t semaphore;
     int num_locations;
     int num_arguments;
+    // Offset from start of file where semaphore is at
+    uint64_t semaphore_offset;
 };
 
 struct bcc_usdt_location {

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -86,7 +86,7 @@ int bpf_detach_kprobe(const char *ev_name);
 
 int bpf_attach_uprobe(int progfd, enum bpf_probe_attach_type attach_type,
                       const char *ev_name, const char *binary_path,
-                      uint64_t offset, pid_t pid);
+                      uint64_t offset, pid_t pid, uint32_t ref_ctr_offset);
 int bpf_detach_uprobe(const char *ev_name);
 
 int bpf_attach_tracepoint(int progfd, const char *tp_category,

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -194,6 +194,7 @@ class Probe {
   std::string provider_;
   std::string name_;
   uint64_t semaphore_;
+  uint64_t semaphore_offset_;
 
   std::vector<Location> locations_;
 
@@ -214,11 +215,13 @@ class Probe {
 
 public:
   Probe(const char *bin_path, const char *provider, const char *name,
-        uint64_t semaphore, const optional<int> &pid, uint8_t mod_match_inode_only = 1);
+        uint64_t semaphore, uint64_t semaphore_offset,
+        const optional<int> &pid, uint8_t mod_match_inode_only = 1);
 
   size_t num_locations() const { return locations_.size(); }
   size_t num_arguments() const { return locations_.front().arguments_.size(); }
   uint64_t semaphore()   const { return semaphore_; }
+  uint64_t semaphore_offset() const { return semaphore_offset_; }
 
   uint64_t address(size_t n = 0) const { return locations_[n].address_; }
   const char *location_bin_path(size_t n = 0) const { return locations_[n].bin_path_.c_str(); }

--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -54,12 +54,13 @@ Location::Location(uint64_t addr, const std::string &bin_path, const char *arg_f
 }
 
 Probe::Probe(const char *bin_path, const char *provider, const char *name,
-             uint64_t semaphore, const optional<int> &pid,
-             uint8_t mod_match_inode_only)
+             uint64_t semaphore, uint64_t semaphore_offset,
+             const optional<int> &pid, uint8_t mod_match_inode_only)
     : bin_path_(bin_path),
       provider_(provider),
       name_(name),
       semaphore_(semaphore),
+      semaphore_offset_(semaphore_offset),
       pid_(pid),
       mod_match_inode_only_(mod_match_inode_only)
       {}
@@ -262,8 +263,8 @@ void Context::add_probe(const char *binpath, const struct bcc_elf_usdt *probe) {
   }
 
   probes_.emplace_back(
-    new Probe(binpath, probe->provider, probe->name, probe->semaphore, pid_,
-              mod_match_inode_only_)
+    new Probe(binpath, probe->provider, probe->name, probe->semaphore,
+              probe->semaphore_offset, pid_, mod_match_inode_only_)
   );
   probes_.back()->add_location(probe->pc, binpath, probe->arg_fmt);
 }
@@ -347,6 +348,7 @@ void Context::each(each_cb callback) {
     info.bin_path = probe->bin_path().c_str();
     info.name = probe->name().c_str();
     info.semaphore = probe->semaphore();
+    info.semaphore_offset = probe->semaphore_offset();
     info.num_locations = probe->num_locations();
     info.num_arguments = probe->num_arguments();
     callback(&info);

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -38,7 +38,7 @@ set(TEST_LIBBCC_SOURCES
 add_executable(test_libbcc ${TEST_LIBBCC_SOURCES})
 
 file(COPY dummy_proc_map.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-add_library(usdt_test_lib SHARED usdt_test_lib.c)
+add_library(usdt_test_lib SHARED usdt_test_lib.cc)
 
 add_dependencies(test_libbcc bcc-shared)
 target_link_libraries(test_libbcc ${PROJECT_BINARY_DIR}/src/cc/libbcc.so dl usdt_test_lib)

--- a/tests/cc/usdt_test_lib.cc
+++ b/tests/cc/usdt_test_lib.cc
@@ -3,8 +3,12 @@
 
 #include "folly/tracing/StaticTracepoint.h"
 
+extern "C" {
+
 int lib_probed_function() {
   int an_int = 42 + getpid();
   FOLLY_SDT(libbcc_test, sample_lib_probe_1, an_int);
   return an_int;
+}
+
 }

--- a/tests/python/include/folly/tracing/StaticTracepoint-ELFx86.h
+++ b/tests/python/include/folly/tracing/StaticTracepoint-ELFx86.h
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +16,12 @@
 
 #pragma once
 
+// clang-format off
+#include <cstddef>
+
 // Default constraint for the probe arguments as operands.
 #ifndef FOLLY_SDT_ARG_CONSTRAINT
-#if defined(__powerpc64__) || defined(__powerpc__)
-#define FOLLY_SDT_ARG_CONSTRAINT      "nZr"
-#else
 #define FOLLY_SDT_ARG_CONSTRAINT      "nor"
-#endif
 #endif
 
 // Instruction to emit for the probe.
@@ -31,6 +30,9 @@
 // Note section properties.
 #define FOLLY_SDT_NOTE_NAME           "stapsdt"
 #define FOLLY_SDT_NOTE_TYPE           3
+
+// Semaphore variables are put in this section
+#define FOLLY_SDT_SEMAPHORE_SECTION   ".probes"
 
 // Size of address depending on platform.
 #ifdef __LP64__
@@ -48,11 +50,14 @@
 #define FOLLY_SDT_ASM_STRING(x)       FOLLY_SDT_ASM_1(.asciz FOLLY_SDT_S(x))
 
 // Helper to determine the size of an argument.
-#define FOLLY_SDT_ISARRAY(x)  (__builtin_classify_type(x) == 14)
-#define FOLLY_SDT_ARGSIZE(x)  (FOLLY_SDT_ISARRAY(x) ? sizeof(void*) : sizeof(x))
+#define FOLLY_SDT_IS_ARRAY_POINTER(x)  ((__builtin_classify_type(x) == 14) ||  \
+                                        (__builtin_classify_type(x) == 5))
+#define FOLLY_SDT_ARGSIZE(x)  (FOLLY_SDT_IS_ARRAY_POINTER(x)                   \
+                               ? sizeof(void*)                                 \
+                               : sizeof(x))
 
 // Format of each probe arguments as operand.
-// Size of the argument tagged with FOLLY_SDT_Sn, with "n" constraint.
+// Size of the arugment tagged with FOLLY_SDT_Sn, with "n" constraint.
 // Value of the argument tagged with FOLLY_SDT_An, with configured constraint.
 #define FOLLY_SDT_ARG(n, x)                                                    \
   [FOLLY_SDT_S##n] "n"                ((size_t)FOLLY_SDT_ARGSIZE(x)),          \
@@ -75,16 +80,11 @@
   FOLLY_SDT_OPERANDS_6(_1, _2, _3, _4, _5, _6), FOLLY_SDT_ARG(7, _7)
 #define FOLLY_SDT_OPERANDS_8(_1, _2, _3, _4, _5, _6, _7, _8)                   \
   FOLLY_SDT_OPERANDS_7(_1, _2, _3, _4, _5, _6, _7), FOLLY_SDT_ARG(8, _8)
+#define FOLLY_SDT_OPERANDS_9(_1, _2, _3, _4, _5, _6, _7, _8, _9)               \
+  FOLLY_SDT_OPERANDS_8(_1, _2, _3, _4, _5, _6, _7, _8), FOLLY_SDT_ARG(9, _9)
 
 // Templates to reference the arguments from operands in note section.
-#if defined(__powerpc64__ ) || defined(__powerpc__)
-#define FOLLY_SDT_ARGTMPL(id)       %I[id]%[id]
-#elif defined(__i386__)
-#define FOLLY_SDT_ARGTMPL(id)       %w[id]
-#else
-#define FOLLY_SDT_ARGTMPL(id)       %[id]
-#endif
-#define FOLLY_SDT_ARGFMT(no)        %n[FOLLY_SDT_S##no]@FOLLY_SDT_ARGTMPL(FOLLY_SDT_A##no)
+#define FOLLY_SDT_ARGFMT(no)        %n[FOLLY_SDT_S##no]@%[FOLLY_SDT_A##no]
 #define FOLLY_SDT_ARG_TEMPLATE_0    /*No arguments*/
 #define FOLLY_SDT_ARG_TEMPLATE_1    FOLLY_SDT_ARGFMT(1)
 #define FOLLY_SDT_ARG_TEMPLATE_2    FOLLY_SDT_ARG_TEMPLATE_1 FOLLY_SDT_ARGFMT(2)
@@ -94,9 +94,30 @@
 #define FOLLY_SDT_ARG_TEMPLATE_6    FOLLY_SDT_ARG_TEMPLATE_5 FOLLY_SDT_ARGFMT(6)
 #define FOLLY_SDT_ARG_TEMPLATE_7    FOLLY_SDT_ARG_TEMPLATE_6 FOLLY_SDT_ARGFMT(7)
 #define FOLLY_SDT_ARG_TEMPLATE_8    FOLLY_SDT_ARG_TEMPLATE_7 FOLLY_SDT_ARGFMT(8)
+#define FOLLY_SDT_ARG_TEMPLATE_9    FOLLY_SDT_ARG_TEMPLATE_8 FOLLY_SDT_ARGFMT(9)
+
+// Semaphore define, declare and probe note format
+
+#define FOLLY_SDT_SEMAPHORE(provider, name)                                    \
+  folly_sdt_semaphore_##provider##_##name
+
+#define FOLLY_SDT_DEFINE_SEMAPHORE(provider, name)                             \
+  extern "C" {                                                                 \
+    volatile unsigned short FOLLY_SDT_SEMAPHORE(provider, name)                \
+    __attribute__((section(FOLLY_SDT_SEMAPHORE_SECTION), used)) = 0;           \
+  }
+
+#define FOLLY_SDT_DECLARE_SEMAPHORE(provider, name)                            \
+  extern "C" volatile unsigned short FOLLY_SDT_SEMAPHORE(provider, name)
+
+#define FOLLY_SDT_SEMAPHORE_NOTE_0(provider, name)                             \
+  FOLLY_SDT_ASM_1(     FOLLY_SDT_ASM_ADDR 0) /*No Semaphore*/                  \
+
+#define FOLLY_SDT_SEMAPHORE_NOTE_1(provider, name)                             \
+  FOLLY_SDT_ASM_1(FOLLY_SDT_ASM_ADDR FOLLY_SDT_SEMAPHORE(provider, name))
 
 // Structure of note section for the probe.
-#define FOLLY_SDT_NOTE_CONTENT(provider, name, arg_template)                   \
+#define FOLLY_SDT_NOTE_CONTENT(provider, name, has_semaphore, arg_template)    \
   FOLLY_SDT_ASM_1(990: FOLLY_SDT_NOP)                                          \
   FOLLY_SDT_ASM_3(     .pushsection .note.stapsdt,"","note")                   \
   FOLLY_SDT_ASM_1(     .balign 4)                                              \
@@ -104,8 +125,8 @@
   FOLLY_SDT_ASM_1(991: .asciz FOLLY_SDT_NOTE_NAME)                             \
   FOLLY_SDT_ASM_1(992: .balign 4)                                              \
   FOLLY_SDT_ASM_1(993: FOLLY_SDT_ASM_ADDR 990b)                                \
-  FOLLY_SDT_ASM_1(     FOLLY_SDT_ASM_ADDR 0) /*Reserved for Semaphore address*/\
-  FOLLY_SDT_ASM_1(     FOLLY_SDT_ASM_ADDR 0) /*Reserved for Semaphore name*/   \
+  FOLLY_SDT_ASM_1(     FOLLY_SDT_ASM_ADDR 0) /*Reserved for Base Address*/     \
+  FOLLY_SDT_SEMAPHORE_NOTE_##has_semaphore(provider, name)                     \
   FOLLY_SDT_ASM_STRING(provider)                                               \
   FOLLY_SDT_ASM_STRING(name)                                                   \
   FOLLY_SDT_ASM_STRING(arg_template)                                           \
@@ -113,15 +134,16 @@
   FOLLY_SDT_ASM_1(     .popsection)
 
 // Main probe Macro.
-#define FOLLY_SDT_PROBE(provider, name, n, arglist)                            \
+#define FOLLY_SDT_PROBE(provider, name, has_semaphore, n, arglist)             \
     __asm__ __volatile__ (                                                     \
-      FOLLY_SDT_NOTE_CONTENT(provider, name, FOLLY_SDT_ARG_TEMPLATE_##n)       \
+      FOLLY_SDT_NOTE_CONTENT(                                                  \
+        provider, name, has_semaphore, FOLLY_SDT_ARG_TEMPLATE_##n)             \
       :: FOLLY_SDT_OPERANDS_##n arglist                                        \
     )                                                                          \
 
 // Helper Macros to handle variadic arguments.
-#define FOLLY_SDT_NARG_(_0, _1, _2, _3, _4, _5, _6, _7, _8, N, ...) N
+#define FOLLY_SDT_NARG_(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, N, ...) N
 #define FOLLY_SDT_NARG(...)                                                    \
-  FOLLY_SDT_NARG_(__VA_ARGS__, 8, 7, 6, 5, 4, 3, 2, 1, 0)
-#define FOLLY_SDT_PROBE_N(provider, name, N, ...)                              \
-  FOLLY_SDT_PROBE(provider, name, N, (__VA_ARGS__))
+  FOLLY_SDT_NARG_(__VA_ARGS__, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define FOLLY_SDT_PROBE_N(provider, name, has_semaphore, N, ...)               \
+  FOLLY_SDT_PROBE(provider, name, has_semaphore, N, (__VA_ARGS__))

--- a/tests/python/include/folly/tracing/StaticTracepoint.h
+++ b/tests/python/include/folly/tracing/StaticTracepoint.h
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,31 @@
 
 #pragma once
 
-#if defined(__ELF__) &&                                                        \
-    (defined(__powerpc64__) || defined(__powerpc__) || defined(__aarch64__) || \
-     defined(__x86_64__) || defined(__i386__))
-#include <folly/tracing/StaticTracepoint-ELF.h>
+#if defined(__ELF__) && (defined(__x86_64__) || defined(__i386__)) && \
+    !FOLLY_DISABLE_SDT
 
-#define FOLLY_SDT(provider, name, ...)                                         \
-  FOLLY_SDT_PROBE_N(                                                           \
-    provider, name, FOLLY_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+#include <folly/tracing/StaticTracepoint-ELFx86.h>
+
+#define FOLLY_SDT(provider, name, ...) \
+  FOLLY_SDT_PROBE_N(                   \
+      provider, name, 0, FOLLY_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+// Use FOLLY_SDT_DEFINE_SEMAPHORE(provider, name) to define the semaphore
+// as global variable before using the FOLLY_SDT_WITH_SEMAPHORE macro
+#define FOLLY_SDT_WITH_SEMAPHORE(provider, name, ...) \
+  FOLLY_SDT_PROBE_N(                                  \
+      provider, name, 1, FOLLY_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
+#define FOLLY_SDT_IS_ENABLED(provider, name) \
+  (FOLLY_SDT_SEMAPHORE(provider, name) > 0)
+
 #else
-#define FOLLY_SDT(provider, name, ...) do {} while(0)
+
+#define FOLLY_SDT(provider, name, ...) \
+  do {                                 \
+  } while (0)
+#define FOLLY_SDT_WITH_SEMAPHORE(provider, name, ...) \
+  do {                                                \
+  } while (0)
+#define FOLLY_SDT_IS_ENABLED(provider, name) (false)
+#define FOLLY_SDT_DEFINE_SEMAPHORE(provider, name)
+#define FOLLY_SDT_DECLARE_SEMAPHORE(provider, name)
 #endif

--- a/tests/python/test_usdt.py
+++ b/tests/python/test_usdt.py
@@ -132,7 +132,7 @@ int do_trace5(struct pt_regs *ctx) {
         self.ftemp = NamedTemporaryFile(delete=False)
         self.ftemp.close()
         comp = Popen(["gcc", "-I", "%s/include" % os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))),
-                      "-x", "c", "-o", self.ftemp.name, "-"],
+                      "-x", "c++", "-o", self.ftemp.name, "-"],
                      stdin=PIPE)
         comp.stdin.write(app_text)
         comp.stdin.close()

--- a/tests/python/test_usdt2.py
+++ b/tests/python/test_usdt2.py
@@ -81,7 +81,7 @@ int do_trace3(struct pt_regs *ctx) {
         self.ftemp = NamedTemporaryFile(delete=False)
         self.ftemp.close()
         comp = Popen(["gcc", "-I", "%s/include" % os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))),
-                      "-x", "c", "-o", self.ftemp.name, "-"],
+                      "-x", "c++", "-o", self.ftemp.name, "-"],
                      stdin=PIPE)
         comp.stdin.write(app_text)
         comp.stdin.close()

--- a/tests/python/test_usdt3.py
+++ b/tests/python/test_usdt3.py
@@ -82,20 +82,20 @@ int do_trace(struct pt_regs *ctx) {
         self.tmp_dir = tempfile.mkdtemp()
         print("temp directory: " + self.tmp_dir)
         _create_file(self.tmp_dir + "/common.h", common_h)
-        _create_file(self.tmp_dir + "/a.c", a_c)
-        _create_file(self.tmp_dir + "/b.c", b_c)
-        _create_file(self.tmp_dir + "/m.c", m_c)
+        _create_file(self.tmp_dir + "/a.cpp", a_c)
+        _create_file(self.tmp_dir + "/b.cpp", b_c)
+        _create_file(self.tmp_dir + "/m.cpp", m_c)
 
         # Compilation
         # the usdt test:probe exists in liba.so, libb.so and a.out
         include_path = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))) + "/include"
-        a_src = self.tmp_dir + "/a.c"
+        a_src = self.tmp_dir + "/a.cpp"
         a_obj = self.tmp_dir + "/a.o"
         a_lib = self.tmp_dir + "/liba.so"
-        b_src = self.tmp_dir + "/b.c"
+        b_src = self.tmp_dir + "/b.cpp"
         b_obj = self.tmp_dir + "/b.o"
         b_lib = self.tmp_dir + "/libb.so"
-        m_src = self.tmp_dir + "/m.c"
+        m_src = self.tmp_dir + "/m.cpp"
         m_bin = self.tmp_dir + "/a.out"
         m_linker_opt = " -L" + self.tmp_dir + " -la -lb"
         self.assertEqual(os.system("gcc -I" + include_path + " -fpic -c -o " + a_obj + " " + a_src), 0)


### PR DESCRIPTION
This argument allows callers to tell the kernel to manage USDT semaphore
counts. It's better than fiddling with the counts in userspace b/c if
the userspace program crashes then the semaphore count does not get
decremented.

It's also better b/c the kernel can activate the semaphore for all
processes that have the target mapped into memory. Currently with bcc,
you have to provide the pid of each process you want to activate a
semaphore for and then bcc will go poke /proc/pid/mem at the right
offset.