### PR TITLE
bcc-test: fix test error

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get install -y \
       libtinfo-dev
 
 RUN pip3 install pyroute2 netaddr dnslib cachetools
-RUN pip install pyroute2 netaddr dnslib cachetools
+RUN pip install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1
 
 # FIXME this is faster than building from source, but it seems there is a bug
 # in probing libruby.so rather than ruby binary


### PR DESCRIPTION
https://github.com/iovisor/bcc/runs/2882081015#step:7:133 (https://github.com/iovisor/bcc/runs/2882081015#step:4:1786)

I tested it and found that `python2` reports this error when using the version of `pyroute2` after 0.6.1.

In view of the fact that `python2` is no longer updated, the installation version of all the packages that `python2` depends on is specified here to avoid the test failure caused by the update of the related dependencies. (https://github.com/iovisor/bcc/runs/2515123487#step:4:1741)