### PR TITLE
biotop and biosnoop: save __data_len at blk_start_request

### DIFF
--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -39,6 +39,12 @@ bpf_text="""
 #include <uapi/linux/ptrace.h>
 #include <linux/blkdev.h>
 
+// for saving the timestamp and __data_len of each request
+struct start_req_t {
+    u64 ts;
+    u64 data_len;
+};
+
 struct val_t {
     u64 ts;
     u32 pid;
@@ -57,7 +63,7 @@ struct data_t {
     char name[TASK_COMM_LEN];
 };
 
-BPF_HASH(start, struct request *);
+BPF_HASH(start, struct request *, struct start_req_t);
 BPF_HASH(infobyreq, struct request *, struct val_t);
 BPF_PERF_OUTPUT(events);
 
@@ -80,42 +86,43 @@ int trace_pid_start(struct pt_regs *ctx, struct request *req)
 // time block I/O
 int trace_req_start(struct pt_regs *ctx, struct request *req)
 {
-    u64 ts;
-    ts = bpf_ktime_get_ns();
-    start.update(&req, &ts);
+    struct start_req_t start_req = {
+        .ts = bpf_ktime_get_ns(),
+        .data_len = req->__data_len
+    };
+    start.update(&req, &start_req);
     return 0;
 }
 
 // output
 int trace_req_completion(struct pt_regs *ctx, struct request *req)
 {
-    u64 *tsp;
+    struct start_req_t *startp;
     struct val_t *valp;
     struct data_t data = {};
     u64 ts;
 
     // fetch timestamp and calculate delta
-    tsp = start.lookup(&req);
-    if (tsp == 0) {
+    startp = start.lookup(&req);
+    if (startp == 0) {
         // missed tracing issue
         return 0;
     }
     ts = bpf_ktime_get_ns();
-    data.delta = ts - *tsp;
+    data.delta = ts - startp->ts;
     data.ts = ts / 1000;
     data.qdelta = 0;
 
     valp = infobyreq.lookup(&req);
+    data.len = startp->data_len;
     if (valp == 0) {
-        data.len = req->__data_len;
         data.name[0] = '?';
         data.name[1] = 0;
     } else {
         if (##QUEUE##) {
-            data.qdelta = *tsp - valp->ts;
+            data.qdelta = startp->ts - valp->ts;
         }
         data.pid = valp->pid;
-        data.len = req->__data_len;
         data.sector = req->__sector;
         bpf_probe_read_kernel(&data.name, sizeof(data.name), valp->name);
         struct gendisk *rq_disk = req->rq_disk;

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -61,6 +61,12 @@ bpf_text = """
 #include <uapi/linux/ptrace.h>
 #include <linux/blkdev.h>
 
+// for saving the timestamp and __data_len of each request
+struct start_req_t {
+    u64 ts;
+    u64 data_len;
+};
+
 // for saving process info by request
 struct who_t {
     u32 pid;
@@ -83,7 +89,7 @@ struct val_t {
     u32 io;
 };
 
-BPF_HASH(start, struct request *);
+BPF_HASH(start, struct request *, struct start_req_t);
 BPF_HASH(whobyreq, struct request *, struct who_t);
 BPF_HASH(counts, struct info_t, struct val_t);
 
@@ -103,28 +109,28 @@ int trace_pid_start(struct pt_regs *ctx, struct request *req)
 // time block I/O
 int trace_req_start(struct pt_regs *ctx, struct request *req)
 {
-    u64 ts;
-
-    ts = bpf_ktime_get_ns();
-    start.update(&req, &ts);
-
+    struct start_req_t start_req = {
+        .ts = bpf_ktime_get_ns(),
+        .data_len = req->__data_len
+    };
+    start.update(&req, &start_req);
     return 0;
 }
 
 // output
 int trace_req_completion(struct pt_regs *ctx, struct request *req)
 {
-    u64 *tsp;
+    struct start_req_t *startp;
 
     // fetch timestamp and calculate delta
-    tsp = start.lookup(&req);
-    if (tsp == 0) {
+    startp = start.lookup(&req);
+    if (startp == 0) {
         return 0;    // missed tracing issue
     }
 
     struct who_t *whop;
     struct val_t *valp, zero = {};
-    u64 delta_us = (bpf_ktime_get_ns() - *tsp) / 1000;
+    u64 delta_us = (bpf_ktime_get_ns() - startp->ts) / 1000;
 
     // setup info_t key
     struct info_t info = {};
@@ -158,7 +164,7 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
     if (valp) {
         // save stats
         valp->us += delta_us;
-        valp->bytes += req->__data_len;
+        valp->bytes += startp->data_len;
         valp->io++;
     }
 


### PR DESCRIPTION
Commit 95c9229ea9f029a1b9e8dcbe86fc67f037c0dfa2 replaced the
blk_account_io_completion kprobe with blk_account_io_done. Unfortunately
the req->__data_len field is 0 in blk_account_io_done, therefore we need
to save the __data_len field in blk_start_request

Resolves #3099