### PR TITLE
libbpf-tools: initialize global variables in cachestat and funclatency

### DIFF
--- a/libbpf-tools/cachestat.bpf.c
+++ b/libbpf-tools/cachestat.bpf.c
@@ -4,9 +4,9 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
-__s64 total;	/* total cache accesses without counting dirties */
-__s64 misses;	/* total of add to lru because of read misses */
-__u64 mbd;	/* total of mark_buffer_dirty events */
+__s64 total = 0;	/* total cache accesses without counting dirties */
+__s64 misses = 0;	/* total of add to lru because of read misses */
+__u64 mbd = 0;  	/* total of mark_buffer_dirty events */
 
 SEC("fentry/add_to_page_cache_lru")
 int BPF_PROG(add_to_page_cache_lru)

--- a/libbpf-tools/funclatency.bpf.c
+++ b/libbpf-tools/funclatency.bpf.c
@@ -7,8 +7,8 @@
 #include "funclatency.h"
 #include "bits.bpf.h"
 
-const volatile pid_t targ_tgid;
-const volatile int units;
+const volatile pid_t targ_tgid = 0;
+const volatile int units = 0;
 
 /* key: pid.  value: start time */
 struct {
@@ -18,7 +18,7 @@ struct {
 	__type(value, u64);
 } starts SEC(".maps");
 
-__u32 hist[MAX_SLOTS];
+__u32 hist[MAX_SLOTS] = {};
 
 SEC("kprobe/dummy_kprobe")
 int BPF_KPROBE(dummy_kprobe)


### PR DESCRIPTION
fix error when make libbpf-tools

```
libbpf: invalid relo for 'targ_tgid' in special section 0xfff2; forgot to initialize global var?..
Error: failed to open BPF object file: Relocation failed
make: *** [Makefile:88: .output/funclatency.skel.h] Error 255
make: *** Deleting file '.output/funclatency.skel.h'
```

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>