### PR TITLE
libbpf-tools: add offcputime

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -15,6 +15,7 @@
 /hardirqs
 /llcstat
 /numamove
+/offcputime
 /opensnoop
 /readahead
 /runqlat

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -32,6 +32,7 @@ APPS = \
 	hardirqs \
 	llcstat \
 	numamove \
+	offcputime \
 	opensnoop \
 	readahead \
 	runqlat \

--- a/libbpf-tools/offcputime.bpf.c
+++ b/libbpf-tools/offcputime.bpf.c
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2021 Wenbo Zhang
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+#include "offcputime.h"
+
+#define PF_KTHREAD		0x00200000	/* I am a kernel thread */
+#define MAX_ENTRIES		10240
+
+const volatile bool kernel_threads_only = false;
+const volatile bool user_threads_only = false;
+const volatile __u64 max_block_ns = -1;
+const volatile __u64 min_block_ns = 1;
+const volatile pid_t targ_tgid = -1;
+const volatile pid_t targ_pid = -1;
+const volatile long state = -1;
+
+struct internal_key {
+	u64 start_ts;
+	struct key_t key;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u32);
+	__type(value, struct internal_key);
+	__uint(max_entries, MAX_ENTRIES);
+} start SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
+	__uint(key_size, sizeof(u32));
+} stackmap SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct key_t);
+	__type(value, struct val_t);
+	__uint(max_entries, MAX_ENTRIES);
+} info SEC(".maps");
+
+static bool allow_record(struct task_struct *t)
+{
+	if (targ_tgid != -1 && targ_tgid != t->tgid)
+		return false;
+	if (targ_pid != -1 && targ_pid != t->pid)
+		return false;
+	if (user_threads_only && t->flags & PF_KTHREAD)
+		return false;
+	else if (kernel_threads_only && !(t->flags & PF_KTHREAD))
+		return false;
+	if (state != -1 && t->state != state)
+		return false;
+	return true;
+}
+
+SEC("tp_btf/sched_switch")
+int BPF_PROG(sched_switch, bool preempt, struct task_struct *prev,
+	     struct task_struct *next)
+{
+	struct internal_key *i_keyp, i_key;
+	struct val_t *valp, val;
+	s64 delta;
+	u32 pid;
+
+	if (allow_record(prev)) {
+		pid = prev->pid;
+		/* To distinguish idle threads of different cores */
+		if (!pid)
+			pid = bpf_get_smp_processor_id();
+		i_key.key.pid = pid;
+		i_key.key.tgid = prev->tgid;
+		i_key.start_ts = bpf_ktime_get_ns();
+
+		if (prev->flags & PF_KTHREAD)
+			i_key.key.user_stack_id = -1;
+		else
+			i_key.key.user_stack_id =
+				bpf_get_stackid(ctx, &stackmap,
+						BPF_F_USER_STACK);
+		i_key.key.kern_stack_id = bpf_get_stackid(ctx, &stackmap, 0);
+		bpf_map_update_elem(&start, &pid, &i_key, 0);
+		bpf_probe_read_str(&val.comm, sizeof(prev->comm), prev->comm);
+		val.delta = 0;
+		bpf_map_update_elem(&info, &i_key.key, &val, BPF_NOEXIST);
+	}
+
+	pid = next->pid;
+	i_keyp = bpf_map_lookup_elem(&start, &pid);
+	if (!i_keyp)
+		return 0;
+	delta = (s64)(bpf_ktime_get_ns() - i_keyp->start_ts);
+	if (delta < 0)
+		goto cleanup;
+	delta /= 1000U;
+	if (delta < min_block_ns || delta > max_block_ns)
+		goto cleanup;
+	valp = bpf_map_lookup_elem(&info, &i_keyp->key);
+	if (!valp)
+		goto cleanup;
+	__sync_fetch_and_add(&valp->delta, delta);
+
+cleanup:
+	bpf_map_delete_elem(&start, &pid);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2021 Wenbo Zhang
+//
+// Based on offcputime(8) from BCC by Brendan Gregg.
+// 19-Mar-2021   Wenbo Zhang   Created this.
+#include <argp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "offcputime.h"
+#include "offcputime.skel.h"
+#include "trace_helpers.h"
+
+static struct env {
+	pid_t pid;
+	pid_t tid;
+	bool user_threads_only;
+	bool kernel_threads_only;
+	int stack_storage_size;
+	int perf_max_stack_depth;
+	__u64 min_block_time;
+	__u64 max_block_time;
+	long state;
+	int duration;
+	bool verbose;
+} env = {
+	.pid = -1,
+	.tid = -1,
+	.stack_storage_size = 1024,
+	.perf_max_stack_depth = 127,
+	.min_block_time = 1,
+	.max_block_time = -1,
+	.state = -1,
+	.duration = 99999999,
+};
+
+static volatile bool exiting;
+
+const char *argp_program_version = "offcputime 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] =
+"Summarize off-CPU time by stack trace.\n"
+"\n"
+"USAGE: offcputime [--help] [-p PID | -u | -k] [-m MIN-BLOCK-TIME] "
+"[-M MAX-BLOCK-TIME] [--state] [--perf-max-stack-depth] [--stack-storage-size] "
+"[duration]\n"
+"EXAMPLES:\n"
+"    offcputime             # trace off-CPU stack time until Ctrl-C\n"
+"    offcputime 5           # trace for 5 seconds only\n"
+"    offcputime -m 1000     # trace only events that last more than 1000 usec\n"
+"    offcputime -M 10000    # trace only events that last less than 10000 usec\n"
+"    offcputime -p 185      # only trace threads for PID 185\n"
+"    offcputime -t 188      # only trace thread 188\n"
+"    offcputime -u          # only trace user threads (no kernel)\n"
+"    offcputime -k          # only trace kernel threads (no user)\n";
+
+#define OPT_PERF_MAX_STACK_DEPTH	1 /* --pef-max-stack-depth */
+#define OPT_STACK_STORAGE_SIZE		2 /* --stack-storage-size */
+#define OPT_STATE			3 /* --state */
+
+static const struct argp_option opts[] = {
+	{ "pid", 'p', "PID", 0, "Trace this PID only" },
+	{ "tid", 't', "TID", 0, "Trace this TID only" },
+	{ "user-threads-only", 'u', NULL, 0,
+	  "User threads only (no kernel threads)" },
+	{ "kernel-threads-only", 'k', NULL, 0,
+	  "Kernel threads only (no user threads)" },
+	{ "perf-max-stack-depth", OPT_PERF_MAX_STACK_DEPTH,
+	  "PERF-MAX-STACK-DEPTH", 0, "the limit for both kernel and user stack traces (default 127)" },
+	{ "stack-storage-size", OPT_STACK_STORAGE_SIZE, "STACK-STORAGE-SIZE", 0,
+	  "the number of unique stack traces that can be stored and displayed (default 1024)" },
+	{ "min-block-time", 'm', "MIN-BLOCK-TIME", 0,
+	  "the amount of time in microseconds over which we store traces (default 1)" },
+	{ "max-block-time", 'M', "MAX-BLOCK-TIME", 0,
+	  "the amount of time in microseconds under which we store traces (default U64_MAX)" },
+	{ "state", OPT_STATE, "STATE", 0, "filter on this thread state bitmask (eg, 2 == TASK_UNINTERRUPTIBLE) see include/linux/sched.h" },
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	static int pos_args;
+
+	switch (key) {
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'p':
+		errno = 0;
+		env.pid = strtol(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "invalid PID: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 't':
+		errno = 0;
+		env.tid = strtol(arg, NULL, 10);
+		if (errno || env.tid <= 0) {
+			fprintf(stderr, "Invalid TID: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 'u':
+		env.user_threads_only = true;
+		break;
+	case 'k':
+		env.kernel_threads_only = true;
+		break;
+	case OPT_PERF_MAX_STACK_DEPTH:
+		errno = 0;
+		env.perf_max_stack_depth = strtol(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "invalid perf max stack depth: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case OPT_STACK_STORAGE_SIZE:
+		errno = 0;
+		env.stack_storage_size = strtol(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "invalid stack storage size: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 'm':
+		errno = 0;
+		env.min_block_time = strtoll(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "Invalid min block time (in us): %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 'M':
+		errno = 0;
+		env.max_block_time = strtoll(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "Invalid min block time (in us): %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case OPT_STATE:
+		errno = 0;
+		env.state = strtol(arg, NULL, 10);
+		if (errno || env.state < 0 || env.state > 2) {
+			fprintf(stderr, "Invalid task state: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case ARGP_KEY_ARG:
+		if (pos_args++) {
+			fprintf(stderr,
+				"Unrecognized positional argument: %s\n", arg);
+			argp_usage(state);
+		}
+		errno = 0;
+		env.duration = strtol(arg, NULL, 10);
+		if (errno || env.duration <= 0) {
+			fprintf(stderr, "Invalid duration (in s): %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+int libbpf_print_fn(enum libbpf_print_level level,
+		    const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_handler(int sig)
+{
+}
+
+static void print_map(struct ksyms *ksyms, struct syms_cache *syms_cache,
+		      struct offcputime_bpf *obj)
+{
+	struct key_t lookup_key = {}, next_key;
+	const struct ksym *ksym;
+	const struct syms *syms;
+	const struct sym *sym;
+	int err, i, ifd, sfd;
+	unsigned long *ip;
+	struct val_t val;
+
+	ip = calloc(env.perf_max_stack_depth, sizeof(*ip));
+	if (!ip) {
+		fprintf(stderr, "failed to alloc ip\n");
+		return;
+	}
+
+	ifd = bpf_map__fd(obj->maps.info);
+	sfd = bpf_map__fd(obj->maps.stackmap);
+	while (!bpf_map_get_next_key(ifd, &lookup_key, &next_key)) {
+		err = bpf_map_lookup_elem(ifd, &next_key, &val);
+		if (err < 0) {
+			fprintf(stderr, "failed to lookup info: %d\n", err);
+			goto cleanup;
+		}
+		lookup_key = next_key;
+		if (val.delta == 0)
+			continue;
+		if (bpf_map_lookup_elem(sfd, &next_key.kern_stack_id, ip) != 0) {
+			fprintf(stderr, "    [Missed Kernel Stack]\n");
+			goto print_ustack;
+		}
+		for (i = 0; i < env.perf_max_stack_depth && ip[i]; i++) {
+			ksym = ksyms__map_addr(ksyms, ip[i]);
+			printf("    %s\n", ksym ? ksym->name : "Unknown");
+		}
+
+print_ustack:
+		if (next_key.user_stack_id == -1)
+			goto skip_ustack;
+
+		if (bpf_map_lookup_elem(sfd, &next_key.user_stack_id, ip) != 0) {
+			fprintf(stderr, "    [Missed User Stack]\n");
+			continue;
+		}
+
+		syms = syms_cache__get_syms(syms_cache, next_key.tgid);
+		if (!syms) {
+			fprintf(stderr, "failed to get syms\n");
+			goto skip_ustack;
+		}
+		for (i = 0; i < env.perf_max_stack_depth && ip[i]; i++) {
+			sym = syms__map_addr(syms, ip[i]);
+			if (sym)
+				printf("    %s\n", sym->name);
+			else
+				printf("    [unknown]\n");
+		}
+
+skip_ustack:
+		printf("    %-16s %s (%d)\n", "-", val.comm, next_key.pid);
+		printf("        %lld\n\n", val.delta);
+	}
+
+cleanup:
+	free(ip);
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct syms_cache *syms_cache = NULL;
+	struct ksyms *ksyms = NULL;
+	struct offcputime_bpf *obj;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+	if (env.user_threads_only && env.kernel_threads_only) {
+		fprintf(stderr, "user_threads_only, kernel_threads_only cann't be used together.\n");
+		return 1;
+	}
+	if (env.min_block_time >= env.max_block_time) {
+		fprintf(stderr, "min_block_time should smaller than max_block_time\n");
+		return 1;
+	}
+
+	libbpf_set_print(libbpf_print_fn);
+
+	err = bump_memlock_rlimit();
+	if (err) {
+		fprintf(stderr, "failed to increase rlimit: %d\n", err);
+		return 1;
+	}
+
+	obj = offcputime_bpf__open();
+	if (!obj) {
+		fprintf(stderr, "failed to open BPF object\n");
+		return 1;
+	}
+
+	/* initialize global data (filtering options) */
+	obj->rodata->targ_tgid = env.pid;
+	obj->rodata->targ_pid = env.tid;
+	obj->rodata->user_threads_only = env.user_threads_only;
+	obj->rodata->kernel_threads_only = env.kernel_threads_only;
+	obj->rodata->state = env.state;
+	obj->rodata->min_block_ns = env.min_block_time;
+	obj->rodata->max_block_ns = env.max_block_time;
+
+	bpf_map__set_value_size(obj->maps.stackmap,
+				env.perf_max_stack_depth * sizeof(unsigned long));
+	bpf_map__set_max_entries(obj->maps.stackmap, env.stack_storage_size);
+
+	err = offcputime_bpf__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF programs\n");
+		goto cleanup;
+	}
+	ksyms = ksyms__load();
+	if (!ksyms) {
+		fprintf(stderr, "failed to load kallsyms\n");
+		goto cleanup;
+	}
+	syms_cache = syms_cache__new(0);
+	if (!syms_cache) {
+		fprintf(stderr, "failed to create syms_cache\n");
+		goto cleanup;
+	}
+	err = offcputime_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+
+	signal(SIGINT, sig_handler);
+
+	/*
+	 * We'll get sleep interrupted when someone presses Ctrl-C (which will
+	 * be "handled" with noop by sig_handler).
+	 */
+	sleep(env.duration);
+
+	print_map(ksyms, syms_cache, obj);
+
+cleanup:
+	offcputime_bpf__destroy(obj);
+	syms_cache__free(syms_cache);
+	ksyms__free(ksyms);
+	return err != 0;
+}

--- a/libbpf-tools/offcputime.h
+++ b/libbpf-tools/offcputime.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __OFFCPUTIME_H
+#define __OFFCPUTIME_H
+
+#define TASK_COMM_LEN		16
+
+struct key_t {
+	__u32 pid;
+	__u32 tgid;
+	int user_stack_id;
+	int kern_stack_id;
+};
+
+struct val_t {
+	__u64 delta;
+	char comm[TASK_COMM_LEN];
+};
+
+#endif /* __OFFCPUTIME_H */

--- a/libbpf-tools/trace_helpers.h
+++ b/libbpf-tools/trace_helpers.h
@@ -20,6 +20,25 @@ const struct ksym *ksyms__map_addr(const struct ksyms *ksyms,
 const struct ksym *ksyms__get_symbol(const struct ksyms *ksyms,
 				     const char *name);
 
+struct sym {
+	const char *name;
+	unsigned long start;
+	unsigned long size;
+};
+
+struct syms;
+
+struct syms *syms__load_pid(int tgid);
+struct syms *syms__load_file(const char *fname);
+void syms__free(struct syms *syms);
+const struct sym *syms__map_addr(const struct syms *syms, unsigned long addr);
+
+struct syms_cache;
+
+struct syms_cache *syms_cache__new(int nr);
+struct syms *syms_cache__get_syms(struct syms_cache *syms_cache, int tgid);
+void syms_cache__free(struct syms_cache *syms_cache);
+
 struct partition {
 	char *name;
 	unsigned int dev;

--- a/libbpf-tools/uprobe_helpers.c
+++ b/libbpf-tools/uprobe_helpers.c
@@ -159,7 +159,7 @@ int resolve_binary_path(const char *binary, pid_t pid, char *path, size_t path_s
  * Opens an elf at `path` of kind ELF_K_ELF.  Returns NULL on failure.  On
  * success, close with close_elf(e, fd_close).
  */
-static Elf *open_elf(const char *path, int *fd_close)
+Elf *open_elf(const char *path, int *fd_close)
 {
 	int fd;
 	Elf *e;
@@ -189,7 +189,30 @@ static Elf *open_elf(const char *path, int *fd_close)
 	return e;
 }
 
-static void close_elf(Elf *e, int fd_close)
+Elf *open_elf_by_fd(int fd)
+{
+	Elf *e;
+
+	if (elf_version(EV_CURRENT) == EV_NONE) {
+		warn("elf init failed\n");
+		return NULL;
+	}
+	e = elf_begin(fd, ELF_C_READ, NULL);
+	if (!e) {
+		warn("elf_begin failed: %s\n", elf_errmsg(-1));
+		close(fd);
+		return NULL;
+	}
+	if (elf_kind(e) != ELF_K_ELF) {
+		warn("elf kind %d is not ELF_K_ELF\n", elf_kind(e));
+		elf_end(e);
+		close(fd);
+		return NULL;
+	}
+	return e;
+}
+
+void close_elf(Elf *e, int fd_close)
 {
 	elf_end(e);
 	close(fd_close);

--- a/libbpf-tools/uprobe_helpers.h
+++ b/libbpf-tools/uprobe_helpers.h
@@ -5,10 +5,14 @@
 
 #include <sys/types.h>
 #include <unistd.h>
+#include <gelf.h>
 
 int get_pid_binary_path(pid_t pid, char *path, size_t path_sz);
 int get_pid_lib_path(pid_t pid, const char *lib, char *path, size_t path_sz);
 int resolve_binary_path(const char *binary, pid_t pid, char *path, size_t path_sz);
 off_t get_elf_func_offset(const char *path, const char *func);
+Elf *open_elf(const char *path, int *fd_close);
+Elf *open_elf_by_fd(int fd);
+void close_elf(Elf *e, int fd_close);
 
 #endif /* __UPROBE_HELPERS_H */


### PR DESCRIPTION
Compared with the previous version, raw_tp/sched_switch is used instead of kprobe/finish_task_switch, because the latter has symbolic name problems under gcc 10 https://github.com/iovisor/bcc/issues/3293.

Functionally compared with the old version, the following features are missing, will be completed in subsequent PR.

Todo list

- [x] Support user stack symbol parsing from ELF & DYN
- [x] Support user stack symbol parsing from vdso
- [ ] Support user stack symbol parsing from perf-map
- [ ] Support user stack symbol parsing with mount ns
- [ ] Sort the results in ascending order according to the length of offcpu time
- [ ] Support folding output results
- [ ] missing stack event report

The output looks like below:
```
    bpf_prog_f8f33eb3e61e9447_sched_switch
    bpf_prog_f8f33eb3e61e9447_sched_switch
    bpf_trace_run3
    __bpf_trace_sched_switch
    __schedule
    schedule
    futex_wait_queue_me
    futex_wait
    do_futex
    __x64_sys_futex
    do_syscall_64
    entry_SYSCALL_64_after_hwframe
    runtime.futex
    runtime.notesleep
    runtime.stopm
    runtime.findrunnable
    runtime.schedule
    runtime.park_m
    runtime.mcall
    [unknown]
    -                containerd (1172)
        69917
```


Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>