### PR TITLE
tools: Fix filtering by mount namespace

### DIFF
--- a/src/python/bcc/containers.py
+++ b/src/python/bcc/containers.py
@@ -51,7 +51,10 @@ def _mntns_filter_func_writer(mntnsmap):
     * more likely to change.
     */
     struct mnt_namespace {
+    // This field was removed in https://github.com/torvalds/linux/commit/1a7b8969e664d6af328f00fe6eb7aabd61a71d13
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
         atomic_t count;
+    #endif
         struct ns_common ns;
     };
 


### PR DESCRIPTION
The filtering by mount namespace implementation relies on the
redefinition of the "struct mnt_namespace" internal kernel structure.
The layout of this structure changed in Linux 5.11 (https://github.com/torvalds/linux/commit/1a7b8969e664d6af328f00fe6eb7aabd61a71d13),
this commit adds a conditional on the kernel version to adapt to this
change.

/cc @alban 