### PR TITLE
bcc internals: Keep track of BPF progs using function instead of section

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -190,68 +190,67 @@ void SourceDebugger::dump() {
   vector<string> LineCache = buildLineCache();
 
   // Start to disassemble with source code annotation section by section
-  for (auto section : sections_)
-    if (!strncmp(fn_prefix_.c_str(), section.first.c_str(),
-                 fn_prefix_.size())) {
-      MCDisassembler::DecodeStatus S;
-      MCInst Inst;
-      uint64_t Size;
-      uint8_t *FuncStart = get<0>(section.second);
-      uint64_t FuncSize = get<1>(section.second);
+  prog_func_info_.for_each_func([&](std::string func_name, FuncInfo &info) {
+    MCDisassembler::DecodeStatus S;
+    MCInst Inst;
+    uint64_t Size;
+    uint8_t *FuncStart = info.start_;
+    uint64_t FuncSize = info.size_;
 #if LLVM_MAJOR_VERSION >= 9
-      unsigned SectionID = get<2>(section.second);
-#endif
-      ArrayRef<uint8_t> Data(FuncStart, FuncSize);
-      uint32_t CurrentSrcLine = 0;
-      string func_name = section.first.substr(fn_prefix_.size());
-
-      errs() << "Disassembly of section " << section.first << ":\n"
-             << func_name << ":\n";
-
-      string src_dbg_str;
-      llvm::raw_string_ostream os(src_dbg_str);
-      for (uint64_t Index = 0; Index < FuncSize; Index += Size) {
-#if LLVM_MAJOR_VERSION >= 10
-        S = DisAsm->getInstruction(Inst, Size, Data.slice(Index), Index,
-                                   nulls());
-#else
-        S = DisAsm->getInstruction(Inst, Size, Data.slice(Index), Index,
-                                   nulls(), nulls());
-#endif
-        if (S != MCDisassembler::Success) {
-          os << "Debug Error: disassembler failed: " << std::to_string(S)
+    auto section = sections_.find(info.section_);
+    if (section == sections_.end()) {
+      errs() << "Debug Error: no section entry for section " << info.section_
              << '\n';
-          break;
-        } else {
-          DILineInfo LineInfo;
-
-          LineTable->getFileLineInfoForAddress(
-#if LLVM_MAJOR_VERSION >= 9
-              {(uint64_t)FuncStart + Index, SectionID},
-#else
-              (uint64_t)FuncStart + Index,
-#endif
-              CU->getCompilationDir(),
-              DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath,
-              LineInfo);
-
-          adjustInstSize(Size, Data[Index], Data[Index + 1]);
-          dumpSrcLine(LineCache, LineInfo.FileName, LineInfo.Line,
-                      CurrentSrcLine, os);
-          os << format("%4" PRIu64 ":", Index >> 3) << '\t';
-          dumpBytes(Data.slice(Index, Size), os);
-#if LLVM_MAJOR_VERSION >= 10
-          IP->printInst(&Inst, 0, "", *STI, os);
-#else
-          IP->printInst(&Inst, os, "", *STI);
-#endif
-          os << '\n';
-        }
-      }
-      os.flush();
-      errs() << src_dbg_str << '\n';
-      src_dbg_fmap_[func_name] = src_dbg_str;
+      return;
     }
+    unsigned SectionID = get<2>(section->second);
+#endif
+    ArrayRef<uint8_t> Data(FuncStart, FuncSize);
+    uint32_t CurrentSrcLine = 0;
+
+    errs() << "Disassembly of function " << func_name << "\n";
+
+    string src_dbg_str;
+    llvm::raw_string_ostream os(src_dbg_str);
+    for (uint64_t Index = 0; Index < FuncSize; Index += Size) {
+#if LLVM_MAJOR_VERSION >= 10
+      S = DisAsm->getInstruction(Inst, Size, Data.slice(Index), Index, nulls());
+#else
+      S = DisAsm->getInstruction(Inst, Size, Data.slice(Index), Index, nulls(),
+                                 nulls());
+#endif
+      if (S != MCDisassembler::Success) {
+        os << "Debug Error: disassembler failed: " << std::to_string(S) << '\n';
+        break;
+      } else {
+        DILineInfo LineInfo;
+
+        LineTable->getFileLineInfoForAddress(
+#if LLVM_MAJOR_VERSION >= 9
+            {(uint64_t)FuncStart + Index, SectionID},
+#else
+            (uint64_t)FuncStart + Index,
+#endif
+            CU->getCompilationDir(),
+            DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath, LineInfo);
+
+        adjustInstSize(Size, Data[Index], Data[Index + 1]);
+        dumpSrcLine(LineCache, LineInfo.FileName, LineInfo.Line, CurrentSrcLine,
+                    os);
+        os << format("%4" PRIu64 ":", Index >> 3) << '\t';
+        dumpBytes(Data.slice(Index, Size), os);
+#if LLVM_MAJOR_VERSION >= 10
+        IP->printInst(&Inst, 0, "", *STI, os);
+#else
+        IP->printInst(&Inst, os, "", *STI);
+#endif
+        os << '\n';
+      }
+    }
+    os.flush();
+    errs() << src_dbg_str << '\n';
+    src_dbg_fmap_[func_name] = src_dbg_str;
+  });
 }
 
 }  // namespace ebpf

