### PR TITLE
Mark test_call1.py mayFail

### DIFF
--- a/tests/python/test_call1.py
+++ b/tests/python/test_call1.py
@@ -10,6 +10,7 @@ from socket import socket, AF_INET, SOCK_DGRAM
 import sys
 from time import sleep
 from unittest import main, TestCase
+from utils import mayFail
 
 arg1 = sys.argv.pop(1)
 
@@ -36,6 +37,7 @@ class TestBPFSocket(TestCase):
         self.jump[c_int(S_EOP)] = c_int(eop_fn.fd)
         self.stats = b.get_table("stats", c_int, c_ulonglong)
 
+    @mayFail("This may fail on github actions environment due to udp packet loss")
     def test_jumps(self):
         udp = socket(AF_INET, SOCK_DGRAM)
         udp.sendto(b"a" * 10, ("172.16.1.1", 5000))


### PR DESCRIPTION
The test send a udp packet to test tailcalls.
The test may fail due to udp packet loss.
Let us mark the test as mayFail.

Signed-off-by: Yonghong Song <yhs@fb.com>