### PR TITLE
Remove APInt/APSInt toString() std::string variants for llvm >= 13

### DIFF
--- a/src/cc/json_map_decl_visitor.cc
+++ b/src/cc/json_map_decl_visitor.cc
@@ -20,6 +20,7 @@
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/RecordLayout.h>
 #include <clang/AST/RecursiveASTVisitor.h>
+#include <llvm/ADT/StringExtras.h>
 #include "common.h"
 #include "table_desc.h"
 
@@ -79,7 +80,11 @@ void BMapDeclVisitor::genJSONForField(FieldDecl *F) {
   result_ += "[";
   TraverseDecl(F);
   if (const ConstantArrayType *T = dyn_cast<ConstantArrayType>(F->getType()))
+#if LLVM_MAJOR_VERSION >= 13
+    result_ += ", [" + toString(T->getSize(), 10, false) + "]";
+#else
     result_ += ", [" + T->getSize().toString(10, false) + "]";
+#endif
   if (F->isBitField())
     result_ += ", " + to_string(F->getBitWidthValue(C));
   result_ += "], ";


### PR DESCRIPTION
clang 13+ has removed this in favour of a pair of llvm::toString
() helpers inside StringExtras.h to improve compile speed by avoiding
hits on <string> header

Signed-off-by: Khem Raj <raj.khem@gmail.com>