### PR TITLE
Fix freezing of 'test_brb' if iperf is not found

### DIFF
--- a/tests/python/test_brb.py
+++ b/tests/python/test_brb.py
@@ -65,7 +65,7 @@ from ctypes import c_uint
 from netaddr import IPAddress, EUI
 from bcc import BPF
 from pyroute2 import IPRoute, NetNS, IPDB, NSPopen
-from utils import NSPopenWithCheck
+from utils import NSPopenWithCheck, mayFail
 import sys
 from time import sleep
 from unittest import main, TestCase
@@ -147,6 +147,7 @@ class TestBPFSocket(TestCase):
         self.br1_rtr[c_uint(0)] = c_uint(self.nsrtr_eth0_out.index)
         self.br2_rtr[c_uint(0)] = c_uint(self.nsrtr_eth1_out.index)
 
+    @mayFail("If the 'iperf', 'netserver' and 'netperf' binaries are unavailable, this is allowed to fail.")
     def test_brb(self):
         try:
             b = BPF(src_file=arg1, debug=0)


### PR DESCRIPTION
If iperf is not installed or installed at a location that is not
in PATH as recgnized by Python, then 'test_brb' will fail while
test_brb2 success.

test_brb:
ERROR: test_brb (__main__.TestBPFSocket)
Traceback (most recent call last):
  File "test_brb.py", line 200, in test_brb
    nsp_server = NSPopenWithCheck(ns2_ipdb.nl.netns, ["iperf", "-s", "-xSC"])
  File "/root/rpmbuild/BUILD/bcc/tests/python/utils.py", line 63, in __init__
    has_executable(name)
  File "/root/rpmbuild/BUILD/bcc/tests/python/utils.py", line 18, in has_executable
    raise Exception(name + ": command not found")
Exception: iperf: command not found

Ran 1 test in 2.546s

FAILED (errors=1)

test_brb2:
CRITICAL:root:WARNING! Test test_brb (__main__.TestBPFSocket) failed, but marked as passed because it is decorated with @mayFail.
CRITICAL:root:  The reason why this mayFail was: This fails on github actions environment, and needs to be fixed
CRITICAL:root:  The failure was: "iperf: command not found"
CRITICAL:root:  Stacktrace: "Traceback (most recent call last):
  File "/root/rpmbuild/BUILD/bcc/tests/python/utils.py", line 35, in wrapper
    res = func(*args, **kwargs)
  File "test_brb.py", line 202, in test_brb
    nsp_server = NSPopenWithCheck(ns2_ipdb.nl.netns, ["iperf", "-s", "-xSC"])
  File "/root/rpmbuild/BUILD/bcc/tests/python/utils.py", line 63, in __init__
    has_executable(name)
  File "/root/rpmbuild/BUILD/bcc/tests/python/utils.py", line 18, in has_executable
    raise Exception(name + ": command not found")
Exception: iperf: command not found
"
.
Ran 1 test in 2.627s

OK

test_brb2 successes because there is @mayFail in it which comes from
commit a47c44fa0d570b64d8cb06449052db4f363e80a4

so add @mayFail in test_brb

Signed-off-by: Liu Chao <liuchao173@huawei.com>