### PR TITLE
Allow python usdt attachment with pid -1

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -289,7 +289,8 @@ class BPF(object):
         return None
 
     def __init__(self, src_file=b"", hdr_file=b"", text=None, debug=0,
-            cflags=[], usdt_contexts=[], allow_rlimit=True, device=None):
+            cflags=[], usdt_contexts=[], allow_rlimit=True, device=None,
+            attach_usdt_ignore_pid=False):
         """Create a new BPF module with the given source code.
 
         Note:
@@ -364,7 +365,7 @@ class BPF(object):
             raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
 
         for usdt_context in usdt_contexts:
-            usdt_context.attach_uprobes(self)
+            usdt_context.attach_uprobes(self, attach_usdt_ignore_pid)
 
         # If any "kprobe__" or "tracepoint__" or "raw_tracepoint__"
         # prefixed functions were defined,

--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -201,9 +201,11 @@ To check which probes are present in the process, use the tplist tool.
 
     # This is called by the BPF module's __init__ when it realizes that there
     # is a USDT context and probes need to be attached.
-    def attach_uprobes(self, bpf):
+    def attach_uprobes(self, bpf, attach_usdt_ignore_pid):
         probes = self.enumerate_active_probes()
         for (binpath, fn_name, addr, pid) in probes:
+            if attach_usdt_ignore_pid:
+                pid = -1
             bpf.attach_uprobe(name=binpath.decode(), fn_name=fn_name.decode(),
                               addr=addr, pid=pid)
 


### PR DESCRIPTION
For usdt with semaphore, user needs to provide pid in order
to create a usdt since enabling semaphore requires write to
virtual memory of the user process.

For attachment to corresponding usdt uprobe, we can pass
valid pid to perf_event_open() syscall so usdt is only
triggered for this process, or pass pid -1 permits usdt is
to triggered for all processes.

There are use cases for usdt to be triggered for other
processes than just one process. For example, for python
usdt function__entry/function__return, users may want to
trace usdt of a particular python process and all its
children processes.

C++ already has API to permit ignoring pid during attachment.
   attach_usdt(const USDT& usdt, pid_t pid = -1)
This patch added similar functionality to python with an
additional parameter to BPF constructor to indicate whether
attach_usdt can ignore pid or not.

Signed-off-by: Yonghong Song <yhs@fb.com>