### PR TITLE
Llvm package order

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,10 +4,10 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 9), cmake,
-    libllvm3.7 [!arm64] | libllvm3.8 [!arm64] | libllvm6.0 | libllvm8.0 | libllvm9,
-    llvm-3.7-dev [!arm64] | llvm-3.8-dev [!arm64] | llvm-6.0-dev | llvm-8.0-dev | llvm-9-dev,
-    libclang-3.7-dev [!arm64] | libclang-3.8-dev [!arm64] | libclang-6.0-dev | libclang-8.0-dev | libclang-9-dev,
-    clang-format | clang-format-3.7 [!arm64] | clang-format-3.8 [!arm64] | clang-format-6.0 | clang-format-8.0 | clang-format-9,
+    libllvm9 | libllvm8.0 | libllvm6.0 | libllvm3.8 [!arm64] | libllvm3.7 [!arm64],
+    llvm-9-dev | llvm-8.0-dev | llvm-6.0-dev | llvm-3.8-dev [!arm64] | llvm-3.7-dev [!arm64],
+    libclang-9-dev | libclang-8.0-dev | libclang-6.0-dev | libclang-3.8-dev [!arm64] | libclang-3.7-dev [!arm64],
+    clang-format-9 | clang-format-8.0 | clang-format-6.0 | clang-format-3.8 [!arm64] | clang-format-3.7 [!arm64] | clang-format,
     libelf-dev, bison, flex, libfl-dev, libedit-dev, zlib1g-dev, git,
     python (>= 2.7), python-netaddr, python-pyroute2 | python3-pyroute2, luajit,
     libluajit-5.1-dev, arping, inetutils-ping | iputils-ping, iperf, netperf,

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 # Builds debian packages using docker wrapper
 
 function help() {
@@ -23,5 +23,5 @@ echo "Building ${distro} ${os_tag} release docker image for ${docker_repo}:${doc
 docker build -t ${docker_repo}:${docker_tag} --build-arg OS_TAG=${os_tag} -f Dockerfile.${distro} .
 
 echo "Copying build artifacts to $(pwd)/output"
-mkdir output
+mkdir -p output
 docker run -v $(pwd)/output:/output ${docker_repo}:${docker_tag} /bin/bash -c "cp /root/bcc/* /output"


### PR DESCRIPTION
Following up on #3141 I noticed that the debian builds are preferring the older versions of LLVM / clang rather than the newer ones.

It appears that this is because of the order in which they are specified in the debian control file. Debian's packaging system seems to just short circuit this conditional - the first one it finds that satisfies is what it uses.

Rather than specify the clang and LLVM packages in ascending order, this specifies them in descending order. This should prefer the newest available LLVM / clang for a given debian distribution.

Prior to this, bcc debian packages would be built (statically) linking to LLVM as follows:

- Ubuntu 16.04: LLVM 3.7
- Ubuntu 18.04: LLVM 6.0
- Ubuntu 20.04: LLVM 6.0

And with this change, bcc will be built with the following linkages:

- Ubuntu 16.04: LLVM 6.0
- Ubuntu 18.04: LLVM 9
- Ubuntu 20.04: LLVM 9

I am unsure how much of a difference this makes, but I imagine that there are some features (perhaps for example BTF?) that will benefit from newer LLVM versions, where there are dependencies on LLVM's newer behavior. I sent an email thread to the iovisor-dev discussion list to see if this is the case.

I am in the process of building and pushing old bcc tags, and am already trying this patch as I do so.

As a side note, it does look like LLVM 10 doesn't build because we are missing some compile flags, so this may also be why #3130 is an issue. I can follow up with a separate PR to fix LLVM 10 and 11 for distributions that have them available.

The build for this available at https://github.com/dalehamel/bcc/actions/runs/320508617

I also made it so that the build script will error if it encounters any errors, which is a minor change to ensure correctness.