### PR TITLE
cpudist.py: fix ONCPU calculation

### DIFF
--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -100,19 +100,13 @@ int sched_switch(struct pt_regs *ctx, struct task_struct *prev)
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 tgid = pid_tgid >> 32, pid = pid_tgid;
 
+    u32 prev_pid = prev->pid;
+    u32 prev_tgid = prev->tgid;
 #ifdef ONCPU
-    if (prev->state == TASK_RUNNING) {
+    update_hist(prev_tgid, prev_pid, ts);
 #else
-    if (1) {
+    store_start(prev_tgid, prev_pid, ts);
 #endif
-        u32 prev_pid = prev->pid;
-        u32 prev_tgid = prev->tgid;
-#ifdef ONCPU
-        update_hist(prev_tgid, prev_pid, ts);
-#else
-        store_start(prev_tgid, prev_pid, ts);
-#endif
-    }
 
 BAIL:
 #ifdef ONCPU


### PR DESCRIPTION
When calculating the ONCPU  time, prev has left the CPU already. It is not necessary to judge whether the process state is TASK_RUNNING or not.