### PR TITLE
libbpf-tools: Fix ext4dist compilation

### DIFF
--- a/libbpf-tools/ext4dist.bpf.c
+++ b/libbpf-tools/ext4dist.bpf.c
@@ -12,7 +12,7 @@ const volatile pid_t targ_tgid = 0;
 
 #define MAX_ENTRIES	10240
 
-struct hist hists[__MAX_FOP_TYPE];
+struct hist hists[__MAX_FOP_TYPE] = {};
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);


### PR DESCRIPTION
Fix compilation error because of un-initialized global variable:

```
$ LLVM_STRIP=llvm-strip-10 make V=1
bin/bpftool gen skeleton .output/ext4dist.bpf.o > .output/ext4dist.skel.h
libbpf: invalid relo for 'hists' in special section 0xfff2; forgot to initialize global var?..
Error: failed to open BPF object file: Relocation failed
make: *** [Makefile:89: .output/ext4dist.skel.h] Error 255
make: *** Deleting file '.output/ext4dist.skel.h'
```

---
I see this error using the shipped `bpftool` and the following clang versions:
```
./bin/bpftool version
./bin/bpftool v5.8.0-rc4

$ clang --version
clang version 10.0.0-4ubuntu1 
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

ref https://github.com/iovisor/bcc/pull/3309
cc @ethercflow 

