### PR TITLE
tools/offcputime: Fix python3 string output

### DIFF
--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -303,7 +303,7 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
                 print("    [Missed Kernel Stack]")
             else:
                 for addr in kernel_stack:
-                    print("    %s" % b.ksym(addr))
+                    print("    %s" % b.ksym(addr).decode('utf-8', 'replace'))
         if not args.kernel_stacks_only:
             if need_delimiter and k.user_stack_id >= 0 and k.kernel_stack_id >= 0:
                 print("    --")
@@ -311,7 +311,7 @@ for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
                 print("    [Missed User Stack]")
             else:
                 for addr in user_stack:
-                    print("    %s" % b.sym(addr, k.tgid))
+                    print("    %s" % b.sym(addr, k.tgid).decode('utf-8', 'replace'))
         print("    %-16s %s (%d)" % ("-", k.name.decode('utf-8', 'replace'), k.pid))
         print("        %d\n" % v.value)
 


### PR DESCRIPTION
When using non-folded output, some of the strings would
be printed as raw byte arrays on python3, like this:

    b'finish_task_switch'
    b'__schedule'
    b'schedule'
    b'worker_thread'
    b'kthread'
    b'ret_from_fork'
    -                kworker/u16:1 (22022)
        2267942

This commit updates the code to treat these as utf8 strings,
consistent with all the other strings printed from this tool.