### PR TITLE
enable filter [-f [FILTER]]

### DIFF
--- a/tools/tplist.py
+++ b/tools/tplist.py
@@ -28,7 +28,7 @@ parser.add_argument("-l", "--lib", default="",
         help="List USDT probes in the specified library or executable")
 parser.add_argument("-v", dest="verbosity", action="count", default=0,
         help="Increase verbosity level (print variables, arguments, etc.)")
-parser.add_argument(dest="filter", nargs="?",
+parser.add_argument("-f", dest="filter", nargs="?",
         help="A filter that specifies which probes/tracepoints to print")
 args = parser.parse_args()
 


### PR DESCRIPTION
[root@localhost study]# ./tplist.py -h
usage: tplist.py [-h] [-p PID] [-l LIB] [-v] [-f [FILTER]]

Display kernel tracepoints or USDT probes and their formats.

optional arguments:
  -h, --help         show this help message and exit
  -p PID, --pid PID  List USDT probes in the specified process
  -l LIB, --lib LIB  List USDT probes in the specified library or executable
  -v                 Increase verbosity level (print variables, arguments,
                     etc.)
  -f [FILTER]        A filter that specifies which probes/tracepoints to print