### PR TITLE
introduced map batch update in Python and Queue/Stack itervalues utility

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -107,12 +107,13 @@ This guide is incomplete. If something feels missing, check the bcc and kernel s
         - [6. items_lookup_and_delete_batch()](#6-items_lookup_and_delete_batch)
         - [7. items_lookup_batch()](#7-items_lookup_batch)
         - [8. items_delete_batch()](#8-items_delete_batch)
-        - [9. print_log2_hist()](#9-print_log2_hist)
-        - [10. print_linear_hist()](#10-print_linear_hist)
-        - [11. open_ring_buffer()](#11-open_ring_buffer)
-        - [12. push()](#12-push)
-        - [13. pop()](#13-pop)
-        - [14. peek()](#14-peek)
+        - [9. items_update_batch()](#9-items_update_batch)
+        - [10. print_log2_hist()](#10-print_log2_hist)
+        - [11. print_linear_hist()](#11-print_linear_hist)
+        - [12. open_ring_buffer()](#12-open_ring_buffer)
+        - [13. push()](#13-push)
+        - [14. pop()](#14-pop)
+        - [15. peek()](#15-peek)
     - [Helpers](#helpers)
         - [1. ksym()](#1-ksym)
         - [2. ksymname()](#2-ksymname)
@@ -2005,7 +2006,19 @@ If a list of keys is given then only those keys and their associated values will
 It requires kernel v5.6.
 
 
-### 9. print_log2_hist()
+### 9. items_update_batch()
+
+Syntax: ```table.items_update_batch(keys, values)```
+
+Update all the provided keys with new values. The two arguments must be the same length and within the map limits (between 1 and the maximum entries).
+
+Arguments:
+
+- keys is the list of keys to be updated
+- values is the list containing the new values.
+
+
+### 10. print_log2_hist()
 
 Syntax: ```table.print_log2_hist(val_type="value", section_header="Bucket ptr", section_print_fn=None)```
 
@@ -2056,7 +2069,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=print_log2_hist+path%3Aexamples+language%3Apython&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=print_log2_hist+path%3Atools+language%3Apython&type=Code)
 
-### 10. print_linear_hist()
+### 11. print_linear_hist()
 
 Syntax: ```table.print_linear_hist(val_type="value", section_header="Bucket ptr", section_print_fn=None)```
 
@@ -2115,7 +2128,7 @@ Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=print_linear_hist+path%3Aexamples+language%3Apython&type=Code),
 [search /tools](https://github.com/iovisor/bcc/search?q=print_linear_hist+path%3Atools+language%3Apython&type=Code)
 
-### 11. open_ring_buffer()
+### 12. open_ring_buffer()
 
 Syntax: ```table.open_ring_buffer(callback, ctx=None)```
 
@@ -2177,7 +2190,7 @@ def print_event(ctx, data, size):
 Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=open_ring_buffer+path%3Aexamples+language%3Apython&type=Code),
 
-### 12. push()
+### 13. push()
 
 Syntax: ```table.push(leaf, flags=0)```
 
@@ -2187,7 +2200,7 @@ Passing QueueStack.BPF_EXIST as a flag causes the Queue or Stack to discard the 
 Examples in situ:
 [search /tests](https://github.com/iovisor/bcc/search?q=push+path%3Atests+language%3Apython&type=Code),
 
-### 13. pop()
+### 14. pop()
 
 Syntax: ```leaf = table.pop()```
 
@@ -2198,7 +2211,7 @@ Raises a KeyError exception if the operation does not succeed.
 Examples in situ:
 [search /tests](https://github.com/iovisor/bcc/search?q=pop+path%3Atests+language%3Apython&type=Code),
 
-### 14. peek()
+### 15. peek()
 
 Syntax: ```leaf = table.peek()```
 

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -370,6 +370,11 @@ int bpf_delete_batch(int fd,  void *keys, __u32 *count)
   return bpf_map_delete_batch(fd, keys, count, NULL);
 }
 
+int bpf_update_batch(int fd, void *keys, void *values, __u32 *count)
+{
+  return bpf_map_update_batch(fd, keys, values, count, NULL);
+}
+
 int bpf_lookup_and_delete_batch(int fd, __u32 *in_batch, __u32 *out_batch,
                                 void *keys, void *values, __u32 *count)
 {

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -85,6 +85,9 @@ lib.bpf_delete_elem.restype = ct.c_int
 lib.bpf_delete_elem.argtypes = [ct.c_int, ct.c_void_p]
 lib.bpf_delete_batch.restype = ct.c_int
 lib.bpf_delete_batch.argtypes = [ct.c_int, ct.c_void_p, ct.c_void_p]
+lib.bpf_update_batch.restype = ct.c_int
+lib.bpf_update_batch.argtypes = [ct.c_int, ct.c_void_p, ct.c_void_p,
+        ct.POINTER(ct.c_uint32)]
 lib.bpf_lookup_batch.restype = ct.c_int
 lib.bpf_lookup_batch.argtypes = [ct.c_int, ct.POINTER(ct.c_uint32),
         ct.POINTER(ct.c_uint32), ct.c_void_p, ct.c_void_p, ct.c_void_p]

--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -314,6 +314,8 @@ class TableBase(MutableMapping):
         self.flags = lib.bpf_table_flags_id(self.bpf.module, self.map_id)
         self._cbs = {}
         self._name = name
+        self.max_entries = int(lib.bpf_table_max_entries_id(self.bpf.module,
+                self.map_id))
 
     def get_fd(self):
         return self.map_fd
@@ -670,9 +672,7 @@ class TableBase(MutableMapping):
 class HashTable(TableBase):
     def __init__(self, *args, **kwargs):
         super(HashTable, self).__init__(*args, **kwargs)
-        self.max_entries = int(lib.bpf_table_max_entries_id(self.bpf.module,
-                                                            self.map_id))
-
+        
     def __len__(self):
         i = 0
         for k in self: i += 1
@@ -685,9 +685,7 @@ class LruHash(HashTable):
 class ArrayBase(TableBase):
     def __init__(self, *args, **kwargs):
         super(ArrayBase, self).__init__(*args, **kwargs)
-        self.max_entries = int(lib.bpf_table_max_entries_id(self.bpf.module,
-                self.map_id))
-
+        
     def _normalize_key(self, key):
         if isinstance(key, int):
             if key < 0:

--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -1157,6 +1157,8 @@ class QueueStack:
         self.Leaf = leaftype
         self.ttype = lib.bpf_table_type_id(self.bpf.module, self.map_id)
         self.flags = lib.bpf_table_flags_id(self.bpf.module, self.map_id)
+        self.max_entries = int(lib.bpf_table_max_entries_id(self.bpf.module,
+                self.map_id))
 
     def leaf_sprintf(self, leaf):
         buf = ct.create_string_buffer(ct.sizeof(self.Leaf) * 8)
@@ -1193,3 +1195,16 @@ class QueueStack:
         if res < 0:
             raise KeyError("Could not peek table")
         return leaf
+    
+    def itervalues(self):
+        # to avoid infinite loop, set maximum pops to max_entries
+        cnt = self.max_entries
+        while cnt:
+            try:
+                yield(self.pop())
+                cnt -= 1
+            except KeyError:
+                return
+
+    def values(self):
+        return [value for value in self.itervalues()]

--- a/tests/python/test_map_batch_ops.py
+++ b/tests/python/test_map_batch_ops.py
@@ -81,9 +81,9 @@ class TestMapBatch(TestCase):
         hmap = self.fill_hashmap()
         # Get 4 keys in this map.
         subset_size = 32
-        keys = [None] * subset_size
+        keys = (hmap.Key * subset_size)()
         i = 0
-        for k, v in hmap.items_lookup_batch():
+        for k, _ in hmap.items_lookup_batch():
             if i < subset_size:
                 keys[i] = k
                 i += 1

--- a/tests/python/test_queuestack.py
+++ b/tests/python/test_queuestack.py
@@ -2,13 +2,12 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 
-from bcc import BPF
 import os
 import distutils.version
 import ctypes as ct
-import random
-import time
-import subprocess
+
+from bcc import BPF
+
 from unittest import main, TestCase, skipUnless
 
 def kernel_version_ge(major, minor):
@@ -22,8 +21,9 @@ def kernel_version_ge(major, minor):
         return False
     return True
 
+@skipUnless(kernel_version_ge(4,20), "requires kernel >= 4.20")
 class TestQueueStack(TestCase):
-    @skipUnless(kernel_version_ge(4,20), "requires kernel >= 4.20")
+    
     def test_stack(self):
         text = """
         BPF_STACK(stack, u64, 10);
@@ -48,9 +48,15 @@ class TestQueueStack(TestCase):
         with self.assertRaises(KeyError):
             stack.pop()
 
+        for i in reversed(range(10)):
+            stack.push(ct.c_uint64(i))
+
+        # testing itervalues()
+        for i,v in enumerate(stack.values()):
+            assert v.value == i
+
         b.cleanup()
 
-    @skipUnless(kernel_version_ge(4,20), "requires kernel >= 4.20")
     def test_queue(self):
         text = """
         BPF_QUEUE(queue, u64, 10);
@@ -75,7 +81,15 @@ class TestQueueStack(TestCase):
         with self.assertRaises(KeyError):
             queue.pop()
 
+        for i in range(10):
+            queue.push(ct.c_uint64(i))
+
+        # testing itervalues()
+        for i,v in enumerate(queue.values()):
+            assert v.value == i
+
         b.cleanup()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pr aims at introducing:
* items_update_batch: batch operation to update multiple key-value pairs at the same time
* Queue/Stack itervalues: to lookup all values consequently

Signed-off-by: Simone Magnani <simonemagnani.96@gmail.com>