### PR TITLE
aarch64: turn off jump table optimization during jit compilation

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -318,7 +318,7 @@ int ClangLoader::do_compile(unique_ptr<llvm::Module> *mod, TableStorage &ts,
   driver::Driver drv("", target_triple, diags);
 
 #if LLVM_MAJOR_VERSION >= 4
-  if (target_triple == "x86_64-unknown-linux-gnu")
+  if (target_triple == "x86_64-unknown-linux-gnu" || target_triple == "aarch64-unknown-linux-gnu")
     flags_cstr.push_back("-fno-jump-tables");
 #endif
 


### PR DESCRIPTION
test_clang.py: test_jump_table will get failed with error messgae:
bpf: Failed to load program: Invalid argument
unknown opcode a0
processed 0 insns (limit 1000000) max_states_per_insn 0 total_states 0
peak_states 0 mark_read 0

HINT: The 'unknown opcode' can happen if you reference a global or
static variable, or data in read-only section. For example, 'char *p =
"hello"' will result in p referencing a read-only section, and 'char p[]
= "hello"' will have "hello" stored on the stack.

Signed-off-by: Chunmei Xu <xuchunmei@linux.alibaba.com>