### PR TITLE
libbpf-tools: fix for block io tracepoints changed

### DIFF
--- a/libbpf-tools/biolatency.bpf.c
+++ b/libbpf-tools/biolatency.bpf.c
@@ -9,8 +9,6 @@
 
 #define MAX_ENTRIES	10240
 
-#define KERNEL_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + (c))
-
 extern int LINUX_KERNEL_VERSION __kconfig;
 
 const volatile bool targ_per_disk = false;

--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -11,6 +11,8 @@
 const volatile bool targ_queued = false;
 const volatile dev_t targ_dev = -1;
 
+extern __u32 LINUX_KERNEL_VERSION __kconfig;
+
 struct piddata {
 	char comm[TASK_COMM_LEN];
 	u32 pid;
@@ -93,15 +95,31 @@ int trace_rq_start(struct request *rq, bool insert)
 }
 
 SEC("tp_btf/block_rq_insert")
-int BPF_PROG(block_rq_insert, struct request_queue *q, struct request *rq)
+int BPF_PROG(block_rq_insert)
 {
-	return trace_rq_start(rq, true);
+	/**
+	 * commit a54895fa (v5.11-rc1) changed tracepoint argument list
+	 * from TP_PROTO(struct request_queue *q, struct request *rq)
+	 * to TP_PROTO(struct request *rq)
+	 */
+	if (LINUX_KERNEL_VERSION > KERNEL_VERSION(5, 10, 0))
+		return trace_rq_start((void *)ctx[0], true);
+	else
+		return trace_rq_start((void *)ctx[1], true);
 }
 
 SEC("tp_btf/block_rq_issue")
-int BPF_PROG(block_rq_issue, struct request_queue *q, struct request *rq)
+int BPF_PROG(block_rq_issue)
 {
-	return trace_rq_start(rq, false);
+	/**
+	 * commit a54895fa (v5.11-rc1) changed tracepoint argument list
+	 * from TP_PROTO(struct request_queue *q, struct request *rq)
+	 * to TP_PROTO(struct request *rq)
+	 */
+	if (LINUX_KERNEL_VERSION > KERNEL_VERSION(5, 10, 0))
+		return trace_rq_start((void *)ctx[0], false);
+	else
+		return trace_rq_start((void *)ctx[1], false);
 }
 
 SEC("tp_btf/block_rq_complete")


### PR DESCRIPTION
Block IO tracepoints block_rq_insert and block_rq_issue are changed by this [commit](https://github.com/torvalds/linux/commit/a54895fa057c67700270777f7661d8d3c7fda88a).

For linux 5.10:
https://github.com/torvalds/linux/blob/v5.10/include/trace/events/block.h#L209

For > linux 5.10
https://github.com/torvalds/linux/blob/v5.11-rc1/include/trace/events/block.h#L206

This change break the libbpf-tools `biolatency`, `biosnoop` and `bitesize`:
```
libbpf: load bpf program failed: Permission denied
libbpf: -- BEGIN DUMP LOG ---
libbpf: 
arg#0 type is not a struct
Unrecognized arg#0 type PTR
; int BPF_PROG(block_rq_insert, struct request_queue *q, struct request *rq)
0: (79) r6 = *(u64 *)(r1 +8)
func 'block_rq_insert' doesn't have 2-th argument
invalid bpf_context access off=8 size=8
processed 1 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0

libbpf: -- END LOG --
libbpf: failed to load program 'block_rq_insert'
libbpf: failed to load object 'biolatency_bpf'
libbpf: failed to load BPF skeleton 'biolatency_bpf': -4007
failed to load BPF object: -4007
```

The pending PR #3317  DON'T work on old kernel, so I send a new PR with two other tools fixed together.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>