### PR TITLE
Export static libraries

### DIFF
--- a/src/cc/api/CMakeLists.txt
+++ b/src/cc/api/CMakeLists.txt
@@ -1,3 +1,4 @@
 set(bcc_api_sources BPF.cc BPFTable.cc)
 add_library(api-static STATIC ${bcc_api_sources})
 install(FILES BPF.h BPFTable.h COMPONENT libbcc DESTINATION include/bcc)
+install(TARGETS api-static LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/cc/frontends/b/CMakeLists.txt
+++ b/src/cc/frontends/b/CMakeLists.txt
@@ -13,3 +13,4 @@ endif()
 
 add_library(b_frontend STATIC loader.cc codegen_llvm.cc node.cc parser.cc printer.cc
   type_check.cc ${BISON_Parser_OUTPUTS} ${FLEX_Lexer_OUTPUTS})
+install(TARGETS b_frontend LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/cc/frontends/clang/CMakeLists.txt
+++ b/src/cc/frontends/clang/CMakeLists.txt
@@ -10,3 +10,4 @@ if(DEFINED BCC_BACKUP_COMPILE)
 endif()
 
 add_library(clang_frontend STATIC loader.cc b_frontend_action.cc tp_frontend_action.cc kbuild_helper.cc ../../common.cc)
+install(TARGETS clang_frontend LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/cc/usdt/CMakeLists.txt
+++ b/src/cc/usdt/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(usdt-static STATIC usdt_args.cc usdt.cc)
+install(TARGETS usdt-static LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Similar use-case to https://github.com/iovisor/bcc/issues/1938.

Without these libraries exported we are missing symbols in our build:

```
undefined reference to `ebpf::ClangLoader::ClangLoader(llvm::LLVMContext*, unsigned int)'
undefined reference to `clang::Preprocessor::getLastMacroWithSpelling(clang::SourceLocation, llvm::ArrayRef<clang::TokenValue>) const'
collect2: error: ld returned 1 exit status
```