### PR TITLE
get the pid namespace by following task_active_pid_ns()

### DIFF
--- a/libbpf-tools/runqlat.bpf.c
+++ b/libbpf-tools/runqlat.bpf.c
@@ -48,6 +48,24 @@ int trace_enqueue(u32 tgid, u32 pid)
 	return 0;
 }
 
+static __always_inline unsigned int pid_namespace(struct task_struct *task)
+{
+	struct pid *pid;
+	unsigned int level;
+	struct upid upid;
+	unsigned int inum;
+
+	/*  get the pid namespace by following task_active_pid_ns(),
+	 *  pid->numbers[pid->level].ns
+	 */
+	pid = BPF_CORE_READ(task, thread_pid);
+	level = BPF_CORE_READ(pid, level);
+	bpf_core_read(&upid, sizeof(upid), &pid->numbers[level]);
+	inum = BPF_CORE_READ(upid.ns, ns.inum);
+
+	return inum;
+}
+
 SEC("tp_btf/sched_wakeup")
 int BPF_PROG(sched_wakeup, struct task_struct *p)
 {
@@ -86,7 +104,7 @@ int BPF_PROG(sched_swith, bool preempt, struct task_struct *prev,
 	else if (targ_per_thread)
 		hkey = pid;
 	else if (targ_per_pidns)
-		hkey = next->nsproxy->pid_ns_for_children->ns.inum;
+		hkey = pid_namespace(next);
 	else
 		hkey = -1;
 	histp = bpf_map_lookup_or_try_init(&hists, &hkey, &zero);


### PR DESCRIPTION
When unsharing of pid namespace, though nsproxy->pid_ns_for_children is
new, the process is still in the orignal pid namespace, only the forked
children processes will be in the new pid namespace.
So it's not correct to get process's pid namespace by nsproxy->pid_ns_for_children,
should get pid namespace by task_active_pid_ns() way, i.e.
pid->numbers[pid->level].ns