### PR TITLE
tools/capable: Set data to zero before setting fields.

### DIFF
--- a/tools/capable.py
+++ b/tools/capable.py
@@ -182,7 +182,15 @@ int kprobe__cap_capable(struct pt_regs *ctx, const struct cred *cred,
     }
 
     u32 uid = bpf_get_current_uid_gid();
-    struct data_t data = {.tgid = tgid, .pid = pid, .uid = uid, .cap = cap, .audit = audit, .insetid = insetid};
+
+    struct data_t data = {};
+
+    data.tgid = tgid;
+    data.pid = pid;
+    data.uid = uid;
+    data.cap = cap;
+    data.audit = audit;
+    data.insetid = insetid;
 #ifdef KERNEL_STACKS
     data.kernel_stack_id = stacks.get_stackid(ctx, 0);
 #endif


### PR DESCRIPTION
Hi.


In our fork, we added a field to `struct data_t`.
Thus, with the actual code and if all fields are not used (*e.g.* by not using `-U` and `-K` options), we would get BPF valider error like the following:
```
...
; bpf_perf_event_output(ctx, bpf_pseudo_fd(1, -1), CUR_CPU_IDENTIFIER, &data, sizeof(data));
74: (bf) r1 = r6
75: (18) r3 = 0xffffffff
77: (b7) r5 = 56
78: (85) call bpf_perf_event_output#25
invalid indirect read from stack off -80+44 size 56
processed 76 insns (limit 1000000) max_states_per_insn 0 total_states 6 peak_states 6 mark_read 6
```

In this commit, I added call to `__builtin_memset` to ensure `data` is full of 0, so unaligned access do not cause trouble anymore.
To be honest, this code is not really needed, as code inside `iovisor/bcc` works.
But I though it could be a good idea to submit you this modification as it makes the code safer (for example if one day a new field is added to the `struct data_t`).
Note that this comment put me on the way:
https://github.com/iovisor/bcc/issues/2623#issuecomment-560214481

If you see any way to improve this PR, feel free to share.


Best regards.
