### PR TITLE
tools: filter/display using PID intead of TID

### DIFF
--- a/tools/gethostlatency.py
+++ b/tools/gethostlatency.py
@@ -61,14 +61,16 @@ int do_entry(struct pt_regs *ctx) {
         return 0;
 
     struct val_t val = {};
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
 
     if (bpf_get_current_comm(&val.comm, sizeof(val.comm)) == 0) {
         bpf_probe_read_user(&val.host, sizeof(val.host),
                        (void *)PT_REGS_PARM1(ctx));
-        val.pid = bpf_get_current_pid_tgid();
+        val.pid = pid;
         val.ts = bpf_ktime_get_ns();
-        start.update(&pid, &val);
+        start.update(&tid, &val);
     }
 
     return 0;
@@ -78,11 +80,12 @@ int do_return(struct pt_regs *ctx) {
     struct val_t *valp;
     struct data_t data = {};
     u64 delta;
-    u32 pid = bpf_get_current_pid_tgid();
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 tid = (u32)pid_tgid;
 
     u64 tsp = bpf_ktime_get_ns();
 
-    valp = start.lookup(&pid);
+    valp = start.lookup(&tid);
     if (valp == 0)
         return 0;       // missed start
 
@@ -91,7 +94,7 @@ int do_return(struct pt_regs *ctx) {
     data.pid = valp->pid;
     data.delta = tsp - valp->ts;
     events.perf_submit(ctx, &data, sizeof(data));
-    start.delete(&pid);
+    start.delete(&tid);
     return 0;
 }
 """
@@ -113,11 +116,11 @@ b.attach_uretprobe(name="c", sym="gethostbyname2", fn_name="do_return",
                    pid=args.pid)
 
 # header
-print("%-9s %-6s %-16s %10s %s" % ("TIME", "PID", "COMM", "LATms", "HOST"))
+print("%-9s %-7s %-16s %10s %s" % ("TIME", "PID", "COMM", "LATms", "HOST"))
 
 def print_event(cpu, data, size):
     event = b["events"].event(data)
-    print("%-9s %-6d %-16s %10.2f %s" % (strftime("%H:%M:%S"), event.pid,
+    print("%-9s %-7d %-16s %10.2f %s" % (strftime("%H:%M:%S"), event.pid,
         event.comm.decode('utf-8', 'replace'), (float(event.delta) / 1000000),
         event.host.decode('utf-8', 'replace')))
 

--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -97,7 +97,7 @@ int trace_tcp_drop(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
 {
     if (sk == NULL)
         return 0;
-    u32 pid = bpf_get_current_pid_tgid();
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
 
     // pull in details from the packet headers and the sock struct
     u16 family = sk->__sk_common.skc_family;
@@ -155,7 +155,7 @@ if debug or args.ebpf:
 # process event
 def print_ipv4_event(cpu, data, size):
     event = b["ipv4_events"].event(data)
-    print("%-8s %-6d %-2d %-20s > %-20s %s (%s)" % (
+    print("%-8s %-7d %-2d %-20s > %-20s %s (%s)" % (
         strftime("%H:%M:%S"), event.pid, event.ip,
         "%s:%d" % (inet_ntop(AF_INET, pack('I', event.saddr)), event.sport),
         "%s:%s" % (inet_ntop(AF_INET, pack('I', event.daddr)), event.dport),
@@ -167,7 +167,7 @@ def print_ipv4_event(cpu, data, size):
 
 def print_ipv6_event(cpu, data, size):
     event = b["ipv6_events"].event(data)
-    print("%-8s %-6d %-2d %-20s > %-20s %s (%s)" % (
+    print("%-8s %-7d %-2d %-20s > %-20s %s (%s)" % (
         strftime("%H:%M:%S"), event.pid, event.ip,
         "%s:%d" % (inet_ntop(AF_INET6, event.saddr), event.sport),
         "%s:%d" % (inet_ntop(AF_INET6, event.daddr), event.dport),
@@ -188,7 +188,7 @@ else:
 stack_traces = b.get_table("stack_traces")
 
 # header
-print("%-8s %-6s %-2s %-20s > %-20s %s (%s)" % ("TIME", "PID", "IP",
+print("%-8s %-7s %-2s %-20s > %-20s %s (%s)" % ("TIME", "PID", "IP",
     "SADDR:SPORT", "DADDR:DPORT", "STATE", "FLAGS"))
 
 # read events


### PR DESCRIPTION
This PR fixes PID filtering in

* gethostlatency.py
* solisten.py
* sslsniff.py
* tcpdrop.py

For background, see #3407 .

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>