### PR TITLE
Add function to print additional information when using `--containersmap`

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -17,6 +17,14 @@ WORKDIR /root/bcc
 RUN /usr/lib/pbuilder/pbuilder-satisfydepends && \
     ./scripts/build-deb.sh ${BUILD_TYPE}
 
+# libbpf-tools
+RUN apt-get -qq update && \
+    apt-get -y install build-essential libelf-dev libfl-dev clang-10 libcap-dev
+
+RUN cd /root/bcc/src/cc/libbpf/src/ && make
+RUN cd /root/bcc/libbpf-tools/ && \
+  CLANG=clang-10 LLVM_STRIP=llvm-strip-10 make -j $(nproc) DESTDIR=/libbpf-tools/ prefix="" install
+
 FROM ubuntu:${OS_TAG}
 
 COPY --from=builder /root/bcc/*.deb /root/bcc/
@@ -30,3 +38,6 @@ RUN \
   fi ; \
   pip3 install dnslib cachetools  && \
   dpkg -i /root/bcc/*.deb
+
+# libbpf-tools
+COPY --from=builder /libbpf-tools/bin/* /bin/libbpf-tools/

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -65,6 +65,7 @@ COMMON_OBJ = \
 	$(OUTPUT)/errno_helpers.o \
 	$(OUTPUT)/map_helpers.o \
 	$(OUTPUT)/uprobe_helpers.o \
+	$(OUTPUT)/containers.o \
 	#
 
 .PHONY: all

--- a/libbpf-tools/bindsnoop.c
+++ b/libbpf-tools/bindsnoop.c
@@ -265,7 +265,7 @@ int main(int argc, char **argv)
 	}
 
 	if (containersmap) {
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	}
 
 	if (emit_timestamp)

--- a/libbpf-tools/bindsnoop.h
+++ b/libbpf-tools/bindsnoop.h
@@ -9,6 +9,7 @@ struct bind_event {
 	__u64 ts_us;
 	__u32 pid;
 	__u32 bound_dev_if;
+	__u64 mntns_id;
 	int ret;
 	__u16 port;
 	__u8 opts;

--- a/libbpf-tools/containers.c
+++ b/libbpf-tools/containers.c
@@ -1,0 +1,19 @@
+#include "containers.h"
+
+#include <stdlib.h>
+#include <bpf/bpf.h>
+
+struct container get_container_info(int map_fd, uint64_t mtnnsid) {
+	struct container container = {
+		.kubernetes_namespace = "<>",
+		.kubernetes_pod = "<>",
+		.kubernetes_container = "<>",
+		.node = "<>"
+	};
+
+	bpf_map_lookup_elem(map_fd, &mtnnsid, &container);
+
+	strncpy(container.node, getenv("NODE_NAME"), NAME_MAX_LENGTH - 1);
+
+	return container;
+}

--- a/libbpf-tools/containers.h
+++ b/libbpf-tools/containers.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __CONTAINERS_H
+#define __CONTAINERS_H
+
+#include <stdint.h>
+
+#define MAX_CONTAINERS_PER_NODE 1024
+#define NAME_MAX_LENGTH 256
+
+struct container {
+	char container_id[NAME_MAX_LENGTH];
+	char kubernetes_namespace[NAME_MAX_LENGTH];
+	char kubernetes_pod[NAME_MAX_LENGTH];
+	char kubernetes_container[NAME_MAX_LENGTH];
+	// this field is not present in the containers map so it's added as the last one here
+	char node[NAME_MAX_LENGTH];
+};
+
+struct container get_container_info(int map_fd, uint64_t mtnnsid);
+
+#endif /* __CONTAINERS_H */

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -347,7 +347,7 @@ int main(int argc, char **argv)
 	}
 	/* print headers */
 	if (env.containersmap) {
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	}
 	if (env.time) {
 		printf("%-9s", "TIME");

--- a/libbpf-tools/execsnoop.h
+++ b/libbpf-tools/execsnoop.h
@@ -16,6 +16,7 @@ struct event {
 	pid_t pid;
 	pid_t ppid;
 	uid_t uid;
+	__u64 mntns_id;
 	int retval;
 	int args_count;
 	unsigned int args_size;

--- a/libbpf-tools/opensnoop.bpf.c
+++ b/libbpf-tools/opensnoop.bpf.c
@@ -3,6 +3,7 @@
 // Copyright (c) 2020 Netflix
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
 #include "opensnoop.h"
 
 #define TASK_RUNNING	0
@@ -12,6 +13,7 @@ const volatile pid_t targ_pid = 0;
 const volatile pid_t targ_tgid = 0;
 const volatile uid_t targ_uid = 0;
 const volatile bool targ_failed = false;
+const volatile bool filter_by_mnt_ns = false;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -26,6 +28,13 @@ struct {
 	__uint(value_size, sizeof(u32));
 } events SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1024);
+	__uint(key_size, sizeof(u64));
+	__uint(value_size, sizeof(u32));
+} mount_ns_set SEC(".maps");
+
 static __always_inline bool valid_uid(uid_t uid) {
 	return uid != INVALID_UID;
 }
