### PR TITLE
Converted tcptop from BCC to libbpf + CORE

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -21,5 +21,6 @@
 /syscount
 /tcpconnect
 /tcpconnlat
+/tcptop
 /vfsstat
 /xfsslower

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -38,6 +38,7 @@ APPS = \
 	syscount \
 	tcpconnect \
 	tcpconnlat \
+	tcptop \
 	vfsstat \
 	xfsslower \
 	#

--- a/libbpf-tools/tcptop.bpf.c
+++ b/libbpf-tools/tcptop.bpf.c
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
+/* Copyright (c) 2020 Facebook */
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+#include "tcptop.h"
+
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+/* Define here, because there are conflicts with include files */
+#define AF_INET		2 || 5
+#define AF_INET6	10
+
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 256 * 1024);
+} rb SEC(".maps");
+
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, struct ipv4_key_t);
+    __type(value, size_t);
+} ipv4_send_bytes SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, struct ipv4_key_t);
+    __type(value, int);
+} ipv4_recv_bytes SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, struct ipv6_key_t);
+    __type(value, size_t);
+} ipv6_send_bytes SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, MAX_ENTRIES);
+    __type(key, struct ipv6_key_t);
+    __type(value, int);
+} ipv6_recv_bytes SEC(".maps");
+
+
+const volatile pid_t filter_pid = 0;
+
+
+static __always_inline void
+trace_v4(struct pt_regs *ctx, struct ipv4_key_t k4, bool is_send, u16 family)
+{
+    struct event *e;
+	e = bpf_ringbuf_reserve(&rb, sizeof(*e), 0);
+	if (!e)
+		return;
+
+	e->pid = k4.pid;
+    e->saddr_v4 = k4.saddr;
+    e->daddr_v4 = k4.daddr;
+    e->sport = k4.lport;
+    e->dport = k4.dport;
+    e->family = family;
+    e->is_send = is_send;
+
+    if(is_send){
+        size_t *st;
+        st = bpf_map_lookup_elem(&ipv4_send_bytes , &k4);
+        if(st) {
+            e->send_size = *st;
+        }
+    }
+    else{
+        int *cp;
+        cp = bpf_map_lookup_elem(&ipv4_recv_bytes , &k4);
+        if(cp) {
+            e->recv_size = *cp;
+        }
+    }
+
+    bpf_get_current_comm(e->comm, sizeof(e->comm));
+    
+    bpf_ringbuf_submit(e, 0);
+}
+
+static __always_inline void
+trace_v6(struct pt_regs *ctx, struct ipv6_key_t k6, bool is_send, u16 family)
+{
+    struct event *e;
+	e = bpf_ringbuf_reserve(&rb, sizeof(*e), 0);
+	if (!e)
+		return;
+
+	e->pid = k6.pid;
+    e->saddr_v6 = k6.saddr;
+    e->daddr_v6 = k6.daddr;
+    e->sport = k6.lport;
+    e->dport = k6.dport;
+    e->family = family;
+    e->is_send = is_send;
+
+    if(is_send){
+        size_t *st;
+        st = bpf_map_lookup_elem(&ipv6_send_bytes , &k6);
+        if(st) {
+            e->send_size = *st;
+        }
+    }
+    else{
+        int *cp;
+        cp = bpf_map_lookup_elem(&ipv6_recv_bytes , &k6);
+        if(cp) {
+            e->recv_size = *cp;
+        }
+    }
+
+    bpf_get_current_comm(e->comm, sizeof(e->comm));
+    
+    bpf_ringbuf_submit(e, 0);
+}
+
+static __always_inline
+int tcp_sendmsg_handler(struct pt_regs *ctx, struct sock *sk,
+    struct msghdr *msg, size_t size)
+{
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+
+
+	if (filter_pid && pid != filter_pid) {
+		return 0;
+	}
+
+    //u16 dport = 0, family;
+    u16 family;
+	BPF_CORE_READ_INTO(&family, sk, __sk_common.skc_family);
+
+    if (family == AF_INET) {
+        struct ipv4_key_t ipv4_key = {.pid = pid};
+		BPF_CORE_READ_INTO(&ipv4_key.saddr, sk, __sk_common.skc_rcv_saddr);
+		BPF_CORE_READ_INTO(&ipv4_key.daddr, sk, __sk_common.skc_daddr);
+		BPF_CORE_READ_INTO(&ipv4_key.lport, sk, __sk_common.skc_num);
+        BPF_CORE_READ_INTO(&ipv4_key.dport, sk, __sk_common.skc_dport);
+    	bpf_map_update_elem(&ipv4_send_bytes, &ipv4_key, &size, 0 /* flags: BPF_ANY */);
+        trace_v4(ctx, ipv4_key, true, family);
+
+    } else if (family == AF_INET6) {
+        struct ipv6_key_t ipv6_key = {.pid = pid};
+        BPF_CORE_READ_INTO(&ipv6_key.saddr, sk, __sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+        BPF_CORE_READ_INTO(&ipv6_key.daddr, sk, __sk_common.skc_v6_daddr.in6_u.u6_addr32);
+        BPF_CORE_READ_INTO(&ipv6_key.lport, sk, __sk_common.skc_num);
+        BPF_CORE_READ_INTO(&ipv6_key.dport, sk, __sk_common.skc_dport);
+        bpf_map_update_elem(&ipv6_send_bytes, &ipv6_key, &size, 0 /* flags: BPF_ANY */);
+        trace_v6(ctx, ipv6_key, true, family);
+    }
+    /*else { //drop | this is commented for testing purposes
+		return 0;
+	}*/
+	return 0;
+}
+
+static __always_inline
+int tcp_cleanup_rbuf_handler(struct pt_regs *ctx, struct sock *sk, int copied)
+{
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+
+	if (filter_pid && pid != filter_pid) {
+		return 0;
+	}
+
+    u16 family;
+	BPF_CORE_READ_INTO(&family, sk, __sk_common.skc_family);
+
+    if (copied <= 0)
+        return 0;
+
+    if (family == AF_INET) {
+        struct ipv4_key_t ipv4_key = {.pid = pid};
+		BPF_CORE_READ_INTO(&ipv4_key.saddr, sk, __sk_common.skc_rcv_saddr);
+		BPF_CORE_READ_INTO(&ipv4_key.daddr, sk, __sk_common.skc_daddr);
+		BPF_CORE_READ_INTO(&ipv4_key.lport, sk, __sk_common.skc_num);
+        BPF_CORE_READ_INTO(&ipv4_key.dport, sk, __sk_common.skc_dport);
+    	bpf_map_update_elem(&ipv4_recv_bytes, &ipv4_key, &copied, 0 /* flags: BPF_ANY */);
+        trace_v4(ctx, ipv4_key, false, family);
+
+    } else if (family == AF_INET6) {
+        struct ipv6_key_t ipv6_key = {.pid = pid};
+        BPF_CORE_READ_INTO(&ipv6_key.saddr, sk, __sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+        BPF_CORE_READ_INTO(&ipv6_key.daddr, sk, __sk_common.skc_v6_daddr.in6_u.u6_addr32);
+        BPF_CORE_READ_INTO(&ipv6_key.lport, sk, __sk_common.skc_num);
+        BPF_CORE_READ_INTO(&ipv6_key.dport, sk, __sk_common.skc_dport);
+        bpf_map_update_elem(&ipv6_recv_bytes, &ipv6_key, &copied, 0 /* flags: BPF_ANY */);
+        trace_v6(ctx, ipv6_key, false, family);
+    }
+    /*else { //drop
+		return 0;
+	}*/	
+	return 0;
+}
+
+SEC("kprobe/tcp_sendmsg")
+int BPF_KPROBE(tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size)
+{
+	return tcp_sendmsg_handler(ctx, sk, msg, size);
+}
+
+SEC("kprobe/tcp_cleanup_rbuf")
+int BPF_KPROBE(tcp_cleanup_rbuf, struct sock *sk, int copied)
+{
+	return tcp_cleanup_rbuf_handler(ctx, sk, copied);
+}

--- a/libbpf-tools/tcptop.bpf.c
+++ b/libbpf-tools/tcptop.bpf.c
@@ -149,6 +149,7 @@ int BPF_KPROBE(tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size)
         bpf_map_update_elem(&ipv6_send_bytes, &ipv6_key, &size, 0 /* flags: BPF_ANY */);
         trace_v6(ctx, ipv6_key, true, family);
     }
+    // else drop
 
 	return 0;
 }
