### PR TITLE
tcpstates: forget sockets when connection is closed

### DIFF
--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -159,8 +159,12 @@ TRACEPOINT_PROBE(sock, inet_sock_set_state)
         ipv6_events.perf_submit(args, &data6, sizeof(data6));
     }
 
-    u64 ts = bpf_ktime_get_ns();
-    last.update(&sk, &ts);
+    if (args->newstate == TCP_CLOSE) {
+        last.delete(&sk);
+    } else {
+        u64 ts = bpf_ktime_get_ns();
+        last.update(&sk, &ts);
+    }
 
     return 0;
 }
@@ -224,8 +228,12 @@ int kprobe__tcp_set_state(struct pt_regs *ctx, struct sock *sk, int state)
         ipv6_events.perf_submit(ctx, &data6, sizeof(data6));
     }
 
-    u64 ts = bpf_ktime_get_ns();
-    last.update(&sk, &ts);
+    if (state == TCP_CLOSE) {
+        last.delete(&sk);
+    } else {
+        u64 ts = bpf_ktime_get_ns();
+        last.update(&sk, &ts);
+    }
 
     return 0;
 


### PR DESCRIPTION
The adress of struct sock, which are used as the map key, are often
reused. When it happens random duration appears in the MS field for
new connections (CLOSE->SYN_SENT and LISTEN->SYN_RECV
transitions). Let's forget about the socket when the connection is
closed.