### PR TITLE
tcpstates: incorrect display of dport

### DIFF
--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -183,6 +183,7 @@ int kprobe__tcp_set_state(struct pt_regs *ctx, struct sock *sk, int state)
 
     // dport is either used in a filter here, or later
     u16 dport = sk->__sk_common.skc_dport;
+    dport = ntohs(dport);
     FILTER_DPORT
 
     // calculate delta

--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -117,6 +117,7 @@ TRACEPOINT_PROBE(sock, inet_sock_set_state)
 
     // dport is either used in a filter here, or later
     u16 dport = args->dport;
+    dport = ntohs(dport);
     FILTER_DPORT
 
     // calculate delta

--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -117,7 +117,6 @@ TRACEPOINT_PROBE(sock, inet_sock_set_state)
 
     // dport is either used in a filter here, or later
     u16 dport = args->dport;
-    dport = ntohs(dport);
     FILTER_DPORT
 
     // calculate delta


### PR DESCRIPTION
`dport` is network order in the kernel and needs `ntohs` to be unravelled for human consumption. 
`sport` is host order and doesn't need to changing, refer #639