### PR TITLE
loader: include bpf_workaround.h header

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -314,6 +314,8 @@ int ClangLoader::do_compile(unique_ptr<llvm::Module> *mod, TableStorage &ts,
     flags_cstr.push_back("-include");
     flags_cstr.push_back("/virtual/include/bcc/bpf.h");
   }
+  flags_cstr.push_back("-include");
+  flags_cstr.push_back("/virtual/include/bcc/bpf_workaround.h");
   flags_cstr.insert(flags_cstr.end(), flags_cstr_rem.begin(),
                     flags_cstr_rem.end());
 


### PR DESCRIPTION
The intent of #3391 was to have `bpf_workaround.h` included after
`bpf.h` when compiling bcc headers. However, that PR only added the file
to the `headers_` map of files that can be included. To actually
include, need to adjust compiler input flags as well.

Fixes: d089013e ("Move HAVE_BUILTIN_BSWAP includes to separate header")