### PR TITLE
libbpf-tools: add sigsnoop

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -21,6 +21,7 @@
 /funclatency
 /gethostlatency
 /hardirqs
+/killsnoop
 /llcstat
 /nfsdist
 /nfsslower
@@ -32,6 +33,7 @@
 /runqlat
 /runqlen
 /runqslower
+/sigsnoop
 /softirqs
 /solisten
 /statsnoop

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -43,6 +43,7 @@ APPS = \
 	runqlat \
 	runqlen \
 	runqslower \
+	sigsnoop \
 	softirqs \
 	solisten \
 	statsnoop \
@@ -54,7 +55,8 @@ APPS = \
 
 FSDIST_ALIASES = btrfsdist ext4dist nfsdist xfsdist
 FSSLOWER_ALIASES = btrfsslower ext4slower nfsslower xfsslower
-APP_ALIASES = $(FSDIST_ALIASES) $(FSSLOWER_ALIASES)
+SIGSNOOP_ALIASES = killsnoop
+APP_ALIASES = $(FSDIST_ALIASES) $(FSSLOWER_ALIASES) $(SIGSNOOP_ALIASES)
 
 COMMON_OBJ = \
 	$(OUTPUT)/trace_helpers.o \
@@ -118,6 +120,10 @@ $(FSSLOWER_ALIASES): fsslower
 	$(Q)ln -f -s $^ $@
 
 $(FSDIST_ALIASES): fsdist
+	$(call msg,SYMLINK,$@)
+	$(Q)ln -f -s $^ $@
+
+$(SIGSNOOP_ALIASES): sigsnoop
 	$(call msg,SYMLINK,$@)
 	$(Q)ln -f -s $^ $@
 

