### PR TITLE
Tools: add the PPID field in mountsnoop

### DIFF
--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -72,6 +72,8 @@ struct data_t {
             /* current->nsproxy->mnt_ns->ns.inum */
             unsigned int mnt_ns;
             char comm[TASK_COMM_LEN];
+            char pcomm[TASK_COMM_LEN];
+            pid_t ppid;
             unsigned long flags;
         } enter;
         /*
@@ -102,6 +104,8 @@ int syscall__mount(struct pt_regs *ctx, char __user *source,
     bpf_get_current_comm(event.enter.comm, sizeof(event.enter.comm));
     event.enter.flags = flags;
     task = (struct task_struct *)bpf_get_current_task();
+    event.enter.ppid = task->real_parent->tgid;
+    bpf_probe_read_kernel_str(&event.enter.pcomm, TASK_COMM_LEN, task->real_parent->comm);
     nsproxy = task->nsproxy;
     mnt_ns = nsproxy->mnt_ns;
     event.enter.mnt_ns = mnt_ns->ns.inum;
@@ -157,6 +161,8 @@ int syscall__umount(struct pt_regs *ctx, char __user *target, int flags)
     bpf_get_current_comm(event.enter.comm, sizeof(event.enter.comm));
     event.enter.flags = flags;
     task = (struct task_struct *)bpf_get_current_task();
+    event.enter.ppid = task->real_parent->tgid;
+    bpf_probe_read_kernel_str(&event.enter.pcomm, TASK_COMM_LEN, task->real_parent->comm);
     nsproxy = task->nsproxy;
     mnt_ns = nsproxy->mnt_ns;
     event.enter.mnt_ns = mnt_ns->ns.inum;
@@ -243,6 +249,8 @@ class EnterData(ctypes.Structure):
     _fields_ = [
         ('mnt_ns', ctypes.c_uint),
         ('comm', ctypes.c_char * TASK_COMM_LEN),
+        ('pcomm', ctypes.c_char * TASK_COMM_LEN),
+        ('ppid', ctypes.c_uint),
         ('flags', ctypes.c_ulong),
     ]
 
@@ -330,7 +338,7 @@ else:
         return '"{}"'.format(''.join(escape_character(c) for c in s))
 
 
-def print_event(mounts, umounts, cpu, data, size):
+def print_event(mounts, umounts, parent, cpu, data, size):
     event = ctypes.cast(data, ctypes.POINTER(Event)).contents
 
     try:
@@ -341,6 +349,8 @@ def print_event(mounts, umounts, cpu, data, size):
                 'mnt_ns': event.union.enter.mnt_ns,
                 'comm': event.union.enter.comm,
                 'flags': event.union.enter.flags,
+                'ppid': event.union.enter.ppid,
+                'pcomm': event.union.enter.pcomm,
             }
         elif event.type == EventType.EVENT_MOUNT_SOURCE:
             mounts[event.pid]['source'] = event.union.str
@@ -358,6 +368,8 @@ def print_event(mounts, umounts, cpu, data, size):
                 'mnt_ns': event.union.enter.mnt_ns,
                 'comm': event.union.enter.comm,
                 'flags': event.union.enter.flags,
+                'ppid': event.union.enter.ppid,
+                'pcomm': event.union.enter.pcomm,
             }
         elif event.type == EventType.EVENT_UMOUNT_TARGET:
             umounts[event.pid]['target'] = event.union.str
@@ -379,9 +391,15 @@ def print_event(mounts, umounts, cpu, data, size):
                     target=decode_mount_string(syscall['target']),
                     flags=decode_umount_flags(syscall['flags']),
                     retval=decode_errno(event.union.retval))
-            print('{:16} {:<7} {:<7} {:<11} {}'.format(
-                syscall['comm'].decode('utf-8', 'replace'), syscall['tgid'],
-                syscall['pid'], syscall['mnt_ns'], call))
+            if parent:
+                print('{:16} {:<7} {:<7} {:16} {:<7} {:<11} {}'.format(
+                    syscall['comm'].decode('utf-8', 'replace'), syscall['tgid'],
+                    syscall['pid'], syscall['pcomm'].decode('utf-8', 'replace'),
+                    syscall['ppid'], syscall['mnt_ns'], call))
+            else:
+                print('{:16} {:<7} {:<7} {:<11} {}'.format(
+                    syscall['comm'].decode('utf-8', 'replace'), syscall['tgid'],
+                    syscall['pid'], syscall['mnt_ns'], call))
     except KeyError:
         # This might happen if we lost an event.
         pass
@@ -393,6 +411,8 @@ def main():
     )
     parser.add_argument("--ebpf", action="store_true",
         help=argparse.SUPPRESS)
+    parser.add_argument("-P", "--parent_process", action="store_true",
+        help="also snoop the parent process")
     args = parser.parse_args()
 
     mounts = {}
@@ -408,9 +428,15 @@ def main():
     b.attach_kprobe(event=umount_fnname, fn_name="syscall__umount")
     b.attach_kretprobe(event=umount_fnname, fn_name="do_ret_sys_umount")
     b['events'].open_perf_buffer(
-        functools.partial(print_event, mounts, umounts))
-    print('{:16} {:<7} {:<7} {:<11} {}'.format(
-        'COMM', 'PID', 'TID', 'MNT_NS', 'CALL'))
+        functools.partial(print_event, mounts, umounts, args.parent_process))
+
+    if args.parent_process:
+        print('{:16} {:<7} {:<7} {:16} {:<7} {:<11} {}'.format(
+              'COMM', 'PID', 'TID', 'PCOMM', 'PPID', 'MNT_NS', 'CALL'))
+    else:
+        print('{:16} {:<7} {:<7} {:<11} {}'.format(
+            'COMM', 'PID', 'TID', 'MNT_NS', 'CALL'))
+
     while True:
         try:
             b.perf_buffer_poll()

--- a/tools/mountsnoop_example.txt
+++ b/tools/mountsnoop_example.txt
@@ -17,6 +17,11 @@ unshare          717     717     4026532160  mount("none", "/", "", MS_REC|MS_PR
 mount            725     725     4026532160  mount("/mnt", "/mnt", "", MS_MGC_VAL|MS_BIND, "") = 0
 umount           728     728     4026532160  umount("/mnt", 0x0) = 0
 
+# ./mountsnoop.py -P
+COMM             PID     TID     PCOMM            PPID    MNT_NS      CALL
+mount            51526   51526   bash             49313   3222937920  mount("/mnt", "/mnt", "", MS_MGC_VAL|MS_BIND, "", "") = 0
+umount           51613   51613   bash             49313   3222937920  umount("/mnt", 0x0) = 0
+
 The output shows the calling command, its process ID and thread ID, the mount
 namespace the call was made in, and the call itself.
 


### PR DESCRIPTION
It is found that in the production environment, the system() function
or shell command is often used to start the mount process temporarily,
so the PPID field needs to be added to find the corresponding program.

Signed-off-by: Wen Yang <wenyang@linux.alibaba.com>