### PR TITLE
tools: handle renamed lookup_fast function in dcache tools

### DIFF
--- a/tools/dcsnoop.py
+++ b/tools/dcsnoop.py
@@ -129,7 +129,7 @@ if args.ebpf:
 # initialize BPF
 b = BPF(text=bpf_text)
 if args.all:
-    b.attach_kprobe(event="lookup_fast", fn_name="trace_fast")
+    b.attach_kprobe(event_re="^lookup_fast$|^lookup_fast.constprop.*.\d$", fn_name="trace_fast")
 
 mode_s = {
     0: 'M',

--- a/tools/dcstat.py
+++ b/tools/dcstat.py
@@ -91,7 +91,7 @@ void count_lookup(struct pt_regs *ctx) {
 
 # load BPF program
 b = BPF(text=bpf_text)
-b.attach_kprobe(event="lookup_fast", fn_name="count_fast")
+b.attach_kprobe(event_re="^lookup_fast$|^lookup_fast.constprop.*.\d$", fn_name="count_fast")
 b.attach_kretprobe(event="d_lookup", fn_name="count_lookup")
 
 # stat column labels and indexes


### PR DESCRIPTION
The lookup_fast function can be rename lookup_fast.constprop.x by gcc
constant propagation optimization and that breaks dcstat and
dcsnoop. Let's look for both name using a regular expression.