### PR TITLE
libbpf-tools: fix EINTR related issues

### DIFF
--- a/libbpf-tools/bindsnoop.c
+++ b/libbpf-tools/bindsnoop.c
@@ -222,7 +222,8 @@ int main(int argc, char **argv)
 	}
 
 	if (signal(SIGINT, sig_int) == SIG_ERR) {
-		warn("can't set signal handler: %s\n", strerror(-errno));
+		warn("can't set signal handler: %s\n", strerror(errno));
+		err = 1;
 		goto cleanup;
 	}
 
@@ -231,15 +232,18 @@ int main(int argc, char **argv)
 	printf("%-7s %-16s %-3s %-5s %-5s %-4s %-5s %-48s\n",
 	       "PID", "COMM", "RET", "PROTO", "OPTS", "IF", "PORT", "ADDR");
 
-	while (1) {
-		if ((err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS)) < 0)
-			break;
-		if (exiting)
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && errno != EINTR) {
+			warn("error polling perf buffer: %s\n", strerror(errno));
 			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
 	}
-	warn("error polling perf buffer: %d\n", err);
 
 cleanup:
+	perf_buffer__free(pb);
 	bindsnoop_bpf__destroy(obj);
 
 	return err != 0;

--- a/libbpf-tools/drsnoop.c
+++ b/libbpf-tools/drsnoop.c
@@ -4,6 +4,7 @@
 // Based on drsnoop(8) from BCC by Wenbo Zhang.
 // 28-Feb-2020   Wenbo Zhang   Created this.
 #include <argp.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -17,6 +18,8 @@
 
 #define PERF_BUFFER_PAGES	16
 #define PERF_POLL_TIMEOUT_MS	100
+
+static volatile sig_atomic_t exiting = 0;
 
 static struct env {
 	pid_t pid;
@@ -107,6 +110,11 @@ int libbpf_print_fn(enum libbpf_print_level level,
 	if (level == LIBBPF_DEBUG && !env.verbose)
 		return 0;
 	return vfprintf(stderr, format, args);
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
 }
 
 void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
@@ -221,14 +229,24 @@ int main(int argc, char **argv)
 	if (env.duration)
 		time_end = get_ktime_ns() + env.duration * NSEC_PER_SEC;
 
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		fprintf(stderr, "can't set signal handler: %s\n", strerror(errno));
+		err = 1;
+		goto cleanup;
+	}
+
 	/* main: poll */
-	while (1) {
-		if ((err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS)) < 0)
-			break;
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && errno != EINTR) {
+			fprintf(stderr, "error polling perf buffer: %s\n", strerror(errno));
+			goto cleanup;
+		}
 		if (env.duration && get_ktime_ns() > time_end)
 			goto cleanup;
+		/* reset err to return 0 if exiting */
+		err = 0;
 	}
-	printf("error polling perf buffer: %d\n", err);
 
 cleanup:
 	perf_buffer__free(pb);

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -4,6 +4,7 @@
 // Based on filelife(8) from BCC by Brendan Gregg & Allan McAleavy.
 // 20-Mar-2020   Wenbo Zhang   Created this.
 #include <argp.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -17,6 +18,8 @@
 
 #define PERF_BUFFER_PAGES	16
 #define PERF_POLL_TIMEOUT_MS	100
+
+static volatile sig_atomic_t exiting = 0;
 
 static struct env {
 	pid_t pid;
@@ -74,6 +77,11 @@ int libbpf_print_fn(enum libbpf_print_level level,
 	if (level == LIBBPF_DEBUG && !env.verbose)
 		return 0;
 	return vfprintf(stderr, format, args);
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
 }
 
 void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
@@ -155,9 +163,21 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	while ((err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS)) >= 0)
-		;
-	fprintf(stderr, "error polling perf buffer: %d\n", err);
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		fprintf(stderr, "can't set signal handler: %s\n", strerror(errno));
+		err = 1;
+		goto cleanup;
+	}
+
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && errno != EINTR) {
+			fprintf(stderr, "error polling perf buffer: %s\n", strerror(errno));
+			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
+	}
 
 cleanup:
 	perf_buffer__free(pb);

--- a/libbpf-tools/filetop.c
+++ b/libbpf-tools/filetop.c
@@ -284,7 +284,8 @@ int main(int argc, char **argv)
 	}
 
 	if (signal(SIGINT, sig_int) == SIG_ERR) {
-		warn("can't set signal handler: %s\n", strerror(-errno));
+		warn("can't set signal handler: %s\n", strerror(errno));
+		err = 1;
 		goto cleanup;
 	}
 

--- a/libbpf-tools/mountsnoop.c
+++ b/libbpf-tools/mountsnoop.c
@@ -282,7 +282,8 @@ int main(int argc, char **argv)
 	}
 
 	if (signal(SIGINT, sig_int) == SIG_ERR) {
-		warn("can't set signal handler: %s\n", strerror(-errno));
+		warn("can't set signal handler: %s\n", strerror(errno));
+		err = 1;
 		goto cleanup;
 	}
 
@@ -292,13 +293,15 @@ int main(int argc, char **argv)
 		printf("%-16s %-7s %-7s %-11s %s\n", "COMM", "PID", "TID", "MNT_NS", "CALL");
 	}
 
