### PR TITLE
ProbeVisitor: Valgrind Conditional jump or move depends on uninitialised value(s)

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -321,7 +321,7 @@ bool MapVisitor::VisitCallExpr(CallExpr *Call) {
 
 ProbeVisitor::ProbeVisitor(ASTContext &C, Rewriter &rewriter,
                            set<Decl *> &m, bool track_helpers) :
-  C(C), rewriter_(rewriter), m_(m), track_helpers_(track_helpers),
+  C(C), rewriter_(rewriter), m_(m), ctx_(nullptr), track_helpers_(track_helpers),
   addrof_stmt_(nullptr), is_addrof_(false) {
   const char **calling_conv_regs = get_call_conv();
   has_overlap_kuaddr_ = calling_conv_regs == calling_conv_regs_s390x;


### PR DESCRIPTION
Found by valgrind.

```
Conditional jump or move depends on uninitialised value(s)
at 0xBABD86: ebpf::ProbeVisitor::IsContextMemberExpr(clang::Expr*) (b_frontend_action.cc:590) 
by 0xBA9CEB: ebpf::ProbeVisitor::assignsExtPtr(clang::Expr*, int*) (b_frontend_action.cc:263) 
by 0xBAAA9F: ebpf::ProbeVisitor::VisitBinaryOperator(clang::BinaryOperator*) (b_frontend_action.cc:410)
by 0xC15B29: clang::RecursiveASTVisitor<ebpf::ProbeVisitor>::WalkUpFromBinaryOperator(clang::BinaryOperator*) (StmtNodes.inc:181)
```