### PR TITLE
tools/criticalstat: Include CONFIG_PREEMPT_TRACER dependency in warni…

### DIFF
--- a/man/man8/criticalstat.8
+++ b/man/man8/criticalstat.8
@@ -17,8 +17,9 @@ Since this uses BPF, only the root user can use this tool. Further, the kernel
 has to be built with certain CONFIG options enabled. See below.
 
 .SH REQUIREMENTS
-Enable CONFIG_PREEMPTIRQ_EVENTS (CONFIG_PREEMPTIRQ_TRACEPOINTS in kernel 4.19
-and later) and CONFIG_DEBUG_PREEMPT. Additionally, the following options
+Enable CONFIG_PREEMPT_TRACER, CONFIG_PREEMPTIRQ_EVENTS
+(CONFIG_PREEMPTIRQ_TRACEPOINTS in kernel 4.19 and later)
+and CONFIG_DEBUG_PREEMPT. Additionally, the following options
 should be DISABLED on older kernels: CONFIG_PROVE_LOCKING, CONFIG_LOCKDEP.
 .SH OPTIONS
 .TP

--- a/tools/criticalstat.py
+++ b/tools/criticalstat.py
@@ -64,6 +64,7 @@ if (not os.path.exists(trace_path + b"irq_disable") or
    not os.path.exists(trace_path + b"preempt_enable")):
     print("ERROR: required tracing events are not available\n" +
         "Make sure the kernel is built with CONFIG_DEBUG_PREEMPT " +
+        "CONFIG_PREEMPT_TRACER " +
         "and CONFIG_PREEMPTIRQ_EVENTS (CONFIG_PREEMPTIRQ_TRACEPOINTS in "
         "kernel 4.19 and later) enabled. Also please disable " +
         "CONFIG_PROVE_LOCKING and CONFIG_LOCKDEP on older kernels.")

--- a/tools/criticalstat_example.txt
+++ b/tools/criticalstat_example.txt
@@ -13,6 +13,7 @@ has to be built with certain CONFIG options enabled inorder for it to work:
 CONFIG_PREEMPTIRQ_EVENTS before kernel 4.19
 CONFIG_PREEMPTIRQ_TRACEPOINTS in kernel 4.19 and later
 CONFIG_DEBUG_PREEMPT
+CONFIG_PREEMPT_TRACER
 Additionally, the following options should be turned off on older kernels:
 CONFIG_PROVE_LOCKING
 CONFIG_LOCKDEP


### PR DESCRIPTION
…ng msg

CONFIG_PREEMPTIRQ_TRACEPOINTS depends on TRACE_PREEMPT_TOGGLE
or TRACE_IRQFLAGS, TRACE_PREEMPT_TOGGLE will
also turn PREEMPT_TRACER on but NOT TRACE_IRQFLAGS. If you enable
TRACE_IRQFLAGS for PREEMPTIRQ_TRACEPOINTS, you need to enable
PREEMPT_TRACER as well.

Signed-off-by: Edward Wu <edwardwu@realtek.com>