### PR TITLE
kernel>=5.14, tsk->state turn to tsk->__state

### DIFF
--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -32,6 +32,7 @@
 #                               process name from 'task_struct* next' in raw tp code.
 #                               bpf_get_current_comm() operates on the current task
 #                               which might already be different than 'next'.
+# 28-Oct-2021   Rong Tao    BUG fix: when kernel>=5.14, tsk->state turn to tsk->__state 
 
 from __future__ import print_function
 from bcc import BPF

--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -182,19 +182,17 @@ RAW_TRACEPOINT_PROBE(sched_switch)
     struct task_struct *prev = (struct task_struct *)ctx->args[1];
     struct task_struct *next= (struct task_struct *)ctx->args[2];
     u32 tgid, pid, prev_pid;
-    long task_state;
+    long state;
 
     // ivcsw: treat like an enqueue event and store timestamp
-//kernel>=5.14, tsk->state turn to tsk->__state                                                                              
+    // kernel>=5.14, tsk->state turn to tsk->__state                                                                              
 #if LINUX_VERSION_MAJOR>=5 && LINUX_VERSION_PATCHLEVEL>=14
-#define state __state
+    bpf_probe_read_kernel(&state, sizeof(long), (const void *)&prev->__state);
 #else
-#define state state
+    bpf_probe_read_kernel(&state, sizeof(long), (const void *)&prev->state);
 #endif
-    bpf_probe_read_kernel(&task_state, sizeof(long), (const void *)&prev->state);
-#undef state
     bpf_probe_read_kernel(&prev_pid, sizeof(prev->pid), &prev->pid);
-    if (task_state == TASK_RUNNING) {
+    if (state == TASK_RUNNING) {
         bpf_probe_read_kernel(&tgid, sizeof(prev->tgid), &prev->tgid);
         u64 ts = bpf_ktime_get_ns();
         if (prev_pid != 0) {

--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -188,6 +188,8 @@ RAW_TRACEPOINT_PROBE(sched_switch)
 //kernel>=5.14, tsk->state turn to tsk->__state                                                                              
 #if LINUX_VERSION_MAJOR>=5 && LINUX_VERSION_PATCHLEVEL>=14
 #define state __state
+#else
+#define state state
 #endif
     bpf_probe_read_kernel(&task_state, sizeof(long), (const void *)&prev->state);
 #undef state


### PR DESCRIPTION
```bash
$ sudo ./runqslower.py 
/virtual/main.c:58:70: error: no member named 'state' in 'struct task_struct'
    bpf_probe_read_kernel(&state, sizeof(long), (const void *)&prev->state);
                                                               ~~~~  ^
1 error generated.
Traceback (most recent call last):
  File "./runqslower.py", line 266, in <module>
    b = BPF(text=bpf_text)
  File "/usr/lib/python3.6/site-packages/bcc/__init__.py", line 480, in __init__
    raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
Exception: Failed to compile BPF module <text>
```