### PR TITLE
bcc/tools: update mountsnoop's based on comment in containers.py

### DIFF
--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -33,7 +33,10 @@ bpf_text = r"""
  * real struct, but we don't need them, and they're more likely to change.
  */
 struct mnt_namespace {
+    // This field was removed in https://github.com/torvalds/linux/commit/1a7b8969e664d6af328f00fe6eb7aabd61a71d13
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
     atomic_t count;
+    #endif
     struct ns_common ns;
 };
 


### PR DESCRIPTION
this patch just replicates the fix done in
ef330a393be4b472627b1bfa7fbe50934e519e25