### PR TITLE
Avoid attempting to build the cpp examples unless needed

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,14 @@
 set(EXAMPLE_PROGRAMS hello_world.py)
 install(PROGRAMS ${EXAMPLE_PROGRAMS} DESTINATION share/bcc/examples)
 
+option(BUILD_CPP_EXAMPLES "Build C++ examples. The binaries are statically linked and can take resources" OFF)
+
 if(ENABLE_CLANG_JIT)
+if(BUILD_CPP_EXAMPLES)
 if(ENABLE_USDT)
 add_subdirectory(cpp)
 endif(ENABLE_USDT)
+endif(BUILD_CPP_EXAMPLES)
 add_subdirectory(lua)
 add_subdirectory(networking)
 add_subdirectory(tracing)

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -9,8 +9,6 @@ include_directories(${PROJECT_SOURCE_DIR}/src/cc/libbpf/include/uapi)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 
-option(INSTALL_CPP_EXAMPLES "Install C++ examples. Those binaries are statically linked and can take plenty of disk space" OFF)
-
 file(GLOB EXAMPLES *.cc)
 foreach(EXAMPLE ${EXAMPLES})
   get_filename_component(NAME ${EXAMPLE} NAME_WE)
@@ -22,9 +20,7 @@ foreach(EXAMPLE ${EXAMPLES})
     target_link_libraries(${NAME} bcc-shared)
   endif()
 
-  if(INSTALL_CPP_EXAMPLES)
-    install (TARGETS ${NAME} DESTINATION share/bcc/examples/cpp)
-  endif(INSTALL_CPP_EXAMPLES)
+  install (TARGETS ${NAME} DESTINATION share/bcc/examples/cpp)
 endforeach()
 
 add_subdirectory(pyperf)

--- a/examples/cpp/pyperf/CMakeLists.txt
+++ b/examples/cpp/pyperf/CMakeLists.txt
@@ -13,6 +13,6 @@ else()
   target_link_libraries(PyPerf bcc-shared)
 endif()
 
-if(INSTALL_CPP_EXAMPLES)
+if(BUILD_CPP_EXAMPLES)
   install (TARGETS PyPerf DESTINATION share/bcc/examples/cpp)
-endif(INSTALL_CPP_EXAMPLES)
+endif(BUILD_CPP_EXAMPLES)


### PR DESCRIPTION
Though the cpp components take a lot of resources as they're statically
linked, it is much worse when llvm is unstripped and was built with debug
symbols. The build consumes 10s of gigabytes of RAM before being killed if
the resources are not available, for components which are not going to be
installed by default, hence only attempt to build them if actually required.