### PR TITLE
cmake: make "-no-pie" optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ endif()
 #  $ cmake -DKERNEL_INCLUDE_DIRS=/tmp/headers/include/ ...
 include_directories(${KERNEL_INCLUDE_DIRS})
 
+option(ENABLE_NO_PIE "Build bcc-lua without PIE" ON)
+
 include(cmake/GetGitRevisionDescription.cmake)
 include(cmake/version.cmake)
 include(CMakeDependentOption)

--- a/cmake/FindCompilerFlag.cmake
+++ b/cmake/FindCompilerFlag.cmake
@@ -1,6 +1,8 @@
 # Copyright (c) 2017 Facebook, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 
+if (ENABLE_NO_PIE)
+
 if (CMAKE_C_COMPILER_ID MATCHES "Clang")
 	set(COMPILER_NOPIE_FLAG "-nopie")
 else()
@@ -15,6 +17,8 @@ else()
 	endif()
 	set(CMAKE_REQUIRED_FLAGS "${_backup_c_flags}")
 endif()
+
+endif(ENABLE_NO_PIE)
 
 # check whether reallocarray availability
 # this is used to satisfy reallocarray usage under src/cc/libbpf/


### PR DESCRIPTION
The recent linux distros already support PIE so it shouldn't be a
problem to remove "-no-pie". To avoid issue#782, we can make
"-no-pie" optional and disable it by default, so that the user can
enable "-no-pie" if really necessary.

Signed-off-by: Gary Lin <glin@suse.com>