### PR TITLE
fix python3 compatible issue for netqtop and tcprtt tools

### DIFF
--- a/tools/netqtop.py
+++ b/tools/netqtop.py
@@ -51,7 +51,7 @@ def print_table(table, qnum):
         headers.append("PPS")
 
     for hd in headers:
-		print(hd.center(COL_WIDTH)),
+        print(hd.center(COL_WIDTH))
     print
 
     # ------- calculates --------------
@@ -180,7 +180,7 @@ if len(dev_name) > IFNAMSIZ-1:
 
 print_interval = args.interval + 0.0
 if print_interval == 0:
-    print "print interval must be non-zero"
+    print ("print interval must be non-zero")
     exit()
 
 ################ get number of queues #####################
@@ -188,7 +188,7 @@ tx_num = 0
 rx_num = 0
 path = ROOT_PATH + "/" + dev_name + "/queues"
 if not os.path.exists(path):
-	print "Net interface", dev_name, "does not exits."
+	print ("Net interface", dev_name, "does not exits.")
 	exit()
 
 list = os.listdir(path)
@@ -199,7 +199,7 @@ for s in list:
         tx_num += 1
 
 if tx_num > MAX_QUEUE_NUM or rx_num > MAX_QUEUE_NUM:
-    print "number of queues over 1024 is not supported."
+    print ("number of queues over 1024 is not supported.")
     exit()
 
 ################## start tracing ##################
@@ -207,7 +207,7 @@ b = BPF(src_file = EBPF_FILE)
 # --------- set hash array --------
 devname_map = b['name_map']
 _name = Devname()
-_name.name = dev_name
+_name.name = dev_name.encode()
 devname_map[0] = _name
 
 while 1:

--- a/tools/tcprtt.py
+++ b/tools/tcprtt.py
@@ -111,35 +111,35 @@ int trace_tcp_rcv(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
 
 # filter for local port
 if args.lport:
-    bpf_text = bpf_text.replace(b'LPORTFILTER',
-        b"""if (ntohs(sport) != %d)
+    bpf_text = bpf_text.replace('LPORTFILTER',
+        """if (ntohs(sport) != %d)
         return 0;""" % int(args.lport))
 else:
-    bpf_text = bpf_text.replace(b'LPORTFILTER', b'')
+    bpf_text = bpf_text.replace('LPORTFILTER', '')
 
 # filter for remote port
 if args.rport:
-    bpf_text = bpf_text.replace(b'RPORTFILTER',
-        b"""if (ntohs(dport) != %d)
+    bpf_text = bpf_text.replace('RPORTFILTER',
+        """if (ntohs(dport) != %d)
         return 0;""" % int(args.rport))
 else:
-    bpf_text = bpf_text.replace(b'RPORTFILTER', b'')
+    bpf_text = bpf_text.replace('RPORTFILTER', '')
 
 # filter for local address
 if args.laddr:
-    bpf_text = bpf_text.replace(b'LADDRFILTER',
-        b"""if (saddr != %d)
+    bpf_text = bpf_text.replace('LADDRFILTER',
+        """if (saddr != %d)
         return 0;""" % struct.unpack("=I", socket.inet_aton(args.laddr))[0])
 else:
-    bpf_text = bpf_text.replace(b'LADDRFILTER', b'')
+    bpf_text = bpf_text.replace('LADDRFILTER', '')
 
 # filter for remote address
 if args.raddr:
-    bpf_text = bpf_text.replace(b'RADDRFILTER',
-        b"""if (daddr != %d)
+    bpf_text = bpf_text.replace('RADDRFILTER',
+        """if (daddr != %d)
         return 0;""" % struct.unpack("=I", socket.inet_aton(args.raddr))[0])
 else:
-    bpf_text = bpf_text.replace(b'RADDRFILTER', b'')
+    bpf_text = bpf_text.replace('RADDRFILTER', '')
 
 # show msecs or usecs[default]
 if args.milliseconds:


### PR DESCRIPTION
Otherwise, we have:
  ...
    File "bcc/tools/netqtop.py", line 54
      print(hd.center(COL_WIDTH)),
                                 ^
  TabError: inconsistent use of tabs and spaces in indentation
  ...

    File "bcc/tools/tcprtt.py", line 117, in <module>
    bpf_text = bpf_text.replace(b'LPORTFILTER', b'')
  TypeError: replace() argument 1 must be str, not bytes
  ...

Signed-off-by: Yonghong Song <yhs@fb.com>