### PR TITLE
tools: add option to include 'LPORT' in tcpconnlat, update man pages

### DIFF
--- a/man/man8/tcpconnlat.8
+++ b/man/man8/tcpconnlat.8
@@ -2,7 +2,7 @@
 .SH NAME
 tcpconnlat \- Trace TCP active connection latency. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B tcpconnlat [\-h] [\-t] [\-p PID] [-v] [min_ms]
+.B tcpconnlat [\-h] [\-t] [\-p PID] [\-L] [-v] [min_ms]
 .SH DESCRIPTION
 This tool traces active TCP connections
 (eg, via a connect() syscall), and shows the latency (time) for the connection
@@ -31,6 +31,9 @@ Include a timestamp column.
 \-p PID
 Trace this process ID only (filtered in-kernel).
 .TP
+\-L
+Include a LPORT column.
+.TP
 \-v
 Print the resulting BPF program, for debugging purposes.
 .TP
@@ -49,6 +52,10 @@ Include timestamps:
 Trace PID 181 only:
 #
 .B tcpconnlat \-p 181
+.TP
+Trace connects, and include LPORT:
+#
+.B tcpconnlat \-L
 .TP
 Trace connects with latency longer than 10 ms:
 #
@@ -76,6 +83,9 @@ Source IP address.
 .TP
 DADDR
 Destination IP address.
+.TP
+LPORT
+Source port
 .TP
 DPORT
 Destination port

--- a/tools/tcpconnlat_example.txt
+++ b/tools/tcpconnlat_example.txt
@@ -34,22 +34,24 @@ if the response is a RST (port closed).
 USAGE message:
 
 # ./tcpconnlat -h
-usage: tcpconnlat [-h] [-t] [-p PID] [min_ms]
+usage: tcpconnlat [-h] [-t] [-p PID] [-L] [-v] [duration_ms]
 
 Trace TCP connects and show connection latency
 
 positional arguments:
-  min_ms             minimum duration to trace, in ms (default 0)
+  duration_ms        minimum duration to trace (ms)
 
 optional arguments:
   -h, --help         show this help message and exit
   -t, --timestamp    include timestamp on output
   -p PID, --pid PID  trace this PID only
+  -L, --lport        include LPORT on output
+  -v, --verbose      print the BPF program for debugging purposes
 
 examples:
     ./tcpconnlat           # trace all TCP connect()s
+    ./tcpconnlat 1         # trace connection latency slower than 1 ms
+    ./tcpconnlat 0.1       # trace connection latency slower than 100 us
     ./tcpconnlat -t        # include timestamps
     ./tcpconnlat -p 181    # only trace PID 181
-    ./tcpconnlat 1         # only show connects longer than 1 ms
-    ./tcpconnlat 0.1       # only show connects longer than 100 us
-    ./tcpconnlat -v        # Show the BPF program
+    ./tcpconnlat -L        # include LPORT while printing outputs


### PR DESCRIPTION
Listing LPORT information is useful while troubleshooting latency issue with tcpdump.
This commit is adding a '-L' option to list the same.
Also updated the man pages and example files.
+++
PID    COMM         IP SADDR            LPORT  DADDR            DPORT LAT(ms)
2734   cups-browsed 4  192.168.8.95     53564  192.168.5.17     631   40.00
2734   cups-browsed 4  192.168.8.95     53566  192.168.5.17     631   39.69
2734   cups-browsed 4  192.168.8.95     53572  192.168.5.17     631   40.05
3467   python3      6  ::1              39340  ::1              3000  0.02
3467   python3      4  127.0.0.1        60846  127.0.0.1        3000  0.04
+++