### PR TITLE
Revert "add macros offsetof and container_of"

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -40,18 +40,6 @@ R"********(
 #endif
 #define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
 
-/* common kernel macros to manipulate data structures. */
-#ifndef offsetof
-#define offsetof(TYPE, MEMBER)  ((unsigned long)&((TYPE *)0)->MEMBER)
-#endif
-#ifndef container_of
-#define container_of(ptr, type, member)                         \
-        ({                                                      \
-                void *__mptr = (void *)(ptr);                   \
-                ((type *)(__mptr - offsetof(type, member)));    \
-        })
-#endif
-
 /* In 4.18 and later, when CONFIG_FUNCTION_TRACER is defined, kernel Makefile adds
  * -DCC_USING_FENTRY. Let do the same for bpf programs.
  */


### PR DESCRIPTION
This reverts commit cda7acdbddb19a5a258f881711845e41463dabbf.

This will tigger ugly compilation macro redefined warnings:
```
  $ sudo ./biolatency.py
  In file included from /virtual/main.c:3:
  In file included from include/linux/blkdev.h:5:
  In file included from include/linux/sched.h:12:
  In file included from arch/x86/include/asm/current.h:6:
  In file included from arch/x86/include/asm/percpu.h:45:
  include/linux/kernel.h:992:9: warning: 'container_of' macro redefined [-Wmacro-redefined]
  #define container_of(ptr, type, member) ({                              \
          ^
  /virtual/include/bcc/helpers.h:48:9: note: previous definition is here
  #define container_of(ptr, type, member)                         \
          ^
  1 warning generated.
  Tracing block device I/O... Hit Ctrl-C to end.
```
Revert now and let us design how to support it better. For example, may
create a different header file to put common kernel macros there to be
used by the program.

Signed-off-by: Yonghong Song <yhs@fb.com>