### PR TITLE
libbpf-tools: Enable compilation warnings for BPF programs

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -104,7 +104,7 @@ $(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT)
 
 $(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(ARCH)/vmlinux.h | $(OUTPUT)
 	$(call msg,BPF,$@)
-	$(Q)$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH)		      \
+	$(Q)$(CLANG) $(CFLAGS) -target bpf -D__TARGET_ARCH_$(ARCH)	      \
 		     -I$(ARCH)/ $(INCLUDES) -c $(filter %.c,$^) -o $@ &&      \
 	$(LLVM_STRIP) -g $@
 

--- a/libbpf-tools/biopattern.bpf.c
+++ b/libbpf-tools/biopattern.bpf.c
@@ -19,7 +19,7 @@ struct {
 SEC("tracepoint/block/block_rq_complete")
 int handle__block_rq_complete(struct trace_event_raw_block_rq_complete *ctx)
 {
-	sector_t *last_sectorp,  sector = ctx->sector;
+	sector_t sector = ctx->sector;
 	struct counter *counterp, zero = {};
 	u32 nr_sector = ctx->nr_sector;
 	dev_t dev = ctx->dev;

--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -126,7 +126,7 @@ SEC("tp_btf/block_rq_complete")
 int BPF_PROG(block_rq_complete, struct request *rq, int error,
 	     unsigned int nr_bytes)
 {
-	u64 slot, ts = bpf_ktime_get_ns();
+	u64 ts = bpf_ktime_get_ns();
 	struct piddata *piddatap;
 	struct event event = {};
 	struct stage *stagep;

--- a/libbpf-tools/biostacks.bpf.c
+++ b/libbpf-tools/biostacks.bpf.c
@@ -84,7 +84,6 @@ int BPF_PROG(blk_account_io_done, struct request *rq)
 {
 	u64 slot, ts = bpf_ktime_get_ns();
 	struct internal_rqinfo *i_rqinfop;
-	struct rqinfo *rqinfop;
 	struct hist *histp;
 	s64 delta;
 

--- a/libbpf-tools/filelife.bpf.c
+++ b/libbpf-tools/filelife.bpf.c
@@ -57,7 +57,6 @@ int BPF_KPROBE(vfs_unlink, struct inode *dir, struct dentry *dentry)
 	const u8 *qs_name_ptr;
 	u32 tgid = id >> 32;
 	u64 *tsp, delta_ns;
-	u32 qs_len;
 
 	tsp = bpf_map_lookup_elem(&start, &dentry);
 	if (!tsp)
@@ -67,7 +66,6 @@ int BPF_KPROBE(vfs_unlink, struct inode *dir, struct dentry *dentry)
 	bpf_map_delete_elem(&start, &dentry);
 
 	qs_name_ptr = BPF_CORE_READ(dentry, d_name.name);
-	qs_len = BPF_CORE_READ(dentry, d_name.len);
 	bpf_probe_read_kernel_str(&event.file, sizeof(event.file), qs_name_ptr);
 	bpf_get_current_comm(&event.task, sizeof(event.task));
 	event.delta_ns = delta_ns;

--- a/libbpf-tools/fsdist.bpf.c
+++ b/libbpf-tools/fsdist.bpf.c
@@ -37,9 +37,7 @@ static int probe_entry()
 
 static int probe_return(enum fs_file_op op)
 {
-	__u64 pid_tgid = bpf_get_current_pid_tgid();
-	__u32 pid = pid_tgid >> 32;
-	__u32 tid = (__u32)pid_tgid;
+	__u32 tid = (__u32)bpf_get_current_pid_tgid();
 	__u64 ts = bpf_ktime_get_ns();
 	__u64 *tsp, slot;
 	__s64 delta;

--- a/libbpf-tools/gethostlatency.bpf.c
+++ b/libbpf-tools/gethostlatency.bpf.c
@@ -46,9 +46,7 @@ static int probe_entry(struct pt_regs *ctx)
 
 static int probe_return(struct pt_regs *ctx)
 {
-	__u64 pid_tgid = bpf_get_current_pid_tgid();
-	__u32 pid = pid_tgid >> 32;
-	__u32 tid = (__u32)pid_tgid;
+	__u32 tid = (__u32)bpf_get_current_pid_tgid();
 	struct event *eventp;
 
 	eventp = bpf_map_lookup_elem(&starts, &tid);

--- a/libbpf-tools/ksnoop.bpf.c
+++ b/libbpf-tools/ksnoop.bpf.c
@@ -221,15 +221,13 @@ static void output_stashed_traces(struct pt_regs *ctx,
 {
 	struct func_stack *func_stack;
 	struct trace *trace = NULL;
-	__u8 stack_depth, i;
+	__u8 i;
 	__u64 task = 0;
 
 	task = bpf_get_current_task();
 	func_stack = bpf_map_lookup_elem(&ksnoop_func_stack, &task);
 	if (!func_stack)
 		return;
-
-	stack_depth = func_stack->stack_depth;
 
 	if (entry) {
 		/* iterate from bottom to top of stack, outputting stashed
@@ -294,9 +292,7 @@ static int ksnoop(struct pt_regs *ctx, bool entry)
 {
 	void *data_ptr = NULL;
 	struct trace *trace;
-	struct func *func;
-	__u16 trace_len;
-	__u64 data, pg;
+	__u64 data;
 	__u32 currpid;
 	int ret;
 	__u8 i;
@@ -304,8 +300,6 @@ static int ksnoop(struct pt_regs *ctx, bool entry)
 	trace = get_trace(ctx, entry);
 	if (!trace)
 		return 0;
-
-	func = &trace->func;
 
 	/* make sure we want events from this pid */
 	currpid = bpf_get_current_pid_tgid();
@@ -399,7 +393,7 @@ static int ksnoop(struct pt_regs *ctx, bool entry)
 			if (!ok) {
 				clear_trace(trace);
 				return 0;
-			}	
+			}
 		}
 
 		if (currtrace->flags & (KSNOOP_F_PTR | KSNOOP_F_MEMBER))

--- a/libbpf-tools/syscount.bpf.c
+++ b/libbpf-tools/syscount.bpf.c
@@ -62,7 +62,6 @@ int sys_enter(struct trace_event_raw_sys_enter *args)
 SEC("tracepoint/raw_syscalls/sys_exit")
 int sys_exit(struct trace_event_raw_sys_exit *args)
 {
-	struct task_struct *current;
 	u64 id = bpf_get_current_pid_tgid();
 	static const struct data_t zero;
 	pid_t pid = id >> 32;


### PR DESCRIPTION
Enable -Wall option when compile BPF programs and fix all
compilation warnings.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>