### PR TITLE
finish to add support of subset in items_*_batch()

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1962,16 +1962,10 @@ Examples in situ:
 
 ### 6. items_lookup_and_delete_batch()
 
-Syntax: ```table.items_lookup_and_delete_batch(keys)```
+Syntax: ```table.items_lookup_and_delete_batch()```
 
 Returns an array of the keys in a table with a single call to BPF syscall. This can be used with BPF_HASH maps to fetch, and iterate, over the keys. It also clears the table: deletes all entries.
-You should rather use table.items_lookup_and_delete_batch() than table.items() followed by table.clear(). You can lookup and delete a subset of a map by giving an array of keys as parameter. Those keys and their associated values will be returned.
-It requires kernel v5.6.
-
-Arguments:
-
-- keys is optional and by default is None.
-
+You should rather use table.items_lookup_and_delete_batch() than table.items() followed by table.clear(). It requires kernel v5.6.
 
 Example:
 
@@ -1986,15 +1980,10 @@ while True:
 
 ### 7. items_lookup_batch()
 
-Syntax: ```table.items_lookup_batch(keys)```
+Syntax: ```table.items_lookup_batch()```
 
 Returns an array of the keys in a table with a single call to BPF syscall. This can be used with BPF_HASH maps to fetch, and iterate, over the keys.
-You should rather use table.items_lookup_batch() than table.items(). You can look up a subset of a map by giving an array of keys as parameter. Those keys and their associated values will be returned.
-It requires kernel v5.6.
-
-Arguments:
-
-- keys is optional and by default is None.
+You should rather use table.items_lookup_batch() than table.items(). It requires kernel v5.6.
 
 Example:
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1962,10 +1962,16 @@ Examples in situ:
 
 ### 6. items_lookup_and_delete_batch()
 
-Syntax: ```table.items_lookup_and_delete_batch()```
+Syntax: ```table.items_lookup_and_delete_batch(keys)```
 
 Returns an array of the keys in a table with a single call to BPF syscall. This can be used with BPF_HASH maps to fetch, and iterate, over the keys. It also clears the table: deletes all entries.
-You should rather use table.items_lookup_and_delete_batch() than table.items() followed by table.clear(). It requires kernel v5.6.
+You should rather use table.items_lookup_and_delete_batch() than table.items() followed by table.clear(). You can lookup and delete a subset of a map by giving an array of keys as parameter. Those keys and their associated values will be returned.
+It requires kernel v5.6.
+
+Arguments:
+
+- keys is optional and by default is None.
+
 
 Example:
 
@@ -1980,10 +1986,15 @@ while True:
 
 ### 7. items_lookup_batch()
 
-Syntax: ```table.items_lookup_batch()```
+Syntax: ```table.items_lookup_batch(keys)```
 
 Returns an array of the keys in a table with a single call to BPF syscall. This can be used with BPF_HASH maps to fetch, and iterate, over the keys.
-You should rather use table.items_lookup_batch() than table.items(). It requires kernel v5.6.
+You should rather use table.items_lookup_batch() than table.items(). You can look up a subset of a map by giving an array of keys as parameter. Those keys and their associated values will be returned.
+It requires kernel v5.6.
+
+Arguments:
+
+- keys is optional and by default is None.
 
 Example:
 
@@ -1999,19 +2010,19 @@ while True:
 
 Syntax: ```table.items_delete_batch(keys)```
 
+It clears all entries of a BPF_HASH map when keys is None. It is more efficient than table.clear() since it generates only one system call. You can delete a subset of a map by giving an array of keys as parameter. Those keys and their associated values will be deleted. It requires kernel v5.6.
+
 Arguments:
 
 - keys is optional and by default is None.
-In that case, it clears all entries of a BPF_HASH map when keys is None. It is more efficient than table.clear() since it generates only one system call.
-If a list of keys is given then only those keys and their associated values will be deleted.
-It requires kernel v5.6.
+
 
 
 ### 9. items_update_batch()
 
 Syntax: ```table.items_update_batch(keys, values)```
 
-Update all the provided keys with new values. The two arguments must be the same length and within the map limits (between 1 and the maximum entries).
+Update all the provided keys with new values. The two arguments must be the same length and within the map limits (between 1 and the maximum entries). It requires kernel v5.6.
 
 Arguments:
 

--- a/tests/python/test_map_batch_ops.py
+++ b/tests/python/test_map_batch_ops.py
@@ -67,8 +67,9 @@ class TestMapBatch(TestCase):
 
     def check_hashmap_values(self, it):
         i = 0
