### PR TITLE
bcc/python: fix attach kprobe/kretprobe using regex

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -19,7 +19,6 @@ import fcntl
 import json
 import os
 import re
-import struct
 import errno
 import sys
 import platform
@@ -30,6 +29,7 @@ from .perf import Perf
 from .utils import get_online_cpus, printb, _assert_is_bytes, ArgString, StrcmpRewrite
 from .version import __version__
 from .disassembler import disassemble_prog, decode_map
+from .usdt import USDT, USDTException
 
 try:
     basestring
@@ -488,7 +488,7 @@ class BPF(object):
                 lib.bpf_function_size(self.module, func_name),
                 lib.bpf_module_license(self.module),
                 lib.bpf_module_kern_version(self.module),
-                log_level, None, 0, device);
+                log_level, None, 0, device)
 
         if fd < 0:
             atexit.register(self.donothing)
@@ -988,7 +988,7 @@ class BPF(object):
         fd = lib.bpf_attach_raw_tracepoint(fn.fd, tp)
         if fd < 0:
             raise Exception("Failed to attach BPF to raw tracepoint")
-        self.raw_tracepoint_fds[tp] = fd;
+        self.raw_tracepoint_fds[tp] = fd
         return self
 
     def detach_raw_tracepoint(self, tp=b""):
@@ -1016,9 +1016,9 @@ class BPF(object):
     def support_kfunc():
         # there's no trampoline support for other than x86_64 arch
         if platform.machine() != 'x86_64':
-            return False;
+            return False
         if not lib.bpf_has_kernel_btf():
-            return False;
+            return False
         # kernel symbol "bpf_trampoline_link_prog" indicates kfunc support
         if BPF.ksymname("bpf_trampoline_link_prog") != -1:
             return True
@@ -1062,7 +1062,7 @@ class BPF(object):
         fd = lib.bpf_attach_kfunc(fn.fd)
         if fd < 0:
             raise Exception("Failed to attach BPF to entry kernel func")
-        self.kfunc_entry_fds[fn_name] = fd;
+        self.kfunc_entry_fds[fn_name] = fd
         return self
 
     def attach_kretfunc(self, fn_name=b""):
@@ -1076,7 +1076,7 @@ class BPF(object):
         fd = lib.bpf_attach_kfunc(fn.fd)
         if fd < 0:
             raise Exception("Failed to attach BPF to exit kernel func")
-        self.kfunc_exit_fds[fn_name] = fd;
+        self.kfunc_exit_fds[fn_name] = fd
         return self
 
     def detach_lsm(self, fn_name=b""):
@@ -1099,7 +1099,7 @@ class BPF(object):
         fd = lib.bpf_attach_lsm(fn.fd)
         if fd < 0:
             raise Exception("Failed to attach LSM")
-        self.lsm_fds[fn_name] = fd;
+        self.lsm_fds[fn_name] = fd
         return self
 
     @staticmethod
@@ -1486,7 +1486,7 @@ class BPF(object):
           b = bcc_stacktrace_build_id()
           b.status = addr.status
           b.build_id = addr.build_id
-          b.u.offset = addr.offset;
+          b.u.offset = addr.offset
           res = lib.bcc_buildsymcache_resolve(BPF._bsymcache,
                                               ct.byref(b),
                                               ct.byref(sym))
@@ -1664,6 +1664,3 @@ class BPF(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.cleanup()
-
-
-from .usdt import USDT, USDTException

--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -20,17 +20,14 @@ except ImportError:
 from time import strftime
 import ctypes as ct
 from functools import reduce
-import multiprocessing
 import os
 import errno
 import re
 import sys
 
 from .libbcc import lib, _RAW_CB_TYPE, _LOST_CB_TYPE, _RINGBUF_CB_TYPE
-from .perf import Perf
 from .utils import get_online_cpus
 from .utils import get_possible_cpus
-from subprocess import check_output
 
 BPF_MAP_TYPE_HASH = 1
 BPF_MAP_TYPE_ARRAY = 2
@@ -183,7 +180,7 @@ def _print_linear_hist(vals, val_type, strip_leading_zero):
     stars = stars_max
 
     if idx_max >= 0:
-        print(header % val_type);
+        print(header % val_type)
     for i in range(0, idx_max + 1):
         val = vals[i]
 
@@ -796,7 +793,7 @@ class TableBase(MutableMapping):
 class HashTable(TableBase):
     def __init__(self, *args, **kwargs):
         super(HashTable, self).__init__(*args, **kwargs)
-        
+
     def __len__(self):
         i = 0
         for k in self: i += 1
@@ -809,7 +806,7 @@ class LruHash(HashTable):
 class ArrayBase(TableBase):
     def __init__(self, *args, **kwargs):
         super(ArrayBase, self).__init__(*args, **kwargs)
-        
+
     def _normalize_key(self, key):
         if isinstance(key, int):
             if key < 0:
@@ -1317,7 +1314,7 @@ class QueueStack:
         if res < 0:
             raise KeyError("Could not peek table")
         return leaf
-    
+
     def itervalues(self):
         # to avoid infinite loop, set maximum pops to max_entries
         cnt = self.max_entries

--- a/src/python/bcc/tcp.py
+++ b/src/python/bcc/tcp.py
@@ -28,31 +28,31 @@ tcpstate[11] = 'CLOSING'
 tcpstate[12] = 'NEW_SYN_RECV'
 
 # from include/net/tcp.h:
-TCPHDR_FIN = 0x01;
-TCPHDR_SYN = 0x02;
-TCPHDR_RST = 0x04;
-TCPHDR_PSH = 0x08;
-TCPHDR_ACK = 0x10;
-TCPHDR_URG = 0x20;
-TCPHDR_ECE = 0x40;
-TCPHDR_CWR = 0x80;
+TCPHDR_FIN = 0x01
+TCPHDR_SYN = 0x02
+TCPHDR_RST = 0x04
+TCPHDR_PSH = 0x08
+TCPHDR_ACK = 0x10
+TCPHDR_URG = 0x20
+TCPHDR_ECE = 0x40
+TCPHDR_CWR = 0x80
 
 def flags2str(flags):
-    arr = [];
+    arr = []
     if flags & TCPHDR_FIN:
-        arr.append("FIN");
+        arr.append("FIN")
     if flags & TCPHDR_SYN:
-        arr.append("SYN");
+        arr.append("SYN")
     if flags & TCPHDR_RST:
-        arr.append("RST");
+        arr.append("RST")
     if flags & TCPHDR_PSH:
-        arr.append("PSH");
+        arr.append("PSH")
     if flags & TCPHDR_ACK:
-        arr.append("ACK");
+        arr.append("ACK")
     if flags & TCPHDR_URG:
-        arr.append("URG");
+        arr.append("URG")
     if flags & TCPHDR_ECE:
-        arr.append("ECE");
+        arr.append("ECE")
     if flags & TCPHDR_CWR:
-        arr.append("CWR");
-    return "|".join(arr);
+        arr.append("CWR")
+    return "|".join(arr)

--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 import ctypes as ct
-import os, sys
+import sys
 from .libbcc import lib, _USDT_CB, _USDT_PROBE_CB, \
                     bcc_usdt_location, bcc_usdt_argument, \
                     BCC_USDT_ARGUMENT_FLAGS


### PR DESCRIPTION
1. remove unused imports, remove redundant semicolon
2. attach kprobe/kretprobe should not fail silently