### PR TITLE
Libbpf-tools/add check BPF_F_MMAPABLE is supported

### DIFF
--- a/libbpf-tools/cachestat.c
+++ b/libbpf-tools/cachestat.c
@@ -150,6 +150,11 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if (!obj->bss) {
+		fprintf(stderr, "Memory-mapping BPF maps is supported starting from Linux 5.7, please upgrade.\n");
+		goto cleanup;
+	}
+
 	err = cachestat_bpf__attach(obj);
 	if (err) {
 		fprintf(stderr, "failed to attach BPF programs\n");

--- a/libbpf-tools/cpufreq.c
+++ b/libbpf-tools/cpufreq.c
@@ -216,6 +216,11 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if (!obj->bss) {
+		fprintf(stderr, "Memory-mapping BPF maps is supported starting from Linux 5.7, please upgrade.\n");
+		goto cleanup;
+	}
+
 	err = init_freqs_hmz(obj->bss->freqs_mhz, nr_cpus);
 	if (err) {
 		fprintf(stderr, "failed to init freqs\n");

--- a/libbpf-tools/ext4dist.c
+++ b/libbpf-tools/ext4dist.c
@@ -218,6 +218,11 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
+	if (!skel->bss) {
+		fprintf(stderr, "Memory-mapping BPF maps is supported starting from Linux 5.7, please upgrade.\n");
+		goto cleanup;
+	}
+
 	err = ext4dist_bpf__attach(skel);
 	if (err) {
 		fprintf(stderr, "failed to attach BPF programs\n");

--- a/libbpf-tools/funclatency.c
+++ b/libbpf-tools/funclatency.c
@@ -307,6 +307,11 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if (!obj->bss) {
+		warn("Memory-mapping BPF maps is supported starting from Linux 5.7, please upgrade.\n");
+		goto cleanup;
+	}
+
 	err = attach_probes(obj);
 	if (err)
 		goto cleanup;

--- a/libbpf-tools/numamove.c
+++ b/libbpf-tools/numamove.c
@@ -90,6 +90,11 @@ int main(int argc, char **argv)
 		fprintf(stderr, "failed to open and/or load BPF object\n");
 		return 1;
 	}
+	
+	if (!obj->bss) {
+		fprintf(stderr, "Memory-mapping BPF maps is supported starting from Linux 5.7, please upgrade.\n");
+		goto cleanup;
+	}
 
 	err = numamove_bpf__attach(obj);
 	if (err) {

--- a/libbpf-tools/readahead.c
+++ b/libbpf-tools/readahead.c
@@ -137,6 +137,11 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
+	if (!obj->bss) {
+		fprintf(stderr, "Memory-mapping BPF maps is supported starting from Linux 5.7, please upgrade.\n");
+		goto cleanup;
+	}
+
 	err = readahead_bpf__attach(obj);
 	if (err) {
 		fprintf(stderr, "failed to attach BPF programs\n");

--- a/libbpf-tools/runqlen.c
+++ b/libbpf-tools/runqlen.c
@@ -263,6 +263,11 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
+	if (!obj->bss) {
+		fprintf(stderr, "Memory-mapping BPF maps is supported starting from Linux 5.7, please upgrade.\n");
+		goto cleanup;
+	}
+
 	err = open_and_attach_perf_event(env.freq, obj->progs.do_sample, links);
 	if (err)
 		goto cleanup;

--- a/libbpf-tools/softirqs.c
+++ b/libbpf-tools/softirqs.c
@@ -216,6 +216,11 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
+	if (!obj->bss) {
+		fprintf(stderr, "Memory-mapping BPF maps is supported starting from Linux 5.7, please upgrade.\n");
+		goto cleanup;
+	}
+
 	err = softirqs_bpf__attach(obj);
 	if (err) {
 		fprintf(stderr, "failed to attach BPF programs\n");

--- a/libbpf-tools/vfsstat.c
+++ b/libbpf-tools/vfsstat.c
@@ -183,6 +183,11 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
+	if (!skel->bss) {
+		fprintf(stderr, "Memory-mapping BPF maps is supported starting from Linux 5.7, please upgrade.\n");
+		goto cleanup;
+	}
+
 	err = vfsstat_bpf__attach(skel);
 	if (err) {
 		fprintf(stderr, "failed to attach BPF programs: %s\n",


### PR DESCRIPTION
reslove https://github.com/iovisor/bcc/issues/3406

Have `skel->rodata or skel->bss or skel->data` , and used after loading.

* cachestat
* cpufreq
* ext4dist
* funclatency
* numamove
* readahead
* runqlen
* softirqs
* vfsstat

Have `skel->rodata or skel->bss or skel->data` , but not used after loading. Or don't have `skel->rodata and skel->bss and skel->data`

* biolatency
* biopattern
* biosnoop
* bitesize
* cpudist
* drsnoop
* execsnoop
* filelife
* gethostlatency
* hardirqs
* llcstat
* offcputime
* opensnoop
* runqlat
* runqslower
* syscount
* tcpconnect
* tcpconnlat
* xfsslower