### PR TITLE
tests/test_array.py: add clock_nanosleep to attach point

### DIFF
--- a/tests/python/test_array.py
+++ b/tests/python/test_array.py
@@ -65,6 +65,8 @@ int do_sys_nanosleep(void *ctx) {
         b = BPF(text=text)
         b.attach_kprobe(event=b.get_syscall_fnname("nanosleep"),
                         fn_name="do_sys_nanosleep")
+        b.attach_kprobe(event=b.get_syscall_fnname("clock_nanosleep"),
+                        fn_name="do_sys_nanosleep")
         b["events"].open_perf_buffer(cb, lost_cb=lost_cb)
         subprocess.call(['sleep', '0.1'])
         b.perf_buffer_poll()
@@ -97,6 +99,8 @@ int do_sys_nanosleep(void *ctx) {
 """
         b = BPF(text=text)
         b.attach_kprobe(event=b.get_syscall_fnname("nanosleep"),
+                        fn_name="do_sys_nanosleep")
+        b.attach_kprobe(event=b.get_syscall_fnname("clock_nanosleep"),
                         fn_name="do_sys_nanosleep")
         b["events"].open_perf_buffer(cb, lost_cb=lost_cb)
         online_cpus = get_online_cpus()


### PR DESCRIPTION
since glibc-2.31, the syscall of sleep is clock_nanosleep instead of
nanosleep

Signed-off-by: Chunmei Xu <xuchunmei@linux.alibaba.com>