### PR TITLE
Update tcpconnect to use "__u32 af" instead of "int af"

### DIFF
--- a/libbpf-tools/tcpconnect.h
+++ b/libbpf-tools/tcpconnect.h
@@ -34,7 +34,7 @@ struct event {
 	};
 	char task[TASK_COMM_LEN];
 	__u64 ts_us;
-	int af; // AF_INET or AF_INET6
+	__u32 af; // AF_INET or AF_INET6
 	__u32 pid;
 	__u32 uid;
 	__u16 dport;


### PR DESCRIPTION
Hi! Please consider updating `tcpconnect` to use `__u32 af` instead of `int af` so it's less error prone to decode an address family on Go side, for example https://github.com/marselester/libbpf-tools/blob/master/cmd/tcpconnect/main.go.