### PR TITLE
bcc: Allow KFUNC_PROBE to instrument function without arguments

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -1309,16 +1309,16 @@ int name(unsigned long long *ctx)                               \
 static int ____##name(unsigned long long *ctx, ##args)
 
 #define KFUNC_PROBE(event, args...) \
-        BPF_PROG(kfunc__ ## event, args)
+        BPF_PROG(kfunc__ ## event, ##args)
 
 #define KRETFUNC_PROBE(event, args...) \
-        BPF_PROG(kretfunc__ ## event, args)
+        BPF_PROG(kretfunc__ ## event, ##args)
 
 #define KMOD_RET(event, args...) \
-        BPF_PROG(kmod_ret__ ## event, args)
+        BPF_PROG(kmod_ret__ ## event, ##args)
 
 #define LSM_PROBE(event, args...) \
-        BPF_PROG(lsm__ ## event, args)
+        BPF_PROG(lsm__ ## event, ##args)
 
 #define BPF_ITER(target) \
         int bpf_iter__ ## target (struct bpf_iter__ ## target *ctx)

--- a/tools/readahead.py
+++ b/tools/readahead.py
@@ -93,7 +93,7 @@ int entry_mark_page_accessed(struct pt_regs *ctx) {
 """
 
 bpf_text_kfunc = """
-KFUNC_PROBE(RA_FUNC, void *unused)
+KFUNC_PROBE(RA_FUNC)
 {
     u32 pid = bpf_get_current_pid_tgid();
     u8 one = 1;
@@ -102,7 +102,7 @@ KFUNC_PROBE(RA_FUNC, void *unused)
     return 0;
 }
 
-KRETFUNC_PROBE(RA_FUNC, void *unused)
+KRETFUNC_PROBE(RA_FUNC)
 {
     u32 pid = bpf_get_current_pid_tgid();
     u8 zero = 0;

--- a/tools/vfsstat.py
+++ b/tools/vfsstat.py
@@ -65,11 +65,11 @@ void do_create(struct pt_regs *ctx) { stats_increment(S_CREATE); }
 """
 
 bpf_text_kfunc = """
-KFUNC_PROBE(vfs_read, int unused)   { stats_increment(S_READ); return 0; }
-KFUNC_PROBE(vfs_write, int unused)  { stats_increment(S_WRITE); return 0; }
-KFUNC_PROBE(vfs_fsync, int unused)  { stats_increment(S_FSYNC); return 0; }
-KFUNC_PROBE(vfs_open, int unused)   { stats_increment(S_OPEN); return 0; }
-KFUNC_PROBE(vfs_create, int unused) { stats_increment(S_CREATE); return 0; }
+KFUNC_PROBE(vfs_read)   { stats_increment(S_READ); return 0; }
+KFUNC_PROBE(vfs_write)  { stats_increment(S_WRITE); return 0; }
+KFUNC_PROBE(vfs_fsync)  { stats_increment(S_FSYNC); return 0; }
+KFUNC_PROBE(vfs_open)   { stats_increment(S_OPEN); return 0; }
+KFUNC_PROBE(vfs_create) { stats_increment(S_CREATE); return 0; }
 """
 
 is_support_kfunc = BPF.support_kfunc()


### PR DESCRIPTION
Update KFUNC_PROBE and its family to allow instrument kernel
function without specifying arguments. Sometimes, we don't need
to bookkeep arguments at function entry, just store a timestamp.
This fix would allow this use case.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>