### PR TITLE
Add filtering capabilities to mountsnoop.py

### DIFF
--- a/src/python/bcc/containers.py
+++ b/src/python/bcc/containers.py
@@ -57,6 +57,20 @@ def _mntns_filter_func_writer(mntnsmap):
     #endif
         struct ns_common ns;
     };
+    /*
+     * To add mountsnoop support for --selector option, we need to call
+     * filter_by_containers().
+     * This function adds code which defines struct mnt_namespace.
+     * The problem is that this struct is also defined in mountsnoop BPF code.
+     * To avoid redefining it in mountnsoop code, we define
+     * MNT_NAMESPACE_DEFINED here.
+     * Then, in mountsnoop code, the struct mnt_namespace definition is guarded
+     * by:
+     * #ifndef MNT_NAMESPACE_DEFINED
+     * // ...
+     * #endif
+     */
+    #define MNT_NAMESPACE_DEFINED
 
     BPF_TABLE_PINNED("hash", u64, u32, mount_ns_set, 1024, "MOUNT_NS_PATH");
 


### PR DESCRIPTION
Hi.


First, I hope you are fine and the same for your relatives.

In  kinvolk/inspektor-gadget#169, I added support for `mountsnoop` gadget.
To be able to use `--selector`, I needed to modify BPF code generated in `mountsnoop.py`.
First, I needed to call `filter_by_containers()` and also add check to `container_should_be_filtered()` in BPF code itself.
As `struct mnt_namespace` is defined in `mountsnoop.py` BPF code (as we want to snoop `mount` operations), I added guard around this definition, so we do not define this structure two times (one time in `mountnsoop.py` and the other in `containers.py`).

I tested these modifications inside `minikube` and using `inspektor-gadget` to interact with `mountsnoop.py`.

If you see any ways to improve this code, feel free to share.


Best regards.