### PR TITLE
ksnoop: Fix info command output

### DIFF
--- a/libbpf-tools/ksnoop.c
+++ b/libbpf-tools/ksnoop.c
@@ -419,11 +419,12 @@ static char *type_id_to_str(struct btf *btf, __s32 type_id, char *str)
 				name = btf__str_by_offset(btf, type->name_off);
 				break;
 			case BTF_KIND_UNION:
-				prefix = "union";
+				prefix = "union ";
 				name = btf__str_by_offset(btf, type->name_off);
 				break;
 			case BTF_KIND_ENUM:
 				prefix = "enum ";
+				name = btf__str_by_offset(btf, type->name_off);
 				break;
 			case BTF_KIND_TYPEDEF:
 				name = btf__str_by_offset(btf, type->name_off);
@@ -445,7 +446,7 @@ static char *value_to_str(struct btf *btf, struct value *val, char *str)
 
 	str = type_id_to_str(btf, val->type_id, str);
 	if (val->flags & KSNOOP_F_PTR)
-		strncat(str, " * ", MAX_STR);
+		strncat(str, "*", MAX_STR);
 	if (strlen(val->name) > 0 &&
 	    strcmp(val->name, KSNOOP_RETURN_NAME) != 0)
 		strncat(str, val->name, MAX_STR);
@@ -680,7 +681,7 @@ static int cmd_info(int argc, char **argv)
 	for (i = 0; i < nr_traces; i++) {
 		struct func *func = &traces[i].func;
 
-		printf("%s %s(",
+		printf("%s%s(",
 		       value_to_str(traces[i].btf, &func->args[KSNOOP_RETURN],
 				    str),
 		       func->name);


### PR DESCRIPTION
The info command is used to print kernel function signature.
This commit makes the output conform to the kernel code style.
Before this fix:
```
$ sudo ./ksnoop info sk_alloc
struct sock  *  sk_alloc(struct net  * net, int family, gfp_t priority, struct proto  * prot, int kern);
$ sudo ./ksnoop info dma_buf_end_cpu_access
$ sudo ./ksnoop info array_map_alloc_check
int array_map_alloc_check(unionbpf_attr *attr);
```
After this fix:
```
$ sudo ./ksnoop info sk_alloc
struct sock *sk_alloc(struct net *net, int family, gfp_t priority, struct proto *prot, int kern);
$ sudo ./ksnoop info dma_buf_end_cpu_access
int dma_buf_end_cpu_access(struct dma_buf *dmabuf, enum dma_data_direction direction);
$ sudo ./ksnoop info array_map_alloc_check
int array_map_alloc_check(union bpf_attr *attr);
```

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>