### PR TITLE
tools: filter using PID intead of TID

### DIFF
--- a/tools/btrfsdist.py
+++ b/tools/btrfsdist.py
@@ -73,11 +73,14 @@ BPF_HISTOGRAM(dist, dist_key_t);
 // time operation
 int trace_entry(struct pt_regs *ctx)
 {
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
     if (FILTER_PID)
         return 0;
     u64 ts = bpf_ktime_get_ns();
-    start.update(&pid, &ts);
+    start.update(&tid, &ts);
     return 0;
 }
 
@@ -86,7 +89,10 @@ int trace_entry(struct pt_regs *ctx)
 // I do by checking file->f_op.
 int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 {
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
     if (FILTER_PID)
         return 0;
 
@@ -96,7 +102,7 @@ int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
         return 0;
 
     u64 ts = bpf_ktime_get_ns();
-    start.update(&pid, &ts);
+    start.update(&tid, &ts);
     return 0;
 }
 
@@ -105,8 +111,10 @@ int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
     struct file *file)
 {
-    u32 pid;
-    pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
     if (FILTER_PID)
         return 0;
 
@@ -115,17 +123,19 @@ int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
         return 0;
 
     u64 ts = bpf_ktime_get_ns();
-    start.update(&pid, &ts);
+    start.update(&tid, &ts);
     return 0;
 }
 
 static int trace_return(struct pt_regs *ctx, const char *op)
 {
     u64 *tsp;
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
 
     // fetch timestamp and calculate delta
-    tsp = start.lookup(&pid);
+    tsp = start.lookup(&tid);
     if (tsp == 0) {
         return 0;   // missed start or filtered
     }
@@ -136,7 +146,7 @@ static int trace_return(struct pt_regs *ctx, const char *op)
     __builtin_memcpy(&key.op, op, sizeof(key.op));
     dist.increment(key);
 
-    start.delete(&pid);
+    start.delete(&tid);
     return 0;
 }
 

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -73,11 +73,14 @@ BPF_HISTOGRAM(dist, dist_key_t);
 // time operation
 int trace_entry(struct pt_regs *ctx)
 {
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
     if (FILTER_PID)
         return 0;
     u64 ts = bpf_ktime_get_ns();
-    start.update(&pid, &ts);
+    start.update(&tid, &ts);
     return 0;
 }
 
@@ -86,15 +89,17 @@ EXT4_TRACE_READ_CODE
 static int trace_return(struct pt_regs *ctx, const char *op)
 {
     u64 *tsp;
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
 
     // fetch timestamp and calculate delta
-    tsp = start.lookup(&pid);
+    tsp = start.lookup(&tid);
     if (tsp == 0) {
         return 0;   // missed start or filtered
     }
     u64 delta = bpf_ktime_get_ns() - *tsp;
-    start.delete(&pid);
+    start.delete(&tid);
 
     // Skip entries with backwards time: temp workaround for #728
     if ((s64) delta < 0)
@@ -164,7 +169,10 @@ else:
     ext4_trace_read_code = """
 int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 {
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
     if (FILTER_PID)
         return 0;
 
@@ -174,7 +182,7 @@ int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
         return 0;
 
     u64 ts = bpf_ktime_get_ns();
-    start.update(&pid, &ts);
+    start.update(&tid, &ts);
     return 0;
 }""" % ext4_file_ops_addr
 

--- a/tools/nfsdist.py
+++ b/tools/nfsdist.py
@@ -68,21 +68,26 @@ BPF_HISTOGRAM(dist, dist_key_t);
 // time operation
 int trace_entry(struct pt_regs *ctx)
 {
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
     if (FILTER_PID)
         return 0;
     u64 ts = bpf_ktime_get_ns();
-    start.update(&pid, &ts);
+    start.update(&tid, &ts);
     return 0;
 }
 
 static int trace_return(struct pt_regs *ctx, const char *op)
 {
     u64 *tsp;
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
 
     // fetch timestamp and calculate delta
-    tsp = start.lookup(&pid);
+    tsp = start.lookup(&tid);
     if (tsp == 0) {
         return 0;   // missed start or filtered
     }
@@ -93,7 +98,7 @@ static int trace_return(struct pt_regs *ctx, const char *op)
     __builtin_memcpy(&key.op, op, sizeof(key.op));
     dist.increment(key);
 
-    start.delete(&pid);
+    start.delete(&tid);
     return 0;
 }
 

--- a/tools/xfsdist.py
+++ b/tools/xfsdist.py
@@ -70,21 +70,26 @@ BPF_HISTOGRAM(dist, dist_key_t);
 // time operation
 int trace_entry(struct pt_regs *ctx)
 {
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
     if (FILTER_PID)
         return 0;
     u64 ts = bpf_ktime_get_ns();
-    start.update(&pid, &ts);
+    start.update(&tid, &ts);
     return 0;
 }
 
 static int trace_return(struct pt_regs *ctx, const char *op)
 {
     u64 *tsp;
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
 
     // fetch timestamp and calculate delta
-    tsp = start.lookup(&pid);
+    tsp = start.lookup(&tid);
     if (tsp == 0) {
         return 0;   // missed start or filtered
     }
@@ -95,7 +100,7 @@ static int trace_return(struct pt_regs *ctx, const char *op)
     __builtin_memcpy(&key.op, op, sizeof(key.op));
     dist.increment(key);
 
-    start.delete(&pid);
+    start.delete(&tid);
     return 0;
 }
 

--- a/tools/zfsdist.py
+++ b/tools/zfsdist.py
@@ -70,21 +70,26 @@ BPF_HISTOGRAM(dist, dist_key_t);
 // time operation
 int trace_entry(struct pt_regs *ctx)
 {
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
     if (FILTER_PID)
         return 0;
     u64 ts = bpf_ktime_get_ns();
-    start.update(&pid, &ts);
+    start.update(&tid, &ts);
     return 0;
 }
 
 static int trace_return(struct pt_regs *ctx, const char *op)
 {
     u64 *tsp;
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
 
     // fetch timestamp and calculate delta
-    tsp = start.lookup(&pid);
+    tsp = start.lookup(&tid);
     if (tsp == 0) {
         return 0;   // missed start or filtered
     }
@@ -95,7 +100,7 @@ static int trace_return(struct pt_regs *ctx, const char *op)
     __builtin_memcpy(&key.op, op, sizeof(key.op));
     dist.increment(key);
 
-    start.delete(&pid);
+    start.delete(&tid);
     return 0;
 }
 


### PR DESCRIPTION
This PR fixes PID filtering in 

- btrfsdist.py
- ext4dist.py
- nfsdist.py
- xfsdist.py
- zfsdist.py

For background, see #3407 .

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>