### PR TITLE
tools: replace add with xadd

### DIFF
--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -334,10 +334,11 @@ u64 __time = bpf_ktime_get_ns();
 
         def _generate_hash_update(self):
                 if self.type == "hist":
-                        return "%s.increment(bpf_log2l(__key));" % \
+                        return "%s.atomic_increment(bpf_log2l(__key));" % \
                                 self.probe_hash_name
                 else:
-                        return "%s.increment(__key);" % self.probe_hash_name
+                        return "%s.atomic_increment(__key);" % \
+                                self.probe_hash_name
 
         def _generate_pid_filter(self):
                 # Kernel probes need to explicitly filter pid, because the

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -132,18 +132,18 @@ if args.disks:
     disk_key_t key = {.slot = bpf_log2l(delta)};
     void *__tmp = (void *)req->rq_disk->disk_name;
     bpf_probe_read(&key.disk, sizeof(key.disk), __tmp);
-    dist.increment(key);
+    dist.atomic_increment(key);
     """
 elif args.flags:
     storage_str += "BPF_HISTOGRAM(dist, flag_key_t);"
     store_str += """
     flag_key_t key = {.slot = bpf_log2l(delta)};
     key.flags = req->cmd_flags;
-    dist.increment(key);
+    dist.atomic_increment(key);
     """
 else:
     storage_str += "BPF_HISTOGRAM(dist);"
-    store_str += "dist.increment(bpf_log2l(delta));"
+    store_str += "dist.atomic_increment(bpf_log2l(delta));"
 
 if args.extension:
     storage_str += "BPF_ARRAY(extension, ext_val_t, 1);"
@@ -254,7 +254,7 @@ while (1):
     else:
         if args.timestamp:
             print("%-8s\n" % strftime("%H:%M:%S"), end="")
-            
+
         if args.flags:
             dist.print_log2_hist(label, "flags", flags_print)
         else:

--- a/tools/bitesize.py
+++ b/tools/bitesize.py
@@ -31,7 +31,7 @@ TRACEPOINT_PROBE(block, block_rq_issue)
 {
     struct proc_key_t key = {.slot = bpf_log2l(args->bytes / 1024)};
     bpf_probe_read_kernel(&key.name, sizeof(key.name), args->comm);
-    dist.increment(key);
+    dist.atomic_increment(key);
     return 0;
 }
 """

--- a/tools/btrfsdist.py
+++ b/tools/btrfsdist.py
@@ -144,7 +144,7 @@ static int trace_return(struct pt_regs *ctx, const char *op)
     // store as histogram
     dist_key_t key = {.slot = bpf_log2l(delta)};
     __builtin_memcpy(&key.op, op, sizeof(key.op));
-    dist.increment(key);
+    dist.atomic_increment(key);
 
     start.delete(&tid);
     return 0;

--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -81,7 +81,7 @@ int do_count(struct pt_regs *ctx) {
     u64 ip;
 
     key.ip = PT_REGS_IP(ctx);
-    counts.increment(key); // update counter
+    counts.atomic_increment(key); // update counter
     return 0;
 }
 

--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -144,7 +144,7 @@ else:
     section = ""
     bpf_text = bpf_text.replace('STORAGE', 'BPF_HISTOGRAM(dist);')
     bpf_text = bpf_text.replace('STORE',
-        'dist.increment(bpf_log2l(delta));')
+        'dist.atomic_increment(bpf_log2l(delta));')
 if debug or args.ebpf:
     print(bpf_text)
     if args.ebpf:

--- a/tools/dbstat.py
+++ b/tools/dbstat.py
@@ -74,7 +74,7 @@ int probe_end(struct pt_regs *ctx) {
     u64 delta = bpf_ktime_get_ns() - *timestampp;
     FILTER
     delta /= SCALE;
-    latency.increment(bpf_log2l(delta));
+    latency.atomic_increment(bpf_log2l(delta));
     temp.delete(&pid);
     return 0;
 }

