### PR TITLE
pull out enums from main BPF class to avoid namespace collisions

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1858,8 +1858,8 @@ Attaches a BPF function of the specified type to a particular ```attachable_fd``
 For example:
 
 ```Python
-b.attach_func(fn, cgroup_fd, b.CGROUP_SOCK_OPS)
-b.attach_func(fn, map_fd, b.SK_MSG_VERDICT)
+b.attach_func(fn, cgroup_fd, BPFAttachType.CGROUP_SOCK_OPS)
+b.attach_func(fn, map_fd, BPFAttachType.SK_MSG_VERDICT)
 ```
 
 Note. When attached to "global" hooks (xdp, tc, lwt, cgroup). If the "BPF function" is no longer needed after the program terminates, be sure to call `detach_func` when the program exits.
@@ -1877,8 +1877,8 @@ Detaches a BPF function of the specified type.
 For example:
 
 ```Python
-b.detach_func(fn, cgroup_fd, b.CGROUP_SOCK_OPS)
-b.detach_func(fn, map_fd, b.SK_MSG_VERDICT)
+b.detach_func(fn, cgroup_fd, BPFAttachType.CGROUP_SOCK_OPS)
+b.detach_func(fn, map_fd, BPFAttachType.SK_MSG_VERDICT)
 ```
 
 Examples in situ:

--- a/examples/networking/sockmap.py
+++ b/examples/networking/sockmap.py
@@ -10,7 +10,7 @@ import time
 import atexit
 import argparse
 
-from bcc import BPF, lib
+from bcc import BPF, BPFAttachType, lib
 
 
 examples = """examples:
@@ -112,12 +112,12 @@ func_sock_redir = bpf.load_func("bpf_redir", bpf.SK_MSG)
 # raise if error
 fd = os.open(args.cgroup, os.O_RDONLY)
 map_fd = lib.bpf_table_fd(bpf.module, b"sock_hash")
-bpf.attach_func(func_sock_ops, fd, bpf.CGROUP_SOCK_OPS)
-bpf.attach_func(func_sock_redir, map_fd, bpf.SK_MSG_VERDICT)
+bpf.attach_func(func_sock_ops, fd, BPFAttachType.CGROUP_SOCK_OPS)
+bpf.attach_func(func_sock_redir, map_fd, BPFAttachType.SK_MSG_VERDICT)
 
 def detach_all():
-    bpf.detach_func(func_sock_ops, fd, bpf.CGROUP_SOCK_OPS)
-    bpf.detach_func(func_sock_redir, map_fd, bpf.SK_MSG_VERDICT)
+    bpf.detach_func(func_sock_ops, fd, BPFAttachType.CGROUP_SOCK_OPS)
+    bpf.detach_func(func_sock_redir, map_fd, BPFAttachType.SK_MSG_VERDICT)
     print("Detaching...")
 
 atexit.register(detach_all)

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -141,7 +141,7 @@ class PerfSWConfig:
     DUMMY = 9
     BPF_OUTPUT = 10
 
-class BPF(object):
+class BPFProgType:
     # From bpf_prog_type in uapi/linux/bpf.h
     SOCKET_FILTER = 1
     KPROBE = 2
@@ -164,20 +164,7 @@ class BPF(object):
     TRACING = 26
     LSM = 29
 
-    # from xdp_action uapi/linux/bpf.h
-    XDP_ABORTED = 0
-    XDP_DROP = 1
-    XDP_PASS = 2
-    XDP_TX = 3
-    XDP_REDIRECT = 4
-
-    # from xdp_flags uapi/linux/if_link.h
-    XDP_FLAGS_UPDATE_IF_NOEXIST = (1 << 0)
-    XDP_FLAGS_SKB_MODE = (1 << 1)
-    XDP_FLAGS_DRV_MODE = (1 << 2)
-    XDP_FLAGS_HW_MODE = (1 << 3)
-    XDP_FLAGS_REPLACE = (1 << 4)
-
+class BPFAttachType:
     # from bpf_attach_type uapi/linux/bpf.h
     CGROUP_INET_INGRESS = 0
     CGROUP_INET_EGRESS = 1
@@ -218,6 +205,62 @@ class BPF(object):
     SK_LOOKUP = 36
     XDP = 37
     SK_SKB_VERDICT = 38
+
+class XDPAction:
+    # from xdp_action uapi/linux/bpf.h
+    XDP_ABORTED = 0
+    XDP_DROP = 1
+    XDP_PASS = 2
+    XDP_TX = 3
+    XDP_REDIRECT = 4
+
+class XDPFlags:
+    # from xdp_flags uapi/linux/if_link.h
+    # unlike similar enum-type holder classes in this file, source for these
+    # is #define XDP_FLAGS_UPDATE_IF_NOEXIST, #define XDP_FLAGS_SKB_MODE, ...
+    UPDATE_IF_NOEXIST = (1 << 0)
+    SKB_MODE = (1 << 1)
+    DRV_MODE = (1 << 2)
+    HW_MODE = (1 << 3)
+    REPLACE = (1 << 4)
+
+class BPF(object):
+    # Here for backwards compatibility only, add new enum members and types
+    # the appropriate wrapper class elsewhere in this file to avoid namespace
+    # collision issues
+    SOCKET_FILTER = BPFProgType.SOCKET_FILTER
+    KPROBE = BPFProgType.KPROBE
+    SCHED_CLS = BPFProgType.SCHED_CLS
+    SCHED_ACT = BPFProgType.SCHED_ACT
+    TRACEPOINT = BPFProgType.TRACEPOINT
+    XDP = BPFProgType.XDP
+    PERF_EVENT = BPFProgType.PERF_EVENT
+    CGROUP_SKB = BPFProgType.CGROUP_SKB
+    CGROUP_SOCK = BPFProgType.CGROUP_SOCK
+    LWT_IN = BPFProgType.LWT_IN
+    LWT_OUT = BPFProgType.LWT_OUT
+    LWT_XMIT = BPFProgType.LWT_XMIT
+    SOCK_OPS = BPFProgType.SOCK_OPS
+    SK_SKB = BPFProgType.SK_SKB
+    CGROUP_DEVICE = BPFProgType.CGROUP_DEVICE
+    SK_MSG = BPFProgType.SK_MSG
+    RAW_TRACEPOINT = BPFProgType.RAW_TRACEPOINT
+    CGROUP_SOCK_ADDR = BPFProgType.CGROUP_SOCK_ADDR
+    TRACING = BPFProgType.TRACING
+    LSM = BPFProgType.LSM
+
+    XDP_ABORTED = XDPAction.XDP_ABORTED
+    XDP_DROP = XDPAction.XDP_DROP
+    XDP_PASS = XDPAction.XDP_PASS
+    XDP_TX = XDPAction.XDP_TX
+    XDP_REDIRECT = XDPAction.XDP_REDIRECT
+
+    XDP_FLAGS_UPDATE_IF_NOEXIST = XDPFlags.UPDATE_IF_NOEXIST
+    XDP_FLAGS_SKB_MODE = XDPFlags.SKB_MODE
+    XDP_FLAGS_DRV_MODE = XDPFlags.DRV_MODE
+    XDP_FLAGS_HW_MODE = XDPFlags.HW_MODE
+    XDP_FLAGS_REPLACE = XDPFlags.REPLACE
+    # END enum backwards compat
 
     _probe_repl = re.compile(b"[^a-zA-Z0-9_]")
     _sym_caches = {}


### PR DESCRIPTION
In #3479, the `bpf_attach_type` enum was pulled into the `BPF` class so
that its members could be used in `attach_func` and `detach_func`
functions introduced to the Python API.

Unfortunately this caused a redefinition of BPF.XDP, which was similarly
pulled in from `bpf_prog_type` enum, thus breaking program loading
(#3489).

Let's pull these enum- and flag-type class variables out into their own
wrapper classes. For backwards compatibility, keep them all (except for
`bpf_attach_type`, which was merged 2 days ago) defined in the BPF
class, but add a comment to not continue doing this.