### PR TITLE
libbpf-tools: gethostlatency allow specify libc path

### DIFF
--- a/libbpf-tools/gethostlatency.h
+++ b/libbpf-tools/gethostlatency.h
@@ -1,15 +1,15 @@
-// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
 #ifndef __GETHOSTLATENCY_H
 #define __GETHOSTLATENCY_H
 
-#define TASK_COMM_LEN 16
-#define HOST_LEN 80
+#define TASK_COMM_LEN	16
+#define HOST_LEN	80
 
-struct val_t {
+struct event {
+	__u64 time;
 	__u32 pid;
 	char comm[TASK_COMM_LEN];
 	char host[HOST_LEN];
-	__u64 time;
 };
 
 #endif /* __GETHOSTLATENCY_H */


### PR DESCRIPTION
This commit adds a new option to gethostlatency which
allows user to specify which libc to use for tracing.
This is useful when application is not linked against
default libc.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>