### PR TITLE
Fix BPF(src_file="foo")

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -252,7 +252,7 @@ class BPF(object):
         if filename:
             if not os.path.isfile(filename):
                 argv0 = ArgString(sys.argv[0])
-                t = b"/".join([os.path.abspath(os.path.dirname(argv0.__str__())), filename])
+                t = b"/".join([os.path.abspath(os.path.dirname(argv0.__bytes__())), filename])
                 if os.path.isfile(t):
                     filename = t
                 else:


### PR DESCRIPTION
Since commit 75f20a15 ("Use string type for comparison to PATH
elements"), src_file isn't working anymore. Somehow, two wrongs
(ArgString __str__() returning a bytes object and joining a bytes and
what was supposed to be a string) did make a right.

It fixes the following error in netqtop and deadlock:
Traceback (most recent call last):
  File "/usr/share/bcc/tools/netqtop", line 207, in <module>
    b = BPF(src_file = EBPF_FILE)
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 335, in __init__
    src_file = BPF._find_file(src_file)
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 255, in _find_file
    t = b"/".join([os.path.abspath(os.path.dirname(argv0.__str__())), filename])
TypeError: sequence item 0: expected a bytes-like object, str found