### PR TITLE
tools/virtiostat: add filter

### DIFF
--- a/man/man8/virtiostat.8
+++ b/man/man8/virtiostat.8
@@ -2,7 +2,7 @@
 .SH NAME
 virtiostat \- Trace VIRTIO devices input/output statistics. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B virtiostat [\-h] [\-T] [\-D] [INTERVAL] [COUNT]
+.B virtiostat [\-h] [\-T] [\-D] [-d DRIVER] [-n DEVNAME] [INTERVAL] [COUNT]
 .SH DESCRIPTION
 This tool traces VIRTIO devices input/output statistics. It works in lower
 layer of VIRTIO base driver, so it could trace all the devices of VIRTIO
@@ -25,6 +25,12 @@ Include a time column on output (HH:MM:SS).
 \-D
 Show debug infomation of bpf text.
 .TP
+\-d DRIVER
+Filter for driver name.
+.TP
+\-n DEVNAME
+Filter for device name.
+.TP
 INTERVAL
 Print output every interval seconds.
 .TP
@@ -35,6 +41,10 @@ Total count of trace in seconds.
 Trace virtio device statistics and print 1 second summaries, 10 times:
 #
 .B virtiostat 1 10
+.TP
+Trace virtio block deivces only:
+#
+.B virtiostat -d virtio_blk
 .SH OVERHEAD
 This traces the kernel virtqueue_add_sgs, virtqueue_add_outbuf,
 virtqueue_add_inbuf, virtqueue_add_inbuf_ctx functions.

--- a/tools/virtiostat_example.txt
+++ b/tools/virtiostat_example.txt
@@ -23,24 +23,41 @@ Tracing virtio devices statistics ... Hit Ctrl-C to end.
   9pnet_virtio  virtio6   requests   91520   91141        1737364      125320785
 
 
+Show virtio block devices only:
+#./virtiostat.py -d virtio_blk
+Tracing virtio devices statistics ... Hit Ctrl-C to end.
+--------
+        Driver   Device    VQ Name  In SGs Out SGs          In BW         Out BW
+    virtio_blk  virtio4      req.0       4       6              4          24640
+    virtio_blk  virtio5      req.0  678756  339378     1390431666        5430048
+
+
 Full USAGE:
 
 #./virtiostat -h
-usage: virtiostat.py [-h] [-T] [-D] [interval] [count]
+usage: virtiostat.py [-h] [-T] [-d DRIVER] [-n DEVNAME] [-D]
+                     [interval] [count]
 
 Show virtio devices input/output statistics
 
 positional arguments:
-  interval         output interval, in seconds
-  count            number of outputs
+  interval              output interval, in seconds
+  count                 number of outputs
 
 optional arguments:
-  -h, --help       show this help message and exit
-  -T, --timestamp  show timestamp on output
-  -D, --debug      print BPF program before starting (for debugging purposes)
+  -h, --help            show this help message and exit
+  -T, --timestamp       show timestamp on output
+  -d DRIVER, --driver DRIVER
+                        filter for driver name
+  -n DEVNAME, --devname DEVNAME
+                        filter for device name
+  -D, --debug           print BPF program before starting (for debugging
+                        purposes)
 
 examples:
-    ./virtiostat            # print 3(default) second summaries
-    ./virtiostat  1  10     # print 1 second summaries, 10 times
-    ./virtiostat -T         # show timestamps
-    ./virtiostat -D         # show debug bpf text
+    ./virtiostat                 # print 3(default) second summaries
+    ./virtiostat  1  10          # print 1 second summaries, 10 times
+    ./virtiostat -T              # show timestamps
+    ./virtiostat -d virtio_blk   # only show virtio block devices
+    ./virtiostat -n virtio0      # only show virtio0 device
+    ./virtiostat -D              # show debug bpf text


### PR DESCRIPTION
Add device driver/name filter for virtiostat.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>