### PR TITLE
tools/funclatency: Should clear() after display that is what we want

### DIFF
--- a/tools/funclatency.py
+++ b/tools/funclatency.py
@@ -396,7 +396,6 @@ while (1):
             bucket_fn=lambda k: (k.ip, k.pid))
     else:
         dist.print_log2_hist(label)
-    dist.clear()
 
     total  = b['avg'][0].value
     counts = b['avg'][1].value
@@ -407,6 +406,9 @@ while (1):
             total /= 1000
         avg = total/counts
         print("\navg = %ld %s, total: %ld %s, count: %ld\n" %(total/counts, label, total, label, counts))
+
+    dist.clear()
+    b['avg'].clear()
 
     if exiting:
         print("Detaching...")


### PR DESCRIPTION
BUG:
funclatency memcpy -i 2
     nsecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 0        |                                        |
       512 -> 1023       : 0        |                                        |
      1024 -> 2047       : 0        |                                        |
      2048 -> 4095       : 28       |************                            |
      4096 -> 8191       : 92       |****************************************|

avg = 4265 nsecs, total: 9413985 nsecs, count: 2207

     nsecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 0        |                                        |
       512 -> 1023       : 0        |                                        |
      1024 -> 2047       : 0        |                                        |
      2048 -> 4095       : 38       |******                                  |
      4096 -> 8191       : 248      |****************************************|

avg = 4304 nsecs, total: 11066321 nsecs, count: 2571

After long-run, you can see the count above is totally wrong.

Also, display together before together clearing is important for better accuracy.

Signed-off-by: Edward Wu <edwardwu@realtek.com>