### PR TITLE
adjust: bpf_attach_xdp report nicer error

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -1413,7 +1413,7 @@ int bpf_attach_xdp(const char *dev_name, int progfd, uint32_t flags) {
   ret = bpf_set_link_xdp_fd(ifindex, progfd, flags);
   if (ret) {
     libbpf_strerror(ret, err_buf, sizeof(err_buf));
-    fprintf(stderr, "bpf: Attaching prog to %s: %s", dev_name, err_buf);
+    fprintf(stderr, "bpf: Attaching prog to %s: %s\n", dev_name, err_buf);
     return -1;
   }
 


### PR DESCRIPTION
before adjust

```
$./examples/networking/xdp/xdp_drop_count.py lo
bpf: Attaching prog to lo: Operation not supportedTraceback (most recent call last):
  File "./examples/networking/xdp/xdp_drop_count.py", line 139, in <module>
    b.attach_xdp(device, fn, flags)
  File "/usr/lib/python2.7/site-packages/bcc/__init__.py", line 766, in attach_xdp
    % (dev, errstr))
Exception: Failed to attach BPF to device lo: No such file or directory
```

after adjust

```
$./examples/networking/xdp/xdp_drop_count.py lo
bpf: Attaching prog to lo: Operation not supported
Traceback (most recent call last):
  File "./examples/networking/xdp/xdp_drop_count.py", line 139, in <module>
    b.attach_xdp(device, fn, flags)
  File "/usr/lib/python2.7/site-packages/bcc/__init__.py", line 766, in attach_xdp
    % (dev, errstr))
Exception: Failed to attach BPF to device lo: No such file or directory
```