### PR TITLE
GCC 7: Coverity 'Uninitialized scalar field'

### DIFF
--- a/src/cc/bcc_exception.h
+++ b/src/cc/bcc_exception.h
@@ -78,7 +78,7 @@ private:
   int ret_;
 
   bool use_enum_code_ = false;
-  Code code_;
+  Code code_ = Code::UNKNOWN;
 
   std::string msg_;
 };


### PR DESCRIPTION
Probably not a real issue but it doesn't hurt to initialize this field to suppress warnings.

```
1. member_decl: Class member declaration for code_.
Code code_;

2. Uninitialized scalar field (UNINIT_CTOR). uninit_member: Non-static class member code_ is not initialized in this constructor nor in any functions that it calls.
StatusTuple(int ret) : ret_(ret) {}
```