### PR TITLE
tools/criticalstat: Add new kconfig option to warning message

### DIFF
--- a/man/man8/criticalstat.8
+++ b/man/man8/criticalstat.8
@@ -17,9 +17,9 @@ Since this uses BPF, only the root user can use this tool. Further, the kernel
 has to be built with certain CONFIG options enabled. See below.
 
 .SH REQUIREMENTS
-Enable CONFIG_PREEMPTIRQ_EVENTS and CONFIG_DEBUG_PREEMPT. Additionally, the
-following options should be DISABLED on older kernels: CONFIG_PROVE_LOCKING,
-CONFIG_LOCKDEP.
+Enable CONFIG_PREEMPTIRQ_EVENTS (CONFIG_PREEMPTIRQ_TRACEPOINTS in kernel 4.19
+and later) and CONFIG_DEBUG_PREEMPT. Additionally, the following options
+should be DISABLED on older kernels: CONFIG_PROVE_LOCKING, CONFIG_LOCKDEP.
 .SH OPTIONS
 .TP
 \-h

--- a/tools/criticalstat.py
+++ b/tools/criticalstat.py
@@ -64,7 +64,8 @@ if (not os.path.exists(trace_path + b"irq_disable") or
    not os.path.exists(trace_path + b"preempt_enable")):
     print("ERROR: required tracing events are not available\n" +
         "Make sure the kernel is built with CONFIG_DEBUG_PREEMPT " +
-        "and CONFIG_PREEMPTIRQ_EVENTS enabled. Also please disable " +
+        "and CONFIG_PREEMPTIRQ_EVENTS (CONFIG_PREEMPTIRQ_TRACEPOINTS in "
+        "kernel 4.19 and later) enabled. Also please disable " +
         "CONFIG_PROVE_LOCKING and CONFIG_LOCKDEP on older kernels.")
     sys.exit(0)
 

--- a/tools/criticalstat_example.txt
+++ b/tools/criticalstat_example.txt
@@ -10,7 +10,8 @@ sections are a source of long latency/responsive issues for real-time systems.
 This works by probing the preempt/irq and cpuidle tracepoints in the kernel.
 Since this uses BPF, only the root user can use this tool. Further, the kernel
 has to be built with certain CONFIG options enabled inorder for it to work:
-CONFIG_PREEMPTIRQ_EVENTS
+CONFIG_PREEMPTIRQ_EVENTS before kernel 4.19
+CONFIG_PREEMPTIRQ_TRACEPOINTS in kernel 4.19 and later
 CONFIG_DEBUG_PREEMPT
 Additionally, the following options should be turned off on older kernels:
 CONFIG_PROVE_LOCKING


### PR DESCRIPTION
In kernel 4.19 and later, the CONFIG_PREEMPTIRQ_EVENTS option is unused.
Instead, it requires a kernel built with CONFIG_PREEMPTIRQ_TRACEPOINTS.