### PR TITLE
Check for kconfig.h presence, not just build dir

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -115,6 +115,16 @@ bool is_dir(const string& path)
   return S_ISDIR(buf.st_mode);
 }
 
+bool is_file(const string& path)
+{
+  struct stat buf;
+
+  if (::stat (path.c_str (), &buf) < 0)
+    return false;
+
+  return S_ISREG(buf.st_mode);
+}
+
 std::pair<bool, string> get_kernel_path_info(const string kdir)
 {
   if (is_dir(kdir + "/build") && is_dir(kdir + "/source"))
@@ -170,7 +180,7 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
   }
 
   // If all attempts to obtain kheaders fail, check for kheaders.tar.xz in sysfs
-  if (!is_dir(kpath)) {
+  if (!is_file(kpath + "/include/linux/kconfig.h")) {
     int ret = get_proc_kheaders(tmpdir);
     if (!ret) {
       kpath = tmpdir;

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -180,6 +180,9 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
   }
 
   // If all attempts to obtain kheaders fail, check for kheaders.tar.xz in sysfs
+  // Checking just for kpath existence is unsufficient, since it can refer to
+  // leftover build directory without headers present anymore.
+  // See https://github.com/iovisor/bcc/pull/3588 for more details.
   if (!is_file(kpath + "/include/linux/kconfig.h")) {
     int ret = get_proc_kheaders(tmpdir);
     if (!ret) {


### PR DESCRIPTION
This is a better check than just checking the presence of the build dir.

In Gentoo Linux, when you remove the kernel source package, the leftover build directory is intentionally left in place. Which means the `/lib/modules/$(uname -r)/build` symlink still remains valid, but there's no `kconfig.h` there anymore[1]. This prevents bcc from using the `kheaders` (`/sys/kernel/kheaders.tar.xz`) fallback, instead making it fail later on:

    <built-in>:1:10: fatal error: './include/linux/kconfig.h' file not found
    #include "./include/linux/kconfig.h"
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    1 error generated.

[1] https://bugs.gentoo.org/809347