### PR TITLE
Fix abnormal symbol parsing when __irqentry_text_end is before __irqe…

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -587,6 +587,12 @@ class BPF(object):
                     if fn == b'__irqentry_text_start':
                         in_irq_section = 1
                         continue
+                    # __irqentry_text_end is not always after
+                    # __irqentry_text_start. But only happens when
+                    # no functions between two irqentry_text
+                    elif fn == b'__irqentry_text_end':
+                        in_irq_section = 2
+                        continue
                 elif in_irq_section == 1:
                     if fn == b'__irqentry_text_end':
                         in_irq_section = 2


### PR DESCRIPTION
…ntry_text_start

On my ARM64 kernel 5.4 case

Symbol:
ffffffc0100820b8 T __irqentry_text_end
ffffffc0100820b8 T __irqentry_text_start

It will ignore all functions after __irqentry_text_start until __irqentry_text_end.
But this case __irqentry_text_end is before __irqentry_text_start.
So the problem happens.

Signed-off-by: Edward Wu <edwardwu@realtek.com>