### PR TITLE
Revert "Remove libbcc-no-libbpf shared library, change libbcc linkage…

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(EXAMPLE ${EXAMPLES})
   if(NOT CMAKE_USE_LIBBPF_PACKAGE)
     target_link_libraries(${NAME} bcc-static)
   else()
-    target_link_libraries(${NAME} bcc-shared)
+    target_link_libraries(${NAME} bcc-shared-no-libbpf)
   endif()
 
   if(INSTALL_CPP_EXAMPLES)

--- a/examples/cpp/pyperf/CMakeLists.txt
+++ b/examples/cpp/pyperf/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(PyPerf bcc-static)
 if(NOT CMAKE_USE_LIBBPF_PACKAGE)
   target_link_libraries(PyPerf bcc-static)
 else()
-  target_link_libraries(PyPerf bcc-shared)
+  target_link_libraries(PyPerf bcc-shared-no-libbpf)
 endif()
 
 if(INSTALL_CPP_EXAMPLES)

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -83,9 +83,6 @@ set(bcc_sym_sources bcc_syms.cc bcc_elf.c bcc_perf_map.c bcc_proc.c)
 set(bcc_common_headers libbpf.h perf_reader.h "${CMAKE_CURRENT_BINARY_DIR}/bcc_version.h")
 set(bcc_table_headers file_desc.h table_desc.h table_storage.h)
 set(bcc_api_headers bcc_common.h bpf_module.h bcc_exception.h bcc_syms.h bcc_proc.h bcc_elf.h)