@@ -33,6 +42,8 @@ static __always_inline bool valid_uid(uid_t uid) {
 static __always_inline
 bool trace_allowed(u32 tgid, u32 pid)
 {
+	struct task_struct *task;
+	u64 mntns_id;
 	u32 uid;
 
 	/* filters */
@@ -46,6 +57,13 @@ bool trace_allowed(u32 tgid, u32 pid)
 			return false;
 		}
 	}
+
+	task = (struct task_struct*)bpf_get_current_task();
+	mntns_id = (u64) BPF_CORE_READ(task, nsproxy, mnt_ns, ns.inum);
+
+	if (filter_by_mnt_ns && !bpf_map_lookup_elem(&mount_ns_set, &mntns_id))
+		return false;
+
 	return true;
 }
 
@@ -92,6 +110,8 @@ int trace_exit(struct trace_event_raw_sys_exit* ctx)
 	struct args_t *ap;
 	int ret;
 	u32 pid = bpf_get_current_pid_tgid();
+	struct task_struct *task;
+	u64 mntns_id;
 
 	ap = bpf_map_lookup_elem(&start, &pid);
 	if (!ap)
@@ -100,6 +120,12 @@ int trace_exit(struct trace_event_raw_sys_exit* ctx)
 	if (targ_failed && ret >= 0)
 		goto cleanup;	/* want failed only */
 
+	task = (struct task_struct*)bpf_get_current_task();
+	mntns_id = (u64) BPF_CORE_READ(task, nsproxy, mnt_ns, ns.inum);
+
+	if (filter_by_mnt_ns && !bpf_map_lookup_elem(&mount_ns_set, &mntns_id))
+		return 0;
+
 	/* event data */
 	event.pid = bpf_get_current_pid_tgid() >> 32;
 	event.uid = bpf_get_current_uid_gid();
@@ -107,6 +133,7 @@ int trace_exit(struct trace_event_raw_sys_exit* ctx)
 	bpf_probe_read_user_str(&event.fname, sizeof(event.fname), ap->fname);
 	event.flags = ap->flags;
 	event.ret = ret;
+	event.mntns_id = mntns_id;
 
 	/* emit event */
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -316,7 +316,7 @@ int main(int argc, char **argv)
 
 	/* print headers */
 	if (env.containersmap) {
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	}
 	if (env.timestamp)
 		printf("%-8s ", "TIME");

