### PR TITLE
libbpf-tools/mountsnoop: Fix example strings.

### DIFF
--- a/libbpf-tools/mountsnoop.c
+++ b/libbpf-tools/mountsnoop.c
@@ -84,7 +84,7 @@ const char argp_program_doc[] =
 "\n"
 "EXAMPLES:\n"
 "    mountsnoop         # trace mount and umount syscalls\n"
-"    mountsnoop -v      # output vertically(one line per column value)\n"
+"    mountsnoop -d      # detailed output (one line per column value)\n"
 "    mountsnoop -p 1216 # only trace PID 1216\n";
 
 static const struct argp_option opts[] = {


### PR DESCRIPTION
Hi.


I modified `mountsnoop.c` in our fork and figured out the example strings were not correct.
I though it can be a good idea to upstream this at it will profit everyone.


Best regards.