### PR TITLE
docs(INSTALL): add libfl-dev to ubuntu dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -387,7 +387,7 @@ sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
 
 # For Eoan (19.10) or Focal (20.04.1 LTS)
 sudo apt install -y bison build-essential cmake flex git libedit-dev \
-  libllvm7 llvm-7-dev libclang-7-dev python zlib1g-dev libelf-dev
+  libllvm7 llvm-7-dev libclang-7-dev python zlib1g-dev libelf-dev libfl-dev
 
 # For other versions
 sudo apt-get -y install bison build-essential cmake flex git libedit-dev \


### PR DESCRIPTION
To compile the software on Ubuntu 20.04 I had trouble compiling the source because my OS is missing the `FlexLexer.h` library. This package is supplied by `libfl-dev`.

I'm not sure if this is the best approach for it but worked in my case.

OS Info:

```
DISTRIB_ID=LinuxMint
DISTRIB_RELEASE=20
DISTRIB_CODENAME=ulyana
DISTRIB_DESCRIPTION="Linux Mint 20 Ulyana"
NAME="Linux Mint"
VERSION="20 (Ulyana)"
VERSION_CODENAME=ulyana
UBUNTU_CODENAME=focal
```
