### PR TITLE
Fix garbled java class name problem of uobjnew.py

### DIFF
--- a/tools/lib/uobjnew.py
+++ b/tools/lib/uobjnew.py
@@ -96,9 +96,11 @@ int alloc_entry(struct pt_regs *ctx) {
     struct key_t key = {};
     struct val_t *valp, zero = {};
     u64 classptr = 0, size = 0;
+    u32 length = 0;
     bpf_usdt_readarg(2, ctx, &classptr);
+    bpf_usdt_readarg(3, ctx, &length);
     bpf_usdt_readarg(4, ctx, &size);
-    bpf_probe_read_user(&key.name, sizeof(key.name), (void *)classptr);
+    bpf_probe_read_user(&key.name, min(sizeof(key.name), (size_t)length), (void *)classptr);
     valp = allocs.lookup_or_try_init(&key, &zero);
     if (valp) {
         valp->total_size += size;


### PR DESCRIPTION
Hi,

Please help review this patch that fixes a garbled java class name problem of uobjnew.py.

Without this patch, the output may look like this:
```
NAME/TYPE                      # ALLOCS      # BYTES
Test                                  1           16
[B��;*                               1         1016
[Ljava/lang/Thread;                   1         4016
[Ljava/lang/String;                   1         4016
[Ljava/lang/Float;%                   1         4016
[D���                               1         8016
```

Apply this patch:
```
NAME/TYPE                      # ALLOCS      # BYTES
Test                                  1           16
[B                                    1         1016
[Ljava/lang/String;                   1         4016
[Ljava/lang/Thread;                   1         4016
[Ljava/lang/Float;                    1         4016
[D                                    1         8016

```

In this patch, I read the third parameter twice with different types. The reason for this is for compatibility reasons: the declaration and definition of this probe in OpenJDK use different types:

- declaration: https://github.com/openjdk/jdk/blob/master/src/hotspot/os/posix/dtrace/hotspot.d#L75
- definition: https://github.com/openjdk/jdk/blob/master/src/hotspot/share/runtime/sharedRuntime.cpp#L1018
  - name->utf8_length() return a int value