### PR TITLE
tools: fix cachestat.py with 5.15 kernel

### DIFF
--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -96,7 +96,15 @@ if debug or args.ebpf:
 b = BPF(text=bpf_text)
 b.attach_kprobe(event="add_to_page_cache_lru", fn_name="do_count")
 b.attach_kprobe(event="mark_page_accessed", fn_name="do_count")
-b.attach_kprobe(event="account_page_dirtied", fn_name="do_count")
+
+# Function account_page_dirtied() is changed to folio_account_dirtied() in 5.15.
+# FIXME: Both folio_account_dirtied() and account_page_dirtied() are
+# static functions and they may be gone during compilation and this may
+# introduce some inaccuracy.
+if BPF.get_kprobe_functions(b'folio_account_dirtied'):
+    b.attach_kprobe(event="folio_account_dirtied", fn_name="do_count")
+elif BPF.get_kprobe_functions(b'account_page_dirtied'):
+    b.attach_kprobe(event="account_page_dirtied", fn_name="do_count")
 b.attach_kprobe(event="mark_buffer_dirty", fn_name="do_count")
 
 # header


### PR DESCRIPTION
Fix issue #3687.
The tool cachestat.py doesn't work with 5.15 kernel due to
kprobe function renaming. Adapt to the new function.
Also added a comment that static functions might
get inlined and the result may not be accurate if this happens.
More work can be done in the future to make the tool
more robust.

Signed-off-by: Yonghong Song <yhs@fb.com>