### PR TITLE
libbpf-tools: fix block io events mismatched

### DIFF
--- a/libbpf-tools/biolatency.bpf.c
+++ b/libbpf-tools/biolatency.bpf.c
@@ -52,15 +52,15 @@ int trace_rq_start(struct request *rq)
 }
 
 SEC("tp_btf/block_rq_insert")
-int BPF_PROG(block_rq_insert, struct request_queue *q, struct request *rq)
+int BPF_PROG(block_rq_insert, struct request *rq)
 {
 	return trace_rq_start(rq);
 }
 
 SEC("tp_btf/block_rq_issue")
-int BPF_PROG(block_rq_issue, struct request_queue *q, struct request *rq)
+int BPF_PROG(block_rq_issue, struct request *rq)
 {
-	if (targ_queued && BPF_CORE_READ(q, elevator))
+	if (targ_queued)
 		return 0;
 	return trace_rq_start(rq);
 }


### PR DESCRIPTION
Two trace functions in `biolatency.bpf.c` have mismatched signatures with the [kernel definitions](https://github.com/torvalds/linux/blob/cd278456d4ca0e6b3d5e10ace4566524baa144eb/include/trace/events/block.h).

Result in following error:
```
libbpf: load bpf program failed: Permission denied
libbpf: -- BEGIN DUMP LOG ---
libbpf: 
arg#0 type is not a struct
Unrecognized arg#0 type PTR
; int BPF_PROG(block_rq_insert, struct request_queue *q, struct request *rq)
0: (79) r6 = *(u64 *)(r1 +8)
func 'block_rq_insert' doesn't have 2-th argument
invalid bpf_context access off=8 size=8
processed 1 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0

libbpf: -- END LOG --
libbpf: failed to load program 'block_rq_insert'
libbpf: failed to load object 'biolatency_bpf'
libbpf: failed to load BPF skeleton 'biolatency_bpf': -4007
failed to load BPF object: -4007
```

This PR aims to fix that.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>