### PR TITLE
ksnoop: remove duplicate include

### DIFF
--- a/libbpf-tools/ksnoop.c
+++ b/libbpf-tools/ksnoop.c
@@ -4,7 +4,6 @@
 #include <ctype.h>
 #include <errno.h>
 #include <getopt.h>
-#include <linux/bpf.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
`ksnoop` is the only libbpf tool which is including both `<linux/bpf.h>` and `<bpf/bpf.h>` - the rest of the tools just include the latter

build fails for me because of redefinition errors as a result. Let's use `<bpf/bpf.h>` like the rest of the tools