### PR TITLE
bcc/tools: remove unused signal handlers

### DIFF
--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -18,7 +18,6 @@ from __future__ import print_function
 from bcc import BPF
 from time import sleep, strftime
 import argparse
-import signal
 from subprocess import call
 
 # arguments
@@ -51,10 +50,6 @@ clear = not int(args.noclear)
 # linux stats
 loadavg = "/proc/loadavg"
 diskstats = "/proc/diskstats"
-
-# signal handler
-def signal_ignore(signal_value, frame):
-    print()
 
 # load BPF program
 bpf_text = """

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 from bcc import BPF
 from time import sleep, strftime
 import argparse
-import signal
 from subprocess import call
 
 # arguments
@@ -58,10 +57,6 @@ debug = 0
 
 # linux stats
 loadavg = "/proc/loadavg"
-
-# signal handler
-def signal_ignore(signal_value, frame):
-    print()
 
 # define BPF program
 bpf_text = """

--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -20,7 +20,6 @@ from bcc import BPF
 from bcc.utils import printb
 from time import sleep, strftime
 import argparse
-import signal
 from subprocess import call
 
 # arguments
@@ -53,10 +52,6 @@ debug = 0
 
 # linux stats
 loadavg = "/proc/loadavg"
-
-# signal handler
-def signal_ignore(signal, frame):
-    print()
 
 # define BPF program
 bpf_text = """


### PR DESCRIPTION
Several top tools defined signal handler, but not used.
They work well without signal handler, so just remove it.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>