### PR TITLE
use correct arch register for the 4th param of x86_64 syscalls

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -1099,6 +1099,7 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #define PT_REGS_PARM2(ctx)	((ctx)->si)
 #define PT_REGS_PARM3(ctx)	((ctx)->dx)
 #define PT_REGS_PARM4(ctx)	((ctx)->cx)
+#define PT_REGS_PARM4_SYSCALL(ctx)	((ctx)->r10) /* for syscall only */
 #define PT_REGS_PARM5(ctx)	((ctx)->r8)
 #define PT_REGS_PARM6(ctx)	((ctx)->r9)
 #define PT_REGS_RET(ctx)	((ctx)->sp)

--- a/src/cc/frontends/clang/arch_helper.h
+++ b/src/cc/frontends/clang/arch_helper.h
@@ -25,9 +25,9 @@ typedef enum {
   BCC_ARCH_X86
 } bcc_arch_t;
 
-typedef void *(*arch_callback_t)(bcc_arch_t arch);
+typedef void *(*arch_callback_t)(bcc_arch_t arch, bool for_syscall);
 
-static void *run_arch_callback(arch_callback_t fn)
+static void *run_arch_callback(arch_callback_t fn, bool for_syscall = false)
 {
   const char *archenv = getenv("ARCH");
 
@@ -35,31 +35,31 @@ static void *run_arch_callback(arch_callback_t fn)
   if (!archenv) {
 #if defined(__powerpc64__)
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    return fn(BCC_ARCH_PPC_LE);
+    return fn(BCC_ARCH_PPC_LE, for_syscall);
 #else
-    return fn(BCC_ARCH_PPC);
+    return fn(BCC_ARCH_PPC, for_syscall);
 #endif
 #elif defined(__s390x__)
-    return fn(BCC_ARCH_S390X);
+    return fn(BCC_ARCH_S390X, for_syscall);
 #elif defined(__aarch64__)
-    return fn(BCC_ARCH_ARM64);
+    return fn(BCC_ARCH_ARM64, for_syscall);
 #else
-    return fn(BCC_ARCH_X86);
+    return fn(BCC_ARCH_X86, for_syscall);
 #endif
   }
 
   /* Otherwise read it from ARCH */
   if (!strcmp(archenv, "powerpc")) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    return fn(BCC_ARCH_PPC_LE);
+    return fn(BCC_ARCH_PPC_LE, for_syscall);
 #else
-    return fn(BCC_ARCH_PPC);
+    return fn(BCC_ARCH_PPC, for_syscall);
 #endif
   } else if (!strcmp(archenv, "s390x")) {
-    return fn(BCC_ARCH_S390X);
+    return fn(BCC_ARCH_S390X, for_syscall);
   } else if (!strcmp(archenv, "arm64")) {
-    return fn(BCC_ARCH_ARM64);
+    return fn(BCC_ARCH_ARM64, for_syscall);
   } else {
-    return fn(BCC_ARCH_X86);
+    return fn(BCC_ARCH_X86, for_syscall);
   }
 }

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -253,7 +253,7 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
   return 0;
 }
 
-void *get_clang_target_cb(bcc_arch_t arch)
+void *get_clang_target_cb(bcc_arch_t arch, bool for_syscall)
 {
   const char *ret;
 


### PR DESCRIPTION
Fix #3150

On x86_64, for syscalls, the calling convension is to use
r10 instead of rcx for the 4th parameter. I have verified this
with disassembling vmlinux codes.
  https://www.systutorials.com/x86-64-calling-convention-by-gcc/

bcc previously used rcx for the 4th parameter for all cases.
This patch fixed the issue by using r10 for syscalls.
A macro PT_REGS_PARM4_SYSCALL() is also introduced in helpers.h
to access the 4th parameter for r10.

Signed-off-by: Yonghong Song <yhs@fb.com>