--- a/tools/dcstat.py
+++ b/tools/dcstat.py
@@ -73,18 +73,15 @@ BPF_ARRAY(stats, u64, S_MAXSTAT);
  */
 void count_fast(struct pt_regs *ctx) {
     int key = S_REFS;
-    u64 *leaf = stats.lookup(&key);
-    if (leaf) (*leaf)++;
+    stats.atomic_increment(key);
 }
 
 void count_lookup(struct pt_regs *ctx) {
     int key = S_SLOW;
-    u64 *leaf = stats.lookup(&key);
-    if (leaf) (*leaf)++;
+    stats.atomic_increment(key);
     if (PT_REGS_RC(ctx) == 0) {
         key = S_MISS;
-        leaf = stats.lookup(&key);
-        if (leaf) (*leaf)++;
+        stats.atomic_increment(key);
     }
 }
 """
@@ -117,7 +114,6 @@ while (1):
     try:
         sleep(interval)
     except KeyboardInterrupt:
-        pass
         exit()
 
     print("%-8s: " % strftime("%H:%M:%S"), end="")

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -110,7 +110,7 @@ static int trace_return(struct pt_regs *ctx, const char *op)
     // store as histogram
     dist_key_t key = {.slot = bpf_log2l(delta)};
     __builtin_memcpy(&key.op, op, sizeof(key.op));
-    dist.increment(key);
+    dist.atomic_increment(key);
 
     return 0;
 }

--- a/tools/funccount.py
+++ b/tools/funccount.py
@@ -168,11 +168,7 @@ int PROBE_FUNCTION(void *ctx) {
     FILTERPID
     FILTERCPU
     int loc = LOCATION;
-    u64 *val = counts.lookup(&loc);
-    if (!val) {
-        return 0;   // Should never happen, # of locations is known
-    }
-    (*val)++;
+    counts.atomic_increment(loc);
     return 0;
 }
         """

--- a/tools/funcinterval.py
+++ b/tools/funcinterval.py
@@ -99,7 +99,7 @@ int trace_func_entry(struct pt_regs *ctx)
     FACTOR
 
     // store as histogram
-    dist.increment(bpf_log2l(delta));
+    dist.atomic_increment(bpf_log2l(delta));
 
 out:
     start.update(&index, &ts);

--- a/tools/funclatency.py
+++ b/tools/funclatency.py
@@ -284,7 +284,7 @@ static inline int stack_push(func_stack_t *stack, func_cache_t *cache) {
     key.key.ip  = ip;
     key.key.pid = %s;
     key.slot    = bpf_log2l(delta);
-    dist.increment(key);
+    dist.atomic_increment(key);
 
     if (stack->head == 0) {
         /* empty */
@@ -309,7 +309,7 @@ static inline int stack_push(func_stack_t *stack, func_cache_t *cache) {
         key.key.ip = ip;
         key.key.pid = %s;
         key.slot = bpf_log2l(delta);
-        dist.increment(key);
+        dist.atomic_increment(key);
         ipaddr.delete(&pid);
     }
                 """ % pid)
@@ -318,7 +318,7 @@ else:
                                            'BPF_HASH(start, u32);')
     bpf_text = bpf_text.replace('ENTRYSTORE', 'start.update(&pid, &ts);')
     bpf_text = bpf_text.replace('STORE',
-        'dist.increment(bpf_log2l(delta));')
+        'dist.atomic_increment(bpf_log2l(delta));')
 
 bpf_text = bpf_text.replace('TYPEDEF', '')
 bpf_text = bpf_text.replace('FUNCTION', '')

--- a/tools/hardirqs.py
+++ b/tools/hardirqs.py
@@ -86,7 +86,7 @@ TRACEPOINT_PROBE(irq, irq_handler_entry)
 {
     irq_key_t key = {.slot = 0 /* ignore */};
     TP_DATA_LOC_READ_CONST(&key.name, name, sizeof(key.name));
-    dist.increment(key);
+    dist.atomic_increment(key);
     return 0;
 }
 """
@@ -139,12 +139,12 @@ if args.dist:
     bpf_text = bpf_text.replace('STORE',
         'irq_key_t key = {.slot = bpf_log2l(delta / %d)};' % factor +
         'bpf_probe_read_kernel(&key.name, sizeof(key.name), name);' +
-        'dist.increment(key);')
+        'dist.atomic_increment(key);')
 else:
     bpf_text = bpf_text.replace('STORE',
         'irq_key_t key = {.slot = 0 /* ignore */};' +
         'bpf_probe_read_kernel(&key.name, sizeof(key.name), name);' +
-        'dist.increment(key, delta);')
+        'dist.atomic_increment(key, delta);')
 if debug or args.ebpf:
     print(bpf_text)
     if args.ebpf:

--- a/tools/inject.py
+++ b/tools/inject.py
@@ -225,7 +225,7 @@ class Probe:
          * If this is the only call in the chain and predicate passes
          */
         if (%s == 1 && %s && overridden < %s) {
-                count.increment(zero);
+                count.atomic_increment(zero);
                 bpf_override_return(ctx, %s);
                 return 0;
         }
@@ -240,7 +240,7 @@ class Probe:
          * If all conds have been met and predicate passes
          */
         if (p->conds_met == %s && %s && overridden < %s) {
-                count.increment(zero);
+                count.atomic_increment(zero);
                 bpf_override_return(ctx, %s);
         }
         return 0;

--- a/tools/nfsdist.py
+++ b/tools/nfsdist.py
@@ -96,7 +96,7 @@ static int trace_return(struct pt_regs *ctx, const char *op)
     // store as histogram
     dist_key_t key = {.slot = bpf_log2l(delta)};
     __builtin_memcpy(&key.op, op, sizeof(key.op));
-    dist.increment(key);
+    dist.atomic_increment(key);
 
     start.delete(&tid);
     return 0;

--- a/tools/pidpersec.py
+++ b/tools/pidpersec.py
@@ -29,8 +29,7 @@ enum stat_types {
 BPF_ARRAY(stats, u64, S_MAXSTAT);
 
 static void stats_increment(int key) {
-    u64 *leaf = stats.lookup(&key);
-    if (leaf) (*leaf)++;
+    stats.atomic_increment(key);
 }
 
 void do_count(struct pt_regs *ctx) { stats_increment(S_COUNT); }

--- a/tools/runqlat.py
+++ b/tools/runqlat.py
@@ -236,12 +236,12 @@ elif args.pidnss:
         'BPF_HISTOGRAM(dist, pidns_key_t);')
     bpf_text = bpf_text.replace('STORE', 'pidns_key_t key = ' +
         '{.id = prev->nsproxy->pid_ns_for_children->ns.inum, ' +
-        '.slot = bpf_log2l(delta)}; dist.increment(key);')
+        '.slot = bpf_log2l(delta)}; dist.atomic_increment(key);')
 else:
     section = ""
     bpf_text = bpf_text.replace('STORAGE', 'BPF_HISTOGRAM(dist);')
     bpf_text = bpf_text.replace('STORE',
-        'dist.increment(bpf_log2l(delta));')
+        'dist.atomic_increment(bpf_log2l(delta));')
 if debug or args.ebpf:
     print(bpf_text)
     if args.ebpf:

--- a/tools/runqlen.py
+++ b/tools/runqlen.py
@@ -170,7 +170,7 @@ if args.cpus:
 else:
     bpf_text = bpf_text.replace('STORAGE',
         'BPF_HISTOGRAM(dist, unsigned int);')
-    bpf_text = bpf_text.replace('STORE', 'dist.increment(len);')
+    bpf_text = bpf_text.replace('STORE', 'dist.atomic_increment(len);')
 
 if check_runnable_weight_field():
     bpf_text = bpf_text.replace('RUNNABLE_WEIGHT_FIELD', 'unsigned long runnable_weight;')

