### PR TITLE
bcc/python: Improvements to python perf_event_attr ctype

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -141,6 +141,34 @@ class PerfSWConfig:
     DUMMY = 9
     BPF_OUTPUT = 10
 
+class PerfEventSampleFormat:
+    # from perf_event_sample_format in uapi/linux/bpf.h
+    IP = (1 << 0)
+    TID = (1 << 1)
+    TIME = (1 << 2)
+    ADDR = (1 << 3)
+    READ = (1 << 4)
+    CALLCHAIN = (1 << 5)
+    ID = (1 << 6)
+    CPU = (1 << 7)
+    PERIOD = (1 << 8)
+    STREAM_ID = (1 << 9)
+    RAW = (1 << 10)
+    BRANCH_STACK = (1 << 11)
+    REGS_USER = (1 << 12)
+    STACK_USER = (1 << 13)
+    WEIGHT = (1 << 14)
+    DATA_SRC = (1 << 15)
+    IDENTIFIER = (1 << 16)
+    TRANSACTION = (1 << 17)
+    REGS_INTR = (1 << 18)
+    PHYS_ADDR = (1 << 19)
+    AUX = (1 << 20)
+    CGROUP = (1 << 21)
+    DATA_PAGE_SIZE = (1 << 22)
+    CODE_PAGE_SIZE = (1 << 23)
+    WEIGHT_STRUCT = (1 << 24)
+
 class BPFProgType:
     # From bpf_prog_type in uapi/linux/bpf.h
     SOCKET_FILTER = 1

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -63,6 +63,8 @@ add_test(NAME py_test_tracepoint WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_test_tracepoint sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_tracepoint.py)
 add_test(NAME py_test_perf_event WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_test_perf_event sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_perf_event.py)
