### PR TITLE
Filter cgroup2 process to support tracing container

### DIFF
--- a/libbpf-tools/biolatency.bpf.c
+++ b/libbpf-tools/biolatency.bpf.c
@@ -11,11 +11,19 @@
 
 extern int LINUX_KERNEL_VERSION __kconfig;
 
+const volatile bool filter_cg = false;
 const volatile bool targ_per_disk = false;
 const volatile bool targ_per_flag = false;
 const volatile bool targ_queued = false;
 const volatile bool targ_ms = false;
 const volatile dev_t targ_dev = -1;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_CGROUP_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+	__uint(max_entries, 1);
+} cgroup_map SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -59,6 +67,9 @@ int trace_rq_start(struct request *rq, int issue)
 SEC("tp_btf/block_rq_insert")
 int block_rq_insert(u64 *ctx)
 {
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
 	/**
 	 * commit a54895fa (v5.11-rc1) changed tracepoint argument list
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
@@ -73,6 +84,9 @@ int block_rq_insert(u64 *ctx)
 SEC("tp_btf/block_rq_issue")
 int block_rq_issue(u64 *ctx)
 {
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
 	/**
 	 * commit a54895fa (v5.11-rc1) changed tracepoint argument list
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
@@ -88,6 +102,9 @@ SEC("tp_btf/block_rq_complete")
 int BPF_PROG(block_rq_complete, struct request *rq, int error,
 	unsigned int nr_bytes)
 {
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
 	u64 slot, *tsp, ts = bpf_ktime_get_ns();
 	struct hist_key hkey = {};
 	struct hist *histp;


### PR DESCRIPTION
- There are many libbpf-tools with various options. But we cannot pass cgroups path for filtering processes in cgroup.
- Example: https://github.com/iovisor/bcc/blob/master/libbpf-tools/tcpconnect.c#L177, cgroup is not yet implemented

### How to trace only cgroup2 processes? Consider the following flow:
- On user side:
  - Pass cgroup path to user code, 
  - Get the fd of cgroup path
  - Update the fd to a map of type BPF_MAP_TYPE_CGROUP_ARRAY. This will store the fd of cgroup path.
- On BPF side 
  - Using bpf_current_task_under_cgroup, 
    - check if current task is not under cgroup fd, then exit
    - If current task is under cgroup fd, then continue BPF code

### Example Usage: biosnoop
- Build biosnoop 
```
$ cd libbpf-tools/
$ make biolatency biosnoop 
```
- Run biosnoop (**Cgroup default-hierarchy=hybrid**)
```
// Terminal 1 
# mkdir /sys/fs/cgroup/unified/test 
# echo $$ > /sys/fs/cgroup/unified/test/cgroup.procs 
# cat /proc/$$/cgroup 
12:freezer:/
11:cpuset:/
10:net_cls,net_prio:/
9:blkio:/user.slice
8:devices:/user.slice
7:perf_event:/
6:rdma:/
5:pids:/user.slice/user-1000.slice/user@1000.service
4:hugetlb:/
3:memory:/user.slice/user-1000.slice/user@1000.service
2:cpu,cpuacct:/user.slice
1:name=systemd:/user.slice/user-1000.slice/user@1000.service/vte-spawn-f9f3e7b6-62bc-4d29-ab24-79464167eb61.scope
0::/test

// Start tracer in Terminal 2
# cat /dev/random > /log 
^C

// Terminal 2 
$ sudo ./biosnoop -c /sys/fs/cgroup/unified/test/
TIME(s)     COMM           PID    DISK    T    SECTOR     BYTES   LAT(ms)
0.000000    cat            116681 nvme0n1 W    42735584   16384     0.025
0.000349    cat            116681 nvme0n1 W    42735616   1040384   0.368
0.000720    cat            116681 nvme0n1 W    42737648   1040384   0.733
0.000728    cat            116681 nvme0n1 W    42739680   16384     0.485
0.001108    cat            116681 nvme0n1 W    42739712   1040384   0.860
0.001497    cat            116681 nvme0n1 W    42741744   1040384   1.242
...<SKIP>...
```

### Example usage with OCI containers
- These options can additionally be used for tracing containers 
- We can get the container cgroup2 path and add path fd to map (Example: OCI runc creates cgroup under `/sys/fs/cgroup/unified/`)
```
// Terminal 1 - launch container with spec cgroupsPath=/runc
# runc run test 
root@runc:/# strace -f -o ./log ping -c 1 localhost 
PING localhost (127.0.0.1) 56(84) bytes of data.
64 bytes from localhost (127.0.0.1): icmp_seq=1 ttl=64 time=0.031 ms

--- localhost ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.031/0.031/0.031/0.000 ms
root@runc:/#

// Terminal 2 
$ sudo ./biosnoop -c /sys/fs/cgroup/unified/runc
TIME(s)     COMM           PID    DISK    T    SECTOR     BYTES   LAT(ms)
0.000000    strace         107385 nvme0n1 RA   906454648  262144    0.245
0.000076    strace         107385 nvme0n1 RA   906456784  77824     0.162
0.000676    strace         107385 nvme0n1 RA   906455160  262144    0.278
0.027123    strace         107385 nvme0n1 W    29156792   20480     0.025
^C
```
- Can also be used with OCI hooks. This will enable us to trace from start of container process.
- Further can be used with K8s-CRIO prestart/postart hooks.

## Conclusion
- Update cgroup2 fd in map and using bpf_current_task_under_cgroup() we can filter only processes under respective cgroup.
  - This will help us trace containers and integrate it with OCI hooks.
- Currently these changes are implemented only for biosnoop and biolatency as example, need community's feedback and suggestions to improve for other tools.