### PR TITLE
update debian changelog for release v0.21.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+bcc (0.21.0-1) unstable; urgency=low
+
+  * Support for kernel up to 5.13
+  * support for debug information from libdebuginfod
+  * finished support for map elements items_*_batch() APIs
+  * add atomic_increment() API
+  * support attach_func() and detach_func() in python
+  * fix displaying PID instead of TID for many tools
+  * new tools: kvmexit.py
+  * new libbpf-tools: gethostlatency, statsnoop, fsdist and solisten
+  * fix tools ttysnoop/readahead for newer kernels
+  * doc update and bug fixes
+
+ -- Yonghong Song <ys114321@gmail.com>  Mon, 16 Jul 2021 17:00:00 +0000
+
 bcc (0.20.0-1) unstable; urgency=low
 
   * Support for kernel up to 5.12


### PR DESCRIPTION
  * Support for kernel up to 5.13
  * support for debug information from libdebuginfod
  * finished support for map elements items_*_batch() APIs
  * add atomic_increment() API
  * support attach_func() and detach_func() in python
  * fix displaying PID instead of TID for many tools
  * new tools: kvmexit.py
  * new libbpf-tools: gethostlatency, statsnoop, fsdist and solisten
  * fix tools ttysnoop/readahead for newer kernels
  * doc update and bug fixes

Signed-off-by: Yonghong Song <yhs@fb.com>