### PR TITLE
Fix a llvm compilation error

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -132,7 +132,8 @@ void SourceDebugger::dump() {
       T->createMCSubtargetInfo(TripleStr, "", ""));
   MCObjectFileInfo MOFI;
 #if LLVM_MAJOR_VERSION >= 13
-  MCContext Ctx(TheTriple, MAI.get(), MRI.get(), &MOFI, STI.get(), nullptr);
+  MCContext Ctx(TheTriple, MAI.get(), MRI.get(), STI.get(), nullptr);
+  Ctx.setObjectFileInfo(&MOFI);
   MOFI.initMCObjectFileInfo(Ctx, false, false);
 #else
   MCContext Ctx(MAI.get(), MRI.get(), &MOFI, nullptr);


### PR DESCRIPTION
Current llvm trunk (https://github.com/llvm/llvm-project)
will cause the following compilation errors:
```
  /home/yhs/work/bcc/src/cc/bcc_debug.cc: In member function ‘void ebpf::SourceDebugger::dump()’:
  /home/yhs/work/bcc/src/cc/bcc_debug.cc:135:75: error: no matching function for call to
     ‘llvm::MCContext::MCContext(llvm::Triple&, std::unique_ptr<llvm::MCAsmInfo>::pointer,
      std::unique_ptr<llvm::MCRegisterInfo>::pointer, llvm::MCObjectFileInfo*,
      std::unique_ptr<llvm::MCSubtargetInfo>::pointer, std::nullptr_t)’
     MCContext Ctx(TheTriple, MAI.get(), MRI.get(), &MOFI, STI.get(), nullptr);
                                                                             ^
     ......
```
This is because upstream patch https://reviews.llvm.org/D101921
refactored MCObjectFileInfo initialization and changed MCContext
constructor signature.

This patch fixed the issue by following the new code patterns
in https://reviews.llvm.org/D101921.