### PR TITLE
tools: fix cachetop.py with 5.15 kernel

### DIFF
--- a/tools/cachetop.py
+++ b/tools/cachetop.py
@@ -169,8 +169,13 @@ def handle_loop(stdscr, args):
     b = BPF(text=bpf_text)
     b.attach_kprobe(event="add_to_page_cache_lru", fn_name="do_count")
     b.attach_kprobe(event="mark_page_accessed", fn_name="do_count")
-    b.attach_kprobe(event="account_page_dirtied", fn_name="do_count")
     b.attach_kprobe(event="mark_buffer_dirty", fn_name="do_count")
+
+    # Function account_page_dirtied() is changed to folio_account_dirtied() in 5.15.
+    if BPF.get_kprobe_functions(b'folio_account_dirtied'):
+        b.attach_kprobe(event="folio_account_dirtied", fn_name="do_count")
+    elif BPF.get_kprobe_functions(b'account_page_dirtied'):
+        b.attach_kprobe(event="account_page_dirtied", fn_name="do_count")
 
     exiting = 0
 


### PR DESCRIPTION
The tool cachetop.py doesn't work with 5.15 kernel due to
kprobe function renaming. Adapt to the new function.
Commit 61087b961716 ("tools: fix cachestat.py with 5.15 kernel")
fixed a similar issue for cachestat.py.

Signed-off-by: Yonghong Song <yhs@fb.com>