### PR TITLE
feature: add `XDP_FLAGS*` in python lib

### DIFF
--- a/examples/networking/xdp/xdp_drop_count.py
+++ b/examples/networking/xdp/xdp_drop_count.py
@@ -33,12 +33,12 @@ maptype = "percpu_array"
 if len(sys.argv) == 3:
     if "-S" in sys.argv:
         # XDP_FLAGS_SKB_MODE
-        flags |= (1 << 1)
+        flags |= BPF.XDP_FLAGS_SKB_MODE
     if "-H" in sys.argv:
         # XDP_FLAGS_HW_MODE
         maptype = "array"
         offload_device = device
-        flags |= (1 << 3)
+        flags |= BPF.XDP_FLAGS_HW_MODE
 
 mode = BPF.XDP
 #mode = BPF.SCHED_CLS

--- a/examples/networking/xdp/xdp_macswap_count.py
+++ b/examples/networking/xdp/xdp_macswap_count.py
@@ -31,7 +31,7 @@ if len(sys.argv) == 2:
 if len(sys.argv) == 3:
     if "-S" in sys.argv:
         # XDP_FLAGS_SKB_MODE
-        flags |= 2 << 0
+        flags |= BPF.XDP_FLAGS_SKB_MODE
 
     if "-S" == sys.argv[1]:
         device = sys.argv[2]

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -177,10 +177,6 @@ class BPF(object):
     XDP_FLAGS_DRV_MODE = (1 << 2)
     XDP_FLAGS_HW_MODE = (1 << 3)
     XDP_FLAGS_REPLACE = (1 << 4)
-    XDP_FLAGS_MODES = (XDP_FLAGS_SKB_MODE | XDP_FLAGS_DRV_MODE | \
-                       XDP_FLAGS_HW_MODE)
-    XDP_FLAGS_MASK = (XDP_FLAGS_UPDATE_IF_NOEXIST | XDP_FLAGS_MODES | \
-                      XDP_FLAGS_REPLACE)
 
     # from bpf_attach_type uapi/linux/bpf.h
     TRACE_FENTRY = 24

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -171,6 +171,17 @@ class BPF(object):
     XDP_TX = 3
     XDP_REDIRECT = 4
 
+    # from xdp_flags uapi/linux/if_link.h
+    XDP_FLAGS_UPDATE_IF_NOEXIST = (1 << 0)
+    XDP_FLAGS_SKB_MODE = (1 << 1)
+    XDP_FLAGS_DRV_MODE = (1 << 2)
+    XDP_FLAGS_HW_MODE = (1 << 3)
+    XDP_FLAGS_REPLACE = (1 << 4)
+    XDP_FLAGS_MODES = (XDP_FLAGS_SKB_MODE | XDP_FLAGS_DRV_MODE | \
+                       XDP_FLAGS_HW_MODE)
+    XDP_FLAGS_MASK = (XDP_FLAGS_UPDATE_IF_NOEXIST | XDP_FLAGS_MODES | \
+                      XDP_FLAGS_REPLACE)
+
     # from bpf_attach_type uapi/linux/bpf.h
     TRACE_FENTRY = 24
     TRACE_FEXIT  = 25


### PR DESCRIPTION
resolve https://github.com/iovisor/bcc/issues/3445

add `XDP_FLAGS*` to `__init__.py`

I will add documentation in the following PR.