### PR TITLE
correct the path of offcputime.lua

### DIFF
--- a/tests/lua/test_standalone.sh
+++ b/tests/lua/test_standalone.sh
@@ -23,7 +23,7 @@ fi
 rm -f probe.lua
 echo "return function(BPF) print(\"Hello world\") end" > probe.lua
 
-PROBE="../../../examples/lua/offcputime.lua"
+PROBE="../../examples/lua/offcputime.lua"
 
 if ! sudo ./bcc-lua "$PROBE" -d 1 >/dev/null 2>/dev/null; then
     fail "bcc-lua cannot run complex probes"


### PR DESCRIPTION
[root@openEuler bcc]# cd src/lua/
[root@openEuler lua]# ./bcc-lua ../../../examples/lua/offcputime.lua -d 1 >/dev/null 2>/dev/null
[root@openEuler lua]# ./bcc-lua ../../../examples/lua/offcputime.lua -d 1
./bcc-lua: cannot open ../../../examples/lua/offcputime.lua: No such file or directory
stack traceback:
        [C]: in function 'dofile'
        bcc.lua:6338: in function <bcc.lua:6288>
        [C]: at 0x557532f676b0
[root@openEuler lua]#