### PR TITLE
BCC tools: compatibility modification of scheduler related tools

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -560,7 +560,7 @@ class BPF(object):
             with open(blacklist_file, "rb") as blacklist_f:
                 blacklist = set([line.rstrip().split()[1] for line in blacklist_f])
         except IOError as e:
-            if e.errno != errno.EPERM:
+            if e.errno != errno.EPERM and e.errno != errno.ENOENT:
                 raise e
             blacklist = set([])
 

--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -94,7 +94,13 @@ static inline void update_hist(u32 tgid, u32 pid, u64 ts)
     STORE
 }
 
-int sched_switch(struct pt_regs *ctx, struct task_struct *prev)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
+struct rq;
+
+int sched_switch(struct pt_regs *ctx, struct rq *rq, struct task_struct *prev) 
+#else
+int sched_switch(struct pt_regs *ctx, struct task_struct *prev) 
+#endif
 {
     u64 ts = bpf_ktime_get_ns();
     u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -134,7 +134,13 @@ struct warn_event_t {
 };
 BPF_PERF_OUTPUT(warn_events);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
+struct rq;
+
+int oncpu(struct pt_regs *ctx, struct rq *rq, struct task_struct *prev) {
+#else
 int oncpu(struct pt_regs *ctx, struct task_struct *prev) {
+#endif
     u32 pid = prev->pid;
     u32 tgid = prev->tgid;
     u64 ts, *tsp;

--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -188,7 +188,13 @@ int waker(struct pt_regs *ctx, struct task_struct *p) {
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
+struct rq;
+
+int oncpu(struct pt_regs *ctx, struct rq *rq, struct task_struct *p) {
+#else
 int oncpu(struct pt_regs *ctx, struct task_struct *p) {
+#endif
     // PID and TGID of the previous Process (Process going into waiting)
     u32 pid = p->pid;
     u32 tgid = p->tgid;

--- a/tools/runqlat.py
+++ b/tools/runqlat.py
@@ -111,7 +111,14 @@ int trace_ttwu_do_wakeup(struct pt_regs *ctx, struct rq *rq, struct task_struct 
 }
 
 // calculate latency
-int trace_run(struct pt_regs *ctx, struct task_struct *prev)
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
+struct rq;
+
+int trace_run(struct pt_regs *ctx, struct rq *rq, struct task_struct *prev) 
+#else
+int trace_run(struct pt_regs *ctx, struct task_struct *prev) 
+#endif
 {
     u32 pid, tgid;
 

--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -107,7 +107,13 @@ int trace_ttwu_do_wakeup(struct pt_regs *ctx, struct rq *rq, struct task_struct 
 }
 
 // calculate latency
-int trace_run(struct pt_regs *ctx, struct task_struct *prev)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
+struct rq;
+
+int trace_run(struct pt_regs *ctx, struct rq *rq, struct task_struct *prev) 
+#else
+int trace_run(struct pt_regs *ctx, struct task_struct *prev) 
+#endif
 {
     u32 pid, tgid;
 


### PR DESCRIPTION
Since some companies are still using Centos 7 distribution, I made this compatibility modification, the tools include:

- cpudist
- offcputime
- offwaketime
- runqlat
- runqslower


Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>