--- a/libbpf-tools/sigsnoop.bpf.c
+++ b/libbpf-tools/sigsnoop.bpf.c
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2021 Hengqi Chen */
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include "sigsnoop.h"
+
+#define MAX_ENTRIES	10240
+
+const volatile pid_t target_pid = 0;
+const volatile int target_signal = 0;
+const volatile bool failed_only = false;
+const volatile bool kill_only = false;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, __u32);
+	__type(value, struct event);
+} values SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(__u32));
+} events SEC(".maps");
+
+static int probe_entry(pid_t target_pid, int sig, enum sig_syscall syscall)
+{
+	__u64 pid_tgid;
+	__u32 pid, tid;
+	struct event event = {};
+
+	if (kill_only && syscall != SYSCALL_KILL)
+		return 0;
+
+	if (target_signal && target_signal != sig)
+		return 0;
+
+	pid_tgid = bpf_get_current_pid_tgid();
+	pid = pid_tgid >> 32;
+	tid = (__u32)pid_tgid;
+	if (target_pid && target_pid != pid)
+		return 0;
+
+	event.pid = pid;
+	event.tpid = target_pid;
+	event.sig = sig;
+	event.syscall = syscall;
+	bpf_get_current_comm(event.comm, sizeof(event.comm));
+	bpf_map_update_elem(&values, &tid, &event, BPF_ANY);
+	return 0;
+}
+
+static int probe_exit(void *ctx, int ret)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 tid = (__u32)pid_tgid;
+	struct event *eventp;
+
+	eventp = bpf_map_lookup_elem(&values, &tid);
+	if (!eventp)
+		return 0;
+
+	if (failed_only && ret >= 0)
+		goto cleanup;
+
+	eventp->ret = ret;
+	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, eventp, sizeof(*eventp));
+
+cleanup:
+	bpf_map_delete_elem(&values, &tid);
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_kill")
+int kill_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	pid_t target_pid = (pid_t)ctx->args[0];
+	int sig = (int)ctx->args[1];
+
+	return probe_entry(target_pid, sig, SYSCALL_KILL);
+}
+
+SEC("tracepoint/syscalls/sys_exit_kill")
+int kill_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_rt_sigqueueinfo")
+int rt_sigqueueinfo_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	pid_t target_pid = (pid_t)ctx->args[0];
+	int sig = (int)ctx->args[1];
+
+	return probe_entry(target_pid, sig, SYSCALL_RT_SIGQUEUEINFO);
+}
+
+SEC("tracepoint/syscalls/sys_exit_rt_sigqueueinfo")
+int rt_sigqueueinfo_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_rt_tgsigqueueinfo")
+int rt_tgsigqueueinfo_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	pid_t target_pid = (pid_t)ctx->args[1];
+	int sig = (int)ctx->args[2];
+
+	return probe_entry(target_pid, sig, SYSCALL_RT_TGSIGQUEUEINFO);
+}
+
+SEC("tracepoint/syscalls/sys_exit_rt_tgsigqueueinfo")
+int rt_tgsigqueueinfo_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_pidfd_send_signal")
+int pidfd_send_signal_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	int pidfd = (int)ctx->args[0];
+	int sig = (int)ctx->args[1];
+
+	return probe_entry(pidfd, sig, SYSCALL_PIDFD_SEND_SIGNAL);
+}
+
+SEC("tracepoint/syscalls/sys_exit_pidfd_send_signal")
+int pidfd_send_signal_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_tgkill")
+int tgkill_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	pid_t target_pid = (pid_t)ctx->args[1];
+	int sig = (int)ctx->args[2];
+
+	return probe_entry(target_pid, sig, SYSCALL_TGKILL);
+}
+
+SEC("tracepoint/syscalls/sys_exit_tgkill")
+int tgkill_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_tkill")
+int tkill_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	pid_t target_pid = (pid_t)ctx->args[0];
+	int sig = (int)ctx->args[1];
+
+	return probe_entry(target_pid, sig, SYSCALL_TKILL);
+}
+
+SEC("tracepoint/syscalls/sys_exit_tkill")
+int tkill_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/libbpf-tools/sigsnoop.c
+++ b/libbpf-tools/sigsnoop.c
@@ -1,0 +1,234 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+
+/*
+ * sigsnoop	Trace standard and real-time signals.
+ *
+ * Copyright (c) 2021 Hengqi Chen
+ *
+ * Based on killsnoop(8) from BCC by Brendan Gregg.
+ * 08-Aug-2021   Hengqi Chen   Created this.
+ */
+#include <argp.h>
+#include <libgen.h>
+#include <errno.h>
+#include <signal.h>
+#include <string.h>
+#include <time.h>
+
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "sigsnoop.h"
+#include "sigsnoop.skel.h"
+#include "trace_helpers.h"
+
+#define PERF_BUFFER_PAGES	16
+#define PERF_POLL_TIMEOUT_MS	100
+#define warn(...) fprintf(stderr, __VA_ARGS__)
+
+static volatile sig_atomic_t exiting = 0;
+
+static pid_t target_pid = 0;
+static int target_signal = 0;
+static bool failed_only = false;
+static bool kill_only = false;
+static bool verbose = false;
+
+static const char *syscall_names[] = {
+	[SYSCALL_KILL]= "kill",
+	[SYSCALL_RT_SIGQUEUEINFO]= "rt_sigqueueinfo",
+	[SYSCALL_RT_TGSIGQUEUEINFO]= "rt_tgsigqueueinfo",
+	[SYSCALL_PIDFD_SEND_SIGNAL]= "pidfd_send_signal",
+	[SYSCALL_TGKILL]= "tgkill",
+	[SYSCALL_TKILL]= "tkill",
+};
+
+const char *argp_program_version = "sigsnoop 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] =
+"Trace standard and real-time signals.\n"
+"\n"
+"USAGE: sigsnoop [-h] [-x] [-k] [-v] [-p PID] [-s SIGNAL]\n"
+"\n"
+"EXAMPLES:\n"
+"    sigsnoop             # trace signals system-wide\n"
+"    sigsnoop -k          # trace signals issued by kill syscall only\n"
+"    sigsnoop -x          # trace failed signals only\n"
+"    sigsnoop -p 1216     # only trace PID 1216\n"
+"    sigsnoop -s 9        # only trace signal 9\n";
+
+static const struct argp_option opts[] = {
+	{ "failed", 'x', NULL, 0, "Trace failed signals only." },
+	{ "kill", 'k', NULL, 0, "Trace signals issued by kill syscall only." },
+	{ "pid", 'p', "PID", 0, "Process ID to trace" },
+	{ "signal", 's', "SIGNAL", 0, "Signal to trace." },
+	{ "verbose", 'v', NULL, 0, "Verbose output." },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	long pid, sig;
+
+	switch (key) {
+	case 'p':
+		errno = 0;
+		pid = strtol(arg, NULL, 10);
+		if (errno || pid <= 0) {
+			warn("Invalid PID: %s\n", arg);
+			argp_usage(state);
+		}
+		target_pid = pid;
+		break;
+	case 's':
+		errno = 0;
+		sig = strtol(arg, NULL, 10);
+		if (errno || sig <= 0) {
+			warn("Invalid SIGNAL: %s\n", arg);
+			argp_usage(state);
+		}
+		target_signal = sig;
+		break;
+	case 'k':
+		kill_only = true;
+		break;
+	case 'x':
+		failed_only = true;
+		break;
+	case 'v':
+		verbose = true;
+		break;
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static void alias_parse(char *prog)
+{
+	char *name = basename(prog);
+
+	if (!strcmp(name, "killsnoop")) {
+		kill_only = true;
+	}
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+{
+	struct event *e = data;
+	time_t t;
+	struct tm *tm;
+	char ts[32];
+
+	time(&t);
+	tm = localtime(&t);
+	strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+	printf("%-8s %-7d %-16s %-4d %-7d %-6d",
+	       ts, e->pid, e->comm, e->sig, e->tpid, e->ret);
+	if (verbose)
+		printf(" %s\n", syscall_names[e->syscall]);
+	else
+		printf("\n");
+}
+
+static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct perf_buffer_opts pb_opts;
+	struct perf_buffer *pb = NULL;
+	struct sigsnoop_bpf *obj;
+	int err;
+
+	alias_parse(argv[0]);
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	err = bump_memlock_rlimit();
+	if (err) {
+		warn("failed to increase rlimit: %d\n", err);
+		return 1;
+	}
+
+	obj = sigsnoop_bpf__open();
+	if (!obj) {
+		warn("failed to open BPF object\n");
+		return 1;
+	}
+
+	obj->rodata->target_pid = target_pid;
+	obj->rodata->target_signal = target_signal;
+	obj->rodata->failed_only = failed_only;
+	obj->rodata->kill_only = kill_only;
+
+	err = sigsnoop_bpf__load(obj);
+	if (err) {
+		warn("failed to load BPF object: %d\n", err);
+		goto cleanup;
+	}
+
+	err = sigsnoop_bpf__attach(obj);
+	if (err) {
+		warn("failed to attach BPF programs: %d\n", err);
+		goto cleanup;
+	}
+
+	pb_opts.sample_cb = handle_event;
+	pb_opts.lost_cb = handle_lost_events;
+	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), PERF_BUFFER_PAGES, &pb_opts);
+	err = libbpf_get_error(pb);
+	if (err) {
+		warn("failed to open perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		warn("can't set signal handler: %s\n", strerror(-errno));
+		goto cleanup;
+	}
+
+	printf("%-8s %-7s %-16s %-4s %-7s %-6s",
+	       "TIME", "PID", "COMM", "SIG", "TPID", "RESULT");
+	if (verbose)
+		printf(" %-s\n", "SYSCALL");
+	else
+		printf("\n");
+
+	while (1) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err == -EINTR) {
+ 			err = 0;
+ 			goto cleanup;
+ 		}
+
+		if (err < 0)
+			break;
+		if (exiting)
+			goto cleanup;
+	}
+	warn("error polling perf buffer: %d\n", err);
+
+cleanup:
+	perf_buffer__free(pb);
+	sigsnoop_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/libbpf-tools/sigsnoop.h
+++ b/libbpf-tools/sigsnoop.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __SIGSNOOP_H
+#define __SIGSNOOP_H
+
+#define TASK_COMM_LEN	16
+
+enum sig_syscall {
+	SYSCALL_KILL,
+	SYSCALL_RT_SIGQUEUEINFO,
+	SYSCALL_RT_TGSIGQUEUEINFO,
+	SYSCALL_PIDFD_SEND_SIGNAL,
+	SYSCALL_TGKILL,
+	SYSCALL_TKILL,
+};
+
+struct event {
+	__u32 pid;
+	__u32 tpid;
+	int sig;
+	int ret;
+	char comm[TASK_COMM_LEN];
+	enum sig_syscall syscall;
+};
+
+#endif /* __SIGSNOOP_H */


### PR DESCRIPTION
Add a sigsnoop tool which can be used to trace signals issued
by syscalls system-wide. This tool is a work based on BCC's
killsnoop, but extended to support more signal-related syscalls.
`sigsnoop -k` will behave the same as the killsnoop tool.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>