### PR TITLE
tools: add LPORT output for tcpconnect tool

### DIFF
--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -19,6 +19,7 @@
 # 09-Jan-2019   Takuma Kume     Support filtering by UID
 # 30-Jul-2019   Xiaozhou Liu    Count connects.
 # 07-Oct-2020   Nabil Schear    Correlate connects with DNS responses
+# 08-Mar-2021   Suresh Kumar    Added LPORT option
 
 from __future__ import print_function
 from bcc import BPF
@@ -87,6 +88,7 @@ struct ipv4_data_t {
     u32 saddr;
     u32 daddr;
     u64 ip;
+    u16 lport;
     u16 dport;
     char task[TASK_COMM_LEN];
 };
@@ -99,6 +101,7 @@ struct ipv6_data_t {
     unsigned __int128 saddr;
     unsigned __int128 daddr;
     u64 ip;
+    u16 lport;
     u16 dport;
     char task[TASK_COMM_LEN];
 };
@@ -161,6 +164,7 @@ static int trace_connect_return(struct pt_regs *ctx, short ipver)
 
     // pull in details
     struct sock *skp = *skpp;
+    u16 lport = skp->__sk_common.skc_num;
     u16 dport = skp->__sk_common.skc_dport;
 
     FILTER_PORT
@@ -202,6 +206,7 @@ struct_init = {'ipv4':
                data4.ts_us = bpf_ktime_get_ns() / 1000;
                data4.saddr = skp->__sk_common.skc_rcv_saddr;
                data4.daddr = skp->__sk_common.skc_daddr;
+               data4.lport = lport;
                data4.dport = ntohs(dport);
                bpf_get_current_comm(&data4.task, sizeof(data4.task));
                ipv4_events.perf_submit(ctx, &data4, sizeof(data4));"""
@@ -225,6 +230,7 @@ struct_init = {'ipv4':
                    skp->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
                bpf_probe_read_kernel(&data6.daddr, sizeof(data6.daddr),
                    skp->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+               data6.lport = lport;
                data6.dport = ntohs(dport);
                bpf_get_current_comm(&data6.task, sizeof(data6.task));
                ipv6_events.perf_submit(ctx, &data6, sizeof(data6));"""
@@ -354,9 +360,9 @@ def print_ipv4_event(cpu, data, size):
     if args.print_uid:
         printb(b"%-6d" % event.uid, nl="")
     dest_ip = inet_ntop(AF_INET, pack("I", event.daddr)).encode()
-    printb(b"%-6d %-12.12s %-2d %-16s %-16s %-6d %s" % (event.pid,
+    printb(b"%-6d %-12.12s %-2d %-16s %-6d %-16s %-6d %s" % (event.pid,
         event.task, event.ip,
-        inet_ntop(AF_INET, pack("I", event.saddr)).encode(),
+        inet_ntop(AF_INET, pack("I", event.saddr)).encode(), event.lport,
         dest_ip, event.dport, print_dns(dest_ip)))
 
 def print_ipv6_event(cpu, data, size):
@@ -369,10 +375,10 @@ def print_ipv6_event(cpu, data, size):
     if args.print_uid:
         printb(b"%-6d" % event.uid, nl="")
     dest_ip = inet_ntop(AF_INET6, event.daddr).encode()
-    printb(b"%-6d %-12.12s %-2d %-16s %-16s %-6d %s" % (event.pid,
+    printb(b"%-6d %-12.12s %-2d %-16s %-6d %-16s %-6d %s" % (event.pid,
         event.task, event.ip,
-        inet_ntop(AF_INET6, event.saddr).encode(), dest_ip,
-        event.dport, print_dns(dest_ip)))
+        inet_ntop(AF_INET6, event.saddr).encode(), event.lport,
+        dest_ip, event.dport, print_dns(dest_ip)))
 
 def depict_cnt(counts_tab, l3prot='ipv4'):
     for k, v in sorted(counts_tab.items(),
@@ -490,8 +496,8 @@ else:
         print("%-9s" % ("TIME(s)"), end="")
     if args.print_uid:
         print("%-6s" % ("UID"), end="")
-    print("%-6s %-12s %-2s %-16s %-16s %-6s" % ("PID", "COMM", "IP", "SADDR",
-        "DADDR", "DPORT"), end="")
+    print("%-6s %-12s %-2s %-16s %-6s %-16s %-6s" % ("PID", "COMM", "IP", "SADDR",
+        "LPORT", "DADDR", "DPORT"), end="")
     if args.dns:
         print(" QUERY")
     else:


### PR DESCRIPTION
LPORT information will help in uniquely  identifying a socket. 
For example, this info will be of much help when analyzing a tcpdump.