### PR TITLE
fix a llvm14 compilation error

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -29,7 +29,11 @@
 #include <llvm/MC/MCInstrInfo.h>
 #include <llvm/MC/MCObjectFileInfo.h>
 #include <llvm/MC/MCRegisterInfo.h>
+#if LLVM_MAJOR_VERSION >= 14
+#include <llvm/MC/TargetRegistry.h>
+#else
 #include <llvm/Support/TargetRegistry.h>
+#endif
 
 #include "bcc_debug.h"
 


### PR DESCRIPTION
Upstream commit https://reviews.llvm.org/D111454
moved header file llvm/Support/TargetRegistry.h to
llvm/MC/TargetRegistry.h. Let us adjust accordingly
to avoid compilation error.

Signed-off-by: Yonghong Song <yhs@fb.com>