### PR TITLE
fix llvm compilation errors

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -128,11 +128,16 @@ void SourceDebugger::dump() {
     return;
   }
 
-  MCObjectFileInfo MOFI;
-  MCContext Ctx(MAI.get(), MRI.get(), &MOFI, nullptr);
-  MOFI.InitMCObjectFileInfo(TheTriple, false, Ctx, false);
   std::unique_ptr<MCSubtargetInfo> STI(
       T->createMCSubtargetInfo(TripleStr, "", ""));
+  MCObjectFileInfo MOFI;
+#if LLVM_MAJOR_VERSION >= 13
+  MCContext Ctx(TheTriple, MAI.get(), MRI.get(), &MOFI, STI.get(), nullptr);
+  MOFI.initMCObjectFileInfo(Ctx, false, false);
+#else
+  MCContext Ctx(MAI.get(), MRI.get(), &MOFI, nullptr);
+  MOFI.InitMCObjectFileInfo(TheTriple, false, Ctx, false);
+#endif
 
   std::unique_ptr<MCInstrInfo> MCII(T->createMCInstrInfo());
   MCInstPrinter *IP = T->createMCInstPrinter(TheTriple, 0, *MAI, *MCII, *MRI);


### PR DESCRIPTION
MCContext and InitMCObjectFileInfo name/signatures
are changed due to upstream patch
  https://reviews.llvm.org/D101462
Adjust related codes in bcc_debug.cc properly to resolve
the compilation error for llvm13.

Signed-off-by: Yonghong Song <yhs@fb.com>