--- a/src/cc/bcc_debug.h
+++ b/src/cc/bcc_debug.h
@@ -15,19 +15,18 @@
  */
 
 #include "bpf_module.h"
+#include "frontends/clang/loader.h"
 
 namespace ebpf {
 
 class SourceDebugger {
  public:
-  SourceDebugger(
-      llvm::Module *mod,
-      sec_map_def &sections,
-      const std::string &fn_prefix, const std::string &mod_src,
-      std::map<std::string, std::string> &src_dbg_fmap)
+  SourceDebugger(llvm::Module *mod, sec_map_def &sections,
+                 ProgFuncInfo &prog_func_info, const std::string &mod_src,
+                 std::map<std::string, std::string> &src_dbg_fmap)
       : mod_(mod),
         sections_(sections),
-        fn_prefix_(fn_prefix),
+        prog_func_info_(prog_func_info),
         mod_src_(mod_src),
         src_dbg_fmap_(src_dbg_fmap) {}
 // Only support dump for llvm 6.x and later.
@@ -56,7 +55,7 @@ class SourceDebugger {
  private:
   llvm::Module *mod_;
   const sec_map_def &sections_;
-  const std::string &fn_prefix_;
+  ProgFuncInfo &prog_func_info_;
   const std::string &mod_src_;
   std::map<std::string, std::string> &src_dbg_fmap_;
 };

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -428,7 +428,7 @@ int BPFModule::load_maps(sec_map_def &sections) {
   // update instructions
   for (auto section : sections) {
     auto sec_name = section.first;
-    if (strncmp(".bpf.fn.", sec_name.c_str(), 8) == 0) {
+    if (strncmp(BPF_FN_PREFIX, sec_name.c_str(), 8) == 0) {
       uint8_t *addr = get<0>(section.second);
       uintptr_t size = get<1>(section.second);
       struct bpf_insn *insns = (struct bpf_insn *)addr;
@@ -903,7 +903,7 @@ int BPFModule::bcc_func_load(int prog_type, const char *name,
     int btf_fd = btf_->get_fd();
     char secname[256];
 
-    ::snprintf(secname, sizeof(secname), ".bpf.fn.%s", name);
+    ::snprintf(secname, sizeof(secname), "%s%s", BPF_FN_PREFIX, name);
     ret = btf_->get_btf_info(secname, &func_info, &func_info_cnt,
                              &finfo_rec_size, &line_info,
                              &line_info_cnt, &linfo_rec_size);

--- a/src/cc/bpf_module.h
+++ b/src/cc/bpf_module.h
@@ -59,14 +59,13 @@ class TableDesc;
 class TableStorage;
 class BLoader;
 class ClangLoader;
-class FuncSource;
+class ProgFuncInfo;
 class BTF;
 
 bool bpf_module_rw_engine_enabled(void);
 
 class BPFModule {
  private:
-  static const std::string FN_PREFIX;
   int init_engine();
   void initialize_rw_engine();
   void cleanup_rw_engine();
@@ -74,6 +73,7 @@ class BPFModule {
   int finalize();
   int annotate();
   void annotate_light();
+  void finalize_prog_func_info();
   std::unique_ptr<llvm::ExecutionEngine> finalize_rw(std::unique_ptr<llvm::Module> mod);
   std::string make_reader(llvm::Module *mod, llvm::Type *type);
   std::string make_writer(llvm::Module *mod, llvm::Type *type);
@@ -162,11 +162,10 @@ class BPFModule {
   std::unique_ptr<llvm::ExecutionEngine> engine_;
   std::unique_ptr<llvm::ExecutionEngine> rw_engine_;
   std::unique_ptr<llvm::Module> mod_;
-  std::unique_ptr<FuncSource> func_src_;
+  std::unique_ptr<ProgFuncInfo> prog_func_info_;
   sec_map_def sections_;
   std::vector<TableDesc *> tables_;
   std::map<std::string, size_t> table_names_;
-  std::vector<std::string> function_names_;
   std::map<llvm::Type *, std::string> readers_;
   std::map<llvm::Type *, std::string> writers_;
   std::string id_;

--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -40,7 +40,7 @@ class StringRef;
 namespace ebpf {
 
 class BFrontendAction;
-class FuncSource;
+class ProgFuncInfo;
 
 // Traces maps with external pointers as values.
 class MapVisitor : public clang::RecursiveASTVisitor<MapVisitor> {
@@ -156,9 +156,8 @@ class BFrontendAction : public clang::ASTFrontendAction {
   // should be written.
   BFrontendAction(llvm::raw_ostream &os, unsigned flags, TableStorage &ts,
                   const std::string &id, const std::string &main_path,
-                  FuncSource &func_src, std::string &mod_src,
-                  const std::string &maps_ns,
-                  fake_fd_map_def &fake_fd_map,
+                  ProgFuncInfo &prog_func_info, std::string &mod_src,
+                  const std::string &maps_ns, fake_fd_map_def &fake_fd_map,
                   std::map<std::string, std::vector<std::string>> &perf_events);
 
   // Called by clang when the AST has been completed, here the output stream
@@ -192,7 +191,7 @@ class BFrontendAction : public clang::ASTFrontendAction {
   friend class BTypeVisitor;
   std::map<std::string, clang::SourceRange> func_range_;
   const std::string &main_path_;
-  FuncSource &func_src_;
+  ProgFuncInfo &prog_func_info_;
   std::string &mod_src_;
   std::set<clang::Decl *> m_;
   int next_fake_fd_;

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -66,6 +66,44 @@ using std::vector;
 
 namespace ebpf {
 
+optional<FuncInfo &> ProgFuncInfo::get_func(std::string name) {
+  auto it = funcs_.find(name);
+  if (it != funcs_.end())
+    return it->second;
+  return nullopt;
+}
+
+optional<FuncInfo &> ProgFuncInfo::get_func(size_t id) {
+  auto it = func_idx_.find(id);
+  if (it != func_idx_.end())
+    return get_func(it->second);
+  return nullopt;
+}
+
+optional<std::string &> ProgFuncInfo::func_name(size_t id) {
+  auto it = func_idx_.find(id);
+  if (it != func_idx_.end())
+    return it->second;
+  return nullopt;
+}
+
+void ProgFuncInfo::for_each_func(
+    std::function<void(std::string, FuncInfo &)> cb) {
+  for (auto it = funcs_.begin(); it != funcs_.end(); ++it) {
+    cb(it->first, it->second);
+  }
+}
+
+optional<FuncInfo &> ProgFuncInfo::add_func(std::string name) {
+  auto fn = get_func(name);
+  if (fn)
+    return nullopt;
+  size_t current = funcs_.size();
+  funcs_.emplace(name, 0);
+  func_idx_.emplace(current, name);
+  return get_func(name);
+}
+
 ClangLoader::ClangLoader(llvm::LLVMContext *ctx, unsigned flags)
     : ctx_(ctx), flags_(flags)
 {
@@ -152,13 +190,12 @@ static int CreateFromArgs(clang::CompilerInvocation &invocation,
 
 }
 
-int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
-                       const string &file, bool in_memory, const char *cflags[],
-                       int ncflags, const std::string &id, FuncSource &func_src,
-                       std::string &mod_src,
-                       const std::string &maps_ns,
-                       fake_fd_map_def &fake_fd_map,
-                       std::map<std::string, std::vector<std::string>> &perf_events) {
+int ClangLoader::parse(
+    unique_ptr<llvm::Module> *mod, TableStorage &ts, const string &file,
+    bool in_memory, const char *cflags[], int ncflags, const std::string &id,
+    ProgFuncInfo &prog_func_info, std::string &mod_src,
+    const std::string &maps_ns, fake_fd_map_def &fake_fd_map,
+    std::map<std::string, std::vector<std::string>> &perf_events) {
   string main_path = "/virtual/main.c";
   unique_ptr<llvm::MemoryBuffer> main_buf;
   struct utsname un;
@@ -280,7 +317,8 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
 #endif
 
   if (do_compile(mod, ts, in_memory, flags_cstr, flags_cstr_rem, main_path,
-                 main_buf, id, func_src, mod_src, true, maps_ns, fake_fd_map, perf_events)) {
+                 main_buf, id, prog_func_info, mod_src, true, maps_ns,
+                 fake_fd_map, perf_events)) {
 #if BCC_BACKUP_COMPILE != 1
     return -1;
 #else
@@ -288,11 +326,12 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
     llvm::errs() << "WARNING: compilation failure, trying with system bpf.h\n";
 
     ts.DeletePrefix(Path({id}));
-    func_src.clear();
+    prog_func_info.clear();
     mod_src.clear();
     fake_fd_map.clear();
     if (do_compile(mod, ts, in_memory, flags_cstr, flags_cstr_rem, main_path,
-                   main_buf, id, func_src, mod_src, false, maps_ns, fake_fd_map, perf_events))
+                   main_buf, id, prog_func_info, mod_src, false, maps_ns,
+                   fake_fd_map, perf_events))
       return -1;
 #endif
   }
@@ -334,17 +373,14 @@ string get_clang_target(void) {
   return string(ret);
 }
 
-int ClangLoader::do_compile(unique_ptr<llvm::Module> *mod, TableStorage &ts,
-                            bool in_memory,
-                            const vector<const char *> &flags_cstr_in,
-                            const vector<const char *> &flags_cstr_rem,
-                            const std::string &main_path,
-                            const unique_ptr<llvm::MemoryBuffer> &main_buf,
-                            const std::string &id, FuncSource &func_src,
-                            std::string &mod_src, bool use_internal_bpfh,
-                            const std::string &maps_ns,
-                            fake_fd_map_def &fake_fd_map,
-                            std::map<std::string, std::vector<std::string>> &perf_events) {
+int ClangLoader::do_compile(
+    unique_ptr<llvm::Module> *mod, TableStorage &ts, bool in_memory,
+    const vector<const char *> &flags_cstr_in,
+    const vector<const char *> &flags_cstr_rem, const std::string &main_path,
+    const unique_ptr<llvm::MemoryBuffer> &main_buf, const std::string &id,
+    ProgFuncInfo &prog_func_info, std::string &mod_src, bool use_internal_bpfh,
+    const std::string &maps_ns, fake_fd_map_def &fake_fd_map,
+    std::map<std::string, std::vector<std::string>> &perf_events) {
   using namespace clang;
 
   vector<const char *> flags_cstr = flags_cstr_in;
@@ -444,7 +480,7 @@ int ClangLoader::do_compile(unique_ptr<llvm::Module> *mod, TableStorage &ts,
   // capture the rewritten c file
   string out_str1;
   llvm::raw_string_ostream os1(out_str1);
-  BFrontendAction bact(os1, flags_, ts, id, main_path, func_src, mod_src,
+  BFrontendAction bact(os1, flags_, ts, id, main_path, prog_func_info, mod_src,
                        maps_ns, fake_fd_map, perf_events);
   if (!compiler1.ExecuteAction(bact))
     return -1;
@@ -474,27 +510,4 @@ int ClangLoader::do_compile(unique_ptr<llvm::Module> *mod, TableStorage &ts,
 
   return 0;
 }
-
-const char * FuncSource::src(const std::string& name) {
-  auto src = funcs_.find(name);
-  if (src == funcs_.end())
-    return "";
-  return src->second.src_.data();
-}
-
-const char * FuncSource::src_rewritten(const std::string& name) {
-  auto src = funcs_.find(name);
-  if (src == funcs_.end())
-    return "";
-  return src->second.src_rewritten_.data();
-}
-
-void FuncSource::set_src(const std::string& name, const std::string& src) {
-  funcs_[name].src_ = src;
-}
-
-void FuncSource::set_src_rewritten(const std::string& name, const std::string& src) {
-  funcs_[name].src_rewritten_ = src;
-}
-
 }  // namespace ebpf


### PR DESCRIPTION
__Context:__ I'm working on a project to enable bcc to create object files which can be loaded by `libbpf`'s loader. This will make enabling "modern" `libbpf` features - e.g. global variables - significantly easier and by its nature would make an AOT-compiled mode for bcc straightforward. bcc programs should be able to use this mode with minimal code changes.

In order to do this we need to support libbpf-style `SEC` attribute annotations, which requires some modification of internal loader/bookkeeping plumbing. The summary of the major commit in this branch elaborates:

```
bcc currently identifies each individual BPF prog in an object file by
putting the prog in a special ".bpf.fn.$FUNC_NAME" section when
preprocessing the AST. After JITting an object file, the location and
size of the section are considered to be "the function's insns".

In order to support libbpf-style loading, we need to support its
sec_def-style SEC() attributes e.g. SEC("tp_btf/softirq_entry"), which
allow libbpf to determine the type of BPF prog - and often other
information like where to attach - based on the section name. These are
not guaranteed to be unique per function, so we can no longer assume
that a section contains only one function.

This commit gets rid of that assumption. bcc now finds the symbol in the
JITed image matching each BPF prog function and uses it to determine
size/location.

Also, this commit only adds the ".bpf.fn.$FUNC_NAME" section attribute
iff there isn't already a custom section attribute set.
```

__Status:__ I need to address a few things before this is in a mergeable state
  * [x] Does `BPFModule` still need `sections_`? If not, let's get rid of it
  * [x] Need to clean up `prog_func_info_`-owned memory similarly to `sections_` now (when not using `rw_engine`)
  * [x] Custom section names should not break execution, but they do currently
  * [x] debug dump (`SOURCE_DEBUG`) should work w/ custom sec names
    *  Sanity check rest of debug flags too
  * [x] Figure out correct LLVM version checks
  * [x] Test on all python tools and some cpp applications