-	while (1) {
-		if ((err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS)) < 0)
-			break;
-		if (exiting)
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && errno != EINTR) {
+			fprintf(stderr, "error polling perf buffer: %s\n", strerror(errno));
 			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
 	}
-	warn("error polling perf buffer: %d\n", err);
 
 cleanup:
 	perf_buffer__free(pb);

--- a/libbpf-tools/solisten.c
+++ b/libbpf-tools/solisten.c
@@ -177,7 +177,8 @@ int main(int argc, char **argv)
 	}
 
 	if (signal(SIGINT, sig_int) == SIG_ERR) {
-		warn("can't set signal handler: %s\n", strerror(-errno));
+		warn("can't set signal handler: %s\n", strerror(errno));
+		err = 1;
 		goto cleanup;
 	}
 
@@ -186,13 +187,15 @@ int main(int argc, char **argv)
 	printf("%-7s %-16s %-3s %-7s %-5s %-5s %-32s\n",
 	       "PID", "COMM", "RET", "BACKLOG", "PROTO", "PORT", "ADDR");
 
-	while (1) {
-		if ((err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS)) < 0)
-			break;
-		if (exiting)
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && errno != EINTR) {
+			warn("error polling perf buffer: %s\n", strerror(errno));
 			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
 	}
-	warn("error polling perf buffer: %d\n", err);
 
 cleanup:
 	perf_buffer__free(pb);

--- a/libbpf-tools/statsnoop.c
+++ b/libbpf-tools/statsnoop.c
@@ -162,7 +162,8 @@ int main(int argc, char **argv)
 	}
 
 	if (signal(SIGINT, sig_int) == SIG_ERR) {
-		warn("can't set signal handler: %s\n", strerror(-errno));
+		warn("can't set signal handler: %s\n", strerror(errno));
+		err = 1;
 		goto cleanup;
 	}
 
@@ -171,15 +172,18 @@ int main(int argc, char **argv)
 	printf("%-7s %-20s %-4s %-4s %-s\n",
 	       "PID", "COMM", "RET", "ERR", "PATH");
 
-	while (1) {
-		if ((err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS)) < 0)
-			break;
-		if (exiting)
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && errno != EINTR) {
+			warn("error polling perf buffer: %s\n", strerror(errno));
 			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
 	}
-	warn("error polling perf buffer: %d\n", err);
 
 cleanup:
+	perf_buffer__free(pb);
 	statsnoop_bpf__destroy(obj);
 
 	return err != 0;

--- a/libbpf-tools/tcpconnlat.c
+++ b/libbpf-tools/tcpconnlat.c
@@ -5,6 +5,7 @@
 // 11-Jul-2020   Wenbo Zhang   Created this.
 #include <argp.h>
 #include <arpa/inet.h>
+#include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <time.h>
@@ -16,6 +17,8 @@
 
 #define PERF_BUFFER_PAGES	16
 #define PERF_POLL_TIMEOUT_MS	100
+
+static volatile sig_atomic_t exiting = 0;
 
 static struct env {
 	__u64 min_us;
@@ -94,6 +97,11 @@ int libbpf_print_fn(enum libbpf_print_level level,
 	if (level == LIBBPF_DEBUG && !env.verbose)
 		return 0;
 	return vfprintf(stderr, format, args);
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
 }
 
 void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
@@ -196,14 +204,25 @@ int main(int argc, char **argv)
 	printf("%-6s %-12s %-2s %-16s %-16s %-5s %s\n",
 		"PID", "COMM", "IP", "SADDR", "DADDR", "DPORT", "LAT(ms)");
 
-	/* main: poll */
-	while (1) {
-		if ((err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS)) < 0)
-			break;
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		fprintf(stderr, "can't set signal handler: %s\n", strerror(errno));
+		err = 1;
+		goto cleanup;
 	}
-	printf("error polling perf buffer: %d\n", err);
+
+	/* main: poll */
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && errno != EINTR) {
+			fprintf(stderr, "error polling perf buffer: %s\n", strerror(errno));
+			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
+	}
 
 cleanup:
+	perf_buffer__free(pb);
 	tcpconnlat_bpf__destroy(obj);
 
 	return err != 0;


### PR DESCRIPTION
1. Most of the tools that use perf_buffer__poll() were not handling the
case when it was interrupted by a signal, they were just ending.
We noticed this issue by running the tools inside a container, after
some seconds they will finish:

```
$ time /execsnoop
...
runc             210198 939      0 /usr/sbin/runc --version
docker-init      210205 939      0 /usr/bin/docker-init --version
Error polling perf buffer: -4

real	0m48.913s
user	0m0.020s
sys	0m0.033s
```

This commit fixes that by checking if errno is EINTR after calling
perf_buffer__poll().

2. Many tools were returning non zero when ended by SIG_INT.

```
$ sudo ./execsnoop
PCOMM            PID    PPID   RET ARGS
runc             203967 939      0 /usr/sbin/runc --version
docker-init      203973 939      0 /usr/bin/docker-init --version
calico           203974 724      0 /opt/cni/bin/calico
portmap          203985 724      0 /opt/cni/bin/portmap
bandwidth        203990 724      0 /opt/cni/bin/bandwidth
^C
$ echo $?
130
```

3. Some tools were missing the SIG_INT handler

Related issue https://github.com/kinvolk/inspektor-gadget/issues/230 

cc @alban 