### PR TITLE
Increase storage size of usdt argument constants to 64 bits

### DIFF
--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -54,7 +54,7 @@ struct bcc_usdt_location {
 struct bcc_usdt_argument {
     int size;
     int valid;
-    int constant;
+    long long constant;
     int deref_offset;
     const char *deref_ident;
     const char *base_register_name;

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -46,7 +46,7 @@ static const std::string COMPILER_BARRIER =
 class Argument {
 private:
   optional<int> arg_size_;
-  optional<int> constant_;
+  optional<long long> constant_;
   optional<int> deref_offset_;
   optional<std::string> deref_ident_;
   optional<std::string> base_register_name_;
@@ -75,7 +75,7 @@ public:
     return index_register_name_;
   }
   const optional<int> scale() const { return scale_; }
-  const optional<int> constant() const { return constant_; }
+  const optional<long long> constant() const { return constant_; }
   const optional<int> deref_offset() const { return deref_offset_; }
 
   friend class ArgumentParser;
@@ -96,6 +96,13 @@ class ArgumentParser {
   ssize_t parse_number(ssize_t pos, optional<int> *result) {
     char *endp;
     int number = strtol(arg_ + pos, &endp, 0);
+    if (endp > arg_ + pos)
+      *result = number;
+    return endp - arg_;
+  }
+  ssize_t parse_number(ssize_t pos, optional<long long> *result) {
+    char *endp;
+    long long number = (long long)strtoull(arg_ + pos, &endp, 0);
     if (endp > arg_ + pos)
       *result = number;
     return endp - arg_;

--- a/src/cc/usdt/usdt_args.cc
+++ b/src/cc/usdt/usdt_args.cc
@@ -64,7 +64,7 @@ bool Argument::assign_to_local(std::ostream &stream,
                                const std::string &binpath,
                                const optional<int> &pid) const {
   if (constant_) {
-    tfm::format(stream, "%s = %d;", local_name, *constant_);
+    tfm::format(stream, "%s = %lld;", local_name, *constant_);
     return true;
   }
 
@@ -228,7 +228,7 @@ bool ArgumentParser_aarch64::parse(Argument *dest) {
     dest->deref_offset_ = offset;
   } else {
     // Parse ...@<value>
-    optional<int> val;
+    optional<long long> val;
     new_pos = parse_number(cur_pos, &val);
     if (cur_pos == new_pos)
       return error_return(cur_pos, cur_pos);
@@ -268,7 +268,7 @@ bool ArgumentParser_powerpc64::parse(Argument *dest) {
     arg_str = &arg_[cur_pos_];
 
     if (std::regex_search(arg_str, matches, arg_op_regex_const)) {
-      dest->constant_ = stoi(matches.str(1));
+      dest->constant_ = (long long)stoull(matches.str(1));
     } else if (std::regex_search(arg_str, matches, arg_op_regex_reg)) {
       dest->base_register_name_ = "gpr[" + matches.str(1) + "]";
     } else if (std::regex_search(arg_str, matches, arg_op_regex_breg_off)) {
@@ -327,7 +327,7 @@ bool ArgumentParser_s390x::parse(Argument *dest) {
     cur_pos_ += matches.length(0);
 
     if (std::regex_search(arg_ + cur_pos_, matches, arg_op_regex_imm)) {
-      dest->constant_ = stoi(matches.str(1));
+      dest->constant_ = (long long)stoull(matches.str(1));
     } else if (std::regex_search(arg_ + cur_pos_, matches, arg_op_regex_reg)) {
       dest->base_register_name_ = "gprs[" + matches.str(1) + "]";
     } else if (std::regex_search(arg_ + cur_pos_, matches, arg_op_regex_mem)) {

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -282,7 +282,7 @@ class bcc_usdt_argument(ct.Structure):
     _fields_ = [
             ('size', ct.c_int),
             ('valid', ct.c_int),
-            ('constant', ct.c_int),
+            ('constant', ct.c_longlong),
             ('deref_offset', ct.c_int),
             ('deref_ident', ct.c_char_p),
             ('base_register_name', ct.c_char_p),

--- a/tests/cc/test_usdt_args.cc
+++ b/tests/cc/test_usdt_args.cc
@@ -23,7 +23,7 @@ using std::experimental::optional;
 using std::experimental::nullopt;
 
 static void verify_register(USDT::ArgumentParser &parser, int arg_size,
-                            int constant) {
+                            long long constant) {
   USDT::Argument arg;
   REQUIRE(parser.parse(&arg));
   REQUIRE(arg.arg_size() == arg_size);
@@ -177,6 +177,8 @@ TEST_CASE("test usdt argument parsing", "[usdt]") {
 #elif defined(__x86_64__)
     USDT::ArgumentParser_x64 parser(
         "-4@$0 8@$1234 %rdi %rax %rsi "
+        "8@$9223372036854775806 8@$18446744073709551614 "
+        "-8@$-1 "
         "-8@%rbx 4@%r12 8@-8(%rbp) 4@(%rax) "
         "-4@global_max_action(%rip) "
         "8@24+mp_(%rip) "
@@ -191,6 +193,9 @@ TEST_CASE("test usdt argument parsing", "[usdt]") {
     verify_register(parser, 8, "di");
     verify_register(parser, 8, "ax");
     verify_register(parser, 8, "si");
+    verify_register(parser, 8, 9223372036854775806ll);
+    verify_register(parser, 8, (long long)18446744073709551614ull);
+    verify_register(parser, -8, -1);
     verify_register(parser, -8, "bx");
     verify_register(parser, 4, "r12");
 


### PR DESCRIPTION
[Systemtap](https://sourceware.org/systemtap/wiki/UserSpaceProbeImplementation) defines the size of an argument as either 1, 2, 4, or 8 bytes (signed or unsigned). Thus the constant variable should be stored in a `long long` instead of an `int` to ensure 8 bytes size.

I've opted for `long long` here rather than `int64_t` to match with `strtoull`'s type.

I've kept this as a signed integer for backwards compatibility, and I've used `strtoull` for the conversion as it correctly handles both the maximum unsigned value and negative values. The sign of the _size_ argument indicates whether the _constant_ value stored is signed or unsigned.

Note: 16-byte constants are possible but AFIK only from non-standard types like `__int128`.
This patch doesn't support that case.