### PR TITLE
Fixed undefined symbols bug in libbcc.a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.12)
 
 project(bcc)
 if(NOT CMAKE_BUILD_TYPE)

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -132,9 +132,9 @@ endif()
 
 if(ENABLE_CPP_API)
   add_subdirectory(api)
-  list(APPEND bcc_common_libs_for_a api-static)
+  list(APPEND bcc_common_libs_for_a api-object)
   # Keep all API functions
-  list(APPEND bcc_common_libs_for_s -Wl,--whole-archive api-static -Wl,--no-whole-archive)
+  list(APPEND bcc_common_libs_for_s api-object)
 endif()
 
 if(ENABLE_USDT)

--- a/src/cc/api/CMakeLists.txt
+++ b/src/cc/api/CMakeLists.txt
@@ -1,3 +1,3 @@
 set(bcc_api_sources BPF.cc BPFTable.cc)
-add_library(api-static STATIC ${bcc_api_sources})
+add_library(api-object OBJECT ${bcc_api_sources})
 install(FILES BPF.h BPFTable.h COMPONENT libbcc DESTINATION include/bcc)


### PR DESCRIPTION
Fixed the issue with build trying to link two static libraries together
resulting in missing symbols from api-static in libbcc.a.
Changing api-static type to an Object library allows for it's seamless
incorporation into other binaries.