### PR TITLE
tcprtt: fix compatibility for python3

### DIFF
--- a/tools/tcprtt.py
+++ b/tools/tcprtt.py
@@ -215,7 +215,7 @@ print("Tracing TCP RTT... Hit Ctrl-C to end.")
 def print_section(addr):
     addrstr = "*******"
     if (addr):
-        addrstr = inet_ntop(AF_INET, struct.pack("I", addr)).encode()
+        addrstr = inet_ntop(AF_INET, struct.pack("I", addr))
 
     avglat = ""
     if args.extension:


### PR DESCRIPTION
Suggested by Yonghong, tcprtt report error on python3:
    TypeError: can't concat str to bytes

Both python2 and python3, inet_ntop returns a string type, there is
no need to encode any more.

Test for python2 and python3, both work fine.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>