### PR TITLE
libbpf-tools: fix finish_task_switch renamed

### DIFF
--- a/libbpf-tools/cpudist.bpf.c
+++ b/libbpf-tools/cpudist.bpf.c
@@ -75,8 +75,7 @@ static __always_inline void update_hist(struct task_struct *task,
 	__sync_fetch_and_add(&histp->slots[slot], 1);
 }
 
-SEC("kprobe/finish_task_switch")
-int BPF_KPROBE(finish_task_switch, struct task_struct *prev)
+static __always_inline int probe(struct task_struct *prev)
 {
 	u32 prev_tgid = BPF_CORE_READ(prev, tgid);
 	u32 prev_pid = BPF_CORE_READ(prev, pid);
@@ -93,6 +92,18 @@ int BPF_KPROBE(finish_task_switch, struct task_struct *prev)
 		store_start(tgid, pid, ts);
 	}
 	return 0;
+}
+
+SEC("kprobe/finish_task_switch")
+int BPF_KPROBE(finish_task_switch, struct task_struct *prev)
+{
+	return probe(prev);
+}
+
+SEC("kprobe/finish_task_switch.isra.0")
+int BPF_KPROBE(finish_task_switch_isra_0, struct task_struct *prev)
+{
+	return probe(prev);
 }
 
 char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
The same as #3315 but for libbpf-tools `cpudist`.

On Linux 5.11.6, I have:
```shell
$ cat /proc/kallsyms | grep finish_task_switch
0000000000000000 t finish_task_switch.isra.0
```

And `cpudist` failed with:
```
libbpf: kprobe perf_event_open() failed: No such file or directory
libbpf: prog 'finish_task_switch': failed to create kprobe 'finish_task_switch' perf event: No such file or directory
libbpf: failed to auto-attach program 'finish_task_switch': -2
failed to attach BPF programs
```

This PR fixes this problem by detecting the ksym on the system and switch to kprobe accordingly.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>