### PR TITLE
tools: include kasan header in slabtoprate

### DIFF
--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -62,6 +62,7 @@ def signal_ignore(signal, frame):
 bpf_text = """
 #include <uapi/linux/ptrace.h>
 #include <linux/mm.h>
+#include <linux/kasan.h>
 
 // memcg_cache_params is a part of kmem_cache, but is not publicly exposed in
 // kernel versions 5.4 to 5.8.  Define an empty struct for it here to allow the


### PR DESCRIPTION
slabtoprate fails on 5.10 kernels because of a missing kasan_reset_tag
declaration. We need to include the kasan header file.

Fixes the following error:
In file included from /virtual/main.c:12:
include/linux/slub_def.h:181:27: warning: implicit declaration of function 'kasan_reset_tag' is invalid in C99 [-Wimplicit-function-declaration]
        return reciprocal_divide(kasan_reset_tag(obj) - addr,
                                 ^
include/linux/slub_def.h:181:48: error: invalid operands to binary expression ('int' and 'void *')
        return reciprocal_divide(kasan_reset_tag(obj) - addr,
                                 ~~~~~~~~~~~~~~~~~~~~ ^ ~~~~
1 warning and 1 error generated.
Traceback (most recent call last):
  File "/usr/share/bcc/tools/slabratetop", line 115, in <module>
    b = BPF(text=bpf_text)
  File "/usr/lib/python3.9/site-packages/bcc/__init__.py", line 364, in __init__
    raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
Exception: Failed to compile BPF module <text>