### PR TITLE
libbpf-tools: fix some tools error info and usage

### DIFF
--- a/libbpf-tools/biolatency.c
+++ b/libbpf-tools/biolatency.c
@@ -40,12 +40,12 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Summarize block device I/O latency as a histogram.\n"
 "\n"
-"USAGE: biolatency [--help] [-T] [-m] [-Q] [-D] [-F] [-d] [interval] [count]\n"
+"USAGE: biolatency [--help] [-T] [-M] [-Q] [-D] [-F] [-d DISK] [interval] [count]\n"
 "\n"
 "EXAMPLES:\n"
 "    biolatency              # summarize block I/O latency as a histogram\n"
 "    biolatency 1 10         # print 1 second summaries, 10 times\n"
-"    biolatency -mT 1        # 1s summaries, milliseconds, and timestamps\n"
+"    biolatency -MT 1        # 1s summaries, milliseconds, and timestamps\n"
 "    biolatency -Q           # include OS queued time in I/O time\n"
 "    biolatency -D           # show each disk device separately\n"
 "    biolatency -F           # show I/O flags separately\n"
@@ -53,7 +53,7 @@ const char argp_program_doc[] =
 
 static const struct argp_option opts[] = {
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
-	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
+	{ "milliseconds", 'M', NULL, 0, "Millisecond histogram" },
 	{ "queued", 'Q', NULL, 0, "Include OS queued time in I/O time" },
 	{ "disk", 'D', NULL, 0, "Print a histogram per disk device" },
 	{ "flag", 'F', NULL, 0, "Print a histogram per set of I/O flags" },
@@ -70,7 +70,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 'v':
 		env.verbose = true;
 		break;
-	case 'm':
+	case 'M':
 		env.milliseconds = true;
 		break;
 	case 'Q':
@@ -250,7 +250,7 @@ int main(int argc, char **argv)
 
 	obj = biolatency_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/biopattern.c
+++ b/libbpf-tools/biopattern.c
@@ -32,7 +32,7 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Show block device I/O pattern.\n"
 "\n"
-"USAGE: biopattern [--help] [-T] [-d] [interval] [count]\n"
+"USAGE: biopattern [--help] [-T] [-d DISK] [interval] [count]\n"
 "\n"
 "EXAMPLES:\n"
 "    biopattern              # show block I/O pattern\n"
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
 
 	obj = biopattern_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/biosnoop.c
+++ b/libbpf-tools/biosnoop.c
@@ -33,7 +33,7 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Trace block I/O.\n"
 "\n"
-"USAGE: biosnoop [--help] [-d] [-Q]\n"
+"USAGE: biosnoop [--help] [-d DISK] [-Q]\n"
 "\n"
 "EXAMPLES:\n"
 "    biosnoop              # trace all block I/O\n"
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
 
 	obj = biosnoop_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/biostacks.c
+++ b/libbpf-tools/biostacks.c
@@ -27,7 +27,7 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Tracing block I/O with init stacks.\n"
 "\n"
-"USAGE: biostacks [--help] [-d disk] [-m] [duration]\n"
+"USAGE: biostacks [--help] [-d DISK] [-M] [duration]\n"
 "\n"
 "EXAMPLES:\n"
 "    biostacks              # trace block I/O with init stacks.\n"
@@ -36,7 +36,7 @@ const char argp_program_doc[] =
 
 static const struct argp_option opts[] = {
 	{ "disk",  'd', "DISK",  0, "Trace this disk only" },
-	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
+	{ "milliseconds", 'M', NULL, 0, "Millisecond histogram" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
 	{},
 };
@@ -56,7 +56,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			argp_usage(state);
 		}
 		break;
-	case 'm':
+	case 'M':
 		env.milliseconds = true;
 		break;
 	case ARGP_KEY_ARG:
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
 
 	obj = biostacks_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/bitesize.c
+++ b/libbpf-tools/bitesize.c
@@ -34,7 +34,7 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Summarize block device I/O size as a histogram.\n"
 "\n"
-"USAGE: bitesize [--help] [-T] [-c] [-d] [interval] [count]\n"
+"USAGE: bitesize [--help] [-T] [-c COMM] [-d DISK] [interval] [count]\n"
 "\n"
 "EXAMPLES:\n"
 "    bitesize              # summarize block I/O latency as a histogram\n"
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
 
 	obj = bitesize_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/cpudist.c
+++ b/libbpf-tools/cpudist.c
@@ -37,20 +37,20 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Summarize on-CPU time per task as a histogram.\n"
 "\n"
-"USAGE: cpudist [--help] [-O] [-T] [-m] [-P] [-L] [-p PID] [interval] [count]\n"
+"USAGE: cpudist [--help] [-O] [-T] [-M] [-P] [-L] [-p PID] [interval] [count]\n"
 "\n"
 "EXAMPLES:\n"
 "    cpudist              # summarize on-CPU time as a histogram"
 "    cpudist -O           # summarize off-CPU time as a histogram"
 "    cpudist 1 10         # print 1 second summaries, 10 times"
-"    cpudist -mT 1        # 1s summaries, milliseconds, and timestamps"
+"    cpudist -MT 1        # 1s summaries, milliseconds, and timestamps"
 "    cpudist -P           # show each PID separately"
 "    cpudist -p 185       # trace PID 185 only";
 
 static const struct argp_option opts[] = {
 	{ "offcpu", 'O', NULL, 0, "Measure off-CPU time" },
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
-	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
+	{ "milliseconds", 'M', NULL, 0, "Millisecond histogram" },
 	{ "pids", 'P', NULL, 0, "Print a histogram per process ID" },
 	{ "tids", 'L', NULL, 0, "Print a histogram per thread ID" },
 	{ "pid", 'p', "PID", 0, "Trace this PID only" },
@@ -66,7 +66,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 'v':
 		env.verbose = true;
 		break;
-	case 'm':
+	case 'M':
 		env.milliseconds = true;
 		break;
 	case 'p':
@@ -203,7 +203,7 @@ int main(int argc, char **argv)
 
 	obj = cpudist_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/drsnoop.c
+++ b/libbpf-tools/drsnoop.c
@@ -31,18 +31,18 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Trace direct reclaim latency.\n"
 "\n"
-"USAGE: drsnoop [--help] [-p PID] [-t TID] [-d DURATION] [-e]\n"
+"USAGE: drsnoop [--help] [-p PID] [-t TID] [-d DURATION] [-E]\n"
 "\n"
 "EXAMPLES:\n"
 "    drsnoop         # trace all direct reclaim events\n"
 "    drsnoop -p 123  # trace pid 123\n"
 "    drsnoop -t 123  # trace tid 123 (use for threads only)\n"
 "    drsnoop -d 10   # trace for 10 seconds only\n"
-"    drsnoop -e      # trace all direct reclaim events with extended faileds\n";
+"    drsnoop -E      # trace all direct reclaim events with extended faileds\n";
 
 static const struct argp_option opts[] = {
 	{ "duration", 'd', "DURATION", 0, "Total duration of trace in seconds" },
-	{ "extended", 'e', NULL, 0, "Extended fields output" },
+	{ "extended", 'E', NULL, 0, "Extended fields output" },
 	{ "pid", 'p', "PID", 0, "Process PID to trace" },
 	{ "tid", 't', "TID", 0, "Thread TID to trace" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
@@ -69,7 +69,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		}
 		env.duration = duration;
 		break;
-	case 'e':
+	case 'E':
 		env.extended = true;
 		break;
 	case 'p':
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
 
 	obj = drsnoop_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF object\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -40,26 +40,26 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Trace open family syscalls\n"
 "\n"
-"USAGE: execsnoop [-h] [-T] [-t] [-x] [-u UID] [-q] [-n NAME] [-l LINE] [-U]\n"
+"USAGE: execsnoop [-h] [-T] [-t] [-X] [-u UID] [-Q] [-n NAME] [-l LINE] [-U]\n"
 "                 [--max-args MAX_ARGS]\n"
 "\n"
 "EXAMPLES:\n"
 "   ./execsnoop           # trace all exec() syscalls\n"
-"   ./execsnoop -x        # include failed exec()s\n"
+"   ./execsnoop -X        # include failed exec()s\n"
 "   ./execsnoop -T        # include time (HH:MM:SS)\n"
 "   ./execsnoop -U        # include UID\n"
 "   ./execsnoop -u 1000   # only trace UID 1000\n"
 "   ./execsnoop -t        # include timestamps\n"
-"   ./execsnoop -q        # add \"quotemarks\" around arguments\n"
+"   ./execsnoop -Q        # add \"quotemarks\" around arguments\n"
 "   ./execsnoop -n main   # only print command lines containing \"main\"\n"
 "   ./execsnoop -l tpkg   # only print command where arguments contains \"tpkg\"";
 
 static const struct argp_option opts[] = {
 	{ "time", 'T', NULL, 0, "include time column on output (HH:MM:SS)"},
 	{ "timestamp", 't', NULL, 0, "include timestamp on output"},
-	{ "fails", 'x', NULL, 0, "include failed exec()s"},
+	{ "fails", 'X', NULL, 0, "include failed exec()s"},
 	{ "uid", 'u', "UID", 0, "trace this UID only"},
-	{ "quote", 'q', NULL, 0, "Add quotemarks (\") around arguments"},
+	{ "quote", 'Q', NULL, 0, "Add quotemarks (\") around arguments"},
 	{ "name", 'n', "NAME", 0, "only print commands matching this name, any arg"},
 	{ "line", 'l', "LINE", 0, "only print commands where arg contains this line"},
 	{ "print-uid", 'U', NULL, 0, "print UID column"},
@@ -83,7 +83,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 't':
 		env.timestamp = true;
 		break;
-	case 'x':
+	case 'X':
 		env.fails = true;
 		break;
 	case 'u':
@@ -95,7 +95,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		}
 		env.uid = uid;
 		break;
-	case 'q':
+	case 'Q':
 		env.quote = true;
 		break;
 	case 'n':
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
 
 	obj = execsnoop_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF object\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
 
 	obj = filelife_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF object\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/hardirqs.c
+++ b/libbpf-tools/hardirqs.c
@@ -36,17 +36,17 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Summarize hard irq event time as histograms.\n"
 "\n"
-"USAGE: hardirqs [--help] [-T] [-N] [-d] [interval] [count]\n"
+"USAGE: hardirqs [--help] [-T] [-N] [-D] [interval] [count]\n"
 "\n"
 "EXAMPLES:\n"
 "    hardirqs            # sum hard irq event time\n"
-"    hardirqs -d         # show hard irq event time as histograms\n"
+"    hardirqs -D         # show hard irq event time as histograms\n"
 "    hardirqs 1 10       # print 1 second summaries, 10 times\n"
 "    hardirqs -NT 1      # 1s summaries, nanoseconds, and timestamps\n";
 
 static const struct argp_option opts[] = {
 	{ "count", 'C', NULL, 0, "Show event counts instead of timing" },
-	{ "distributed", 'd', NULL, 0, "Show distributions as histograms" },
+	{ "distributed", 'D', NULL, 0, "Show distributions as histograms" },
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
 	{ "nanoseconds", 'N', NULL, 0, "Output in nanoseconds" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
@@ -61,7 +61,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 'v':
 		env.verbose = true;
 		break;
-	case 'd':
+	case 'D':
 		env.distributed = true;
 		break;
 	case 'C':
@@ -191,7 +191,7 @@ int main(int argc, char **argv)
 
 	obj = hardirqs_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF object\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/llcstat.c
+++ b/libbpf-tools/llcstat.c
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
 
 	obj = llcstat_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF object\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -48,24 +48,24 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Trace open family syscalls\n"
 "\n"
-"USAGE: opensnoop [-h] [-T] [-U] [-x] [-p PID] [-t TID] [-u UID] [-d DURATION]\n"
-"                 [-n NAME] [-e]\n"
+"USAGE: opensnoop [-h] [-T] [-U] [-X] [-p PID] [-t TID] [-u UID] [-d DURATION]\n"
+"                 [-n NAME] [-E]\n"
 "\n"
 "EXAMPLES:\n"
 "    ./opensnoop           # trace all open() syscalls\n"
 "    ./opensnoop -T        # include timestamps\n"
 "    ./opensnoop -U        # include UID\n"
-"    ./opensnoop -x        # only show failed opens\n"
+"    ./opensnoop -X        # only show failed opens\n"
 "    ./opensnoop -p 181    # only trace PID 181\n"
 "    ./opensnoop -t 123    # only trace TID 123\n"
 "    ./opensnoop -u 1000   # only trace UID 1000\n"
 "    ./opensnoop -d 10     # trace for 10 seconds only\n"
 "    ./opensnoop -n main   # only print process names containing \"main\"\n"
-"    ./opensnoop -e        # show extended fields\n";
+"    ./opensnoop -E        # show extended fields\n";
 
 static const struct argp_option opts[] = {
 	{ "duration", 'd', "DURATION", 0, "Duration to trace"},
-	{ "extended-fields", 'e', NULL, 0, "Print extended fields"},
+	{ "extended-fields", 'E', NULL, 0, "Print extended fields"},
 	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help"},
 	{ "name", 'n', "NAME", 0, "Trace process names containing this"},
 	{ "pid", 'p', "PID", 0, "Process ID to trace"},
@@ -74,7 +74,7 @@ static const struct argp_option opts[] = {
 	{ "uid", 'u', "UID", 0, "User ID to trace"},
 	{ "print-uid", 'U', NULL, 0, "Print UID"},
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
-	{ "failed", 'x', NULL, 0, "Failed opens only"},
+	{ "failed", 'X', NULL, 0, "Failed opens only"},
 	{},
 };
 
@@ -84,7 +84,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	long int pid, uid, duration;
 
 	switch (key) {
-	case 'e':
+	case 'E':
 		env.extended = true;
 		break;
 	case 'h':
@@ -99,7 +99,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 'v':
 		env.verbose = true;
 		break;
-	case 'x':
+	case 'X':
 		env.failed = true;
 		break;
 	case 'd':
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
 
 	obj = opensnoop_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF object\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/readahead.c
+++ b/libbpf-tools/readahead.c
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
 
 	obj = readahead_bpf__open_and_load();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		fprintf(stderr, "failed to open and/or load BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/runqlat.c
+++ b/libbpf-tools/runqlat.c
@@ -38,12 +38,12 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Summarize run queue (scheduler) latency as a histogram.\n"
 "\n"
-"USAGE: runqlat [--help] [-T] [-m] [--pidnss] [-L] [-P] [-p PID] [interval] [count]\n"
+"USAGE: runqlat [--help] [-T] [-M] [--pidnss] [-L] [-P] [-p PID] [interval] [count]\n"
 "\n"
 "EXAMPLES:\n"
 "    runqlat         # summarize run queue latency as a histogram\n"
 "    runqlat 1 10    # print 1 second summaries, 10 times\n"
-"    runqlat -mT 1   # 1s summaries, milliseconds, and timestamps\n"
+"    runqlat -MT 1   # 1s summaries, milliseconds, and timestamps\n"
 "    runqlat -P      # show each PID separately\n"
 "    runqlat -p 185  # trace PID 185 only\n";
 
@@ -51,7 +51,7 @@ const char argp_program_doc[] =
 
 static const struct argp_option opts[] = {
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
-	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
+	{ "milliseconds", 'M', NULL, 0, "Millisecond histogram" },
 	{ "pidnss", OPT_PIDNSS, NULL, 0, "Print a histogram per PID namespace" },
 	{ "pids", 'P', NULL, 0, "Print a histogram per process ID" },
 	{ "tids", 'L', NULL, 0, "Print a histogram per thread ID" },
@@ -68,7 +68,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 'v':
 		env.verbose = true;
 		break;
-	case 'm':
+	case 'M':
 		env.milliseconds = true;
 		break;
 	case 'p':
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
 
 	obj = runqlat_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF object\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/runqslower.c
+++ b/libbpf-tools/runqslower.c
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
 
 	obj = runqslower_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF object\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/softirqs.c
+++ b/libbpf-tools/softirqs.c
@@ -35,16 +35,16 @@ const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
 const char argp_program_doc[] =
 "Summarize soft irq event time as histograms.\n"
 "\n"
-"USAGE: softirqs [--help] [-T] [-N] [-d] [interval] [count]\n"
+"USAGE: softirqs [--help] [-T] [-N] [-D] [interval] [count]\n"
 "\n"
 "EXAMPLES:\n"
 "    softirqss            # sum soft irq event time\n"
-"    softirqss -d         # show soft irq event time as histograms\n"
+"    softirqss -D         # show soft irq event time as histograms\n"
 "    softirqss 1 10       # print 1 second summaries, 10 times\n"
 "    softirqss -NT 1      # 1s summaries, nanoseconds, and timestamps\n";
 
 static const struct argp_option opts[] = {
-	{ "distributed", 'd', NULL, 0, "Show distributions as histograms" },
+	{ "distributed", 'D', NULL, 0, "Show distributions as histograms" },
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
 	{ "nanoseconds", 'N', NULL, 0, "Output in nanoseconds" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
@@ -59,7 +59,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 'v':
 		env.verbose = true;
 		break;
-	case 'd':
+	case 'D':
 		env.distributed = true;
 		break;
 	case 'N':
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
 
 	obj = softirqs_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF object\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 

--- a/libbpf-tools/syscount.c
+++ b/libbpf-tools/syscount.c
@@ -394,7 +394,7 @@ int main(int argc, char **argv)
 
 	obj = syscount_bpf__open();
 	if (!obj) {
-		warn("failed to open and/or load BPF object\n");
+		warn("failed to open BPF object\n");
 		err = 1;
 		goto free_names;
 	}

--- a/libbpf-tools/tcpconnlat.c
+++ b/libbpf-tools/tcpconnlat.c
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
 
 	obj = tcpconnlat_bpf__open();
 	if (!obj) {
-		fprintf(stderr, "failed to open and/or load BPF ojbect\n");
+		fprintf(stderr, "failed to open BPF object\n");
 		return 1;
 	}
 


### PR DESCRIPTION
- Fix the error message in the open phase
- Fix spelling error: ojbect -> object
- Complete parameter information in usage
- Capitalize parameters that do not require parameter values ​​for easy memory

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>