### PR TITLE
Drop ubuntu xenial support from release, it is EOL

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       matrix:
         env:
-        - NAME: xenial-release
-          OS_RELEASE: 16.04
         - NAME: bionic-release
           OS_RELEASE: 18.04
         - NAME: focal-release

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -23,5 +23,10 @@ COPY --from=builder /root/bcc/*.deb /root/bcc/
 
 RUN \
   apt-get update -y && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y python python3 binutils libelf1 kmod python-dnslib python-cachetools python3-dnslib python3-cachetools && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y python python3 python3-pip binutils libelf1 kmod  && \
+  if [ ${OS_TAG} = "18.04" ];then \
+    apt-get -y install python-pip && \
+    pip install dnslib cachetools ; \
+  fi ; \
+  pip3 install dnslib cachetools  && \
   dpkg -i /root/bcc/*.deb


### PR DESCRIPTION
https://github.com/iovisor/bcc/pull/3128 broke the release process, as it tries to install packages that are not available on ubuntu xenial (16.04)

This should repair this problem by checking the version and not installing this libraries on ubuntu xenial