### PR TITLE
fix debian build settings for LLVM package names

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,10 +4,10 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 9), cmake,
-    libllvm9 | libllvm8.0 | libllvm6.0 | libllvm3.8 [!arm64] | libllvm3.7 [!arm64],
-    llvm-9-dev | llvm-8.0-dev | llvm-6.0-dev | llvm-3.8-dev [!arm64] | llvm-3.7-dev [!arm64],
-    libclang-9-dev | libclang-8.0-dev | libclang-6.0-dev | libclang-3.8-dev [!arm64] | libclang-3.7-dev [!arm64],
-    clang-format-9 | clang-format-8.0 | clang-format-6.0 | clang-format-3.8 [!arm64] | clang-format-3.7 [!arm64] | clang-format,
+    libllvm9 | libllvm8 | libllvm6.0 | libllvm3.8 [!arm64] | libllvm3.7 [!arm64],
+    llvm-9-dev | llvm-8-dev | llvm-6.0-dev | llvm-3.8-dev [!arm64] | llvm-3.7-dev [!arm64],
+    libclang-9-dev | libclang-8-dev | libclang-6.0-dev | libclang-3.8-dev [!arm64] | libclang-3.7-dev [!arm64],
+    clang-format-9 | clang-format-8 | clang-format-6.0 | clang-format-3.8 [!arm64] | clang-format-3.7 [!arm64] | clang-format,
     libelf-dev, bison, flex, libfl-dev, libedit-dev, zlib1g-dev, git,
     python (>= 2.7), python-netaddr, python-pyroute2 | python3-pyroute2, luajit,
     libluajit-5.1-dev, arping, inetutils-ping | iputils-ping, iperf, netperf,


### PR DESCRIPTION
There's no `llvm-8.0`, but instead, it's `llvm-8` in Ubuntu.

Ubuntu 16.04 is affected by this change, choosing llvm-8 instead of llvm-3.8.