### PR TITLE
Disable -Wmacro-redefined to prevent compilation warnings when running tools

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -134,6 +134,7 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
 
   cflags->push_back("-Wno-unused-value");
   cflags->push_back("-Wno-pointer-sign");
+  cflags->push_back("-Wno-macro-redefined");
   cflags->push_back("-fno-stack-protector");
 
   return 0;


### PR DESCRIPTION
Clang warns of macro redefinitions by default. Usually this is
a Good Thing, but running the tools results in noisy macro warnings
depending on kernel version. This is a bit useless since the last
definition still always wins. Disabling the warning changes nothing.

Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>