### PR TITLE
In GCC10.2 suffix '.isra.0' was appended to 'finish_task_switch'

### DIFF
--- a/examples/tracing/task_switch.py
+++ b/examples/tracing/task_switch.py
@@ -6,7 +6,8 @@ from bcc import BPF
 from time import sleep
 
 b = BPF(src_file="task_switch.c")
-b.attach_kprobe(event="finish_task_switch", fn_name="count_sched")
+b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+                fn_name="count_sched")
 
 # generate many schedule events
 for i in range(0, 100): sleep(0.01)

--- a/tests/python/test_trace2.py
+++ b/tests/python/test_trace2.py
@@ -31,7 +31,8 @@ class TestTracingEvent(TestCase):
     def setUp(self):
         b = BPF(text=text, debug=0)
         self.stats = b.get_table("stats")
-        b.attach_kprobe(event="finish_task_switch", fn_name="count_sched")
+        b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+                        fn_name="count_sched")
 
     def test_sched1(self):
         for i in range(0, 100):

--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -159,7 +159,8 @@ if debug or args.ebpf:
 max_pid = int(open("/proc/sys/kernel/pid_max").read())
 
 b = BPF(text=bpf_text, cflags=["-DMAX_PID=%d" % max_pid])
-b.attach_kprobe(event="finish_task_switch", fn_name="sched_switch")
+b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+                fn_name="sched_switch")
 
 print("Tracing %s-CPU time... Hit Ctrl-C to end." %
       ("off" if args.offcpu else "on"))

--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -251,7 +251,8 @@ if debug or args.ebpf:
 
 # initialize BPF
 b = BPF(text=bpf_text)
-b.attach_kprobe(event="finish_task_switch", fn_name="oncpu")
+b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+                fn_name="oncpu")
 matched = b.num_open_kprobes()
 if matched == 0:
     print("error: 0 functions traced. Exiting.", file=stderr)

--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -288,7 +288,8 @@ if args.ebpf:
 
 # initialize BPF
 b = BPF(text=bpf_text)
-b.attach_kprobe(event="finish_task_switch", fn_name="oncpu")
+b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+                fn_name="oncpu")
 b.attach_kprobe(event="try_to_wake_up", fn_name="waker")
 matched = b.num_open_kprobes()
 if matched == 0:

--- a/tools/runqlat.py
+++ b/tools/runqlat.py
@@ -252,7 +252,8 @@ b = BPF(text=bpf_text)
 if not is_support_raw_tp:
     b.attach_kprobe(event="ttwu_do_wakeup", fn_name="trace_ttwu_do_wakeup")
     b.attach_kprobe(event="wake_up_new_task", fn_name="trace_wake_up_new_task")
-    b.attach_kprobe(event="finish_task_switch", fn_name="trace_run")
+    b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+                    fn_name="trace_run")
 
 print("Tracing run queue latency... Hit Ctrl-C to end.")
 

--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -255,7 +255,8 @@ b = BPF(text=bpf_text)
 if not is_support_raw_tp:
     b.attach_kprobe(event="ttwu_do_wakeup", fn_name="trace_ttwu_do_wakeup")
     b.attach_kprobe(event="wake_up_new_task", fn_name="trace_wake_up_new_task")
-    b.attach_kprobe(event="finish_task_switch", fn_name="trace_run")
+    b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+                    fn_name="trace_run")
 
 print("Tracing run queue latency higher than %d us" % min_us)
 print("%-8s %-16s %-6s %14s" % ("TIME", "COMM", "TID", "LAT(us)"))


### PR DESCRIPTION
When buildiing kernel with GCC10 [2] in Debian on an Arm64 machine, it was
found the new "inter-procedural optimization improvements" [1] makes symbol
name 'finish_task_switch' changed to 'finish_task_switch.isra.0'.

Details:
The results, when built with gcc 9.3:
nm ../linux.buildout/kernel/sched/core.o | grep finish_task_switch
0000000000001288 t finish_task_switch

However, when built with gcc 10.2:
nm ../linux.buildout/kernel/sched/core.o | grep finish_task_switch
00000000000012d0 t finish_task_switch.isra.0

The same symbols (with xxx.isra.0 or without, respectively of course) also
appear in final file 'System.map' and in '/proc/kallsyms' when booting. This
negatively impact the tracing tools commonly used in kernel debugging, such
as bcc tools offcputime and runqlat. They hardcode 'finish_task_switch'
(without the .isra.0 suffix) into their scripts.

This patch fix the issue by changing the hardcoded 'finish_task_switch' string
to a python regular expression pattern who can match both the traditional form
'finish_task_switch' and the new gcc10 form 'finish_task_switch.isra.0'
(with single digit at the end). attach_kprobe()'s input parameter 'event_re'
is used for this type of pattern matching.

[1] https://gcc.gnu.org/gcc-10/changes.html
[2] ARCH=arm64 make Image

Signed-off-by: Guodong Xu <guodong.xu@linaro.org>