### PR TITLE
libbpf-tools: parse -h option

### DIFF
--- a/libbpf-tools/biolatency.c
+++ b/libbpf-tools/biolatency.c
@@ -60,6 +60,7 @@ static const struct argp_option opts[] = {
 	{ "flag", 'F', NULL, 0, "Print a histogram per set of I/O flags" },
 	{ "disk",  'd', "DISK",  0, "Trace this disk only" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -68,6 +69,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/biopattern.c
+++ b/libbpf-tools/biopattern.c
@@ -45,6 +45,7 @@ static const struct argp_option opts[] = {
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
 	{ "disk",  'd', "DISK",  0, "Trace this disk only" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -53,6 +54,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/biosnoop.c
+++ b/libbpf-tools/biosnoop.c
@@ -46,6 +46,7 @@ static const struct argp_option opts[] = {
 	{ "queued", 'Q', NULL, 0, "Include OS queued time in I/O time" },
 	{ "disk",  'd', "DISK",  0, "Trace this disk only" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -54,6 +55,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/biostacks.c
+++ b/libbpf-tools/biostacks.c
@@ -39,6 +39,7 @@ static const struct argp_option opts[] = {
 	{ "disk",  'd', "DISK",  0, "Trace this disk only" },
 	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -47,6 +48,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/bitesize.c
+++ b/libbpf-tools/bitesize.c
@@ -48,6 +48,7 @@ static const struct argp_option opts[] = {
 	{ "comm",  'c', "COMM",  0, "Trace this comm only" },
 	{ "disk",  'd', "DISK",  0, "Trace this disk only" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -56,6 +57,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args, len;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/cachestat.c
+++ b/libbpf-tools/cachestat.c
@@ -41,6 +41,7 @@ const char argp_program_doc[] =
 static const struct argp_option opts[] = {
 	{ "timestamp", 'T', NULL, 0, "Print timestamp" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -49,6 +50,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/cpudist.c
+++ b/libbpf-tools/cpudist.c
@@ -56,6 +56,7 @@ static const struct argp_option opts[] = {
 	{ "tids", 'L', NULL, 0, "Print a histogram per thread ID" },
 	{ "pid", 'p', "PID", 0, "Trace this PID only" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -64,6 +65,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/cpufreq.c
+++ b/libbpf-tools/cpufreq.c
@@ -43,12 +43,16 @@ static const struct argp_option opts[] = {
 	{ "duration", 'd', "DURATION", 0, "Duration to sample in seconds" },
 	{ "frequency", 'f', "FREQUENCY", 0, "Sample with a certain frequency" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
 static error_t parse_arg(int key, char *arg, struct argp_state *state)
 {
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/drsnoop.c
+++ b/libbpf-tools/drsnoop.c
@@ -47,6 +47,7 @@ static const struct argp_option opts[] = {
 	{ "pid", 'p', "PID", 0, "Process PID to trace" },
 	{ "tid", 't', "TID", 0, "Thread TID to trace" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -58,6 +59,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	int pid;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -67,6 +67,7 @@ static const struct argp_option opts[] = {
 	{ "max-args", MAX_ARGS_KEY, "MAX_ARGS", 0,
 		"maximum number of arguments parsed and displayed, defaults to 20"},
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -76,7 +77,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 
 	switch (key) {
 	case 'h':
-		argp_usage(state);
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
 		break;
 	case 'T':
 		env.time = true;

--- a/libbpf-tools/ext4dist.c
+++ b/libbpf-tools/ext4dist.c
@@ -49,6 +49,7 @@ static const struct argp_option opts[] = {
 	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
 	{ "pid", 'p', "PID", 0, "Process PID to trace" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -57,6 +58,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -38,6 +38,7 @@ const char argp_program_doc[] =
 static const struct argp_option opts[] = {
 	{ "pid", 'p', "PID", 0, "Process PID to trace" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -46,6 +47,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	int pid;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/hardirqs.c
+++ b/libbpf-tools/hardirqs.c
@@ -51,6 +51,7 @@ static const struct argp_option opts[] = {
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
 	{ "nanoseconds", 'N', NULL, 0, "Output in nanoseconds" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -59,6 +60,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/llcstat.c
+++ b/libbpf-tools/llcstat.c
@@ -39,6 +39,7 @@ static const struct argp_option opts[] = {
 	{ "sample_period", 'c', "SAMPLE_PERIOD", 0, "Sample one in this many "
 	  "number of cache reference / miss events" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -47,6 +48,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/numamove.c
+++ b/libbpf-tools/numamove.c
@@ -32,12 +32,16 @@ const char argp_program_doc[] =
 
 static const struct argp_option opts[] = {
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
 static error_t parse_arg(int key, char *arg, struct argp_state *state)
 {
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -80,6 +80,7 @@ static const struct argp_option opts[] = {
 	  "the amount of time in microseconds under which we store traces (default U64_MAX)" },
 	{ "state", OPT_STATE, "STATE", 0, "filter on this thread state bitmask (eg, 2 == TASK_UNINTERRUPTIBLE) see include/linux/sched.h" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -88,6 +89,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/readahead.c
+++ b/libbpf-tools/readahead.c
@@ -37,12 +37,16 @@ const char argp_program_doc[] =
 static const struct argp_option opts[] = {
 	{ "duration", 'd', "DURATION", 0, "Duration to trace"},
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
 static error_t parse_arg(int key, char *arg, struct argp_state *state)
 {
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/runqlat.c
+++ b/libbpf-tools/runqlat.c
@@ -58,6 +58,7 @@ static const struct argp_option opts[] = {
 	{ "tids", 'L', NULL, 0, "Print a histogram per thread ID" },
 	{ "pid", 'p', "PID", 0, "Trace this PID only" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -66,6 +67,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/runqlen.c
+++ b/libbpf-tools/runqlen.c
@@ -62,6 +62,7 @@ static const struct argp_option opts[] = {
 	{ "runqocc", 'O', NULL, 0, "Report run queue occupancy" },
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -70,6 +71,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/runqslower.c
+++ b/libbpf-tools/runqslower.c
@@ -41,6 +41,7 @@ static const struct argp_option opts[] = {
 	{ "pid", 'p', "PID", 0, "Process PID to trace"},
 	{ "tid", 't', "TID", 0, "Thread TID to trace"},
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -51,6 +52,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	long long min_us;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/softirqs.c
+++ b/libbpf-tools/softirqs.c
@@ -49,6 +49,7 @@ static const struct argp_option opts[] = {
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
 	{ "nanoseconds", 'N', NULL, 0, "Output in nanoseconds" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -57,6 +58,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/syscount.c
+++ b/libbpf-tools/syscount.c
@@ -56,6 +56,7 @@ static const struct argp_option opts[] = {
 	{ "errno", 'e', "ERRNO", 0, "Trace only syscalls that return this error"
 				 "(numeric or EPERM, etc.)" },
 	{ "list", 'l', NULL, 0, "Print list of recognized syscalls and exit" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -288,6 +289,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	int err;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -111,6 +111,7 @@ static const struct argp_option opts[] = {
 	  "Comma-separated list of destination ports to trace" },
 	{ "cgroupmap", 'C', "PATH", 0, "trace cgroups in this map" },
 	{ "mntnsmap", 'M', "PATH", 0, "trace mount namespaces in this map" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -133,6 +134,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	int nports;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/tcpconnlat.c
+++ b/libbpf-tools/tcpconnlat.c
@@ -43,6 +43,7 @@ static const struct argp_option opts[] = {
 	{ "timestamp", 't', NULL, 0, "Include timestamp on output" },
 	{ "pid", 'p', "PID", 0, "Trace this PID only" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -51,6 +52,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	static int pos_args;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/vfsstat.c
+++ b/libbpf-tools/vfsstat.c
@@ -23,6 +23,7 @@ static char args_doc[] = "[interval [count]]";
 
 static const struct argp_option opts[] = {
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -40,6 +41,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	long count;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;

--- a/libbpf-tools/xfsslower.c
+++ b/libbpf-tools/xfsslower.c
@@ -49,6 +49,7 @@ static const struct argp_option opts[] = {
 	{ "pid", 'p', "PID", 0, "Process PID to trace" },
 	{ "min", 'm', "MIN", 0, "Min latency of trace in ms (default 10)" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
 };
 
@@ -59,6 +60,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	int pid;
 
 	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
 	case 'v':
 		env.verbose = true;
 		break;


### PR DESCRIPTION
`ext4dist` did not parse `-h` option, this PR fixes it.

```
$ sudo ./ext4dist -h
./ext4dist: invalid option -- 'h'
Try `ext4dist --help' or `ext4dist --usage' for more information.
```
Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>