### PR TITLE
Fix compile error: call to 'make_unique' is ambiguous

### DIFF
--- a/src/cc/frontends/b/loader.cc
+++ b/src/cc/frontends/b/loader.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "common.h"
 #include "parser.h"
 #include "type_check.h"
 #include "codegen_llvm.h"


### PR DESCRIPTION
## Problem

When building with c++14, `std::make_unique` is available. This surfaces a bug in the code whereby the `src/cc/frontends/b/loader.cc` breaks like:

```
FAILED: src/cc/frontends/b/CMakeFiles/b_frontend.dir/loader.cc.o 
/home/myuser/mason/mason_packages/linux-x86_64/llvm/11.0.0/bin/clang++    -fPIC -stdlib=libc++ -std=c++14 -Wall  -fno-rtti -fPIC -DBCC_PROG_TAG_DIR='"/var/tmp/bcc"' -DLLVM_MAJOR_VERSION=11 -O3 -DNDEBUG -I/home/myuser/mason/mason_packages/linux-x86_64/llvm/11.0.0/include/../tools/clang/include -I../src -Isrc -Isrc/cc -I../src/cc -Isrc/cc/frontends/b -I../src/cc/frontends/b -I../src/cc/frontends/clang -I/home/myuser/mason/mason_packages/linux-x86_64/llvm/11.0.0/include -I/home/myuser/mason/mason_packages/linux-x86_64/elfutils/0.170/include -I../src/cc/compat    -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -MMD -MT src/cc/frontends/b/CMakeFiles/b_frontend.dir/loader.cc.o -MF "src/cc/frontends/b/CMakeFiles/b_frontend.dir/loader.cc.o.d" -o src/cc/frontends/b/CMakeFiles/b_frontend.dir/loader.cc.o -c ../src/cc/frontends/b/loader.cc
../src/cc/frontends/b/loader.cc:39:19: error: call to 'make_unique' is ambiguous
  proto_parser_ = make_unique<ebpf::cc::Parser>(proto_filename);
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/myuser/mason/mason_packages/linux-x86_64/llvm/11.0.0/bin/../include/c++/v1/memory:2925:1: note: candidate function [with _Tp = ebpf::cc::Parser, _Args = <const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> &>]
make_unique(_Args&&... __args)
^
../src/cc/common.h:28:1: note: candidate function [with T = ebpf::cc::Parser, Args = <const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> &>]
make_unique(Args &&... args) {
^
../src/cc/frontends/b/loader.cc:46:13: error: call to 'make_unique' is ambiguous
  parser_ = make_unique<ebpf::cc::Parser>(filename);
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/myuser/mason/mason_packages/linux-x86_64/llvm/11.0.0/bin/../include/c++/v1/memory:2925:1: note: candidate function [with _Tp = ebpf::cc::Parser, _Args = <const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> &>]
make_unique(_Args&&... __args)
^
../src/cc/common.h:28:1: note: candidate function [with T = ebpf::cc::Parser, Args = <const std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> &>]
make_unique(Args &&... args) {
^
```

See when building with LLVM 10.0.0 and `libc++`.

## Solution

I'm able to fix this by including `common.h` in `loader.cc`. 