### PR TITLE
libbpf-tools: fix some minor issues of ext4dist

### DIFF
--- a/libbpf-tools/ext4dist.bpf.c
+++ b/libbpf-tools/ext4dist.bpf.c
@@ -12,7 +12,7 @@ const volatile pid_t targ_tgid = 0;
 
 #define MAX_ENTRIES	10240
 
-struct hist hists[__MAX_FOP_TYPE];
+struct hist hists[__MAX_FOP_TYPE] = {};
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);

--- a/libbpf-tools/ext4dist.c
+++ b/libbpf-tools/ext4dist.c
@@ -152,7 +152,7 @@ static bool should_fallback(void)
 	 * we can use fentry to get better performance, otherwise we need
 	 * to fall back to use kprobe to be compatible with the old kernel.
 	 */
-	if (is_kernel_module("ext4") && !access("/sys/kernel/btf/ext4", R_OK))
+	if (is_kernel_module("ext4") && access("/sys/kernel/btf/ext4", R_OK))
 		return true;
 	return false;
 }


### PR DESCRIPTION
Fix below minor issues of ext4dist

* Fix the check of the existence of module BTFs
* Initialize the global variable

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>