### PR TITLE
libbpf-tools: runqslow: add '-P' optional

### DIFF
--- a/libbpf-tools/runqslower.bpf.c
+++ b/libbpf-tools/runqslower.bpf.c
@@ -88,8 +88,10 @@ int handle__sched_switch(u64 *ctx)
 		return 0;
 
 	event.pid = pid;
+	event.prev_pid = prev->pid;
 	event.delta_us = delta_us;
 	bpf_probe_read_kernel_str(&event.task, sizeof(event.task), next->comm);
+	bpf_probe_read_kernel_str(&event.prev_task, sizeof(event.prev_task), prev->comm);
 
 	/* output */
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,

--- a/libbpf-tools/runqslower.h
+++ b/libbpf-tools/runqslower.h
@@ -6,8 +6,10 @@
 
 struct event {
 	char task[TASK_COMM_LEN];
+	char prev_task[TASK_COMM_LEN];
 	__u64 delta_us;
 	pid_t pid;
+	pid_t prev_pid;
 };
 
 #endif /* __RUNQSLOWER_H */


### PR DESCRIPTION
Sync change 508d9694ba7ea503cce821175ffca5a7740b832b.

During a task hits schedule delay, in the high probability, the
previous task takes a long time to run. It's possible to dump the
previous task comm and TID by '-P' or '--previous' option.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>