### PR TITLE
biolatency.py Add -j flag

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1204,8 +1204,8 @@ Syntax: ```map.increment(key[, increment_amount])```
 Increments the key's value by `increment_amount`, which defaults to 1. Used for histograms.
 
 Examples in situ:
-[search /examples](https://github.com/iovisor/bcc/search?q=.increment(+path%3Aexamples&type=Code),
-[search /tools](https://github.com/iovisor/bcc/search?q=.increment(+path%3Atools&type=Code)
+[search /examples](https://github.com/iovisor/bcc/search?q=increment+path%3Aexamples&type=Code),
+[search /tools](https://github.com/iovisor/bcc/search?q=increment+path%3Atools&type=Code)
 
 ### 23. map.get_stackid()
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1204,8 +1204,8 @@ Syntax: ```map.increment(key[, increment_amount])```
 Increments the key's value by `increment_amount`, which defaults to 1. Used for histograms.
 
 Examples in situ:
-[search /examples](https://github.com/iovisor/bcc/search?q=increment+path%3Aexamples&type=Code),
-[search /tools](https://github.com/iovisor/bcc/search?q=increment+path%3Atools&type=Code)
+[search /examples](https://github.com/iovisor/bcc/search?q=.increment(+path%3Aexamples&type=Code),
+[search /tools](https://github.com/iovisor/bcc/search?q=.increment(+path%3Atools&type=Code)
 
 ### 23. map.get_stackid()
 

--- a/man/man8/biolatency.8
+++ b/man/man8/biolatency.8
@@ -36,6 +36,12 @@ Print a histogram per disk device.
 \-F
 Print a histogram per set of I/O flags.
 .TP
+\-j
+Print a histogram dictionary along with the histogram
+.TP
+\-f
+Write the histogram dictionary to the specified file path. Used with -j
+.TP
 interval
 Output interval, in seconds.
 .TP
@@ -63,6 +69,14 @@ Include OS queued time in I/O time:
 Show a latency histogram for each disk device separately:
 #
 .B biolatency \-D
+.TP
+Show a latency histogram in a dictionary format:
+#
+.B biolatency \-j
+.TP
+Store the histogram dictionary in the specified file:
+#
+.B biolatency \-jf ./histogram.json
 .SH FIELDS
 .TP
 usecs

--- a/man/man8/biolatency.8
+++ b/man/man8/biolatency.8
@@ -37,10 +37,7 @@ Print a histogram per disk device.
 Print a histogram per set of I/O flags.
 .TP
 \-j
-Print a histogram dictionary along with the histogram
-.TP
-\-f
-Write the histogram dictionary to the specified file path. Used with -j
+Print a histogram dictionary
 .TP
 interval
 Output interval, in seconds.
@@ -73,10 +70,6 @@ Show a latency histogram for each disk device separately:
 Show a latency histogram in a dictionary format:
 #
 .B biolatency \-j
-.TP
-Store the histogram dictionary in the specified file:
-#
-.B biolatency \-jf ./histogram.json
 .SH FIELDS
 .TP
 usecs

--- a/man/man8/biolatency.8
+++ b/man/man8/biolatency.8
@@ -1,4 +1,4 @@
-.TH biolatency 8  "2020-12-29" "USER COMMANDS"
+.TH biolatency 8  "2020-12-30" "USER COMMANDS"
 .SH NAME
 biolatency \- Summarize block device I/O latency as a histogram.
 .SH SYNOPSIS

--- a/man/man8/biolatency.8
+++ b/man/man8/biolatency.8
@@ -1,4 +1,4 @@
-.TH biolatency 8  "2019-12-12" "USER COMMANDS"
+.TH biolatency 8  "2020-12-29" "USER COMMANDS"
 .SH NAME
 biolatency \- Summarize block device I/O latency as a histogram.
 .SH SYNOPSIS

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -51,7 +51,8 @@ parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
 parser.add_argument("-j", "--json", action="store_true",
     help="json output")
-parser.add_argument("-f", "--file", type=str)
+parser.add_argument("-f", "--file", type=str,
+    help="write json output to specified file")
 
 args = parser.parse_args()
 countdown = int(args.count)
@@ -229,6 +230,7 @@ while (1):
             elif k.value <= max_nonzero_idx+1:
                 index = index * 2
                 hist_dict[int(index)] = int(v.value)
+        hist_dict.pop(0, None)
         if args.file:
             path = os.path.dirname(args.file)
             if not os.path.exists(path):

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -153,7 +153,7 @@ else:
 b.attach_kprobe(event="blk_account_io_done",
     fn_name="trace_req_done")
 
-if not args.json and not args.file:
+if not (args.json and args.file):
     print("Tracing block device I/O... Hit Ctrl-C to end.")
 
 # see blk_fill_rwbs():

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -94,7 +94,7 @@ int trace_req_start(struct pt_regs *ctx, struct request *req)
 int trace_req_done(struct pt_regs *ctx, struct request *req)
 {
     u64 *tsp, delta;
-    
+
     // fetch timestamp and calculate delta
     tsp = start.lookup(&req);
     if (tsp == 0) {
@@ -102,10 +102,10 @@ int trace_req_done(struct pt_regs *ctx, struct request *req)
     }
     delta = bpf_ktime_get_ns() - *tsp;
     FACTOR
-    
+
     // store as histogram
     STORE
-    
+
     start.delete(&req);
     return 0;
 }

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -15,6 +15,7 @@ from __future__ import print_function
 from bcc import BPF
 from time import sleep, strftime
 import argparse
+import ctypes as ct
 
 # arguments
 examples = """examples:
@@ -200,27 +201,65 @@ def flags_print(flags):
     return desc
 
 
-def print_json_hist(self):
+def _print_json_hist(vals, val_type, section_bucket=None):
     hist_list = []
     max_nonzero_idx = 0
-    for k, v in self.items():
-        if v.value != 0:
-            max_nonzero_idx = k.value
+    for i in range(len(vals)):
+        if vals[i] != 0:
+            max_nonzero_idx = i
     index = 1
     prev = 0
-    for k, v in self.items():
-        if k.value != 0 and k.value <= max_nonzero_idx:
+    for i in range(len(vals)):
+        if i != 0 and i <= max_nonzero_idx:
             index = index * 2
 
             list_obj = {}
             list_obj['interval-start'] = prev
             list_obj['interval-end'] = int(index) - 1
-            list_obj['count'] = int(v.value)
+            list_obj['count'] = int(vals[i])
 
             hist_list.append(list_obj)
 
             prev = index
-    print(hist_list)
+    histogram = {"ts": strftime("%Y-%m-%d %H:%M:%S"), "val_type": val_type, "data": hist_list}
+    if section_bucket:
+        histogram[section_bucket[0]] = section_bucket[1]
+    print(histogram)
+
+
+def print_json_hist(self, val_type="value", section_header="Bucket ptr",
+                       section_print_fn=None, bucket_fn=None, bucket_sort_fn=None):
+    log2_index_max = 65 # this is a temporary workaround. Variable available in table.py
+    if isinstance(self.Key(), ct.Structure):
+        tmp = {}
+        f1 = self.Key._fields_[0][0]
+        f2 = self.Key._fields_[1][0]
+
+        if f2 == '__pad_1' and len(self.Key._fields_) == 3:
+            f2 = self.Key._fields_[2][0]
+        for k, v in self.items():
+            bucket = getattr(k, f1)
+            if bucket_fn:
+                bucket = bucket_fn(bucket)
+            vals = tmp[bucket] = tmp.get(bucket, [0] * log2_index_max)
+            slot = getattr(k, f2)
+            vals[slot] = v.value
+        buckets = list(tmp.keys())
+        if bucket_sort_fn:
+            buckets = bucket_sort_fn(buckets)
+        for bucket in buckets:
+            vals = tmp[bucket]
+            if section_print_fn:
+                section_bucket = (section_header, section_print_fn(bucket))
+            else:
+                section_bucket = (section_header, bucket)
+            _print_json_hist(vals, val_type, section_bucket)
+
+    else:
+        vals = [0] * log2_index_max
+        for k, v in self.items():
+            vals[k.value] = v.value
+        _print_json_hist(vals, val_type)
 
 
 # output
@@ -233,16 +272,26 @@ while (1):
         exiting = 1
 
     print()
-    if args.timestamp:
-        print("%-8s\n" % strftime("%H:%M:%S"), end="")
-
     if args.json:
-        print_json_hist(dist)
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
 
-    if args.flags:
-        dist.print_log2_hist(label, "flags", flags_print)
-    elif not args.json:
-        dist.print_log2_hist(label, "disk")
+        if args.flags:
+            print_json_hist(dist, label, "flags", flags_print)
+
+        else:
+            print_json_hist(dist, label)
+
+    else:
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
+            
+        if args.flags:
+            dist.print_log2_hist(label, "flags", flags_print)
+
+        else:
+            dist.print_log2_hist(label, "disk")
+
     dist.clear()
 
     countdown -= 1

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -219,7 +219,7 @@ while (1):
                 hist_dict[int(k.value)] = v.value
             elif k.value <= max_nonzero_idx+1:
                 index = index * 2
-                hist_dict[int(index)] = v.value
+                hist_dict[int(index)] = int(v.value)
         if args.file:
             path = os.path.dirname(args.file)
             if not os.path.exists(path):

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -20,13 +20,14 @@ import os.path
 
 # arguments
 examples = """examples:
-    ./biolatency            # summarize block I/O latency as a histogram
-    ./biolatency 1 10       # print 1 second summaries, 10 times
-    ./biolatency -mT 1      # 1s summaries, milliseconds, and timestamps
-    ./biolatency -Q         # include OS queued time in I/O time
-    ./biolatency -D         # show each disk device separately
-    ./biolatency -F         # show I/O flags separately
-    ./biolatency -j         # output a dict                                 # github.com/swiftomkar
+    ./biolatency                    # summarize block I/O latency as a histogram
+    ./biolatency 1 10               # print 1 second summaries, 10 times
+    ./biolatency -mT 1              # 1s summaries, milliseconds, and timestamps
+    ./biolatency -Q                 # include OS queued time in I/O time
+    ./biolatency -D                 # show each disk device separately
+    ./biolatency -F                 # show I/O flags separately
+    ./biolatency -j                 # print a dictionary
+    ./biolatency -j -f name.json    # Dump the histogram dictionary to name.json file
 """
 parser = argparse.ArgumentParser(
     description="Summarize block device I/O latency as a histogram",

--- a/tools/biolatency_example.txt
+++ b/tools/biolatency_example.txt
@@ -293,61 +293,46 @@ These can be handled differently by the storage device, and this mode lets us
 examine their performance in isolation.
 
 The -j option prints a dictionary of the histogram.
-In most cases, this flag will be used with the -f flag. For example:
+For example:
 
 # ./biolatency.py -j
-Tracing block device I/O... Hit Ctrl-C to end.
 ^C
-{32: 4, 2: 0, 4096: 32, 4: 0, 1024: 10, 8192: 0, 8: 0, 64: 38, 128: 42, 256: 5, 16: 0, 512: 1, 2048: 0}
-     usecs               : count     distribution
-         0 -> 1          : 0        |                                        |
-         2 -> 3          : 0        |                                        |
-         4 -> 7          : 0        |                                        |
-         8 -> 15         : 0        |                                        |
-        16 -> 31         : 4        |***                                     |
-        32 -> 63         : 38       |************************************    |
-        64 -> 127        : 42       |****************************************|
-       128 -> 255        : 5        |****                                    |
-       256 -> 511        : 1        |                                        |
-       512 -> 1023       : 10       |*********                               |
-      1024 -> 2047       : 0        |                                        |
-      2048 -> 4095       : 32       |******************************          |
+{'ts': '2020-12-30 14:33:03', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 0}, {'interval-start': 32, 'interval-end': 63, 'count': 2}, {'interval-start': 64, 'interval-end': 127, 'count': 75}, {'interval-start': 128, 'interval-end': 255, 'count': 7}, {'interval-start': 256, 'interval-end': 511, 'count': 0}, {'interval-start': 512, 'interval-end': 1023, 'count': 6}, {'interval-start': 1024, 'interval-end': 2047, 'count': 3}, {'interval-start': 2048, 'interval-end': 4095, 'count': 31}]}
 
-Each value in the dictionary represents the number of block I/O's that took less usecs than the key but
-more usecs than the previous key. eg: in the above example, there were 10 I/O operations with latency between 512
-and 1024 usecs. You can use the tabular histogram to compare and understand the histogram dictionary.
+the key `data` is the list of the log2 histogram intervals. The `interval-start` and `interval-end` define the
+latency bucket and `count` is the number of I/O's that lie in that latency range.
 
 
 The -j and -f option together lets you write the histogram dictionary into a json file.
 With these flags, it is possible to store the histogram as a dictionary/json file which
 can be imported easily to be analyzed with libraries like Pandas.
 
-# ./biolatency.py -j -f ./histogram.json
+# ./biolatency.py -jF
 ^C
-     usecs               : count     distribution
-         0 -> 1          : 0        |                                        |
-         2 -> 3          : 0        |                                        |
-         4 -> 7          : 0        |                                        |
-         8 -> 15         : 0        |                                        |
-        16 -> 31         : 0        |                                        |
-        32 -> 63         : 7        |*******                                 |
-        64 -> 127        : 23       |************************                |
-       128 -> 255        : 33       |***********************************     |
-       256 -> 511        : 4        |****                                    |
-       512 -> 1023       : 16       |*****************                       |
-      1024 -> 2047       : 4        |****                                    |
-      2048 -> 4095       : 37       |****************************************|
-# ls
-biolatency.py  histogram.json
-# cat histogram.json
-{"32": 0, "2": 0, "4096": 37, "4": 0, "1024": 16, "8192": 0, "8": 0, "64": 7, "128": 23, "256": 32, "16": 0, "512": 4, "2048": 4}
-The histogram.json file contains the histogram data.
+{'ts': '2020-12-30 14:37:59', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 1}, {'interval-start': 32, 'interval-end': 63, 'count': 1}, {'interval-start': 64, 'interval-end': 127, 'count': 0}, {'interval-start': 128, 'interval-end': 255, 'count': 0}, {'interval-start': 256, 'interval-end': 511, 'count': 0}, {'interval-start': 512, 'interval-end': 1023, 'count': 0}, {'interval-start': 1024, 'interval-end': 2047, 'count': 2}], 'flags': 'Sync-Write'}
+{'ts': '2020-12-30 14:37:59', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 0}, {'interval-start': 32, 'interval-end': 63, 'count': 0}, {'interval-start': 64, 'interval-end': 127, 'count': 0}, {'interval-start': 128, 'interval-end': 255, 'count': 2}, {'interval-start': 256, 'interval-end': 511, 'count': 0}, {'interval-start': 512, 'interval-end': 1023, 'count': 2}, {'interval-start': 1024, 'interval-end': 2047, 'count': 1}], 'flags': 'Unknown'}
+{'ts': '2020-12-30 14:37:59', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 0}, {'interval-start': 32, 'interval-end': 63, 'count': 0}, {'interval-start': 64, 'interval-end': 127, 'count': 0}, {'interval-start': 128, 'interval-end': 255, 'count': 0}, {'interval-start': 256, 'interval-end': 511, 'count': 0}, {'interval-start': 512, 'interval-end': 1023, 'count': 0}, {'interval-start': 1024, 'interval-end': 2047, 'count': 1}], 'flags': 'Write'}
+{'ts': '2020-12-30 14:37:59', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 0}, {'interval-start': 32, 'interval-end': 63, 'count': 0}, {'interval-start': 64, 'interval-end': 127, 'count': 0}, {'interval-start': 128, 'interval-end': 255, 'count': 0}, {'interval-start': 256, 'interval-end': 511, 'count': 0}, {'interval-start': 512, 'interval-end': 1023, 'count': 4}], 'flags': 'Flush'}
+
+The -j option used with -F prints a histogram dictionary per set of I/O flags.
+
+# ./biolatency.py -jD
+^C
+{'ts': '2020-12-30 14:40:00', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 0}, {'interval-start': 32, 'interval-end': 63, 'count': 1}, {'interval-start': 64, 'interval-end': 127, 'count': 1}, {'interval-start': 128, 'interval-end': 255, 'count': 1}, {'interval-start': 256, 'interval-end': 511, 'count': 1}, {'interval-start': 512, 'interval-end': 1023, 'count': 6}, {'interval-start': 1024, 'interval-end': 2047, 'count': 1}, {'interval-start': 2048, 'interval-end': 4095, 'count': 3}], 'Bucket ptr': b'sda'}
+
+The -j option used with -D prints a histogram dictionary per disk device.
+
+# ./biolatency.py -jm
+^C
+{'ts': '2020-12-30 14:42:03', 'val_type': 'msecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 11}, {'interval-start': 2, 'interval-end': 3, 'count': 3}]}
+
+The -j with -m prints a millisecond histogram dictionary. The `value_type` key is set to msecs.
 
 USAGE message:
 
 # ./biolatency -h
-usage: biolatency_2.py [-h] [-T] [-Q] [-m] [-D] [-F] [-j] [-f FILE]
-                       [interval] [count]
+usage: biolatency.py [-h] [-T] [-Q] [-m] [-D] [-F] [-j]
+                              [interval] [count]
 
 Summarize block device I/O latency as a histogram
 
@@ -356,14 +341,13 @@ positional arguments:
   count               number of outputs
 
 optional arguments:
-  -h, --help            show this help message and exit
-  -T, --timestamp       include timestamp on output
-  -Q, --queued          include OS queued time in I/O time
-  -m, --milliseconds    millisecond histogram
-  -D, --disks           print a histogram per disk device
-  -F, --flags           print a histogram per set of I/O flags
-  -j, --json            json output
-  -f FILE, --file FILE  write json output to specified file
+  -h, --help          show this help message and exit
+  -T, --timestamp     include timestamp on output
+  -Q, --queued        include OS queued time in I/O time
+  -m, --milliseconds  millisecond histogram
+  -D, --disks         print a histogram per disk device
+  -F, --flags         print a histogram per set of I/O flags
+  -j, --json          json output
 
 examples:
     ./biolatency                    # summarize block I/O latency as a histogram
@@ -373,4 +357,3 @@ examples:
     ./biolatency -D                 # show each disk device separately
     ./biolatency -F                 # show I/O flags separately
     ./biolatency -j                 # print a dictionary
-    ./biolatency -j -f name.json    # Dump the histogram dictionary to name.json file

--- a/tools/biolatency_example.txt
+++ b/tools/biolatency_example.txt
@@ -292,11 +292,62 @@ flags = Priority-Metadata-Write
 These can be handled differently by the storage device, and this mode lets us
 examine their performance in isolation.
 
+The -j option prints a dictionary of the histogram.
+In most cases, this flag will be used with the -f flag. For example:
+
+# ./biolatency.py -j
+Tracing block device I/O... Hit Ctrl-C to end.
+^C
+{32: 4, 2: 0, 4096: 32, 4: 0, 1024: 10, 8192: 0, 8: 0, 64: 38, 128: 42, 256: 5, 16: 0, 512: 1, 2048: 0}
+     usecs               : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 0        |                                        |
+         8 -> 15         : 0        |                                        |
+        16 -> 31         : 4        |***                                     |
+        32 -> 63         : 38       |************************************    |
+        64 -> 127        : 42       |****************************************|
+       128 -> 255        : 5        |****                                    |
+       256 -> 511        : 1        |                                        |
+       512 -> 1023       : 10       |*********                               |
+      1024 -> 2047       : 0        |                                        |
+      2048 -> 4095       : 32       |******************************          |
+
+Each value in the dictionary represents the number of block I/O's that took less usecs than the key but
+more usecs than the previous key. eg: in the above example, there were 10 I/O operations with latency between 512
+and 1024 usecs. You can use the tabular histogram to compare and understand the histogram dictionary.
+
+
+The -j and -f option together lets you write the histogram dictionary into a json file.
+With these flags, it is possible to store the histogram as a dictionary/json file which
+can be imported easily to be analyzed with libraries like Pandas.
+
+# ./biolatency.py -j -f ./histogram.json
+^C
+     usecs               : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 0        |                                        |
+         8 -> 15         : 0        |                                        |
+        16 -> 31         : 0        |                                        |
+        32 -> 63         : 7        |*******                                 |
+        64 -> 127        : 23       |************************                |
+       128 -> 255        : 33       |***********************************     |
+       256 -> 511        : 4        |****                                    |
+       512 -> 1023       : 16       |*****************                       |
+      1024 -> 2047       : 4        |****                                    |
+      2048 -> 4095       : 37       |****************************************|
+# ls
+biolatency.py  histogram.json
+# cat histogram.json
+{"32": 0, "2": 0, "4096": 37, "4": 0, "1024": 16, "8192": 0, "8": 0, "64": 7, "128": 23, "256": 32, "16": 0, "512": 4, "2048": 4}
+The histogram.json file contains the histogram data.
 
 USAGE message:
 
 # ./biolatency -h
-usage: biolatency [-h] [-T] [-Q] [-m] [-D] [-F] [interval] [count]
+usage: biolatency_2.py [-h] [-T] [-Q] [-m] [-D] [-F] [-j] [-f FILE]
+                       [interval] [count]
 
 Summarize block device I/O latency as a histogram
 
@@ -305,17 +356,21 @@ positional arguments:
   count               number of outputs
 
 optional arguments:
-  -h, --help          show this help message and exit
-  -T, --timestamp     include timestamp on output
-  -Q, --queued        include OS queued time in I/O time
-  -m, --milliseconds  millisecond histogram
-  -D, --disks         print a histogram per disk device
-  -F, --flags         print a histogram per set of I/O flags
+  -h, --help            show this help message and exit
+  -T, --timestamp       include timestamp on output
+  -Q, --queued          include OS queued time in I/O time
+  -m, --milliseconds    millisecond histogram
+  -D, --disks           print a histogram per disk device
+  -F, --flags           print a histogram per set of I/O flags
+  -j, --json            json output
+  -f FILE, --file FILE  write json output to specified file
 
 examples:
-    ./biolatency            # summarize block I/O latency as a histogram
-    ./biolatency 1 10       # print 1 second summaries, 10 times
-    ./biolatency -mT 1      # 1s summaries, milliseconds, and timestamps
-    ./biolatency -Q         # include OS queued time in I/O time
-    ./biolatency -D         # show each disk device separately
-    ./biolatency -F         # show I/O flags separately
+    ./biolatency                    # summarize block I/O latency as a histogram
+    ./biolatency 1 10               # print 1 second summaries, 10 times
+    ./biolatency -mT 1              # 1s summaries, milliseconds, and timestamps
+    ./biolatency -Q                 # include OS queued time in I/O time
+    ./biolatency -D                 # show each disk device separately
+    ./biolatency -F                 # show I/O flags separately
+    ./biolatency -j                 # print a dictionary
+    ./biolatency -j -f name.json    # Dump the histogram dictionary to name.json file

--- a/tools/biolatency_example.txt
+++ b/tools/biolatency_example.txt
@@ -302,11 +302,6 @@ For example:
 the key `data` is the list of the log2 histogram intervals. The `interval-start` and `interval-end` define the
 latency bucket and `count` is the number of I/O's that lie in that latency range.
 
-
-The -j and -f option together lets you write the histogram dictionary into a json file.
-With these flags, it is possible to store the histogram as a dictionary/json file which
-can be imported easily to be analyzed with libraries like Pandas.
-
 # ./biolatency.py -jF
 ^C
 {'ts': '2020-12-30 14:37:59', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 1}, {'interval-start': 32, 'interval-end': 63, 'count': 1}, {'interval-start': 64, 'interval-end': 127, 'count': 0}, {'interval-start': 128, 'interval-end': 255, 'count': 0}, {'interval-start': 256, 'interval-end': 511, 'count': 0}, {'interval-start': 512, 'interval-end': 1023, 'count': 0}, {'interval-start': 1024, 'interval-end': 2047, 'count': 2}], 'flags': 'Sync-Write'}


### PR DESCRIPTION
### Why
In it's current form, storing the histogram data and analyzing the same for a large set of machines is difficult.
With this flag, it is possible to store the histogram as a dictionary/json file which can be imported easily to be analyzed with libraries like Pandas. 

### Example output
```
{
0: 0, 
2: 0, 
4: 0, 
8: 0, 
16: 0, 
32: 0, 
64: 13, 
128: 44, 
256: 41, 
512: 14, 
1024: 27, 
2048: 1, 
4096: 10,  
8192: 0
}
```
### Updated example output - v1
```
[
    {'interval-start': 0, 'interval-end': 1, 'count': 0}, 
    {'interval-start': 2, 'interval-end': 3, 'count': 5}, 
    {'interval-start': 4, 'interval-end': 7, 'count': 143}
]
```
### Updated example output - v2
```
{
    'ts': '2020-12-30 14:49:37', 
    'val_type': 'msecs', 
    'data': 
        [
            {'interval-start': 0, 'interval-end': 1, 'count': 2}, 
            {'interval-start': 2, 'interval-end': 3, 'count': 1}
        ], 
    'flags': 'Sync-Write'
}

```