-        for k, v in it:
-            self.assertEqual(k, v)
+        for k, v in sorted(it):
+            self.assertEqual(k, i)
+            self.assertEqual(v, i)
             i += 1
         return i
 
@@ -84,19 +85,6 @@ class TestMapBatch(TestCase):
         count = sum(1 for _ in hmap.items())
         self.assertEqual(count, 0)
 
-    def test_lookup_and_delete_batch_subset(self):
-        # Delete only a subset of key/value in the map
-        # fill the hashmap
-        hmap = self.fill_hashmap()
-        keys = self.prepare_keys_subset(hmap)
-        # check values and count them
-        count = sum(1 for _ in hmap.items_lookup_and_delete_batch(keys))
-        self.assertEqual(count, self.SUBSET_SIZE)
-
-        # and check the delete has worked.
-        count = sum(1 for _ in hmap.items())
-        self.assertEqual(count, self.MAPSIZE - self.SUBSET_SIZE)
-
     def test_lookup_batch_all_keys(self):
         # fill the hashmap
         hmap = self.fill_hashmap()
@@ -104,15 +92,6 @@ class TestMapBatch(TestCase):
         # check values and count them
         count = self.check_hashmap_values(hmap.items_lookup_batch())
         self.assertEqual(count, self.MAPSIZE)
-
-    def test_lookup_batch_subset(self):
-        # fill the hashmap
-        hmap = self.fill_hashmap()
-        keys = self.prepare_keys_subset(hmap, count=self.SUBSET_SIZE)
-
-        # check values and count them
-        count = self.check_hashmap_values(hmap.items_lookup_batch(keys))
-        self.assertEqual(count, self.SUBSET_SIZE)
 
     def test_delete_batch_all_keys(self):
         # Delete all key/value in the map

--- a/tests/python/test_map_batch_ops.py
+++ b/tests/python/test_map_batch_ops.py
@@ -29,6 +29,7 @@ def kernel_version_ge(major, minor):
 @skipUnless(kernel_version_ge(5, 6), "requires kernel >= 5.6")
 class TestMapBatch(TestCase):
     MAPSIZE = 1024
+    SUBSET_SIZE = 32
 
     def fill_hashmap(self):
         b = BPF(text=b"""BPF_HASH(map, int, int, %d);""" % self.MAPSIZE)
@@ -37,15 +38,41 @@ class TestMapBatch(TestCase):
             hmap[ct.c_int(i)] = ct.c_int(i)
         return hmap
 
+    def prepare_keys_subset(self, hmap, count=None):
+        if not count:
+            count = self.SUBSET_SIZE
+        keys = (hmap.Key * count)()
+        i = 0
+        for k, _ in sorted(hmap.items_lookup_batch()):
+            if i < count:
+                keys[i] = k
+                i += 1
+            else:
+                break
+
+        return keys
+
+    def prepare_values_subset(self, hmap, count=None):
+        if not count:
+            count = self.SUBSET_SIZE
+        values = (hmap.Leaf * count)()
+        i = 0
+        for _, v in sorted(hmap.items_lookup_batch()):
+            if i < count:
+                values[i] = v*v
+                i += 1
+            else:
+                break
+        return values
+
     def check_hashmap_values(self, it):
         i = 0
-        for k, v in sorted(it):
-            self.assertEqual(k, i)
-            self.assertEqual(v, i)
+        for k, v in it:
+            self.assertEqual(k, v)
             i += 1
         return i
 
-    def test_lookup_and_delete_batch(self):
+    def test_lookup_and_delete_batch_all_keys(self):
         # fill the hashmap
         hmap = self.fill_hashmap()
 
@@ -54,10 +81,23 @@ class TestMapBatch(TestCase):
         self.assertEqual(count, self.MAPSIZE)
 
         # and check the delete has worked, i.e map is now empty
-        count = sum(1 for _ in hmap.items_lookup_batch())
+        count = sum(1 for _ in hmap.items())
         self.assertEqual(count, 0)
 
-    def test_lookup_batch(self):
+    def test_lookup_and_delete_batch_subset(self):
+        # Delete only a subset of key/value in the map
+        # fill the hashmap
+        hmap = self.fill_hashmap()
+        keys = self.prepare_keys_subset(hmap)
+        # check values and count them
+        count = sum(1 for _ in hmap.items_lookup_and_delete_batch(keys))
+        self.assertEqual(count, self.SUBSET_SIZE)
+
+        # and check the delete has worked.
+        count = sum(1 for _ in hmap.items())
+        self.assertEqual(count, self.MAPSIZE - self.SUBSET_SIZE)
+
+    def test_lookup_batch_all_keys(self):
         # fill the hashmap
         hmap = self.fill_hashmap()
 
