### PR TITLE
ProcSyms should treat the executable like any other mapped file when symbolizing

### DIFF
--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -116,29 +116,7 @@ ProcSyms::ProcSyms(int pid, struct bcc_symbol_option *option)
   load_modules();
 }
 
-int ProcSyms::_add_load_sections(uint64_t v_addr, uint64_t mem_sz,
-                                 uint64_t file_offset, void *payload) {
-  auto module = static_cast<Module *>(payload);
-  module->ranges_.emplace_back(v_addr, v_addr + mem_sz, file_offset);
-  return 0;
-}
-
-void ProcSyms::load_exe() {
-  std::string exe = ebpf::get_pid_exe(pid_);
-  Module module(exe.c_str(), exe.c_str(), &symbol_option_);
-
-  if (module.type_ != ModuleType::EXEC)
-    return;
-
-
-  bcc_elf_foreach_load_section(exe.c_str(), &_add_load_sections, &module);
-
-  if (!module.ranges_.empty())
-    modules_.emplace_back(std::move(module));
-}
-
 void ProcSyms::load_modules() {
-  load_exe();
   bcc_procutils_each_module(pid_, _add_module, this);
 }
 

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -156,10 +156,7 @@ class ProcSyms : SymbolCache {
   ProcStat procstat_;
   bcc_symbol_option symbol_option_;
 
-  static int _add_load_sections(uint64_t v_addr, uint64_t mem_sz,
-                                uint64_t file_offset, void *payload);
   static int _add_module(mod_info *, int, void *);
-  void load_exe();
   void load_modules();
 
 public:


### PR DESCRIPTION
As reported in #3487, when `/proc/PID/exe`'s symlink points to a
mountns-relative path from a different mountns than the tracing process,
we can fail to open it as we don't prepend `/proc/PID/root` .

A few potential solutions were discussed in that issue, we settled on
treating the main exe like any other map in `/proc/PID/maps`. Since it's
always the first map we can reuse existing code and get rid of
exe-specific helpers.

While writing this I noticed that the remaining place `get_pid_exe` is used, the USDT code, potentially also has a bug due to `get_pid_exe` and shouldn't be using it either if so. Will follow up

I still need to validate this. Plan on doing so with `libbpf-tools`' offcputime and hopefully some example that can be committed 