### PR TITLE
ClangLoader: Pull out common remapped file operations

### DIFF
--- a/src/cc/frontends/clang/loader.h
+++ b/src/cc/frontends/clang/loader.h
@@ -20,6 +20,8 @@
 #include <memory>
 #include <string>
 
+#include <clang/Frontend/CompilerInvocation.h>
+
 #include "table_storage.h"
 
 namespace llvm {
@@ -69,6 +71,10 @@ class ClangLoader {
                  const std::string &maps_ns,
                  fake_fd_map_def &fake_fd_map,
                  std::map<std::string, std::vector<std::string>> &perf_events);
+  void add_remapped_includes(clang::CompilerInvocation& invocation);
+  void add_main_input(clang::CompilerInvocation& invocation,
+                      const std::string& main_path,
+                      llvm::MemoryBuffer *main_buf);
 
  private:
   std::map<std::string, std::unique_ptr<llvm::MemoryBuffer>> remapped_headers_;


### PR DESCRIPTION
I'm making some larger modifications to the loader. While reading
through the `do_compile` code I noticed that the common "remapped file"
operations - telling various CompilerInvocations about 'virtual'
includes and the virtual main c file - could be factored out to enhance
clarity.

This patch doesn't change functionality at all, nor does it try to make
any opinionated refactoring changes.