### PR TITLE
test:Fix the test_libbcc/test_libbcc_no_libbpf testcase failure when the kernel version is lower than 4.20

### DIFF
--- a/tests/cc/test_cg_storage.cc
+++ b/tests/cc/test_cg_storage.cc
@@ -63,7 +63,8 @@ int test(struct bpf_sock_ops *skops)
     REQUIRE(res.code() != 0);
   }
 }
-
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
 TEST_CASE("test percpu cgroup storage", "[percpu_cgroup_storage]") {
   {
     const std::string BPF_PROGRAM = R"(


### PR DESCRIPTION
The BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE type is only supported in the version of the kernel >=4.20, causing the bpf_init function failed on the low kernel version.

test/cc/test_cg_storage.cc
`TEST_CASE("test percpu cgroup storage", "[percpu_cgroup_storage]") {
  {
    const std::string BPF_PROGRAM = R"(
BPF_PERCPU_CGROUP_STORAGE(cg_storage1, long long);
BPF_PERCPU_CGROUP_STORAGE(cg_storage2, long long);
int test(struct bpf_sock_ops *skops)
`


after modify, the test case can be executed successfully :
3/43 Test  #3: test_libbcc ......................   Passed   18.58 sec
      Start  4: test_libbcc_no_libbpf
4/43 Test  #4: test_libbcc_no_libbpf ............   Passed   18.46 sec
      Start  5: py_test_stat1_b



