### PR TITLE
python: import ABCs from collections.abc

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from collections import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 import ctypes as ct
 from functools import reduce
 import multiprocessing


### PR DESCRIPTION
Importing Abstract Base Classes (ABCs) from the collections module is [deprecated since Python 3.3](https://docs.python.org/3/library/collections.abc.html), it [emits a warning since Python 3.8](https://github.com/python/cpython/commit/c66f9f8d3909f588c251957d499599a1680e2320), and it will stop working in Python 3.10.

Try importing MutableMapping from collections.abc (the preferred way since Python 3.3) and, in case of error (Python < 3.3) fall back to importing it from collections.

This patch eliminates warnings in Python 3.8+ while preserving compatibility with Python < 3.3.