@@ -65,7 +105,16 @@ class TestMapBatch(TestCase):
         count = self.check_hashmap_values(hmap.items_lookup_batch())
         self.assertEqual(count, self.MAPSIZE)
 
-    def test_delete_batch_all_keysp(self):
+    def test_lookup_batch_subset(self):
+        # fill the hashmap
+        hmap = self.fill_hashmap()
+        keys = self.prepare_keys_subset(hmap, count=self.SUBSET_SIZE)
+
+        # check values and count them
+        count = self.check_hashmap_values(hmap.items_lookup_batch(keys))
+        self.assertEqual(count, self.SUBSET_SIZE)
+
+    def test_delete_batch_all_keys(self):
         # Delete all key/value in the map
         # fill the hashmap
         hmap = self.fill_hashmap()
@@ -79,23 +128,14 @@ class TestMapBatch(TestCase):
         # Delete only a subset of key/value in the map
         # fill the hashmap
         hmap = self.fill_hashmap()
-        # Get 4 keys in this map.
-        subset_size = 32
-        keys = (hmap.Key * subset_size)()
-        i = 0
-        for k, _ in hmap.items_lookup_batch():
-            if i < subset_size:
-                keys[i] = k
-                i += 1
-            else:
-                break
+        keys = self.prepare_keys_subset(hmap)
 
         hmap.items_delete_batch(keys)
         # check the delete has worked, i.e map is now empty
         count = sum(1 for _ in hmap.items())
-        self.assertEqual(count, self.MAPSIZE - subset_size)
+        self.assertEqual(count, self.MAPSIZE - self.SUBSET_SIZE)
 
-    def test_update_batch(self):
+    def test_update_batch_all_keys(self):
         hmap = self.fill_hashmap()
 
         # preparing keys and new values arrays
@@ -109,6 +149,27 @@ class TestMapBatch(TestCase):
         # check the update has worked, i.e sum of values is -NUM_KEYS
         count = sum(v.value for v in hmap.values())
         self.assertEqual(count, -1*self.MAPSIZE)
+
+    def test_update_batch_subset(self):
+        # fill the hashmap
+        hmap = self.fill_hashmap()
+        keys = self.prepare_keys_subset(hmap, count=self.SUBSET_SIZE)
+        new_values = self.prepare_values_subset(hmap, count=self.SUBSET_SIZE)
+
+        hmap.items_update_batch(keys, new_values)
+
+        # check all the values in the map
+        # the first self.SUBSET_SIZE keys follow this rule value = keys * keys
+        # the remaning keys follow this rule : value = keys
+        i = 0
+        for k, v in sorted(hmap.items_lookup_batch()):
+            if i < self.SUBSET_SIZE:
+                self.assertEqual(v, k*k)  # values are the square of the keys
+                i += 1
+            else:
+                self.assertEqual(v, k)  # values = keys
+
+        self.assertEqual(i, self.SUBSET_SIZE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hello,
Here is a partial PR in order to :
 - add items_lookup_batch() on subset keys
 - add items_lookup_and_delete_batch() on subset keys
 - add docstring on items_*_batch()
 - update the reference_guide.md
This is a partial PT because I am stuck with items_lookup_batch and items_lookup_and_delete_batch on a subset. Sometimes tests are Ok and sometimes they fails. See the output of tests.
``` 
python git:(add_subset_for_batch_ops) ✗ sudo python3 ./test_map_batch_ops.py
...F....
======================================================================
FAIL: test_lookup_and_delete_batch_subset (__main__.TestMapBatch)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./test_map_batch_ops.py", line 94, in test_lookup_and_delete_batch_subset
    self.assertEqual(count, self.SUBSET_SIZE)
AssertionError: 31 != 32

----------------------------------------------------------------------
Ran 8 tests in 2.635s

FAILED (failures=1)
➜  python git:(add_subset_for_batch_ops) ✗ sudo python3 ./test_map_batch_ops.py
........
----------------------------------------------------------------------
Ran 8 tests in 2.613s

OK
```
Do I need to call the lib.bpf_lookup_and_delete_batch() several times until the sum of the nb of elements returned matches the subset size ? For example, If my subset size is 32 and get only 31 elem on the first call, do I need to call it again for the last element ? :thinking: 

