### PR TITLE
Add sk_lookup to kernel-versions.md

### DIFF
--- a/docs/kernel-versions.md
+++ b/docs/kernel-versions.md
@@ -81,6 +81,7 @@ BPF cgroup sysctl | 5.2 | [`7b146cebe30c`](https://github.com/torvalds/linux/com
 BPF raw tracepoint writable | 5.2 | [`9df1c28bb752`](https://github.com/torvalds/linux/commit/9df1c28bb75217b244257152ab7d788bb2a386d0)
 BPF trampoline | 5.5 | [`fec56f5890d9`](https://github.com/torvalds/linux/commit/fec56f5890d93fc2ed74166c397dc186b1c25951)
 BPF LSM hook | 5.7 | [`fc611f47f218`](https://github.com/torvalds/linux/commit/fc611f47f2188ade2b48ff6902d5cce8baac0c58) [`641cd7b06c91`](https://github.com/torvalds/linux/commit/641cd7b06c911c5935c34f24850ea18690649917)
+BPF socket lookup hook | 5.9 | [`e9ddbb7707ff`](https://github.com/torvalds/linux/commit/e9ddbb7707ff5891616240026062b8c1e29864ca)
 
 ## Tables (_a.k.a._ Maps)
 


### PR DESCRIPTION
sk_lookup programs allow intercepting socket lookup per namespace.