### PR TITLE
remove ubuntu 16.04 from bcc-test github action

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -7,8 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04] # 16.04.4 release has 4.15 kernel
-                                         # 18.04.3 release has 5.0.0 kernel
+        os: [ubuntu-18.04] # 18.04.3 release has 5.0.0 kernel                                        
         env:
         - TYPE: Debug
           PYTHON_TEST_LOGFILE: critical.log


### PR DESCRIPTION
As per [github](https://github.com/actions/virtual-environments/issues/3287), this is no longer supported. CI fails with errors like

```
This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.
```

I will add 20.04 in a followup PR to match `publish.yml`. Want to keep it separate in case adding 20.04 causes issues, removing 16.04 should be much less likely to.