### PR TITLE
libbpf-tools: fix local/remote address byte ordering in tcprtt

### DIFF
--- a/libbpf-tools/tcprtt.bpf.c
+++ b/libbpf-tools/tcprtt.bpf.c
@@ -95,7 +95,7 @@ int BPF_KPROBE(tcp_rcv_kprobe, struct sock *sk)
 	if (targ_saddr && targ_saddr != saddr)
 		return 0;
 	bpf_probe_read_kernel(&daddr, sizeof(daddr), &sk->__sk_common.skc_daddr);
-	if (targ_daddr && targ_saddr != saddr)
+	if (targ_daddr && targ_daddr != daddr)
 		return 0;
 
 	if (targ_laddr_hist)

--- a/libbpf-tools/tcprtt.c
+++ b/libbpf-tools/tcprtt.c
@@ -10,7 +10,6 @@
 #include <signal.h>
 #include <unistd.h>
 #include <time.h>
-#include <arpa/inet.h>
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
 #include "tcprtt.h"
@@ -131,14 +130,14 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			fprintf(stderr, "invalid local address: %s\n", arg);
 			argp_usage(state);
 		}
-		env.laddr = htonl(addr.s_addr);
+		env.laddr = addr.s_addr;
 		break;
 	case 'A':
 		if (inet_aton(arg, &addr) < 0) {
 			fprintf(stderr, "invalid remote address: %s\n", arg);
 			argp_usage(state);
 		}
-		env.raddr = htonl(addr.s_addr);
+		env.raddr = addr.s_addr;
 		break;
 	case 'b':
 		env.laddr_hist = true;
@@ -186,7 +185,7 @@ static int print_map(struct bpf_map *map)
 		if (env.laddr_hist)
 			printf("Local Address = %s ", inet_ntoa(addr));
 		else if (env.raddr_hist)
-			printf("Remote Addres = %s ", inet_ntoa(addr));
+			printf("Remote Address = %s ", inet_ntoa(addr));
 		else
 			printf("All Addresses = ****** ");
 		if (env.extended)


### PR DESCRIPTION
Since inet_aton() converts IPv4 numbers-and-dots notation to binary in network byte order, there is no need to do htonl() again.

Signed-off-by: chendotjs <chendotjs@gmail.com>