### PR TITLE
bcc: remove trailing semicolon of macro

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -1347,20 +1347,20 @@ static int ____##name(unsigned long long *ctx, ##args)
         do {                                                              \
             unsigned short __offset = args->data_loc_##field & 0xFFFF;    \
             bpf_probe_read((void *)dst, length, (char *)args + __offset); \
-        } while (0);
+        } while (0)
 
 #define TP_DATA_LOC_READ(dst, field)                                        \
         do {                                                                \
             unsigned short __offset = args->data_loc_##field & 0xFFFF;      \
             unsigned short __length = args->data_loc_##field >> 16;         \
             bpf_probe_read((void *)dst, __length, (char *)args + __offset); \
-        } while (0);
+        } while (0)
 
 #define TP_DATA_LOC_READ_STR(dst, field, length)                                \
         do {                                                                    \
             unsigned short __offset = args->data_loc_##field & 0xFFFF;          \
             bpf_probe_read_str((void *)dst, length, (char *)args + __offset);   \
-        } while (0);
+        } while (0)
 
 #endif
 )********"


### PR DESCRIPTION
The trailing semicolon of a do-while style macro will cause an if-else condition without braces to fail compilation.

For example, Let's say we have a simple if-else statement:
```
if (condition)
    foo(x);
else
    bar(x);
```

Now we want to replace the `foo()` function with other macro `FOO`:

```
#define FOO(a)         \
do {                   \
// do something with a \
}   while(0);

if (condition)
    FOO(x);
else
    bar(x);
```

The above code will fail the compilation because of the redundant semicolon will end the statement of `if` clause, causing an orphan `else` clause.

Also notice that other do-while style macros are free of the trailing semicolon, so I think it's a good idea to make them align.