--- a/libbpf-tools/opensnoop.h
+++ b/libbpf-tools/opensnoop.h
@@ -16,6 +16,7 @@ struct event {
 	__u64 ts;
 	pid_t pid;
 	uid_t uid;
+	__u64 mntns_id;
 	int ret;
 	int flags;
 	char comm[TASK_COMM_LEN];

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -287,7 +287,7 @@ static void print_count(int map_fd_ipv4, int map_fd_ipv6)
 static void print_events_header()
 {
 	if (env.containersmap)
-		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME");
+		printf("%-16s %-16s %-16s %-16s", "NODE", "NAMESPACE", "POD", "CONTAINER");
 	if (env.print_timestamp)
 		printf("%-9s", "TIME(s)");
 	if (env.print_uid)

--- a/libbpf-tools/tcpconnect.h
+++ b/libbpf-tools/tcpconnect.h
@@ -38,6 +38,7 @@ struct event {
 	__u32 pid;
 	__u32 uid;
 	__u16 dport;
+	__u64 mntns_id;
 };
 
 #endif /* __TCPCONNECT_H */

--- a/src/python/bcc/containers.py
+++ b/src/python/bcc/containers.py
@@ -136,9 +136,9 @@ BUFFER_SIZE = 256
 class ContainerC(ct.Structure):
     _fields_ = [
         ("ContainerID", ct.c_char*BUFFER_SIZE ),
-        ("KubernetesNamespace", ct.c_char*BUFFER_SIZE),
-        ("KubernetesPod", ct.c_char*BUFFER_SIZE),
-        ("KubernetesContainer", ct.c_char*BUFFER_SIZE),
+        ("Namespace", ct.c_char*BUFFER_SIZE),
+        ("Pod", ct.c_char*BUFFER_SIZE),
+        ("Container", ct.c_char*BUFFER_SIZE),
     ]
 
 
@@ -169,16 +169,16 @@ class ContainersMap:
         if int(ret) != 0:
             return container
 
-        container.Namespace = containerC.KubernetesNamespace
-        container.PodName = containerC.KubernetesPod
-        container.ContainerName = containerC.KubernetesContainer
+        container.Namespace = containerC.Namespace
+        container.PodName = containerC.Pod
+        container.ContainerName = containerC.Container
 
         return container
 
     def enrich_json_event(self, eventJ, mntnsid):
         container = self.get_container(mntnsid)
 
-        eventJ["node_name"] = container.NodeName
-        eventJ["pod_name"] = container.PodName
-        eventJ["container_name"] = container.ContainerName
+        eventJ["node"] = container.NodeName
+        eventJ["pod"] = container.PodName
+        eventJ["container"] = container.ContainerName
         eventJ["namespace"] = container.Namespace

--- a/src/python/bcc/containers.py
+++ b/src/python/bcc/containers.py
@@ -15,6 +15,7 @@
 from bcc.libbcc import lib
 import ctypes as ct
 import os
+import sys
 
 get_mntns_id_text = """
     #ifndef __GET_MTN_NS_ID
@@ -173,3 +174,11 @@ class ContainersMap:
         container.ContainerName = containerC.KubernetesContainer
 
         return container
+
+    def enrich_json_event(self, eventJ, mntnsid):
+        container = self.get_container(mntnsid)
+
+        eventJ["node_name"] = container.NodeName
+        eventJ["pod_name"] = container.PodName
+        eventJ["container_name"] = container.ContainerName
+        eventJ["namespace"] = container.Namespace

--- a/src/python/bcc/containers.py
+++ b/src/python/bcc/containers.py
@@ -133,6 +133,14 @@ def print_container_info():
 # keep synchronized with definition in gadget tracer manager
 BUFFER_SIZE = 256
 
+NODE_HEADER = "NODE";
+NAMESPACE_HEADER = "NAMESPACE";
+POD_HEADER = "POD";
+CONTAINER_HEADER = "CONTAINER";
+
+def print_additional_info_header():
+	print('{:16} {:16} {:16} {:16}'.format(NODE_HEADER, NAMESPACE_HEADER, POD_HEADER, CONTAINER_HEADER), end = '')
+
 class ContainerC(ct.Structure):
     _fields_ = [
         ("ContainerID", ct.c_char*BUFFER_SIZE ),

--- a/src/python/bcc/utils.py
+++ b/src/python/bcc/utils.py
@@ -145,3 +145,12 @@ static inline bool %s(char const *ignored, uintptr_t str) {
             "probeid": probeid
         }
         return rdict
+
+def __stubprintb(s, file=sys.stdout, nl=1):
+        return
+
+def disable_stdout():
+    orig = sys.stdout
+    sys.stdout = open("/dev/null", 'w', buffering=1)
+
+    return (orig, __stubprintb)

--- a/tools/bindsnoop.py
+++ b/tools/bindsnoop.py
@@ -551,7 +551,7 @@ if args.count:
 else:
     # header
     if args.containersmap:
-        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
     if args.timestamp:
         print("%-9s " % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/bindsnoop.py
+++ b/tools/bindsnoop.py
@@ -28,7 +28,7 @@
 
 from __future__ import print_function, absolute_import, unicode_literals
 from bcc import BPF, DEBUG_SOURCE
-from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info, print_additional_info_header
 from bcc.utils import printb, disable_stdout
 import argparse
 import json
@@ -551,7 +551,7 @@ if args.count:
 else:
     # header
     if args.containersmap:
-        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
+        print_additional_info_header()
     if args.timestamp:
         print("%-9s " % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -262,7 +262,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 
 if args.extra:
     print("%-9s %-6s %-6s %-6s %-16s %-4s %-20s %-6s %s" % (

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 from os import getpid
 from functools import partial
 from bcc import BPF
-from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info, print_additional_info_header
 from bcc.utils import disable_stdout
 import errno
 import argparse
@@ -262,7 +262,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
+    print_additional_info_header()
 
 if args.extra:
     print("%-9s %-6s %-6s %-6s %-16s %-4s %-20s %-6s %s" % (

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -252,7 +252,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 if args.time:
     print("%-9s" % ("TIME"), end="")
 if args.timestamp:

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -17,7 +17,7 @@
 
 from __future__ import print_function
 from bcc import ArgString, BPF
-from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info, print_additional_info_header
 from bcc.utils import printb, disable_stdout
 import argparse
 import json
@@ -357,7 +357,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
+    print_additional_info_header()
 if args.timestamp:
     print("%-14s" % ("TIME(s)"), end="")
 if args.print_uid:

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -357,7 +357,7 @@ if args.json:
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 if args.timestamp:
     print("%-14s" % ("TIME(s)"), end="")
 if args.print_uid:

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -23,7 +23,7 @@
 
 from __future__ import print_function
 from bcc import BPF
-from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info, print_additional_info_header
 from bcc.utils import printb, disable_stdout
 import argparse
 import json
@@ -585,7 +585,7 @@ if args.count:
 else:
     # header
     if args.containersmap:
-        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
+        print_additional_info_header()
     if args.timestamp:
         print("%-9s" % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -190,7 +190,7 @@ static int trace_connect_return(struct pt_regs *ctx, short ipver)
     u16 dport = skp->__sk_common.skc_dport;
 
     FILTER_PORT
-    
+
     FILTER_FAMILY
 
     if (ipver == 4) {
@@ -585,7 +585,7 @@ if args.count:
 else:
     # header
     if args.containersmap:
-        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
     if args.timestamp:
         print("%-9s" % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -23,7 +23,7 @@
 
 from __future__ import print_function
 from bcc import BPF
-from bcc.containers import filter_by_containers
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info
 from bcc.utils import printb
 import argparse
 from socket import inet_ntop, ntohs, AF_INET, AF_INET6
@@ -75,6 +75,8 @@ parser.add_argument("--cgroupmap",
     help="trace cgroups in this BPF map only")
 parser.add_argument("--mntnsmap",
     help="trace mount namespaces in this BPF map only")
+parser.add_argument("--containersmap",
+    help="print additional information about the containers where the events are executed")
 parser.add_argument("-d", "--dns", action="store_true",
     help="include likely DNS query associated with each connect")
 parser.add_argument("--ebpf", action="store_true",
@@ -101,6 +103,9 @@ struct ipv4_data_t {
     u16 lport;
     u16 dport;
     char task[TASK_COMM_LEN];
+#ifdef PRINT_CONTAINER_INFO
+    u64 mntnsid;
+#endif
 };
 BPF_PERF_OUTPUT(ipv4_events);
 
@@ -114,6 +119,9 @@ struct ipv6_data_t {
     u16 lport;
     u16 dport;
     char task[TASK_COMM_LEN];
+#ifdef PRINT_CONTAINER_INFO
+    u64 mntnsid;
+#endif
 };
 BPF_PERF_OUTPUT(ipv6_events);
 
@@ -220,6 +228,9 @@ struct_init = {'ipv4':
                data4.daddr = skp->__sk_common.skc_daddr;
                data4.lport = lport;
                data4.dport = ntohs(dport);
+#ifdef PRINT_CONTAINER_INFO
+               data4.mntnsid = get_mntns_id();
+#endif
                bpf_get_current_comm(&data4.task, sizeof(data4.task));
                ipv4_events.perf_submit(ctx, &data4, sizeof(data4));"""
                },
@@ -244,6 +255,9 @@ struct_init = {'ipv4':
                    skp->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
                data6.lport = lport;
                data6.dport = ntohs(dport);
+#ifdef PRINT_CONTAINER_INFO
+               data6.mntnsid = get_mntns_id();
+#endif
                bpf_get_current_comm(&data6.task, sizeof(data6.task));
                ipv6_events.perf_submit(ctx, &data6, sizeof(data6));"""
                }
@@ -353,6 +367,8 @@ elif args.ipv6:
 if args.uid:
     bpf_text = bpf_text.replace('FILTER_UID',
         'if (uid != %s) { return 0; }' % args.uid)
+if args.containersmap:
+    bpf_text = print_container_info() + bpf_text
 bpf_text = filter_by_containers(args) + bpf_text
 
 bpf_text = bpf_text.replace('FILTER_PID', '')
@@ -368,10 +384,16 @@ if debug or args.ebpf:
     if args.ebpf:
         exit()
 
+if args.containersmap:
+    containers_map = ContainersMap(args.containersmap)
+
 # process event
 def print_ipv4_event(cpu, data, size):
     event = b["ipv4_events"].event(data)
     global start_ts
+    if args.containersmap:
+        container = containers_map.get_container(event.mntnsid)
+        printb("%-16s %-16s %-16s %-16s" % (container.NodeName, container.Namespace, container.PodName, container.ContainerName), nl="")
     if args.timestamp:
         if start_ts == 0:
             start_ts = event.ts_us
@@ -393,6 +415,9 @@ def print_ipv4_event(cpu, data, size):
 def print_ipv6_event(cpu, data, size):
     event = b["ipv6_events"].event(data)
     global start_ts
+    if args.containersmap:
+        container = containers_map.get_container(event.mntnsid)
+        printb("%-16s %-16s %-16s %-16s" % (container.NodeName, container.Namespace, container.PodName, container.ContainerName), nl="")
     if args.timestamp:
         if start_ts == 0:
             start_ts = event.ts_us
@@ -523,6 +548,8 @@ if args.count:
 # read events
 else:
     # header
+    if args.containersmap:
+        print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
     if args.timestamp:
         print("%-9s" % ("TIME(s)"), end="")
     if args.print_uid:

--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -729,7 +729,7 @@ print("Tracing TCP established connections. Ctrl-C to end.")
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "PODNAME", "CONTAINERNAME"), end="")
+    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
 if args.verbose:
     if args.timestamp:
         print("%-14s" % ("TIME(ns)"), end="")

--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -16,7 +16,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 from __future__ import print_function
 from bcc import BPF
-from bcc.containers import filter_by_containers, ContainersMap, print_container_info
+from bcc.containers import filter_by_containers, ContainersMap, print_container_info, print_additional_info_header
 from bcc.utils import disable_stdout
 
 import argparse as ap
@@ -729,7 +729,7 @@ print("Tracing TCP established connections. Ctrl-C to end.")
 
 # header
 if args.containersmap:
-    print("%-16s %-16s %-16s %-16s" % ("NODE", "NAMESPACE", "POD", "CONTAINER"), end="")
+    print_additional_info_header()
 if args.verbose:
     if args.timestamp:
         print("%-14s" % ("TIME(ns)"), end="")


### PR DESCRIPTION
Hi.


In this PR, I added `print_additional_info_header` which basically prints:
```
NODE             NAMESPACE        POD          CONTAINER
```
when `--containersmap` is used.
It makes the code easier to change, as now if we want to modify header name, we just need to modify corresponding values in `containers.py`.


Best regards.