### PR TITLE
libbpf-tools: Fix build dependence for parallel builds

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -80,7 +80,7 @@ $(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) $(COMMON_OBJ) | $(OUTPUT)
 
 $(patsubst %,$(OUTPUT)/%.o,$(APPS)): %.o: %.skel.h
 
-$(OUTPUT)/%.o: %.c $(wildcard %.h) | $(OUTPUT)
+$(OUTPUT)/%.o: %.c $(wildcard %.h) $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,CC,$@)
 	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
 


### PR DESCRIPTION
Add LIBBPF_OBJ dependence to `%.o'.

When libbpf-tools built in parallel (with `make -j`) sometimes
`map_helpers.o' is built before `libbpf.a' causing build error:
```
  $ make -j8 -C libbpf-tools BPFTOOL=/usr/sbin/bpftool
  ...
  make: Entering directory '/usr/src/RPM/BUILD/bcc-0.19.0/libbpf-tools'
    CC       map_helpers.o
  In file included from map_helpers.c:7:
  ./map_helpers.h:6:10: fatal error: 'bpf/bpf.h' file not found
	   ^~~~~~~~~~~
  1 error generated.
  ...
  make: Leaving directory '/usr/src/RPM/BUILD/bcc-0.19.0/libbpf-tools'
    INSTALL  bpf.h libbpf.h btf.h xsk.h libbpf_util.h bpf_helpers.h bpf_helper_defs.h bpf_tracing.h bpf_endian.h bpf_core_read.h libbpf_common.h
  ...
    INSTALL  libbpf.a
  error: Bad exit status from /usr/src/tmp/rpm-tmp.63536 (%build)
```
Fixes: #3412
