### PR TITLE
cmake: sync submodule libbpf when do cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,20 @@ endif()
 enable_testing()
 
 # populate submodules (libbpf)
-if(NOT CMAKE_USE_LIBBPF_PACKAGE AND NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/src)
-  execute_process(COMMAND git submodule update --init --recursive
+if(NOT CMAKE_USE_LIBBPF_PACKAGE)
+   if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/src)
+	execute_process(COMMAND git submodule update --init --recursive
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+   else()
+	execute_process(COMMAND git diff --shortstat ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/
+		OUTPUT_VARIABLE DIFF_STATUS)
+	if("${DIFF_STATUS}" STREQUAL "")
+		execute_process(COMMAND git submodule update --init --recursive
+			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+	else()
+		message(WARNING "submodule libbpf dirty, so no sync")
+	endif()
+   endif()
 endif()
 
 # It's possible to use other kernel headers with


### PR DESCRIPTION
Meet the following compiler error:
/mnt/trace-tools/eBPF/bcc/src/cc/frontends/clang/b_frontend_action.cc:
In member function bool
ebpf::BTypeVisitor::VisitVarDecl(clang::VarDecl*):]
/mnt/trace-tools/eBPF/bcc/src/cc/frontends/clang/b_frontend_action.cc:1449:18:
error: BPF_MAP_TYPE_RINGBUF was not declared in this scope; did you mean
BPF_MAP_TYPE_QUEUE?
1449 | map_type = BPF_MAP_TYPE_RINGBUF; | ^~~~~~~~~~~~~~~~~~~~ |
     BPF_MAP_TYPE_QUEUE
make[2]: ***  [src/cc/frontends/clang/CMakeFiles/clang_frontend.dir/build.make:95:
rc/cc/frontends/clang/CMakeFiles/clang_frontend.dir/b_frontend_action.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1065: src/cc/frontends/clang/CMakeFiles/clang_frontend.dir/all] Error 2
make: *** [Makefile:160: all] Error 2

This because, submodule libbpf can't sync when do cmake.
So enlarger the sync contion: only submodule is clean, we do sync
submodle when do cmake.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>