### PR TITLE
Guard artifact upload with environment variable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,8 @@ jobs:
 
     # Uploads the packages built in docker to the github build as an artifact for convenience
     - uses: actions/upload-artifact@v1
+      if: >
+        steps.vars.outputs.QUAY_PUBLISH
       with:
         name: ${{ matrix.env['NAME'] }}
         path: output


### PR DESCRIPTION
I noticed that https://github.com/iovisor/bcc/runs/1284916926?check_suite_focus=true failed when #3141 was merged, because I missed the check on a step to upload the artifacts.

Please merge to fix CI @yonghong-song, sorry I missed this.