### PR TITLE
fix compilation issues with latest llvm12 trunk

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -466,7 +466,9 @@ int BPFModule::finalize() {
   builder.setErrorStr(&err);
   builder.setMCJITMemoryManager(ebpf::make_unique<MyMemoryManager>(sections_p));
   builder.setMArch("bpf");
+#if LLVM_MAJOR_VERSION <= 11
   builder.setUseOrcMCJITReplacement(false);
+#endif
   engine_ = unique_ptr<ExecutionEngine>(builder.create());
   if (!engine_) {
     fprintf(stderr, "Could not create ExecutionEngine: %s\n", err.c_str());

--- a/src/cc/bpf_module_rw_engine.cc
+++ b/src/cc/bpf_module_rw_engine.cc
@@ -356,7 +356,9 @@ unique_ptr<ExecutionEngine> BPFModule::finalize_rw(unique_ptr<Module> m) {
   string err;
   EngineBuilder builder(move(m));
   builder.setErrorStr(&err);
+#if LLVM_MAJOR_VERSION <= 11
   builder.setUseOrcMCJITReplacement(false);
+#endif
   auto engine = unique_ptr<ExecutionEngine>(builder.create());
   if (!engine)
     fprintf(stderr, "Could not create ExecutionEngine: %s\n", err.c_str());

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -1700,7 +1700,11 @@ void BFrontendAction::DoMiscWorkAround() {
     false);
 
   rewriter_->getEditBuffer(rewriter_->getSourceMgr().getMainFileID()).InsertTextAfter(
+#if LLVM_MAJOR_VERSION >= 12
+    rewriter_->getSourceMgr().getBufferOrFake(rewriter_->getSourceMgr().getMainFileID()).getBufferSize(),
+#else
     rewriter_->getSourceMgr().getBuffer(rewriter_->getSourceMgr().getMainFileID())->getBufferSize(),
+#endif
     "\n#include <bcc/footer.h>\n");
 }
 


### PR DESCRIPTION
With latest llvm12 trunk, we got two compilation bugs.

Bug #1:
  /home/yhs/work/bcc/src/cc/frontends/clang/b_frontend_action.cc:
     In member function ‘void ebpf::BFrontendAction::DoMiscWorkAround()’:
  /home/yhs/work/bcc/src/cc/frontends/clang/b_frontend_action.cc:1706:31:
     error: ‘class clang::SourceManage’ has no member named ‘getBuffer’; did you mean ‘getBufferData’?
     rewriter_->getSourceMgr().getBuffer(rewriter_->getSourceMgr().getMainFileID())->getBufferSize(),
                               ^~~~~~~~~
                               getBufferData

  This is due to upstream change https://reviews.llvm.org/D89394.
  To fix, follow upstream examples in https://reviews.llvm.org/D89394.

Bug #2:
  /home/yhs/work/bcc/src/cc/bpf_module.cc: In member function ‘int ebpf::BPFModule::finalize()’:
  /home/yhs/work/bcc/src/cc/bpf_module.cc:470:11:
    error: ‘class llvm::EngineBuilder’ has no member named ‘setUseOrcMCJITReplacement’
   builder.setUseOrcMCJITReplacement(false);
           ^~~~~~~~~~~~~~~~~~~~~~~~~

  This is due to upstream
    https://github.com/llvm/llvm-project/commit/6154c4115cd4b78d0171892aac21e340e72e32bd

  It seems builder.setUseOrcMCJITReplacement() is not needed any more. So just remove it
  from bcc.

Signed-off-by: Yonghong Song <yhs@fb.com>