### PR TITLE
Add required libfl-dev in Ubuntu Bionic

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -335,7 +335,7 @@ sudo apt-get update
 
 # For Bionic (18.04 LTS)
 sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
-  libllvm6.0 llvm-6.0-dev libclang-6.0-dev python zlib1g-dev libelf-dev
+  libllvm6.0 llvm-6.0-dev libclang-6.0-dev python zlib1g-dev libelf-dev libfl-dev
 
 # For Eoan (19.10) or Focal (20.04.1 LTS)
 sudo apt install -y bison build-essential cmake flex git libedit-dev \


### PR DESCRIPTION
Otherwise the `make` fails with lack of `FlexLexer.h` error.