### PR TITLE
Use string type for funccount comparison to PATH elements

### DIFF
--- a/src/python/bcc/utils.py
+++ b/src/python/bcc/utils.py
@@ -77,7 +77,7 @@ class ArgString(object):
         return self.s.encode(FILESYSTEMENCODING)
 
     def __str__(self):
-        return self.__bytes__()
+        return self.s
 
 def warn_with_traceback(message, category, filename, lineno, file=None, line=None):
     log = file if hasattr(file, "write") else sys.stderr
@@ -140,8 +140,8 @@ static inline bool %s(char const *ignored, uintptr_t str) {
             probeid += 1
             expr = expr.replace("STRCMP", fname, 1)
         rdict = {
-            "expr" : expr,
-            "streq_functions" : streq_functions,
-            "probeid" : probeid
+            "expr": expr,
+            "streq_functions": streq_functions,
+            "probeid": probeid
         }
         return rdict

--- a/tools/funccount.py
+++ b/tools/funccount.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 from bcc import ArgString, BPF, USDT
 from time import sleep, strftime
 import argparse
-import os
 import re
 import signal
 import sys
@@ -74,7 +73,7 @@ class Probe(object):
             libpath = BPF.find_library(self.library)
             if libpath is None:
                 # This might be an executable (e.g. 'bash')
-                libpath = BPF.find_exe(self.library)
+                libpath = BPF.find_exe(str(self.library))
             if libpath is None or len(libpath) == 0:
                 raise Exception("unable to find library %s" % self.library)
             self.library = libpath
@@ -147,7 +146,7 @@ class Probe(object):
             for tracepoint in tracepoints:
                 text += self._add_function(template, tracepoint)
         elif self.type == b"u":
-            self.usdt = USDT(path=self.library, pid=self.pid)
+            self.usdt = USDT(path=str(self.library), pid=self.pid)
             matches = []
             for probe in self.usdt.enumerate_probes():
                 if not self.pid and (probe.bin_path != self.library):


### PR DESCRIPTION
`BPF.find_exe` requires a string to match against `PATH`, and the `USDT` constructor requires a string for the `path` parameter, so that it can be encoded. However, the `ArgString` class returns a `bytes` from the `__str__` method. With Python 3, these type mismatches cause errors.

The fix modifies `ArgString` to return a `str` from `__str__` and uses that to pass a `str` in `funccount.py`.