### PR TITLE
Enable CMP0074 to allow `${pkg}_ROOT`, especially for LLVM_ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 cmake_minimum_required(VERSION 2.8.7)
+cmake_policy(SET CMP0074 NEW)
 
 project(bcc)
 if(NOT CMAKE_BUILD_TYPE)
@@ -73,7 +74,7 @@ endif()
 
 if(NOT PYTHON_ONLY)
 find_package(LLVM REQUIRED CONFIG)
-message(STATUS "Found LLVM: ${LLVM_INCLUDE_DIRS} ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Found LLVM: ${LLVM_INCLUDE_DIRS} ${LLVM_PACKAGE_VERSION} (Use LLVM_ROOT envronment variable for another version of LLVM)")
 
 if(ENABLE_CLANG_JIT)
 find_package(BISON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 cmake_minimum_required(VERSION 2.8.7)
-cmake_policy(SET CMP0074 NEW)
+
+if (${CMAKE_VERSION} VERSION_EQUAL 3.12.0 OR ${CMAKE_VERSION} VERSION_GREATER 3.12.0)
+  cmake_policy(SET CMP0074 NEW)
+endif()
 
 project(bcc)
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Since CMake 3.12, `${pkg}_ROOT` is supported if `CMP0074` is set to `NEW`. This allows users to select a particular version of LLVM very easily. For example, `cmake ... -DLLVM_ROOT=/usr/lib/llvm-13`.

See https://cmake.org/cmake/help/latest/policy/CMP0074.html#policy:CMP0074 for details.