### PR TITLE
libbpf-tools: readahead: don't mark struct hist as static

### DIFF
--- a/libbpf-tools/readahead.bpf.c
+++ b/libbpf-tools/readahead.bpf.c
@@ -24,7 +24,7 @@ struct {
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } birth SEC(".maps");
 
-static struct hist hist;
+struct hist hist = {};
 
 SEC("fentry/do_page_cache_ra")
 int BPF_PROG(do_page_cache_ra)


### PR DESCRIPTION
Libbpf readahead tool does not compile with bpftool v5.14. Since
commit 31332ccb756 ("bpftool: Stop emitting static variables in BPF
skeleton"), bpftool gen skeleton does not include static variables
into the skeleton file anymore.

Fixes the following compilation error:
readahead.c: In function 'main':
readahead.c:153:26: error: 'struct readahead_bpf__bss' has no member named 'hist'
  153 |         histp = &obj->bss->hist;
      |                          ^~