### PR TITLE
profile.py: Remove unused kernel_ret_ip

### DIFF
--- a/tools/profile.py
+++ b/tools/profile.py
@@ -142,7 +142,6 @@ bpf_text = """
 struct key_t {
     u32 pid;
     u64 kernel_ip;
-    u64 kernel_ret_ip;
     int user_stack_id;
     int kernel_stack_id;
     char name[TASK_COMM_LEN];


### PR DESCRIPTION
With 715f7e6ec, `DO_KERNEL_RIP` was removed. That was the only user of the `kernel_ret_ip` field. I believe we can now remove that field.