--- a/tools/softirqs.py
+++ b/tools/softirqs.py
@@ -119,11 +119,11 @@ TRACEPOINT_PROBE(irq, softirq_exit)
 if args.dist:
     bpf_text = bpf_text.replace('STORE',
         'key.vec = vec; key.slot = bpf_log2l(delta / %d); ' % factor +
-        'dist.increment(key);')
+        'dist.atomic_increment(key);')
 else:
     bpf_text = bpf_text.replace('STORE',
         'key.vec = valp->vec; ' +
-        'dist.increment(key, delta);')
+        'dist.atomic_increment(key, delta);')
 if debug or args.ebpf:
     print(bpf_text)
     if args.ebpf:

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -129,7 +129,7 @@ int trace_count(void *ctx) {
     key.tgid = GET_TGID;
     STORE_COMM
     %s
-    counts.increment(key);
+    counts.atomic_increment(key);
     return 0;
 }
         """

--- a/tools/tcprtt.py
+++ b/tools/tcprtt.py
@@ -123,7 +123,7 @@ int trace_tcp_rcv(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
 
     STORE_HIST
     key.slot = bpf_log2l(srtt);
-    hist_srtt.increment(key);
+    hist_srtt.atomic_increment(key);
 
     STORE_LATENCY
 

--- a/tools/tcpsubnet.py
+++ b/tools/tcpsubnet.py
@@ -175,7 +175,7 @@ def generate_bpf_subnets(subnets):
         if (!categorized && (__NET_ADDR__ & __NET_MASK__) ==
              (dst & __NET_MASK__)) {
           struct index_key_t key = {.index = __POS__};
-          ipv4_send_bytes.increment(key, size);
+          ipv4_send_bytes.atomic_increment(key, size);
           categorized = 1;
         }
     """

--- a/tools/tcpsynbl.py
+++ b/tools/tcpsynbl.py
@@ -33,7 +33,7 @@ int do_entry(struct pt_regs *ctx) {
     backlog_key_t key = {};
     key.backlog = sk->sk_max_ack_backlog;
     key.slot = bpf_log2l(sk->sk_ack_backlog);
-    dist.increment(key);
+    dist.atomic_increment(key);
 
     return 0;
 };

--- a/tools/vfscount.py
+++ b/tools/vfscount.py
@@ -40,7 +40,7 @@ BPF_HASH(counts, struct key_t, u64, 256);
 int do_count(struct pt_regs *ctx) {
     struct key_t key = {};
     key.ip = PT_REGS_IP(ctx);
-    counts.increment(key);
+    counts.atomic_increment(key);
     return 0;
 }
 """)

--- a/tools/vfsstat.py
+++ b/tools/vfsstat.py
@@ -52,8 +52,7 @@ enum stat_types {
 BPF_ARRAY(stats, u64, S_MAXSTAT);
 
 static void stats_increment(int key) {
-    u64 *leaf = stats.lookup(&key);
-    if (leaf) (*leaf)++;
+    stats.atomic_increment(key);
 }
 """
 

--- a/tools/wakeuptime.py
+++ b/tools/wakeuptime.py
@@ -142,7 +142,7 @@ static int wakeup(ARG0, struct task_struct *p) {
     bpf_probe_read_kernel(&key.target, sizeof(key.target), p->comm);
     bpf_get_current_comm(&key.waker, sizeof(key.waker));
 
-    counts.increment(key, delta);
+    counts.atomic_increment(key, delta);
     return 0;
 }
 """

--- a/tools/xfsdist.py
+++ b/tools/xfsdist.py
@@ -98,7 +98,7 @@ static int trace_return(struct pt_regs *ctx, const char *op)
     // store as histogram
     dist_key_t key = {.slot = bpf_log2l(delta)};
     __builtin_memcpy(&key.op, op, sizeof(key.op));
-    dist.increment(key);
+    dist.atomic_increment(key);
 
     start.delete(&tid);
     return 0;

--- a/tools/zfsdist.py
+++ b/tools/zfsdist.py
@@ -98,7 +98,7 @@ static int trace_return(struct pt_regs *ctx, const char *op)
     // store as histogram
     dist_key_t key = {.slot = bpf_log2l(delta)};
     __builtin_memcpy(&key.op, op, sizeof(key.op));
-    dist.increment(key);
+    dist.atomic_increment(key);
 
     start.delete(&tid);
     return 0;


### PR DESCRIPTION
resolve https://github.com/iovisor/bcc/issues/3481

Here are some tools that don't need to be adjusted.

* biolatpts.py: uses per_cpu_map.
* bindsnoop.py:  There is no synchronous writing of the same key.
* cachetop.py: ditto. 
* llcstat.py: ditto.
* biolatpcts.py: ditto.
* offcputime.py: ditto.
* profile.py: ditto.
* offwaketime.py: ditto.
* tcpretrans.py: ditto.
* tcptop.py: ditto.
* tcpconnect.py: ditto.