### PR TITLE
Fix perf_submit() calls with array arg1 crashing libbcc

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -925,8 +925,8 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
           // events.perf_submit(ctx, &data, sizeof(data));
           // ...
           //                       &data   ->     data    ->  typeof(data)        ->   data_t
-          auto type_arg1 = Call->getArg(1)->IgnoreCasts()->getType().getTypePtr()->getPointeeType().getTypePtr();
-          if (type_arg1->isStructureType()) {
+          auto type_arg1 = Call->getArg(1)->IgnoreCasts()->getType().getTypePtr()->getPointeeType().getTypePtrOrNull();
+          if (type_arg1 && type_arg1->isStructureType()) {
             auto event_type = type_arg1->getAsTagDecl();
             const auto *r = dyn_cast<RecordDecl>(event_type);
             std::vector<std::string> perf_event;


### PR DESCRIPTION
I'm writing a tool that streams unstructured data. Tried to use ringbuf but sadly it's available only since 5.8, which I don't have running now :(
So I'm using `BPF_PERF_OUTPUT` and trying to pass an array like:

```
unsigned char buf[16] = ...;
output.perf_submit(ctx, buf, sizeof(buf));
```
but it crashes libbcc.

Now that I understand the issue, changing the code to use `&buf` avoids it, but I think it's worth fixing the crash anyway.

This commit adds the first use of the `getTypePtrOrNull` to bcc, I'm not sure in which LLVM version it was added, but I checked and it exists at least since [LLVM 3](https://github.com/llvm/llvm-project/blob/llvmorg-3.0.0/clang/include/clang/AST/Type.h#L505), which is old enough, I guess.

I tested `opensnoop` which makes use of the autogenerated perf data structures feature, to ensure I didn't completely disable it (and all cases that now don't go into the `if` would have crashed before, anyway...)