### PR TITLE
Enable kernel headers through /sys/kern/kheaders.tar.xz

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,7 @@ CONFIG_HAVE_BPF_JIT=y
 CONFIG_HAVE_EBPF_JIT=y
 # [optional, for kprobes]
 CONFIG_BPF_EVENTS=y
-# Need kernel headers through /sys/kern/kheaders.tar.xz
+# Need kernel headers through /sys/kernel/kheaders.tar.xz
 CONFIG_IKHEADERS=y
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,6 +43,8 @@ CONFIG_HAVE_BPF_JIT=y
 CONFIG_HAVE_EBPF_JIT=y
 # [optional, for kprobes]
 CONFIG_BPF_EVENTS=y
+# Need kernel headers through /sys/kern/kheaders.tar.xz
+CONFIG_IKHEADERS=y
 ```
 
 There are a few optional kernel flags needed for running bcc networking examples on vanilla kernel:


### PR DESCRIPTION
It's required by BCC. Opted to make it built-in rather than a module in the snippet.