### PR TITLE
Guarantee strict weak order in Probe::finalize_locations

### DIFF
--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -222,7 +222,7 @@ void Probe::add_location(uint64_t addr, const std::string &bin_path, const char 
 void Probe::finalize_locations() {
   std::sort(locations_.begin(), locations_.end(),
             [](const Location &a, const Location &b) {
-              return a.bin_path_ < b.bin_path_ || a.address_ < b.address_;
+              return std::tie(a.bin_path_, a.address_) < std::tie(b.bin_path_, b.address_);
             });
   auto last = std::unique(locations_.begin(), locations_.end(),
                           [](const Location &a, const Location &b) {


### PR DESCRIPTION
Currently, `Probe::finalize_locations` uses `std::sort` on its `locations_` via a custom defined lambda. The provided lambda though, does not guarantee [strict weak ordering](https://en.cppreference.com/w/cpp/concepts/strict_weak_order), and thus, violates one of the [requirements of the compare function](https://en.cppreference.com/w/cpp/named_req/Compare).

The comparison function `a.bin_path_ < b.bin_path_ || a.address_ < b.address_` fails the guarantee that `If comp(a,b)==true then comp(b,a)==false`. Quick example, let `a = ("a", 3)` and `b = ("b", 1)`. In this case, both `comp(a,b)==true and comp(b,a)==true`. Code sample: https://godbolt.org/z/vWbcazTvj

In practice, this undefined behavior might lead to weird behavior such as random segmentation faults which I managed to hit in some of my production binaries. i.e:
```
*** Signal 11 (SIGSEGV) received by PID X (code: -6), stack trace: ***
    @ (unknown)
    @ __memcmp_avx2_movbe
    @ void std::__unguarded_linear_insert<__gnu_cxx::__normal_iterator<USDT::Location*, std::vector<USDT::Location, std::allocator<USDT::Location> > >, __gnu_cxx::__ops::_Val_comp_iter<USDT::Probe::finalize_locations()::{lambda(USDT::Location const&, USDT::Location const&)#1}> >(__gnu_cxx::__normal_iterator<USDT::Location*, std::vector<USDT::Location, std::allocator<USDT::Location> > >, __gnu_cxx::__ops::_Val_comp_iter<USDT::Probe::finalize_locations()::{lambda(USDT::Location const&, USDT::Location const&)#1}>)
    @ USDT::Probe::finalize_locations()
     ... user code ...
```

To solve this, we just need to guarantee the strict weak order through the use of `std::tie`. This allows it to have a lexicographical comparison and hence, no more undefined behavior. Performance-wise, this just creates a tuple in place with no copies, so it shouldn't be a big regression.