### PR TITLE
tools/netqtop: fix rx queue id

### DIFF
--- a/tools/netqtop.c
+++ b/tools/netqtop.c
@@ -95,19 +95,33 @@ TRACEPOINT_PROBE(net, net_dev_start_xmit){
 }
 
 TRACEPOINT_PROBE(net, netif_receive_skb){
-    struct sk_buff* skb = (struct sk_buff*)args->skbaddr;
-    if(!name_filter(skb)){
+    struct sk_buff skb;
+
+    bpf_probe_read(&skb, sizeof(skb), args->skbaddr);
+    if(!name_filter(&skb)){
         return 0;
     }
 
-    u16 qid = skb->queue_mapping;
+    /* case 1: if the NIC does not support multi-queue feature, there is only
+     *         one queue(qid is always 0).
+     * case 2: if the NIC supports multi-queue feature, there are several queues
+     *         with different qid(from 0 to n-1).
+     * The net device driver should mark queue id by API 'skb_record_rx_queue'
+     * for a recieved skb, otherwise it should be a BUG(all of the packets are
+     * reported as queue 0). For example, virtio net driver is fixed for linux:
+     * commit: 133bbb18ab1a2("virtio-net: per-queue RPS config")
+     */
+    u16 qid = 0;
+    if (skb_rx_queue_recorded(&skb))
+        qid = skb_get_rx_queue(&skb);
+
     struct queue_data newdata;
     __builtin_memset(&newdata, 0, sizeof(newdata));
     struct queue_data *data = rx_q.lookup_or_try_init(&qid, &newdata);
     if(!data){
         return 0;
     }
-    updata_data(data, skb->len);
+    updata_data(data, skb.len);
     
     return 0;
 }


### PR DESCRIPTION
Net device driver uses 'skb_record_rx_queue' to mark rx queue
mapping during receiving a packet. Also need to call
'skb_get_rx_queue' to get rx queue id.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>