### PR TITLE
libbpf-tools: Don't redefine _GNU_SOURCE to avoid redefinition warning

### DIFF
--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -3,7 +3,9 @@
 //
 // Based on ksyms improvements from Andrii Nakryiko, add more helpers.
 // 28-Feb-2020   Wenbo Zhang   Created this.
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/libbpf-tools/uprobe_helpers.c
+++ b/libbpf-tools/uprobe_helpers.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2021 Google LLC. */
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>


### PR DESCRIPTION
Similar to past commits like 667988ce9e2a051ff608b727f6c89a5baa01fa67,
my toolchain complains that `_GNU_SOURCE` is redefined. Let's only
define it when it passes `ifndef`