### PR TITLE
libbpf-tools: pass -Wall explicitly while compiling the BPF C code

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -104,7 +104,7 @@ $(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT)
 
 $(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(ARCH)/vmlinux.h | $(OUTPUT)
 	$(call msg,BPF,$@)
-	$(Q)$(CLANG) $(CFLAGS) -target bpf -D__TARGET_ARCH_$(ARCH)	      \
+	$(Q)$(CLANG) -g -O2 -Wall -target bpf -D__TARGET_ARCH_$(ARCH)	      \
 		     -I$(ARCH)/ $(INCLUDES) -c $(filter %.c,$^) -o $@ &&      \
 	$(LLVM_STRIP) -g $@
 


### PR DESCRIPTION
This partly reverts the part of 531b698cdc205 where CFLAGS were passed
to clang to turn on all the warnings to make it possible to build
libbpf and the libbpf tools with ASan/UBsan again. Without this patch
clang complains that `-fsanitize` isn't supported for target `bpf`:

```
clang -fsanitize=address,undefined -g -target bpf -D__TARGET_ARCH_x86	      \
	     -Ix86/ -I.output -I../src/cc/libbpf/include/uapi -c bindsnoop.bpf.c -o .output/bindsnoop.bpf.o &&      \
llvm-strip -g .output/bindsnoop.bpf.o
clang-11: error: unsupported option '-fsanitize=address' for target 'bpf'
make: *** [Makefile:107: .output/bindsnoop.bpf.o] Error 1
```

Signed-off-by: Evgeny Vereshchagin <evvers@ya.ru>