### PR TITLE
Add FENTRY_PROBE/FEXIT_PROBE

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -18,8 +18,10 @@ This guide is incomplete. If something feels missing, check the bcc and kernel s
         - [8. system call tracepoints](#8-system-call-tracepoints)
         - [9. kfuncs](#9-kfuncs)
         - [10. kretfuncs](#10-kretfuncs)
-        - [11. lsm probes](#11-lsm-probes)
-        - [12. bpf iterators](#12-bpf-iterators)
+        - [11. fentry](#11-fentry)
+        - [12. fexit](#12-fexit)
+        - [13. lsm probes](#13-lsm-probes)
+        - [14. bpf iterators](#14-bpf-iterators)
     - [Data](#data)
         - [1. bpf_probe_read_kernel()](#1-bpf_probe_read_kernel)
         - [2. bpf_probe_read_kernel_str()](#2-bpf_probe_read_kernel_str)
@@ -401,8 +403,55 @@ accessible as standard argument values together with its return value.
 Examples in situ:
 [search /tools](https://github.com/iovisor/bcc/search?q=KRETFUNC_PROBE+path%3Atools&type=Code)
 
+### 11. fentry
 
-### 11. LSM Probes
+Syntax: FENTRY_PROBE(*function*, typeof(arg1) arg1, typeof(arg2) arge ...)
+
+This is a macro that instruments the kernel function via trampoline
+*before* the function is executed. It's defined by *function* name and
+the function arguments defined as *argX*.
+
+FENTRY_PROBE is an alias to KFUNC_PROBE.
+
+For example:
+```C
+FENTRY_PROBE(do_sys_open, int dfd, const char *filename, int flags, int mode)
+{
+    ...
+```
+
+This instruments the do_sys_open kernel function and make its arguments
+accessible as standard argument values.
+
+Examples in situ:
+[search /tools](https://github.com/iovisor/bcc/search?q=FENTRY_PROBE+path%3Atools&type=Code)
+
+### 12. fexit
+
+Syntax: FEXIT_PROBE(*event*, typeof(arg1) arg1, typeof(arg2) arge ..., int ret)
+
+This is a macro that instruments the kernel function via trampoline
+*after* the function is executed. It's defined by *function* name and
+the function arguments defined as *argX*.
+
+The last argument of the probe is the return value of the instrumented function.
+
+FEXIT_PROBE is an alias to KRETFUNC_PROBE.
+
+For example:
+```C
+FEXIT_PROBE(do_sys_open, int dfd, const char *filename, int flags, int mode, int ret)
+{
+    ...
+```
+
+This instruments the do_sys_open kernel function and make its arguments
+accessible as standard argument values together with its return value.
+
+Examples in situ:
+[search /tools](https://github.com/iovisor/bcc/search?q=FEXIT_PROBE+path%3Atools&type=Code)
+
+### 13. LSM Probes
 
 Syntax: LSM_PROBE(*hook*, typeof(arg1) arg1, typeof(arg2) arg2 ...)
 
@@ -440,7 +489,7 @@ LSM probes require at least a 5.7+ kernel with the following configuation option
 Examples in situ:
 [search /tests](https://github.com/iovisor/bcc/search?q=LSM_PROBE+path%3Atests&type=Code)
 
-### 12. BPF ITERATORS
+### 14. BPF ITERATORS
 
 Syntax: BPF_ITER(target)
 

--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -1312,6 +1312,12 @@ static int ____##name(unsigned long long *ctx, ##args)
 #define KRETFUNC_PROBE(event, args...) \
         BPF_PROG(kretfunc__ ## event, args)
 
+#define FENTRY_PROBE(event, args...) \
+        BPF_PROG(kfunc__ ## event, args)
+
+#define FEXIT_PROBE(event, args...) \
+        BPF_PROG(kretfunc__ ## event, args)
+
 #define KMOD_RET(event, args...) \
         BPF_PROG(kmod_ret__ ## event, args)
 

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1086,6 +1086,10 @@ class BPF(object):
         return False
 
     @staticmethod
+    def support_fentry():
+        return BPF.support_kfunc()
+
+    @staticmethod
     def support_lsm():
         if not lib.bpf_has_kernel_btf():
             return False
@@ -1139,6 +1143,18 @@ class BPF(object):
             raise Exception("Failed to attach BPF to exit kernel func")
         self.kfunc_exit_fds[fn_name] = fd
         return self
+
+    def detach_fentry(self, fn_name=b""):
+        return self.detach_kfunc(fn_name)
+
+    def detach_fexit(self, fn_name=b""):
+        return self.detach_kretfunc(fn_name)
+
+    def attach_fentry(self, fn_name=b""):
+        return self.attach_kfunc(fn_name)
+
+    def attach_fexit(self, fn_name=b""):
+        return self.attach_kretfunc(fn_name)
 
     def detach_lsm(self, fn_name=b""):
         fn_name = _assert_is_bytes(fn_name)

--- a/tools/readahead.py
+++ b/tools/readahead.py
@@ -10,7 +10,8 @@
 # published by Addison Wesley. ISBN-13: 9780136554820
 # When copying or porting, include this comment.
 #
-# 20-Aug-2020   Suchakra Sharma   Ported from bpftrace to BCC
+# 20-Aug-2020   Suchakra Sharma     Ported from bpftrace to BCC
+# 14-Sep-2021   Hengqi Chen         Migrated to fentry
 
 from __future__ import print_function
 from bcc import BPF
@@ -34,7 +35,7 @@ if not args.duration:
     args.duration = 99999999
 
 # BPF program
-program = """
+bpf_text = """
 #include <uapi/linux/ptrace.h>
 #include <linux/mm_types.h>
 
@@ -42,7 +43,9 @@ BPF_HASH(flag, u32, u8);            // used to track if we are in do_page_cache_
 BPF_HASH(birth, struct page*, u64); // used to track timestamps of cache alloc'ed page
 BPF_ARRAY(pages);                   // increment/decrement readahead pages
 BPF_HISTOGRAM(dist);
+"""
 
+bpf_text_kprobe = """
 int entry__do_page_cache_readahead(struct pt_regs *ctx) {
     u32 pid;
     u8 one = 1;
@@ -89,15 +92,78 @@ int entry_mark_page_accessed(struct pt_regs *ctx) {
 }
 """
 
-b = BPF(text=program)
-if BPF.get_kprobe_functions(b"__do_page_cache_readahead"):
-    ra_event = "__do_page_cache_readahead"
+bpf_text_fentry = """
+FENTRY_PROBE(RA_FUNC, void *arg0)
+{
+    u32 pid;
+    u8 one = 1;
+
+    pid = bpf_get_current_pid_tgid();
+    flag.update(&pid, &one);
+    return 0;
+}
+
+FEXIT_PROBE(RA_FUNC, void *arg0)
+{
+    u32 pid;
+    u8 zero = 0;
+
+    pid = bpf_get_current_pid_tgid();
+    flag.update(&pid, &zero);
+    return 0;
+}
+
+FEXIT_PROBE(__page_cache_alloc, gfp_t gfp, struct page *retval)
+{
+    u32 pid;
+    u64 ts;
+    u32 zero = 0; // static key for accessing pages[0]
+    pid = bpf_get_current_pid_tgid();
+    u8 *f;
+
+    f = flag.lookup(&pid);
+    if (f != NULL && *f == 1) {
+        ts = bpf_ktime_get_ns();
+        birth.update(&retval, &ts);
+        pages.atomic_increment(zero);
+    }
+    return 0;
+}
+
+FENTRY_PROBE(mark_page_accessed, struct page *arg0)
+{
+    u64 ts, delta;
+    u32 zero = 0; // static key for accessing pages[0]
+    u64 *bts = birth.lookup(&arg0);
+
+    if (bts != NULL) {
+        delta = bpf_ktime_get_ns() - *bts;
+        dist.atomic_increment(bpf_log2l(delta/1000000));
+        pages.atomic_increment(zero, -1);
+        birth.delete(&arg0); // remove the entry from hashmap
+    }
+    return 0;
+}
+"""
+
+if BPF.support_fentry():
+    if BPF.get_kprobe_functions(b"__do_page_cache_readahead"):
+        ra_func = "__do_page_cache_readahead"
+    else:
+        ra_func = "do_page_cache_ra"
+    bpf_text += bpf_text_fentry.replace("RA_FUNC", ra_func)
+    b = BPF(text=bpf_text)
 else:
-    ra_event = "do_page_cache_ra"
-b.attach_kprobe(event=ra_event, fn_name="entry__do_page_cache_readahead")
-b.attach_kretprobe(event=ra_event, fn_name="exit__do_page_cache_readahead")
-b.attach_kretprobe(event="__page_cache_alloc", fn_name="exit__page_cache_alloc")
-b.attach_kprobe(event="mark_page_accessed", fn_name="entry_mark_page_accessed")
+    bpf_text += bpf_text_kprobe
+    b = BPF(text=bpf_text)
+    if BPF.get_kprobe_functions(b"__do_page_cache_readahead"):
+        ra_event = "__do_page_cache_readahead"
+    else:
+        ra_event = "do_page_cache_ra"
+    b.attach_kprobe(event=ra_event, fn_name="entry__do_page_cache_readahead")
+    b.attach_kretprobe(event=ra_event, fn_name="exit__do_page_cache_readahead")
+    b.attach_kretprobe(event="__page_cache_alloc", fn_name="exit__page_cache_alloc")
+    b.attach_kprobe(event="mark_page_accessed", fn_name="entry_mark_page_accessed")
 
 # header
 print("Tracing... Hit Ctrl-C to end.")


### PR DESCRIPTION
I was prototyping some new tools with fentry using BCC, but the docs has nothing related to `fentry`.

After some research I found that fentry/fexit are implemented as kfunc/kretfunc in BCC. Actually, only this [issue](https://github.com/iovisor/bpftrace/issues/1833) mentioned this.

I think it's helpful to add this to BCC.