### PR TITLE
fix a llvm-triggered compilation error

### DIFF
--- a/src/cc/frontends/b/codegen_llvm.cc
+++ b/src/cc/frontends/b/codegen_llvm.cc
@@ -716,8 +716,14 @@ StatusTuple CodegenLLVM::emit_atomic_add(MethodCallExprNode *n) {
   Value *lhs = B.CreateBitCast(pop_expr(), Type::getInt64PtrTy(ctx()));
   TRY2(n->args_[1]->accept(this));
   Value *rhs = B.CreateSExt(pop_expr(), B.getInt64Ty());
+#if LLVM_MAJOR_VERSION >= 13
+  AtomicRMWInst *atomic_inst = B.CreateAtomicRMW(
+      AtomicRMWInst::Add, lhs, rhs, Align(8),
+      AtomicOrdering::SequentiallyConsistent);
+#else
   AtomicRMWInst *atomic_inst = B.CreateAtomicRMW(
       AtomicRMWInst::Add, lhs, rhs, AtomicOrdering::SequentiallyConsistent);
+#endif
   atomic_inst->setVolatile(false);
   return StatusTuple::OK();
 }


### PR DESCRIPTION
Upstream (llvm13) patch
  https://reviews.llvm.org/D97223
changed function signature for CreateAtomicRMW().
The error message:
```
  /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc:
     In member function ‘ebpf::StatusTuple ebpf::cc::CodegenLLVM
        ::emit_atomic_add(ebpf::cc::MethodCallExprNode*)’:
  /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc:720:75:
     error: no matching function for call to
        ‘llvm::IRBuilder<>::CreateAtomicRMW(llvm::AtomicRMWInst::BinOp,
         llvm::Value*&, llvm::Value*&, llvm:: AtomicOrdering)’
       AtomicRMWInst::Add, lhs, rhs, AtomicOrdering::SequentiallyConsistent);
                                                                           ^
  In file included from /home/yhs/work/bcc/src/cc/frontends/b/codegen_llvm.cc:31:
  /home/yhs/work/llvm-project/llvm/build/install/include/llvm/IR/IRBuilder.h:1721:18:
      note: candidate:
  ‘llvm::AtomicRMWInst* llvm::IRBuilderBase::CreateAtomicRMW(llvm::AtomicRMWInst::BinOp,
      llvm::Value*, llvm::Value*, llvm::MaybeAlign, llvm::AtomicOrdering,
      llvm::SyncScope::ID)’
   AtomicRMWInst *CreateAtomicRMW(AtomicRMWInst::BinOp Op, Value *Ptr,
                  ^~~~~~~~~~~~~~~
  /home/yhs/work/llvm-project/llvm/build/install/include/llvm/IR/IRBuilder.h:1721:18: note:
  candidate expects 6 arguments, 4 provided
```
Fixed the issue with correct arguments.

Signed-off-by: Yonghong Song <yhs@fb.com>