### PR TITLE
libbpf-tools: syscall_helpers: fix a warning

### DIFF
--- a/libbpf-tools/syscall_helpers.c
+++ b/libbpf-tools/syscall_helpers.c
@@ -59,8 +59,8 @@ void init_syscall_names(void)
 		goto close;
 	}
 
-	/* skip the header */
-	fgets(buf, sizeof(buf), f);
+	/* skip the header, ignore the result of fgets, outwit the comiler */
+	(void) !!fgets(buf, sizeof(buf), f);
 
 	while (fgets(buf, sizeof(buf), f)) {
 		if (buf[strlen(buf) - 1] == '\n')


### PR DESCRIPTION
Fix the following warning when building libbpf-tools:

    syscall_helpers.c: In function ‘init_syscall_names’:
    syscall_helpers.c:63:2: warning: ignoring return value of ‘fgets’, declared with attribute warn_unused_result [-Wunused-result]
       63 |  fgets(buf, sizeof(buf), f);
          |  ^~~~~~~~~~~~~~~~~~~~~~~~~~

We're not interested in the return value of the first call to fgets, because we
want to skip the first line and in the case of error it will be caught by the
following call to fgets. A funny note is that we can't say just "(void) f()" to
suppress the warning, so I wrote it as "(void) !!f()", which works.

Signed-off-by: Anton Protopopov <a.s.protopopov@gmail.com>