### PR TITLE
Add BPFStackTable::free_symcache() to free the symbol cache for an PID

### DIFF
--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -274,6 +274,14 @@ BPFStackTable::~BPFStackTable() {
     bcc_free_symcache(it.second, it.first);
 }
 
+void BPFStackTable::free_symcache(int pid) {
+  auto iter = pid_sym_.find(pid);
+  if (iter != pid_sym_.end()) {
+    bcc_free_symcache(iter->second, iter->first);
+    pid_sym_.erase(iter);
+  }
+}
+
 void BPFStackTable::clear_table_non_atomic() {
   for (int i = 0; size_t(i) < capacity(); i++) {
     remove(&i);

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -398,6 +398,7 @@ class BPFStackBuildIdTable : public BPFTableBase<int, stacktrace_buildid_t> {
                        bool check_debug_file_crc, void *bsymcache);
   ~BPFStackBuildIdTable() = default;
 
+  void free_symcache(int pid);
   void clear_table_non_atomic();
   std::vector<bpf_stack_build_id> get_stack_addr(int stack_id);
   std::vector<std::string> get_stack_symbol(int stack_id);

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -378,6 +378,7 @@ class BPFStackTable : public BPFTableBase<int, stacktrace_t> {
   BPFStackTable(BPFStackTable&& that);
   ~BPFStackTable();
 
+  void free_symcache(int pid);
   void clear_table_non_atomic();
   std::vector<uintptr_t> get_stack_addr(int stack_id);
   std::vector<std::string> get_stack_symbol(int stack_id, int pid);
@@ -398,7 +399,6 @@ class BPFStackBuildIdTable : public BPFTableBase<int, stacktrace_buildid_t> {
                        bool check_debug_file_crc, void *bsymcache);
   ~BPFStackBuildIdTable() = default;
 
-  void free_symcache(int pid);
   void clear_table_non_atomic();
   std::vector<bpf_stack_build_id> get_stack_addr(int stack_id);
   std::vector<std::string> get_stack_symbol(int stack_id);


### PR DESCRIPTION
This is useful when BPFStackTable is used by a long running program to
limit the memory usage, by removing the cached symbols of an exited
process.