### PR TITLE
Mention kernel version which fixed the bug

### DIFF
--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -164,7 +164,7 @@ Things to learn:
 1. ```key = 0```: We'll only store one key/value pair in this hash, where the key is hardwired to zero.
 1. ```last.lookup(&key)```: Lookup the key in the hash, and return a pointer to its value if it exists, else NULL. We pass the key in as an address to a pointer.
 1. ```if (tsp != NULL) {```: The verifier requires that pointer values derived from a map lookup must be checked for a null value before they can be dereferenced and used.
-1. ```last.delete(&key)```: Delete the key from the hash. This is currently required because of [a kernel bug in `.update()`](https://git.kernel.org/cgit/linux/kernel/git/davem/net.git/commit/?id=a6ed3ea65d9868fdf9eff84e6fe4f666b8d14b02).
+1. ```last.delete(&key)```: Delete the key from the hash. This is currently required because of [a kernel bug in `.update()`](https://git.kernel.org/cgit/linux/kernel/git/davem/net.git/commit/?id=a6ed3ea65d9868fdf9eff84e6fe4f666b8d14b02) (fixed in 4.8.10).
 1. ```last.update(&key, &ts)```: Associate the value in the 2nd argument to the key, overwriting any previous value. This records the timestamp.
 
 ### Lesson 5. sync_count.py


### PR DESCRIPTION
I'm not familiar with the kernel, I just looked these commits up and was confused by the mention that the bug is still not fixed.

Apparently that kernel bug is fixed in 4.8-rc3 and what broke there is fixed in 4.8.10
according to https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.8.10

mentioned as:

bpf: fix htab map destruction when extra reserve is in use
Fixes: a6ed3ea65d98 ("bpf: restore behavior of bpf_map_update_elem")

