### PR TITLE
libbpf-tools: fix non-C89-compliant for loop variable declarations

### DIFF
--- a/libbpf-tools/errno_helpers.c
+++ b/libbpf-tools/errno_helpers.c
@@ -159,7 +159,7 @@ static int errno_by_name_x86_64(const char *errno_name)
 /* Try to find the errno number using the errno(1) program */
 static int errno_by_name_dynamic(const char *errno_name)
 {
-	int len = strlen(errno_name);
+	int i, len = strlen(errno_name);
 	int err, number = -1;
 	char buf[128];
 	char cmd[64];
@@ -168,7 +168,7 @@ static int errno_by_name_dynamic(const char *errno_name)
 	FILE *f;
 
 	/* sanity check to not call popen with random input */
-	for (int i = 0; i < len; i++) {
+	for (i = 0; i < len; i++) {
 		if (errno_name[i] < 'A' || errno_name[i] > 'Z') {
 			warn("errno_name contains invalid char 0x%02x: %s\n",
 					errno_name[i], errno_name);

--- a/libbpf-tools/execsnoop.bpf.c
+++ b/libbpf-tools/execsnoop.bpf.c
@@ -38,6 +38,7 @@ int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter* ctx
 	const char **args = (const char **)(ctx->args[1]);
 	const char *argp;
 	uid_t uid = (u32)bpf_get_current_uid_gid();
+	int i;
 
 	if (valid_uid(targ_uid) && targ_uid != uid)
 		return 0;
@@ -71,7 +72,7 @@ int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter* ctx
 
 	event->args_count++;
 	#pragma unroll
-	for (int i = 1; i < TOTAL_MAX_ARGS && i < max_args; i++) {
+	for (i = 1; i < TOTAL_MAX_ARGS && i < max_args; i++) {
 		bpf_probe_read_user(&argp, sizeof(argp), &args[i]);
 		if (!argp)
 			return 0;

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -174,13 +174,14 @@ static void inline quoted_symbol(char c) {
 
 static void print_args(const struct event *e, bool quote)
 {
-	int args_counter = 0;
+	int i, args_counter = 0;
 
 	if (env.quote)
 		putchar('"');
 
-	for (int i = 0; i < e->args_size && args_counter < e->args_count; i++) {
+	for (i = 0; i < e->args_size && args_counter < e->args_count; i++) {
 		char c = e->args[i];
+
 		if (env.quote) {
 			if (c == '\0') {
 				args_counter++;

--- a/libbpf-tools/funclatency.c
+++ b/libbpf-tools/funclatency.c
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
 		.doc = program_doc,
 	};
 	struct funclatency_bpf *obj;
-	int err;
+	int i, err;
 	struct tm *tm;
 	char ts[32];
 	time_t t;
@@ -312,7 +312,7 @@ int main(int argc, char **argv)
 
 	printf("Tracing %s.  Hit Ctrl-C to exit\n", env.funcname);
 
-	for (int i = 0; i < env.iterations && !exiting; i++) {
+	for (i = 0; i < env.iterations && !exiting; i++) {
 		sleep(env.interval);
 
 		printf("\n");

--- a/libbpf-tools/map_helpers.c
+++ b/libbpf-tools/map_helpers.c
@@ -17,7 +17,7 @@ dump_hash_iter(int map_fd, void *keys, __u32 key_size,
 {
 	__u8 key[key_size], next_key[key_size];
 	__u32 n = 0;
-	int err;
+	int i, err;
 
 	/* First get keys */
 	__builtin_memcpy(key, invalid_key, key_size);
@@ -34,7 +34,7 @@ dump_hash_iter(int map_fd, void *keys, __u32 key_size,
 	}
 
 	/* Now read values */
-	for (int i = 0; i < n; i++) {
+	for (i = 0; i < n; i++) {
 		err = bpf_map_lookup_elem(map_fd, keys + key_size * i,
 					  values + value_size * i);
 		if (err)

--- a/libbpf-tools/syscall_helpers.c
+++ b/libbpf-tools/syscall_helpers.c
@@ -116,7 +116,9 @@ close:
 
 void free_syscall_names(void)
 {
-	for (size_t i = 0; i < syscall_names_size; i++)
+	size_t i;
+
+	for (i = 0; i < syscall_names_size; i++)
 		free((void *) syscall_names[i]);
 	free(syscall_names);
 }
@@ -507,7 +509,7 @@ void syscall_name(unsigned n, char *buf, size_t size)
 int list_syscalls(void)
 {
 	const char **list = syscall_names;
-	size_t size = syscall_names_size;
+	size_t i, size = syscall_names_size;
 
 #ifdef __x86_64__
 	if (!size) {
@@ -516,7 +518,7 @@ int list_syscalls(void)
 	}
 #endif
 
-	for (size_t i = 0; i < size; i++) {
+	for (i = 0; i < size; i++) {
 		if (list[i])
 			printf("%3zd: %s\n", i, list[i]);
 	}

--- a/libbpf-tools/syscount.c
+++ b/libbpf-tools/syscount.c
@@ -149,9 +149,10 @@ static void print_latency(struct data_ext_t *vals, size_t count)
 {
 	double div = env.milliseconds ? 1000000.0 : 1000.0;
 	char buf[2 * TASK_COMM_LEN];
+	int i;
 
 	print_latency_header();
-	for (int i = 0; i < count && i < env.top; i++)
+	for (i = 0; i < count && i < env.top; i++)
 		printf("%-22s %8llu %16.3lf\n",
 		       agg_col(&vals[i], buf, sizeof(buf)),
 		       vals[i].count, vals[i].total_ns / div);
@@ -161,9 +162,10 @@ static void print_latency(struct data_ext_t *vals, size_t count)
 static void print_count(struct data_ext_t *vals, size_t count)
 {
 	char buf[2 * TASK_COMM_LEN];
+	int i;
 
 	print_count_header();
-	for (int i = 0; i < count && i < env.top; i++)
+	for (i = 0; i < count && i < env.top; i++)
 		printf("%-22s %8llu\n",
 		       agg_col(&vals[i], buf, sizeof(buf)), vals[i].count);
 	printf("\n");
@@ -186,7 +188,7 @@ static bool read_vals_batch(int fd, struct data_ext_t *vals, __u32 *count)
 {
 	struct data_t orig_vals[*count];
 	void *in = NULL, *out;
-	__u32 n, n_read = 0;
+	__u32 i, n, n_read = 0;
 	__u32 keys[*count];
 	int err = 0;
 
@@ -206,7 +208,7 @@ static bool read_vals_batch(int fd, struct data_ext_t *vals, __u32 *count)
 		in = out;
 	}
 
-	for (__u32 i = 0; i < n_read; i++) {
+	for (i = 0; i < n_read; i++) {
 		vals[i].count = orig_vals[i].count;
 		vals[i].total_ns = orig_vals[i].total_ns;
 		vals[i].key = keys[i];
@@ -223,7 +225,7 @@ static bool read_vals(int fd, struct data_ext_t *vals, __u32 *count)
 	struct data_t val;
 	__u32 key = -1;
 	__u32 next_key;
-	int i = 0;
+	int i = 0, j;
 	int err;
 
 	if (batch_map_ops) {
@@ -250,7 +252,7 @@ static bool read_vals(int fd, struct data_ext_t *vals, __u32 *count)
 		key = keys[i++] = next_key;
 	}
 
-	for (int j = 0; j < i; j++) {
+	for (j = 0; j < i; j++) {
 		err = bpf_map_lookup_elem(fd, &keys[j], &val);
 		if (err && errno != ENOENT) {
 			warn("failed to lookup element: %s\n", strerror(errno));
@@ -267,7 +269,7 @@ static bool read_vals(int fd, struct data_ext_t *vals, __u32 *count)
 	 * will be fixed in future by using bpf_map_lookup_and_delete_batch,
 	 * but this function is too fresh to use it in bcc. */
 
-	for (int j = 0; j < i; j++) {
+	for (j = 0; j < i; j++) {
 		err = bpf_map_delete_elem(fd, &keys[j]);
 		if (err) {
 			warn("failed to delete element: %s\n", strerror(errno));

--- a/libbpf-tools/tcpconnect.bpf.c
+++ b/libbpf-tools/tcpconnect.bpf.c
@@ -53,10 +53,12 @@ struct {
 
 static __always_inline bool filter_port(__u16 port)
 {
+	int i;
+
 	if (filter_ports_len == 0)
 		return false;
 
-	for (int i = 0; i < filter_ports_len; i++) {
+	for (i = 0; i < filter_ports_len; i++) {
 		if (port == filter_ports[i])
 			return false;
 	}

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -203,7 +203,7 @@ static void print_count_ipv4(int map_fd)
 	static __u64 counts[MAX_ENTRIES];
 	char s[INET_ADDRSTRLEN];
 	char d[INET_ADDRSTRLEN];
-	__u32 n = MAX_ENTRIES;
+	__u32 i, n = MAX_ENTRIES;
 	struct in_addr src;
 	struct in_addr dst;
 
@@ -212,7 +212,7 @@ static void print_count_ipv4(int map_fd)
 		return;
 	}
 
-	for (__u32 i = 0; i < n; i++) {
+	for (i = 0; i < n; i++) {
 		src.s_addr = keys[i].saddr;
 		dst.s_addr = keys[i].daddr;
 
@@ -232,7 +232,7 @@ static void print_count_ipv6(int map_fd)
 	static __u64 counts[MAX_ENTRIES];
 	char s[INET6_ADDRSTRLEN];
 	char d[INET6_ADDRSTRLEN];
-	__u32 n = MAX_ENTRIES;
+	__u32 i, n = MAX_ENTRIES;
 	struct in6_addr src;
 	struct in6_addr dst;
 
@@ -241,7 +241,7 @@ static void print_count_ipv6(int map_fd)
 		return;
 	}
 
-	for (__u32 i = 0; i < n; i++) {
+	for (i = 0; i < n; i++) {
 		memcpy(src.s6_addr, keys[i].saddr, sizeof(src.s6_addr));
 		memcpy(dst.s6_addr, keys[i].daddr, sizeof(src.s6_addr));
 
@@ -357,7 +357,7 @@ int main(int argc, char **argv)
 		.args_doc = NULL,
 	};
 	struct tcpconnect_bpf *obj;
-	int err;
+	int i, err;
 
 	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
 	if (err)
@@ -385,7 +385,7 @@ int main(int argc, char **argv)
 		obj->rodata->filter_uid = env.uid;
 	if (env.nports > 0) {
 		obj->rodata->filter_ports_len = env.nports;
-		for (int i = 0; i < env.nports; i++) {
+		for (i = 0; i < env.nports; i++) {
 			obj->rodata->filter_ports[i] = htons(env.ports[i]);
 		}
 	}

--- a/libbpf-tools/uprobe_helpers.c
+++ b/libbpf-tools/uprobe_helpers.c
@@ -199,7 +199,7 @@ static void close_elf(Elf *e, int fd_close)
 off_t get_elf_func_offset(const char *path, const char *func)
 {
 	off_t ret = -1;
-	int fd = -1;
+	int i, fd = -1;
 	Elf *e;
 	Elf_Scn *scn;
 	Elf_Data *data;
@@ -221,7 +221,7 @@ off_t get_elf_func_offset(const char *path, const char *func)
 			continue;
 		data = NULL;
 		while ((data = elf_getdata(scn, data))) {
-			for (int i = 0; gelf_getsym(data, i, sym); i++) {
+			for (i = 0; gelf_getsym(data, i, sym); i++) {
 				n = elf_strptr(e, shdr->sh_link, sym->st_name);
 				if (!n)
 					continue;

--- a/libbpf-tools/vfsstat.c
+++ b/libbpf-tools/vfsstat.c
@@ -109,8 +109,10 @@ static const char *stat_types_names[] = {
 
 static void print_header(void)
 {
+	int i;
+
 	printf("%-8s  ", "TIME");
-	for (int i = 0; i < S_MAXSTAT; i++)
+	for (i = 0; i < S_MAXSTAT; i++)
 		printf(" %6s/s", stat_types_names[i]);
 	printf("\n");
 }
@@ -119,9 +121,10 @@ static void print_and_reset_stats(__u64 stats[S_MAXSTAT])
 {
 	char s[16];
 	__u64 val;
+	int i;
 
 	printf("%-8s: ", strftime_now(s, sizeof(s), "%H:%M:%S"));
-	for (int i = 0; i < S_MAXSTAT; i++) {
+	for (i = 0; i < S_MAXSTAT; i++) {
 		val = __atomic_exchange_n(&stats[i], 0, __ATOMIC_RELAXED);
 		printf(" %8llu", val / env.interval);
 	}


### PR DESCRIPTION
Fix all the found instances of declaring loop variable inside for() construct,
which is not supported in C89 standard, which is what libbpf-tools are trying
to adhere to, both in user-space and BPF source code. It actually causes
compilation errors on some versions of GCC, as reported by customers in
private conversations.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>