### PR TITLE
Fix LINUX_KERNEL_VERSION check for TP of block_rq_insert/block_rq_issue

### DIFF
--- a/libbpf-tools/biolatency.bpf.c
+++ b/libbpf-tools/biolatency.bpf.c
@@ -64,7 +64,7 @@ int block_rq_insert(u64 *ctx)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION <= KERNEL_VERSION(5, 10, 0))
+	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0))
 		return trace_rq_start((void *)ctx[1], false);
 	else
 		return trace_rq_start((void *)ctx[0], false);
@@ -78,7 +78,7 @@ int block_rq_issue(u64 *ctx)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION <= KERNEL_VERSION(5, 10, 0))
+	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0))
 		return trace_rq_start((void *)ctx[1], true);
 	else
 		return trace_rq_start((void *)ctx[0], true);

--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -102,10 +102,10 @@ int BPF_PROG(block_rq_insert)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION > KERNEL_VERSION(5, 10, 0))
-		return trace_rq_start((void *)ctx[0], true);
-	else
+	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0))
 		return trace_rq_start((void *)ctx[1], true);
+	else
+		return trace_rq_start((void *)ctx[0], true);
 }
 
 SEC("tp_btf/block_rq_issue")
@@ -116,10 +116,10 @@ int BPF_PROG(block_rq_issue)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION > KERNEL_VERSION(5, 10, 0))
-		return trace_rq_start((void *)ctx[0], false);
-	else
+	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0))
 		return trace_rq_start((void *)ctx[1], false);
+	else
+		return trace_rq_start((void *)ctx[0], false);
 }
 
 SEC("tp_btf/block_rq_complete")

--- a/libbpf-tools/bitesize.bpf.c
+++ b/libbpf-tools/bitesize.bpf.c
@@ -75,10 +75,10 @@ int BPF_PROG(block_rq_issue)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION > KERNEL_VERSION(5, 10, 0))
-		return trace_rq_issue((void *)ctx[0]);
-	else
+	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0))
 		return trace_rq_issue((void *)ctx[1]);
+	else
+		return trace_rq_issue((void *)ctx[0]);
 }
 
 char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
The TP_PROTO for block_rq_insert and block_rq_issue are still
TP_PROTO(struct request_queue *q, struct request *rq) in kernel version
5.10.x which is bigger than 5.10.0, so the version check should be:
LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0)

Signed-off-by: Li Chengyuan chengyuanli@hotmail.com