### PR TITLE
libbpf-tools: add option to include 'LPORT' in tcpconnlat

### DIFF
--- a/libbpf-tools/tcpconnlat.bpf.c
+++ b/libbpf-tools/tcpconnlat.bpf.c
@@ -36,7 +36,7 @@ static __always_inline int trace_connect(struct sock *sk)
 	u32 tgid = bpf_get_current_pid_tgid() >> 32;
 	struct piddata piddata = {};
 
-	if (targ_tgid  && targ_tgid != tgid)
+	if (targ_tgid && targ_tgid != tgid)
 		return 0;
 
 	bpf_get_current_comm(&piddata.comm, sizeof(piddata.comm));
@@ -85,6 +85,7 @@ int BPF_PROG(tcp_rcv_state_process, struct sock *sk)
 			sizeof(event.comm));
 	event.ts_us = ts / 1000;
 	event.tgid = piddatap->tgid;
+	event.lport = sk->__sk_common.skc_num;
 	event.dport = sk->__sk_common.skc_dport;
 	event.af = sk->__sk_common.skc_family;
 	if (event.af == AF_INET) {

--- a/libbpf-tools/tcpconnlat.h
+++ b/libbpf-tools/tcpconnlat.h
@@ -18,6 +18,7 @@ struct event {
 	__u64 ts_us;
 	__u32 tgid;
 	int af;
+	__u16 lport;
 	__u16 dport;
 };
 


### PR DESCRIPTION
Add `-L` option introduced in https://github.com/iovisor/bcc/pull/3316 , make libbpf-tools `tcpconnlat` consistent with `tools/tcpconnlat.py`.

Signed-off-by: chendotjs <chendotjs@gmail.com>