@@ -186,6 +187,7 @@ int BPF_KPROBE(tcp_cleanup_rbuf, struct sock *sk, int copied)
         bpf_map_update_elem(&ipv6_recv_bytes, &ipv6_key, &copied, 0 /* flags: BPF_ANY */);
         trace_v6(ctx, ipv6_key, false, family);
     }
+    // else drop
 
 	return 0;
 }

--- a/libbpf-tools/tcptop.c
+++ b/libbpf-tools/tcptop.c
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2021 Daniel Castro
+ * 
+ * Based on tcptop from BCC by Brendan Gregg
+ * 
+ * 22-Feb-2021   Daniel Castro   Converted this from BCC */
+
+#include <argp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <time.h>
+#include <sys/resource.h>
+#include <bpf/libbpf.h>
+#include "tcptop.h"
+#include "tcptop.skel.h"
+
+#include <arpa/inet.h>
+
+#define warn(...) fprintf(stderr, __VA_ARGS__)
+
+const char *argp_program_version = "tcptop 0.1";
+const char *argp_program_bug_address = "<bpf@vger.kernel.org>";
+const char argp_program_doc[] =
+	"\ntcptop: Summarize TCP send/recv throughput by host.\n"
+	"\n"
+	"EXAMPLES:\n"
+    "	 ./tcptop           # trace TCP send/recv by host\n"
+    "	 ./tcptop -t        # include timestamps\n"
+    "	 ./tcptop -p 181    # only trace PID 181\n"
+	;
+
+static const struct argp_option opts[] = {
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ "pid", 'p', "PID", 0, "Process PID to trace" },
+	{ "timestamp", 't', NULL, 0, "Include timestamp on output"},
+	{},
+};
+
+static struct env {
+	bool verbose;
+	pid_t pid;
+	bool print_timestamp;
+} env;
+
+static int get_int(const char *arg, int *ret, int min, int max)
+{
+	char *end;
+	long val;
+
+	errno = 0;
+	val = strtol(arg, &end, 10);
+	if (errno) {
+		warn("strtol: %s: %s\n", arg, strerror(errno));
+		return -1;
+	} else if (end == arg || val < min || val > max) {
+		return -1;
+	}
+	if (ret)
+		*ret = val;
+	return 0;
+}
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	int err;
+	//int npids;
+
+	switch (key) {
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'p':
+		err = get_int(arg, &env.pid, 1, INT_MAX);
+		if (err) {
+			warn("invalid PID: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 't':
+		env.print_timestamp = true;
+		break;
+	case ARGP_KEY_ARG:
+		argp_usage(state);
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static const struct argp argp = {
+	.options = opts,
+	.parser = parse_arg,
+	.doc = argp_program_doc,
+};
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void bump_memlock_rlimit(void)
+{
+	struct rlimit rlim_new = {
+		.rlim_cur	= RLIM_INFINITY,
+		.rlim_max	= RLIM_INFINITY,
+	};
+
+	if (setrlimit(RLIMIT_MEMLOCK, &rlim_new)) {
+		fprintf(stderr, "Failed to increase RLIMIT_MEMLOCK limit!\n");
+		exit(1);
+	}
+}
+
+static volatile bool exiting = false;
+
+static void sig_handler(int sig)
+{
+	exiting = true;
+}
+
+static void print_events_header()
+{
+	if (env.print_timestamp)
+		printf("%-8s ", "TIME");
+	printf("%-6s %-16s %-4s %-21s %-21s %-5s %-2s\n",
+		   "PID", "COMM", "TYPE", "S_ADDR", "D_ADDR", "MSG_KB", "AF");
+}
+
+static int handle_event(void *ctx, void *data, size_t data_sz)
+{
+	const struct event *e = data;
+
+	char src[INET6_ADDRSTRLEN];
+	char dst[INET6_ADDRSTRLEN];
+	union {
+		struct in_addr  x4;
+		struct in6_addr x6;
+	} s, d;
+
+	if(env.print_timestamp){
+		struct tm *tm;
+		char ts[32];
+		time_t t;
+
+		time(&t);
+		tm = localtime(&t);
+		strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+		printf("%-8s ", ts);
+	}
+
+	if (e->family == AF_INET) {
+		s.x4.s_addr = e->saddr_v4;
+		d.x4.s_addr = e->daddr_v4;
+	} else if (e->family == AF_INET6) {
+		memcpy(&s.x6.s6_addr, &e->saddr_v6, sizeof(s.x6.s6_addr));
+		memcpy(&d.x6.s6_addr, &e->daddr_v6, sizeof(d.x6.s6_addr));
+	} else {
+		warn("broken event: e->family=%d", e->family);
+		return 0;
+	}
+
+	int size = (int)e->send_size;
+	
+	char s_addr[80];
+	char sport[10];
+	strcpy(s_addr, inet_ntop(e->family, &s, src, sizeof(src)));
+	strcat(s_addr, ":");
+	sprintf(sport, "%u", ntohs(e->sport));
+	strcat(s_addr, sport);
+
+	char d_addr[80];
+	char dport[10];
+	strcpy(d_addr, inet_ntop(e->family, &d, dst, sizeof(dst)));
+	strcat(d_addr, ":");
+	sprintf(dport, "%u", ntohs(e->dport));
+	strcat(d_addr, dport);
+
+	printf("%-6d %-16s %-4s %-21s %-21s %-6d %-2d\n",
+	 	   e->pid, e->comm, e->is_send ? "SND":"RCV",
+	       s_addr, d_addr, size, e->family);
+
+	return 0;
+}
+
+static void print_events(int ring_map_fd)
+{
+	struct ring_buffer *rb = NULL;
+	int err;
+
+	/* Set up ring buffer polling */
+	rb = ring_buffer__new(ring_map_fd, handle_event, NULL, NULL);
+	if (!rb) {
+		rb = NULL;
+		fprintf(stderr, "Failed to create ring buffer\n");
+		goto cleanup;
+	}
+
+	/* Process events */
+	print_events_header();
+	while (!exiting) {
+		err = ring_buffer__poll(rb, 100 /* timeout, ms */);
+		/* Ctrl-C will cause -EINTR */
+		if (err == -EINTR) {
+			goto cleanup;
+		}
+		if (err < 0) {
+			warn("Error polling ring buffer: %d\n", err);
+			goto cleanup;
+		}
+	}
+
+cleanup:
+	ring_buffer__free(rb);
+}
+
+int main(int argc, char **argv)
+{
+	struct tcptop_bpf *skel;
+	int err;
+
+	/* Parse command line arguments */
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	/* Set up libbpf errors and debug info callback */
+	libbpf_set_print(libbpf_print_fn);
+
+	/* Bump RLIMIT_MEMLOCK to create BPF maps */
+	bump_memlock_rlimit();
+
+	/* Cleaner handling of Ctrl-C */
+	signal(SIGINT, sig_handler);
+	signal(SIGTERM, sig_handler);
+
+	/* Load and verify BPF application */
+	skel = tcptop_bpf__open();
+	if (!skel) {
+		fprintf(stderr, "Failed to open and load BPF skeleton\n");
+		return 1;
+	}
+
+	/* Parameterize BPF code with minimum duration parameter */
+	skel->rodata->filter_pid = env.pid;
+
+	/* Load & verify BPF programs */
+	err = tcptop_bpf__load(skel);
+	if (err) {
+		fprintf(stderr, "Failed to load and verify BPF skeleton\n");
+		goto cleanup;
+	}
+
+	/* Attach tracepoints */
+	err = tcptop_bpf__attach(skel);
+	if (err) {
+		fprintf(stderr, "Failed to attach BPF skeleton\n");
+		goto cleanup;
+	}
+	
+	print_events(bpf_map__fd(skel->maps.rb));
+
+
+cleanup:
+	/* Clean up */
+	tcptop_bpf__destroy(skel);
+
+	return err < 0 ? -err : 0;
+}

--- a/libbpf-tools/tcptop.h
+++ b/libbpf-tools/tcptop.h
@@ -1,0 +1,47 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2020 Facebook */
+#ifndef __TCPTOP_H
+#define __TCPTOP_H
+
+#define TASK_COMM_LEN 16
+#define MAX_ENTRIES 10240
+
+struct ipv4_key_t {
+    __u32 pid;
+    __u32 saddr;
+    __u32 daddr;
+    __u16 lport;
+    __u16 dport;
+};
+
+struct ipv6_key_t {
+    unsigned __int128 saddr;
+    unsigned __int128 daddr;
+    __u32 pid;
+    __u16 lport;
+    __u16 dport;
+    __u64 __pad__;
+};
+
+struct event {
+	__u32 pid;
+	union {
+		__u32 saddr_v4;
+		unsigned __int128 saddr_v6;
+	};
+	union {
+		__u32 daddr_v4;
+		unsigned __int128 daddr_v6;
+	};
+    __u16 sport;
+    __u16 dport;
+	int family; // AF_INET or AF_INET6
+	char comm[TASK_COMM_LEN];
+    bool is_send;
+	union {
+        int send_size;
+        int recv_size;
+	};
+};
+
+#endif /* __TCPTOP_H */


### PR DESCRIPTION
Converted the tool tcptop.py (that can be found on the bcc/tools folder) to libbpf + CORE.