### PR TITLE
tools/funclatency: support nested or recursive functions

### DIFF
--- a/man/man8/funclatency.8
+++ b/man/man8/funclatency.8
@@ -40,6 +40,9 @@ Print output every interval seconds.
 \-d DURATION
 Total duration of trace, in seconds.
 .TP
+\-l LEVEL
+Set the level of nested or recursive functions.
+.TP
 \-T
 Include timestamps on output.
 .TP

--- a/tools/funclatency_example.txt
+++ b/tools/funclatency_example.txt
@@ -29,7 +29,7 @@ Tracing do_sys_open... Hit Ctrl-C to end.
   524288 -> 1048575  : 0        |                                      |
  1048576 -> 2097151  : 0        |                                      |
  2097152 -> 4194303  : 1        |                                      |
- 
+
 avg = 13746 nsecs, total: 6543360 nsecs, count: 476
 
 Detaching...
@@ -383,6 +383,8 @@ optional arguments:
   -F, --function        show a separate histogram per function
   -r, --regexp          use regular expressions. Default is "*" wildcards
                         only.
+  -l LEVEL, --level LEVEL
+                        set the level of nested or recursive functions
   -v, --verbose         print the BPF program (for debugging purposes)
 
 examples:


### PR DESCRIPTION
# Implementation

add `-l level` option to support nested or recursive functions.

without `-l` option, funclatency tool worked as before.

```
typedef struct {
    u64 ip;
    u64 start_ts;
} func_cache_t;

/* LIFO */
typedef struct {
    u32          head;
    func_cache_t cache[STACK_DEPTH];
} func_stack_t;

BPF_HASH(func_stack, u32, func_stack_t);
```

cache stack(LIFO) per pid.