+add_test(NAME py_test_attach_perf_event WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_test_attach_perf_event sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_attach_perf_event.py)
 add_test(NAME py_test_utils WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_test_utils sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_utils.py)
 add_test(NAME py_test_percpu WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/python/test_attach_perf_event.py
+++ b/tests/python/test_attach_perf_event.py
@@ -6,7 +6,7 @@ import bcc
 import os
 import time
 import unittest
-from bcc import BPF, PerfType, PerfHWConfig, PerfEventSampleFormat
+from bcc import BPF, PerfType, PerfHWConfig, PerfSWConfig, PerfEventSampleFormat
 from bcc import Perf
 from time import sleep
 from utils import kernel_version_ge, mayFail
@@ -14,7 +14,8 @@ from utils import kernel_version_ge, mayFail
 class TestPerfAttachRaw(unittest.TestCase):
     @mayFail("This fails on github actions environment, hw perf events are not supported")
     @unittest.skipUnless(kernel_version_ge(4,9), "requires kernel >= 4.9")
-    def test_attach_raw_event(self):
+    def test_attach_raw_event_powerpc(self):
+        # on PowerPC, 'addr' is always written to; for x86 see _x86 version of test
         bpf_text="""
 #include <linux/perf_event.h>
 struct key_t {
@@ -41,7 +42,7 @@ int on_sample_hit(struct bpf_perf_event_data *ctx) {
     if (data)
         bpf_probe_read(&addr, sizeof(u64), &(data->addr));
 
-    bpf_trace_printk("Hit a sample with pid: %ld, comm: %s, addr: 0x%llx\\n", key.pid, key.name, addr);
+    bpf_trace_printk("test_attach_raw_event_powerpc: pid: %ld, comm: %s, addr: 0x%llx\\n", key.pid, key.name, addr);
     return 0;
 }
 
@@ -62,6 +63,97 @@ int on_sample_hit(struct bpf_perf_event_data *ctx) {
 
         print("Running for 2 seconds or hit Ctrl-C to end. Check trace file for samples information written by bpf_trace_printk.")
         sleep(2)
+
+    @mayFail("This fails on github actions environment, hw perf events are not supported")
+    @unittest.skipUnless(kernel_version_ge(4,17), "bpf_perf_event_data->addr requires kernel >= 4.17")
+    def test_attach_raw_event_x86(self):
+        # on x86, need to set precise_ip in order for perf_events to write to 'addr'
+        bpf_text="""
+#include <linux/perf_event.h>
+struct key_t {
+    int cpu;
+    int pid;
+    char name[100];
+};
+
+static inline __attribute__((always_inline)) void get_key(struct key_t* key) {
+    key->cpu = bpf_get_smp_processor_id();
+    key->pid = bpf_get_current_pid_tgid();
+    bpf_get_current_comm(&(key->name), sizeof(key->name));
+}
+
+int on_sample_hit(struct bpf_perf_event_data *ctx) {
+    struct key_t key = {};
+    get_key(&key);
+    u64 addr = ctx->addr;
+
+    bpf_trace_printk("test_attach_raw_event_x86: pid: %ld, comm: %s, addr: 0x%llx\\n", key.pid, key.name, addr);
+    return 0;
+}
+
+"""
+
+        b = BPF(text=bpf_text)
+        try:
+            event_attr = Perf.perf_event_attr()
+            event_attr.type = Perf.PERF_TYPE_HARDWARE
+            event_attr.config = PerfHWConfig.CPU_CYCLES
+            event_attr.sample_period = 1000000
+            event_attr.sample_type = PerfEventSampleFormat.ADDR
+            event_attr.exclude_kernel = 1
+            event_attr.precise_ip = 2
+            b.attach_perf_event_raw(attr=event_attr, fn_name="on_sample_hit", pid=-1, cpu=-1)
+        except Exception:
+            print("Failed to attach to a raw event. Please check the event attr used")
+            exit()
+
+        print("Running for 1 seconds or hit Ctrl-C to end. Check trace file for samples information written by bpf_trace_printk.")
+        sleep(1)
+
+
+    # SW perf events should work on GH actions, so expect this to succeed
+    @unittest.skipUnless(kernel_version_ge(4,17), "bpf_perf_event_data->addr requires kernel >= 4.17")
+    def test_attach_raw_sw_event(self):
+        bpf_text="""
+#include <linux/perf_event.h>
+struct key_t {
+    int cpu;
+    int pid;
+    char name[100];
+};
+
+static inline __attribute__((always_inline)) void get_key(struct key_t* key) {
+    key->cpu = bpf_get_smp_processor_id();
+    key->pid = bpf_get_current_pid_tgid();
+    bpf_get_current_comm(&(key->name), sizeof(key->name));
+}
+
+int on_sample_hit(struct bpf_perf_event_data *ctx) {
+    struct key_t key = {};
+    get_key(&key);
+    u64 addr = ctx->addr;
+
+    bpf_trace_printk("test_attach_raw_sw_event: pid: %ld, comm: %s, addr: 0x%llx\\n", key.pid, key.name, addr);
+    return 0;
+}
+
+"""
+
+        b = BPF(text=bpf_text)
+        try:
+            event_attr = Perf.perf_event_attr()
+            event_attr.type = Perf.PERF_TYPE_SOFTWARE
+            event_attr.config = PerfSWConfig.PAGE_FAULTS
+            event_attr.sample_period = 100
+            event_attr.sample_type = PerfEventSampleFormat.ADDR
+            event_attr.exclude_kernel = 1
+            b.attach_perf_event_raw(attr=event_attr, fn_name="on_sample_hit", pid=-1, cpu=-1)
+        except Exception:
+            print("Failed to attach to a raw event. Please check the event attr used")
+            exit()
+
+        print("Running for 1 seconds or hit Ctrl-C to end. Check trace file for samples information written by bpf_trace_printk.")
+        sleep(1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -5,12 +5,12 @@
 from bcc import BPF
 import ctypes as ct
 from unittest import main, skipUnless, TestCase
+from utils import kernel_version_ge
 import os
 import sys
 import socket
 import struct
 from contextlib import contextmanager
-import distutils.version
 
 @contextmanager
 def redirect_stderr(to):
@@ -23,17 +23,6 @@ def redirect_stderr(to):
         finally:
             sys.stderr.flush()
             os.dup2(copied.fileno(), stderr_fd)
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
 
 class TestClang(TestCase):
     def test_complex(self):

--- a/tests/python/test_free_bcc_memory.py
+++ b/tests/python/test_free_bcc_memory.py
@@ -9,19 +9,8 @@ from __future__ import print_function
 from bcc import BPF
 from unittest import main, skipUnless, TestCase
 from subprocess import Popen, PIPE
-import distutils.version
+from utils import kernel_version_ge
 import os
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
 
 class TestFreeLLVMMemory(TestCase):
     def getRssFile(self):

--- a/tests/python/test_lpm_trie.py
+++ b/tests/python/test_lpm_trie.py
@@ -3,22 +3,11 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 
 import ctypes as ct
-import distutils.version
 import os
 from unittest import main, skipUnless, TestCase
+from utils import kernel_version_ge
 from bcc import BPF
 from netaddr import IPAddress
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
 
 class KeyV4(ct.Structure):
     _fields_ = [("prefixlen", ct.c_uint),

--- a/tests/python/test_map_batch_ops.py
+++ b/tests/python/test_map_batch_ops.py
@@ -7,23 +7,11 @@
 
 from __future__ import print_function
 from unittest import main, skipUnless, TestCase
+from utils import kernel_version_ge
 from bcc import BPF
 
 import os
-import distutils.version
 import ctypes as ct
-
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
 
 
 @skipUnless(kernel_version_ge(5, 6), "requires kernel >= 5.6")

--- a/tests/python/test_map_in_map.py
+++ b/tests/python/test_map_in_map.py
@@ -7,8 +7,8 @@
 
 from __future__ import print_function
 from bcc import BPF
-import distutils.version
 from unittest import main, skipUnless, TestCase
+from utils import kernel_version_ge
 import ctypes as ct
 import os
 
@@ -18,17 +18,6 @@ class CustomKey(ct.Structure):
     ("value_1", ct.c_int),
     ("value_2", ct.c_int)
   ]
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
 
 @skipUnless(kernel_version_ge(4,11), "requires kernel >= 4.11")
 class TestUDST(TestCase):

--- a/tests/python/test_queuestack.py
+++ b/tests/python/test_queuestack.py
@@ -3,27 +3,16 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 
 import os
-import distutils.version
 import ctypes as ct
 
 from bcc import BPF
 
 from unittest import main, TestCase, skipUnless
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
+from utils import kernel_version_ge
 
 @skipUnless(kernel_version_ge(4,20), "requires kernel >= 4.20")
 class TestQueueStack(TestCase):
-    
+
     def test_stack(self):
         text = """
         BPF_STACK(stack, u64, 10);

--- a/tests/python/test_ringbuf.py
+++ b/tests/python/test_ringbuf.py
@@ -4,23 +4,12 @@
 
 from bcc import BPF
 import os
-import distutils.version
 import ctypes as ct
 import random
 import time
 import subprocess
 from unittest import main, TestCase, skipUnless
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
+from utils import kernel_version_ge
 
 class TestRingbuf(TestCase):
     @skipUnless(kernel_version_ge(5,8), "requires kernel >= 5.8")

--- a/tests/python/test_stackid.py
+++ b/tests/python/test_stackid.py
@@ -3,22 +3,10 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 
 import bcc
-import distutils.version
 import os
 import unittest
-from utils import mayFail
+from utils import mayFail, kernel_version_ge
 import subprocess
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
 
 
 @unittest.skipUnless(kernel_version_ge(4,6), "requires kernel >= 4.6")

--- a/tests/python/test_tools_memleak.py
+++ b/tests/python/test_tools_memleak.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from unittest import main, skipUnless, TestCase
-import distutils.version
+from utils import kernel_version_ge
 import os
 import subprocess
 import sys
@@ -17,18 +17,6 @@ class cfg:
     # for its own needs in libc, so this amount should be large enough to be
     # the biggest allocation.
     leaking_amount = 30000
-
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
 
 
 def setUpModule():

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -7,20 +7,9 @@ import subprocess
 import os
 import re
 from unittest import main, skipUnless, TestCase
-from utils import mayFail
+from utils import mayFail, kernel_version_ge
 
 TOOLS_DIR = "../../tools/"
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
 
 @skipUnless(kernel_version_ge(4,1), "requires kernel >= 4.1")
 class SmokeTests(TestCase):

--- a/tests/python/test_tracepoint.py
+++ b/tests/python/test_tracepoint.py
@@ -5,20 +5,9 @@
 import bcc
 import unittest
 from time import sleep
-import distutils.version
+from utils import kernel_version_ge
 import os
 import subprocess
-
-def kernel_version_ge(major, minor):
-    # True if running kernel is >= X.Y
-    version = distutils.version.LooseVersion(os.uname()[2]).version
-    if version[0] > major:
-        return True
-    if version[0] < major:
-        return False
-    if minor and version[1] < minor:
-        return False
-    return True
 
 @unittest.skipUnless(kernel_version_ge(4,7), "requires kernel >= 4.7")
 class TestTracepoint(unittest.TestCase):

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -1,6 +1,7 @@
 from pyroute2 import NSPopen
 from distutils.spawn import find_executable
 import traceback
+import distutils.version
 
 import logging, os, sys
 
@@ -62,3 +63,14 @@ class NSPopenWithCheck(NSPopen):
         name = list(argv)[0][0]
         has_executable(name)
         super(NSPopenWithCheck, self).__init__(nsname, *argv, **kwarg)
+
+def kernel_version_ge(major, minor):
+    # True if running kernel is >= X.Y
+    version = distutils.version.LooseVersion(os.uname()[2]).version
+    if version[0] > major:
+        return True
+    if version[0] < major:
+        return False
+    if minor and version[1] < minor:
+        return False
+    return True


### PR DESCRIPTION
Discussion in #3571 identified some low-hanging fruit improvements to the perf_event_attr ctype. This PR adds these improvements as well as adding the new test from #3571 to CMakeFiles.

First commit focuses on `perf_event_attr` ctype improvements: 

```
    bcc/python: extend perf_event_attr ctype

    This commit brings the Perf.perf_event_attr ctype in line with version 6
    of struct perf_event_attr (see uapi/linux/perf_event.h kernel header).
    Specifically:
      * All named fields are added, including field names within anonymous
      unions and bitfields
      * Perf.perf_event_attr now complains when a field which isn't part of
      the ctype struct is set.
        * Goal here is to prevent users from setting a
        recently-added field - which we haven't updated the ctype _fields_ to
        include - and getting confused when it doesn't propagate to the
        perf_event_open syscall. This bit me in #3571 and I am pretty
        familiar with bcc internals so I'd like to prevent this from
        confusing others down the line.
      * Perf.perf_event_attr's 'flags' field is removed as it was a standin
      for the bitfields. The _old_ profile.py was the only script in bcc
      tools that I could find using this.

    The last bullet is a breaking change. Although `tools/old/profile.py`
    has been migrated to use the bitfield it was flipping using `flags`,
    there could be some scripts out in the wild which break. I don't think
    this is likely: this stuff hasn't been significantly touched since 2016
    and I suspect if users of the python interface were writing lots of
    perf_event programs we would've seen more python tools or activity here.

    Regardless, there is probably a way to keep `flags` field working while
    also exposing named bitfields, but I suspect it'll be ugly and wanted to
    see if anyone thought it was necessary.
```

second pulls out kernel_version_ge into utils for use in further commits:

```
    bcc/python tests: pull kernel_version_ge into utils

    This helper is replicated in a few different places, let's pull it out.
```

third adds `test_attach_perf_event.py` to test infra. The single test in that file fails due to old kernel headers on ubuntu 16.04, and regardless fails on everything due to lack of hw perf event support

```
    bcc/python: Add test_attach_perf_event.py to CMake tests

    Add to CMakeLists.txt of tests so that the test is run as part of github
    actions test suite. Shorten the sleep duration so test finishes faster -
    since it's just testing attach currently the extra time isn't producing
    more signal.

    Also add python equivalent of `perf_event_sample_format` enum so
    `sample_type` can be more clearly set.

    v2: The test doesn't work on ubuntu 16.04 due to old kernel headers. It
    doesn't work on the rest of the github actions VMs due to hardware perf
    events not being supported, so add necessary check / skip.
```

Fourth commit:
```
bcc/python: Add x86 and sw test to test_attach_perf_event.py
Since the current test can't run on github actions since there's no HW
perf counter access, add a test using software page faults perf
event, which might work.

Also, rename the current HW test in there to highlight that it'll work
for PowerPC, and add a similar test for x86.
```

/cc @athira-rajeev 