### PR TITLE
add macros offsetof and container_of

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -40,6 +40,18 @@ R"********(
 #endif
 #define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
 
+/* common kernel macros to manipulate data structures. */
+#ifndef offsetof
+#define offsetof(TYPE, MEMBER)  ((unsigned long)&((TYPE *)0)->MEMBER)
+#endif
+#ifndef container_of
+#define container_of(ptr, type, member)                         \
+        ({                                                      \
+                void *__mptr = (void *)(ptr);                   \
+                ((type *)(__mptr - offsetof(type, member)));    \
+        })
+#endif
+
 /* In 4.18 and later, when CONFIG_FUNCTION_TRACER is defined, kernel Makefile adds
  * -DCC_USING_FENTRY. Let do the same for bpf programs.
  */


### PR DESCRIPTION
These are two common kernel macros to manipulate data
structures. Let us add them to helpers.h so bpf program
can use them.

Signed-off-by: Yonghong Song <yhs@fb.com>