### PR TITLE
tools/offcputime Filter out negative offcpu duration

### DIFF
--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -146,8 +146,13 @@ int oncpu(struct pt_regs *ctx, struct task_struct *prev) {
     }
 
     // calculate current thread's delta time
-    u64 delta = bpf_ktime_get_ns() - *tsp;
+    u64 t_start = *tsp;
+    u64 t_end = bpf_ktime_get_ns();
     start.delete(&pid);
+    if (t_start > t_end) {
+        return 0;
+    }
+    u64 delta = t_end - t_start;
     delta = delta / 1000;
     if ((delta < MINBLOCK_US) || (delta > MAXBLOCK_US)) {
         return 0;


### PR DESCRIPTION
I think the current `offcputime.py` counts not only events properly filtered in but also some events with short duration due to regressing value from `bpf_ktime_get_ns()`.

bcc version: latest on git
kernel version: CentOS7, 3.10.0-1127.18.2.el7


## Background

I was developing my own version of offcputime.py that produces events for each long offcpu event including duration of the task stayed off-cpu.
After getting some samples, I realized that in some cases duration (`u64 delta = bpf_ktime_get_ns() - *tsp`) is insanely large number and figured out that it is due to negative numbers printed as unsigned 64bit.

## Reproducing the issue

I thought there should be the same issue exists in `offcputime.py` and modified it as below:

```diff
diff --git a/tools/offcputime.py b/tools/offcputime.py
index 068c7076..11d8a4d8 100755
--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -146,7 +146,12 @@ int oncpu(struct pt_regs *ctx, struct task_struct *prev) {
     }
 
     // calculate current thread's delta time
-    u64 delta = bpf_ktime_get_ns() - *tsp;
+    u64 t_start = *tsp;
+    u64 t_end = bpf_ktime_get_ns();
+    if (t_start > t_end) {
+        bpf_trace_printk("Clock regression!: %u > %u\\n", t_start, t_end);
+    }
+    u64 delta = t_end - t_start;
     start.delete(&pid);
     delta = delta / 1000;
     if ((delta < MINBLOCK_US) || (delta > MAXBLOCK_US)) {
@@ -246,6 +251,7 @@ if not folded:
     else:
         print("... Hit Ctrl-C to end.")
 
+b.trace_print()
 try:
     sleep(duration)
 except KeyboardInterrupt:
```

As I executed the modified version on my system, I could confirm that there are some events with negative delta (the time stored in `start` > current time).

```
$ ~/offcputime.py -m 100000 3
Tracing off-CPU time (us) of all threads by user + kernel stack for 3 secs.
           <...>-123820 [000] d... 3548318.327993: : Clock regression!: 59599178 > 59567229
           <...>-76871 [000] d... 3548330.825545: : Clock regression!: 3968610353 > 3967622873
           <...>-123810 [000] d... 3548353.203783: : Clock regression!: 577745979 > 576818764
          <idle>-0     [002] d... 3548378.357934: : Clock regression!: 4257954648 > 4256982417
          <idle>-0     [003] d... 3548404.022071: : Clock regression!: 4153185458 > 4152188905
```

## Cause

I think this is caused by regressing return value from `bpf_ktime_get_ns()`, which calls `ktime_get_mono_fast_ns`. The document of `ktime_get_mono_fast_ns` actually [states it isn't guaranteed to always return monotonic value](https://github.com/torvalds/linux/blob/65f0d2414b7079556fbbcc070b3d1c9f9587606d/kernel/time/timekeeping.c#L456).

## Proposed fix

Just filter out cases where the end time is larger than the start time. I assume such cases happen only when the actual duration between last off-cpu and on-cpu is short, so I think it's better than accidentally counting them in.
