### PR TITLE
tools: add option to include 'LPORT' in tcpconnect otuput

### DIFF
--- a/man/man8/tcpconnect.8
+++ b/man/man8/tcpconnect.8
@@ -2,7 +2,7 @@
 .SH NAME
 tcpconnect \- Trace TCP active connections (connect()). Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B tcpconnect [\-h] [\-c] [\-t] [\-p PID] [-P PORT] [-u UID] [-U] [\-\-cgroupmap MAPPATH] [\-\-mntnsmap MAPPATH] [\-d]
+.B tcpconnect [\-h] [\-c] [\-t] [\-p PID] [-P PORT] [\-L] [-u UID] [-U] [\-\-cgroupmap MAPPATH] [\-\-mntnsmap MAPPATH] [\-d]
 .SH DESCRIPTION
 This tool traces active TCP connections (eg, via a connect() syscall;
 accept() are passive connections). This can be useful for general
@@ -42,6 +42,9 @@ Trace this process ID only (filtered in-kernel).
 .TP
 \-P PORT
 Comma-separated list of destination ports to trace (filtered in-kernel).
+.TP
+\-L
+Include a LPORT column.
 .TP
 \-U
 Include a UID column.
@@ -96,6 +99,10 @@ Trace ports 80 and 81 only:
 #
 .B tcpconnect \-P 80,81
 .TP
+Trace all TCP connects, and include LPORT:
+#
+.B tcpconnect \-L
+.TP
 Trace all TCP connects, and include UID:
 #
 .B tcpconnect \-U
@@ -134,6 +141,9 @@ IP address family (4 or 6)
 .TP
 SADDR
 Source IP address.
+.TP
+LPORT
+Source port
 .TP
 DADDR
 Destination IP address.

--- a/tools/tcpconnect_example.txt
+++ b/tools/tcpconnect_example.txt
@@ -55,6 +55,15 @@ PID    COMM         IP SADDR            DADDR            DPORT QUERY
 2015   ssh          6  fe80::2000:bff:fe82:3ac fe80::2000:bff:fe82:3ac 22    anotherhost.org
 
 
+The -L option prints a LPORT column:
+
+# ./tcpconnect -L
+PID    COMM         IP SADDR            LPORT  DADDR            DPORT
+3706   nc           4  192.168.122.205  57266  192.168.122.150  5000
+3722   ssh          4  192.168.122.205  50966  192.168.122.150  22
+3779   ssh          6  fe80::1          52328  fe80::2          22
+
+
 The -U option prints a UID column:
 
 # ./tcpconnect -U
@@ -97,7 +106,7 @@ USAGE message:
 
 # ./tcpconnect -h
 
-usage: tcpconnect.py [-h] [-t] [-p PID] [-P PORT] [-U] [-u UID] [-c]
+usage: tcpconnect.py [-h] [-t] [-p PID] [-P PORT] [-L] [-U] [-u UID] [-c]
                      [--cgroupmap CGROUPMAP] [--mntnsmap MNTNSMAP] [-d]
 
 Trace TCP connects
@@ -107,6 +116,7 @@ optional arguments:
   -t, --timestamp       include timestamp on output
   -p PID, --pid PID     trace this PID only
   -P PORT, --port PORT  comma-separated list of destination ports to trace.
+  -L, --lport           include LPORT on output
   -U, --print-uid       include UID on output
   -u UID, --uid UID     trace this UID only
   -c, --count           count connects per src ip and dest ip/port
@@ -118,11 +128,13 @@ optional arguments:
 examples:
     ./tcpconnect           # trace all TCP connect()s
     ./tcpconnect -t        # include timestamps
+    ./tcpconnect -d        # include DNS queries associated with connects
     ./tcpconnect -p 181    # only trace PID 181
     ./tcpconnect -P 80     # only trace port 80
     ./tcpconnect -P 80,81  # only trace port 80 and 81
     ./tcpconnect -U        # include UID
     ./tcpconnect -u 1000   # only trace UID 1000
     ./tcpconnect -c        # count connects per src ip and dest ip/port
+    ./tcpconnect -L        # include LPORT while printing outputs
     ./tcpconnect --cgroupmap mappath  # only trace cgroups in this BPF map
     ./tcpconnect --mntnsmap mappath   # only trace mount namespaces in the map


### PR DESCRIPTION
LPORT information will help in uniquely identifying a socket.
For example, this info will be of much help when analyzing a tcpdump.
As suggested by @brendangregg,  using '-L' option to print LPORT