-if(LIBBPF_FOUND)
-  set(bcc_common_sources ${bcc_common_sources} libbpf.c perf_reader.c)
-endif()
 
 if(ENABLE_CLANG_JIT)
 add_library(bcc-shared SHARED
@@ -93,6 +90,16 @@ add_library(bcc-shared SHARED
   ${bcc_util_sources})
 set_target_properties(bcc-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
 set_target_properties(bcc-shared PROPERTIES OUTPUT_NAME bcc)
+
+# If there's libbpf detected we build the libbcc-no-libbpf.so library, that
+# dynamicaly links libbpf.so, in comparison to static link in libbcc.so.
+if(LIBBPF_FOUND)
+  add_library(bcc-shared-no-libbpf SHARED
+    link_all.cc ${bcc_common_sources} ${bcc_table_sources} ${bcc_sym_sources}
+    ${bcc_util_sources} libbpf.c perf_reader.c)
+  set_target_properties(bcc-shared-no-libbpf PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
+  set_target_properties(bcc-shared-no-libbpf PROPERTIES OUTPUT_NAME bcc-no-libbpf)
+endif()
 
 if(ENABLE_USDT)
   set(bcc_usdt_sources usdt/usdt.cc usdt/usdt_args.cc)
@@ -116,25 +123,18 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${llvm_lib_exclude_f
 set(bcc_common_libs b_frontend clang_frontend
   -Wl,--whole-archive ${clang_libs} ${llvm_libs} -Wl,--no-whole-archive
   ${LIBELF_LIBRARIES})
-set(bcc_common_libs_for_a ${bcc_common_libs})
-set(bcc_common_libs_for_s ${bcc_common_libs})
-set(bcc_common_libs_for_lua b_frontend clang_frontend
+set(bcc_common_libs_for_a ${bcc_common_libs} bpf-static)
+set(bcc_common_libs_for_s ${bcc_common_libs} bpf-static)
+set(bcc_common_libs_for_n ${bcc_common_libs})
+set(bcc_common_libs_for_lua b_frontend clang_frontend bpf-static
   ${clang_libs} ${llvm_libs} ${LIBELF_LIBRARIES})
-if(LIBBPF_FOUND)
-  list(APPEND bcc_common_libs_for_a ${LIBBPF_LIBRARIES})
-  list(APPEND bcc_common_libs_for_s ${LIBBPF_LIBRARIES})
-  list(APPEND bcc_common_libs_for_lua ${LIBBPF_LIBRARIES})
-else()
-  list(APPEND bcc_common_libs_for_a bpf-static)
-  list(APPEND bcc_common_libs_for_s bpf-static)
-  list(APPEND bcc_common_libs_for_lua bpf-static)
-endif()
 
 if(ENABLE_CPP_API)
   add_subdirectory(api)
   list(APPEND bcc_common_libs_for_a api-static)
   # Keep all API functions
   list(APPEND bcc_common_libs_for_s -Wl,--whole-archive api-static -Wl,--no-whole-archive)
+  list(APPEND bcc_common_libs_for_n -Wl,--whole-archive api-static -Wl,--no-whole-archive)
 endif()
 
 if(ENABLE_USDT)
@@ -142,6 +142,7 @@ if(ENABLE_USDT)
   add_subdirectory(usdt)
   list(APPEND bcc_common_libs_for_a usdt-static)
   list(APPEND bcc_common_libs_for_s usdt-static)
+  list(APPEND bcc_common_libs_for_n usdt-static)
   list(APPEND bcc_common_libs_for_lua usdt-static)
 endif()
 
@@ -151,6 +152,11 @@ add_subdirectory(frontends)
 target_link_libraries(bcc-shared ${bcc_common_libs_for_s})
 target_link_libraries(bcc-static ${bcc_common_libs_for_a} bcc-loader-static)
 set(bcc-lua-static ${bcc-lua-static} ${bcc_common_libs_for_lua})
+
+if(LIBBPF_FOUND)
+  target_link_libraries(bcc-shared-no-libbpf ${bcc_common_libs_for_n} ${LIBBPF_LIBRARIES})
+  install(TARGETS bcc-shared-no-libbpf LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
 
 install(TARGETS bcc-shared bcc-static bcc-loader-static bpf-static LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${bcc_table_headers} DESTINATION include/bcc)

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(test_static test_static.c)
 if(NOT CMAKE_USE_LIBBPF_PACKAGE)
   target_link_libraries(test_static bcc-static)
 else()
-  target_link_libraries(test_static bcc-shared)
+  target_link_libraries(test_static bcc-shared-no-libbpf)
 endif()
 
 add_test(NAME c_test_static COMMAND ${TEST_WRAPPER} c_test_static sudo ${CMAKE_CURRENT_BINARY_DIR}/test_static)
@@ -55,11 +55,11 @@ endif()
 
 if(LIBBPF_FOUND)
   add_executable(test_libbcc_no_libbpf ${TEST_LIBBCC_SOURCES})
-  add_dependencies(test_libbcc_no_libbpf bcc-shared)
+  add_dependencies(test_libbcc_no_libbpf bcc-shared-no-libbpf)
 
-  target_link_libraries(test_libbcc_no_libbpf ${PROJECT_BINARY_DIR}/src/cc/libbcc.so dl usdt_test_lib ${LIBBPF_LIBRARIES})
+  target_link_libraries(test_libbcc_no_libbpf ${PROJECT_BINARY_DIR}/src/cc/libbcc-no-libbpf.so dl usdt_test_lib ${LIBBPF_LIBRARIES})
   set_target_properties(test_libbcc_no_libbpf PROPERTIES INSTALL_RPATH ${PROJECT_BINARY_DIR}/src/cc)
-  target_compile_definitions(test_libbcc_no_libbpf PRIVATE -DLIBBCC_NAME=\"libbcc.so\")
+  target_compile_definitions(test_libbcc_no_libbpf PRIVATE -DLIBBCC_NAME=\"libbcc-no-libbpf.so\")
 
   add_test(NAME test_libbcc_no_libbpf COMMAND ${TEST_WRAPPER} c_test_all_no_libbpf sudo ${CMAKE_CURRENT_BINARY_DIR}/test_libbcc_no_libbpf)
 endif()


### PR DESCRIPTION
I'm surprised you'd remove library that's being used.

bpftrace in fedora is using it:
  -DLIBBCC_LIBRARIES:PATH=/usr/lib64/libbcc-no-libbpf.so

It's the only way to have libcc together with dynamicaly linked libbpf.so.

Please let's keep it in.