### PR TITLE
[py3:tools/deadlock.py] fix usage of str.replace() method to make it py3 compatible

### DIFF
--- a/tools/deadlock.py
+++ b/tools/deadlock.py
@@ -477,8 +477,8 @@ def main():
 
     with open('deadlock.c') as f:
         text = f.read()
-    text = text.replace(b'MAX_THREADS', str(args.threads));
-    text = text.replace(b'MAX_EDGES', str(args.edges));
+    text = text.replace('MAX_THREADS', str(args.threads));
+    text = text.replace('MAX_EDGES', str(args.edges));
     bpf = BPF(text=text)
 
     # Trace where threads are created


### PR DESCRIPTION
deadlock.py fails on py3 with `TypeError: replace() argument 1 must be str, not bytes`

```
Traceback (most recent call last):
  File "/home/oleg/tinfoil.runfiles/libbcc/tools/deadlock.py", line 570, in <module>
    main()
  File "/home/oleg/tinfoil.runfiles/libbcc/tools/deadlock.py", line 480, in main
    text = text.replace(b'MAX_THREADS', str(args.threads));
TypeError: replace() argument 1 must be str, not bytes
```