### PR TITLE
Fix RPM build error

### DIFF
--- a/SPECS/bcc+clang.spec
+++ b/SPECS/bcc+clang.spec
@@ -1,5 +1,6 @@
 %define debug_package %{nil}
-%define llvmver 3.7.1
+%define _unpackaged_files_terminate_build 0
+%define llvmver 7.0.1
 
 Name:           bcc
 Version:        @REVISION@

--- a/SPECS/bcc.spec
+++ b/SPECS/bcc.spec
@@ -31,6 +31,8 @@
 %endif
 
 %define debug_package %{nil}
+%define _unpackaged_files_terminate_build 0
+
 
 Name:           bcc
 Version:        @REVISION@

--- a/scripts/build-release-rpm.sh
+++ b/scripts/build-release-rpm.sh
@@ -12,7 +12,7 @@ trap cleanup EXIT
 
 mkdir $TMP/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
-llvmver=3.7.1
+llvmver=7.0.1
 
 # populate submodules
 git submodule update --init --recursive


### PR DESCRIPTION
Hi, I've tried to build bcc-0.19 rpm package on CentOS 7, but it's not working fine.

It looks seems the LLVM version is older in rpm build spec and I've tried changing the LLVM version to 7.0.1.

It's worked for the following environments.

* `Linux 0e0614f3 5.4.56-200.el7.x86_64 #1 SMP Sat Aug 8 21:08:01 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux`
* `CentOS Linux release 7.8.2003 (Core)`
