### PR TITLE
fix llvm compilation failure

### DIFF
--- a/src/cc/bpf_module_rw_engine.cc
+++ b/src/cc/bpf_module_rw_engine.cc
@@ -47,9 +47,28 @@ void BPFModule::cleanup_rw_engine() {
   rw_engine_.reset();
 }
 
+static LoadInst *createLoad(IRBuilder<> &B, Value *addr, bool isVolatile = false)
+{
+#if LLVM_MAJOR_VERSION >= 14
+  return B.CreateLoad(addr->getType()->getPointerElementType(), addr, isVolatile);
+#else
+  return B.CreateLoad(addr, isVolatile);
+#endif
+}
+
+static Value *createInBoundsGEP(IRBuilder<> &B, Value *ptr, ArrayRef<Value *>idxlist)
+{
+#if LLVM_MAJOR_VERSION >= 14
+  return B.CreateInBoundsGEP(ptr->getType()->getScalarType()->getPointerElementType(),
+                             ptr, idxlist);
+#else
+  return B.CreateInBoundsGEP(ptr, idxlist);
+#endif
+}
+
 static void debug_printf(Module *mod, IRBuilder<> &B, const string &fmt, vector<Value *> args) {
   GlobalVariable *fmt_gvar = B.CreateGlobalString(fmt, "fmt");
-  args.insert(args.begin(), B.CreateInBoundsGEP(fmt_gvar, vector<Value *>({B.getInt64(0), B.getInt64(0)})));
+  args.insert(args.begin(), createInBoundsGEP(B, fmt_gvar, vector<Value *>({B.getInt64(0), B.getInt64(0)})));
   args.insert(args.begin(), B.getInt64((uintptr_t)stderr));
   Function *fprintf_fn = mod->getFunction("fprintf");
   if (!fprintf_fn) {
@@ -76,8 +95,8 @@ static void finish_sscanf(IRBuilder<> &B, vector<Value *> *args, string *fmt,
   *fmt += "%n";
   B.CreateStore(B.getInt32(0), nread);
   GlobalVariable *fmt_gvar = B.CreateGlobalString(*fmt, "fmt");
-  (*args)[1] = B.CreateInBoundsGEP(fmt_gvar, {B.getInt64(0), B.getInt64(0)});
-  (*args)[0] = B.CreateLoad(sptr);
+  (*args)[1] = createInBoundsGEP(B, fmt_gvar, {B.getInt64(0), B.getInt64(0)});
+  (*args)[0] = createLoad(B, sptr);
   args->push_back(nread);
   CallInst *call = B.CreateCall(sscanf_fn, *args);
   call->setTailCall(true);
@@ -97,7 +116,7 @@ static void finish_sscanf(IRBuilder<> &B, vector<Value *> *args, string *fmt,
   B.SetInsertPoint(label_false);
   // s = &s[nread];
   B.CreateStore(
-      B.CreateInBoundsGEP(B.CreateLoad(sptr), B.CreateLoad(nread, true)), sptr);
+      createInBoundsGEP(B, createLoad(B, sptr), createLoad(B, nread, true)), sptr);
 
   args->resize(2);
   fmt->clear();
@@ -196,7 +215,7 @@ static void parse_type(IRBuilder<> &B, vector<Value *> *args, string *fmt,
       *fmt += "x";
     else
       *fmt += "i";
-    args->push_back(is_writer ? B.CreateLoad(out) : out);
+    args->push_back(is_writer ? createLoad(B, out) : out);
   }
 }
 
@@ -326,7 +345,7 @@ string BPFModule::make_writer(Module *mod, Type *type) {
 
   GlobalVariable *fmt_gvar = B.CreateGlobalString(fmt, "fmt");
 
-  args[2] = B.CreateInBoundsGEP(fmt_gvar, vector<Value *>({B.getInt64(0), B.getInt64(0)}));
+  args[2] = createInBoundsGEP(B, fmt_gvar, vector<Value *>({B.getInt64(0), B.getInt64(0)}));
 
   if (0)
     debug_printf(mod, B, "%d %p %p\n", vector<Value *>({arg_len, arg_out, arg_in}));

--- a/src/cc/frontends/b/codegen_llvm.h
+++ b/src/cc/frontends/b/codegen_llvm.h
@@ -35,6 +35,7 @@ class Constant;
 class Instruction;
 class IRBuilderBase;
 class LLVMContext;
+class LoadInst;
 class Module;
 class StructType;
 class SwitchInst;
@@ -108,6 +109,8 @@ class CodegenLLVM : public Visitor {
                                  StructDeclStmtNode **decl = nullptr) const;
   llvm::CallInst *createCall(llvm::Value *Callee,
                              llvm::ArrayRef<llvm::Value *> Args);
+  llvm::LoadInst *createLoad(llvm::Value *Addr);
+  llvm::Value *createInBoundsGEP(llvm::Value *Ptr, llvm::ArrayRef<llvm::Value *> IdxList);
 
   template <typename... Args> void emit(const char *fmt, Args&&... params);
   void emit(const char *s);


### PR DESCRIPTION
Fix issue #3734

llvm upstream commit
  89eb85ac6eab [IRBuilder] Remove deprecated methods
deprecated some functions which are used by bcc.
Let us follow the above commit to use the underlying
implementation instead.

Note that I didn't create a common header for the newer
functions since b language support will be removed in
the near future.

Signed-off-by: Yonghong Song <yhs@fb.com>