### PR TITLE
tools/deadlock: support specifies maxnum of threads and edge cases

### DIFF
--- a/man/man8/deadlock.8
+++ b/man/man8/deadlock.8
@@ -58,6 +58,14 @@ These symbols cannot be inlined in the binary.
 Comma-separated list of unlock symbols to trace. Default is
 pthread_mutex_unlock. These symbols cannot be inlined in the binary.
 .TP
+\-t THREADS, --threads THREADS
+Specifies the maximum number of threads to trace. default 65536.
+Note. 40 bytes per thread.
+.TP
+\-e EDGES, --edges EDGES
+Specifies the maximum number of edge cases that can be
+recorded. default 65536. Note. 88 bytes per edge case.
+.TP
 pid
 Pid to trace
 .SH EXAMPLES

--- a/tools/deadlock.c
+++ b/tools/deadlock.c
@@ -30,7 +30,7 @@ struct thread_to_held_mutex_leaf_t {
 };
 
 // Map of thread ID -> array of (mutex addresses, stack id)
-BPF_HASH(thread_to_held_mutexes, u32, struct thread_to_held_mutex_leaf_t, 2097152);
+BPF_HASH(thread_to_held_mutexes, u32, struct thread_to_held_mutex_leaf_t, MAX_THREADS);
 
 // Key type for edges. Represents an edge from mutex1 => mutex2.
 struct edges_key_t {
@@ -47,7 +47,7 @@ struct edges_leaf_t {
 };
 
 // Represents all edges currently in the mutex wait graph.
-BPF_HASH(edges, struct edges_key_t, struct edges_leaf_t, 2097152);
+BPF_HASH(edges, struct edges_key_t, struct edges_leaf_t, MAX_EDGES);
 
 // Info about parent thread when a child thread is created.
 struct thread_created_leaf_t {

--- a/tools/deadlock.py
+++ b/tools/deadlock.py
@@ -475,7 +475,8 @@ def main():
             print('%s. Is the process (pid=%d) running?' % (str(e), args.pid))
             sys.exit(1)
 
-    text = open('deadlock.c').read()
+    with open('deadlock.c') as f:
+        text = f.read()
     text = text.replace(b'MAX_THREADS', str(args.threads));
     text = text.replace(b'MAX_EDGES', str(args.edges));
     bpf = BPF(text=text)

--- a/tools/deadlock.py
+++ b/tools/deadlock.py
@@ -457,6 +457,16 @@ def main():
         help='Comma-separated list of unlock symbols to trace. Default is '
         'pthread_mutex_unlock. These symbols cannot be inlined in the binary.',
     )
+    parser.add_argument(
+        '-t', '--threads', type=int, default=65536,
+        help='Specifies the maximum number of threads to trace. default 65536. '
+             'Note. 40 bytes per thread.'
+    )
+    parser.add_argument(
+        '-e', '--edges', type=int, default=65536,
+        help='Specifies the maximum number of edge cases that can be recorded. '
+             'default 65536. Note. 88 bytes per edge case.'
+    )
     args = parser.parse_args()
     if not args.binary:
         try:
@@ -465,7 +475,10 @@ def main():
             print('%s. Is the process (pid=%d) running?' % (str(e), args.pid))
             sys.exit(1)
 
-    bpf = BPF(src_file=b'deadlock.c')
+    text = open('deadlock.c').read()
+    text = text.replace(b'MAX_THREADS', str(args.threads));
+    text = text.replace(b'MAX_EDGES', str(args.edges));
+    bpf = BPF(text=text)
 
     # Trace where threads are created
     bpf.attach_kretprobe(event=bpf.get_syscall_fnname('clone'), fn_name='trace_clone')

--- a/tools/deadlock_example.txt
+++ b/tools/deadlock_example.txt
@@ -340,6 +340,12 @@ optional arguments:
                         Comma-separated list of unlock symbols to trace.
                         Default is pthread_mutex_unlock. These symbols cannot
                         be inlined in the binary.
+  -t THREADS, --threads THREADS
+                        Specifies the maximum number of threads to trace.
+                        default 65536. Note. 40 bytes per thread.
+  -e EDGES, --edges EDGES
+                        Specifies the maximum number of edge cases that can be
+                        recorded. default 65536. Note. 88 bytes per edge case.
 
 Examples:
     deadlock 181                 # Analyze PID 181


### PR DESCRIPTION
https://github.com/iovisor/bcc/issues/3453

support specifies maxnum of threads and edge cases.

The default size of memory that deadlock needs to allocate is too large. Sometimes this will cause OOM for particular system, or the memory limit has been exceeded.

```
[16536.857153] oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),cpuset=/,mems_allowed=0,global_oom,task_memcg=/user.slice/user-0.slice/session-1.scope,task=trace.py,pid=4971,uid=0
[16536.857622] Out of memory: Killed process 4971 (trace.py) total-vm:470116kB, anon-rss:0kB, file-rss:0kB, shmem-rss:0kB, UID:0 pgtables:528kB oom_score_adj:0
```