### PR TITLE
!StatusTuple::ok() replaced StatusTuple::code() != 0 for files under src/ dir

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -92,7 +92,7 @@ std::string sanitize_str(std::string str, bool (*validator)(char),
 StatusTuple BPF::init_usdt(const USDT& usdt) {
   USDT u(usdt);
   StatusTuple init_stp = u.init();
-  if (init_stp.code() != 0) {
+  if (!init_stp.ok()) {
     return init_stp;
   }
 
@@ -112,7 +112,7 @@ StatusTuple BPF::init(const std::string& bpf_program,
   usdt_.reserve(usdt.size());
   for (const auto& u : usdt) {
     StatusTuple init_stp = init_usdt(u);
-    if (init_stp.code() != 0) {
+    if (!init_stp.ok()) {
       init_fail_reset();
       return init_stp;
     }
@@ -134,7 +134,7 @@ StatusTuple BPF::init(const std::string& bpf_program,
 
 BPF::~BPF() {
   auto res = detach_all();
-  if (res.code() != 0)
+  if (!res.ok())
     std::cerr << "Failed to detach all probes on destruction: " << std::endl
               << res.msg() << std::endl;
   bcc_free_buildsymcache(bsymcache_);
@@ -147,7 +147,7 @@ StatusTuple BPF::detach_all() {
 
   for (auto& it : kprobes_) {
     auto res = detach_kprobe_event(it.first, it.second);
-    if (res.code() != 0) {
+    if (!res.ok()) {
       error_msg += "Failed to detach kprobe event " + it.first + ": ";
       error_msg += res.msg() + "\n";
       has_error = true;
@@ -156,7 +156,7 @@ StatusTuple BPF::detach_all() {
 
   for (auto& it : uprobes_) {
     auto res = detach_uprobe_event(it.first, it.second);
-    if (res.code() != 0) {
+    if (!res.ok()) {
       error_msg += "Failed to detach uprobe event " + it.first + ": ";
       error_msg += res.msg() + "\n";
       has_error = true;
@@ -165,7 +165,7 @@ StatusTuple BPF::detach_all() {
 
   for (auto& it : tracepoints_) {
     auto res = detach_tracepoint_event(it.first, it.second);
-    if (res.code() != 0) {
+    if (!res.ok()) {
       error_msg += "Failed to detach Tracepoint " + it.first + ": ";
       error_msg += res.msg() + "\n";
       has_error = true;
@@ -174,7 +174,7 @@ StatusTuple BPF::detach_all() {
 
   for (auto& it : raw_tracepoints_) {
     auto res = detach_raw_tracepoint_event(it.first, it.second);
-    if (res.code() != 0) {
+    if (!res.ok()) {
       error_msg += "Failed to detach Raw tracepoint " + it.first + ": ";
       error_msg += res.msg() + "\n";
       has_error = true;
@@ -183,7 +183,7 @@ StatusTuple BPF::detach_all() {
 
   for (auto& it : perf_buffers_) {
     auto res = it.second->close_all_cpu();
-    if (res.code() != 0) {
+    if (!res.ok()) {
       error_msg += "Failed to close perf buffer " + it.first + ": ";
       error_msg += res.msg() + "\n";
       has_error = true;
@@ -193,7 +193,7 @@ StatusTuple BPF::detach_all() {
 
   for (auto& it : perf_event_arrays_) {
     auto res = it.second->close_all_cpu();
-    if (res.code() != 0) {
+    if (!res.ok()) {
       error_msg += "Failed to close perf event array " + it.first + ": ";
       error_msg += res.msg() + "\n";
       has_error = true;
@@ -203,7 +203,7 @@ StatusTuple BPF::detach_all() {
 
   for (auto& it : perf_events_) {
     auto res = detach_perf_event_all_cpu(it.second);
-    if (res.code() != 0) {
+    if (!res.ok()) {
       error_msg += res.msg() + "\n";
       has_error = true;
     }

--- a/src/cc/api/BPFTable.cc
+++ b/src/cc/api/BPFTable.cc
@@ -47,7 +47,7 @@ StatusTuple BPFTable::get_value(const std::string& key_str,
   StatusTuple r(0);
 
   r = string_to_key(key_str, key);
-  if (r.code() != 0)
+  if (!r.ok())
     return r;
 
   if (!lookup(key, value))
@@ -65,7 +65,7 @@ StatusTuple BPFTable::get_value(const std::string& key_str,
   StatusTuple r(0);
 
   r = string_to_key(key_str, key);
-  if (r.code() != 0)
+  if (!r.ok())
     return r;
 
   if (!lookup(key, value))
@@ -75,7 +75,7 @@ StatusTuple BPFTable::get_value(const std::string& key_str,
 
   for (size_t i = 0; i < ncpus; i++) {
     r = leaf_to_string(value + i * desc.leaf_size, value_str.at(i));
-    if (r.code() != 0)
+    if (!r.ok())
       return r;
   }
   return StatusTuple::OK();
@@ -89,11 +89,11 @@ StatusTuple BPFTable::update_value(const std::string& key_str,
   StatusTuple r(0);
 
   r = string_to_key(key_str, key);
-  if (r.code() != 0)
+  if (!r.ok())
     return r;
 
   r = string_to_leaf(value_str, value);
-  if (r.code() != 0)
+  if (!r.ok())
     return r;
 
   if (!update(key, value))
@@ -111,7 +111,7 @@ StatusTuple BPFTable::update_value(const std::string& key_str,
   StatusTuple r(0);
 
   r = string_to_key(key_str, key);
-  if (r.code() != 0)
+  if (!r.ok())
     return r;
 
   if (value_str.size() != ncpus)
@@ -119,7 +119,7 @@ StatusTuple BPFTable::update_value(const std::string& key_str,
 
   for (size_t i = 0; i < ncpus; i++) {
     r = string_to_leaf(value_str.at(i), value + i * desc.leaf_size);
-    if (r.code() != 0)
+    if (!r.ok())
       return r;
   }
 
@@ -135,7 +135,7 @@ StatusTuple BPFTable::remove_value(const std::string& key_str) {
   StatusTuple r(0);
 
   r = string_to_key(key_str, key);
-  if (r.code() != 0)
+  if (!r.ok())
     return r;
 
   if (!remove(key))
@@ -213,11 +213,11 @@ StatusTuple BPFTable::get_table_offline(
       }
 
       r = key_to_string(&i, key_str);
-      if (r.code() != 0)
+      if (!r.ok())
         return r;
 
       r = leaf_to_string(value.get(), value_str);
-      if (r.code() != 0)
+      if (!r.ok())
         return r;
       res.emplace_back(key_str, value_str);
     }
@@ -231,11 +231,11 @@ StatusTuple BPFTable::get_table_offline(
       if (!this->lookup(key.get(), value.get()))
         break;
       r = key_to_string(key.get(), key_str);
-      if (r.code() != 0)
+      if (!r.ok())
         return r;
 
       r = leaf_to_string(value.get(), value_str);
-      if (r.code() != 0)
+      if (!r.ok())
         return r;
       res.emplace_back(key_str, value_str);
       if (!this->next(key.get(), key.get()))
@@ -440,7 +440,7 @@ StatusTuple BPFPerfBuffer::open_all_cpu(perf_reader_raw_cb cb,
 
   for (int i : cpus) {
     auto res = open_on_cpu(cb, lost_cb, i, cb_cookie, page_cnt);
-    if (res.code() != 0) {
+    if (!res.ok()) {
       TRY2(close_all_cpu());
       return res;
     }
@@ -478,7 +478,7 @@ StatusTuple BPFPerfBuffer::close_all_cpu() {
     opened_cpus.push_back(it.first);
   for (int i : opened_cpus) {
     auto res = close_on_cpu(i);
-    if (res.code() != 0) {
+    if (!res.ok()) {
       errors += "Failed to close CPU" + std::to_string(i) + " perf buffer: ";
       errors += res.msg() + "\n";
       has_error = true;
@@ -502,7 +502,7 @@ int BPFPerfBuffer::poll(int timeout_ms) {
 
 BPFPerfBuffer::~BPFPerfBuffer() {
   auto res = close_all_cpu();
-  if (res.code() != 0)
+  if (!res.ok())
     std::cerr << "Failed to close all perf buffer on destruction: " << res.msg()
               << std::endl;
 }
@@ -522,7 +522,7 @@ StatusTuple BPFPerfEventArray::open_all_cpu(uint32_t type, uint64_t config) {
 
   for (int i : cpus) {
     auto res = open_on_cpu(i, type, config);
-    if (res.code() != 0) {
+    if (!res.ok()) {
       TRY2(close_all_cpu());
       return res;
     }
@@ -539,7 +539,7 @@ StatusTuple BPFPerfEventArray::close_all_cpu() {
     opened_cpus.push_back(it.first);
   for (int i : opened_cpus) {
     auto res = close_on_cpu(i);
-    if (res.code() != 0) {
+    if (!res.ok()) {
       errors += "Failed to close CPU" + std::to_string(i) + " perf event: ";
       errors += res.msg() + "\n";
       has_error = true;
@@ -581,7 +581,7 @@ StatusTuple BPFPerfEventArray::close_on_cpu(int cpu) {
 
 BPFPerfEventArray::~BPFPerfEventArray() {
   auto res = close_all_cpu();
-  if (res.code() != 0) {
+  if (!res.ok()) {
     std::cerr << "Failed to close all perf buffer on destruction: " << res.msg()
               << std::endl;
   }

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -312,7 +312,7 @@ class BPFHashTable : public BPFTableBase<KeyType, ValueType> {
 
     while (true) {
       r = get_value(cur, value);
-      if (r.code() != 0)
+      if (!r.ok())
         break;
       res.emplace_back(cur, value);
       if (!this->next(&cur, &cur))

--- a/src/cc/bcc_exception.h
+++ b/src/cc/bcc_exception.h
@@ -86,7 +86,7 @@ private:
 #define TRY2(CMD)                    \
   do {                               \
     ebpf::StatusTuple __stp = (CMD); \
-    if (!__stp.ok()) {         \
+    if (!__stp.ok()) {               \
       return __stp;                  \
     }                                \
   } while (0)

--- a/src/cc/bcc_exception.h
+++ b/src/cc/bcc_exception.h
@@ -86,7 +86,7 @@ private:
 #define TRY2(CMD)                    \
   do {                               \
     ebpf::StatusTuple __stp = (CMD); \
-    if (__stp.code() != 0) {         \
+    if (!__stp.ok()) {         \
       return __stp;                  \
     }                                \
   } while (0)

--- a/src/cc/frontends/b/loader.cc
+++ b/src/cc/frontends/b/loader.cc
@@ -56,14 +56,14 @@ int BLoader::parse(llvm::Module *mod, const string &filename, const string &prot
 
   ebpf::cc::TypeCheck type_check(parser_->scopes_.get(), proto_parser_->scopes_.get());
   auto ret = type_check.visit(parser_->root_node_);
-  if (ret.code() != 0 || ret.msg().size()) {
+  if (!ret.ok() || ret.msg().size()) {
     fprintf(stderr, "Type error @line=%d: %s\n", ret.code(), ret.msg().c_str());
     return -1;
   }
 
   codegen_ = ebpf::make_unique<ebpf::cc::CodegenLLVM>(mod, parser_->scopes_.get(), proto_parser_->scopes_.get());
   ret = codegen_->visit(parser_->root_node_, ts, id, maps_ns);
-  if (ret.code() != 0 || ret.msg().size()) {
+  if (!ret.ok() || ret.msg().size()) {
     fprintf(stderr, "Codegen error @line=%d: %s\n", ret.code(), ret.msg().c_str());
     return ret.code();
   }


### PR DESCRIPTION
This is done with the shell command:
```
sed -i 's|\([A-Z_a-z]\+\).code() != 0|!\1.ok()|' $(grep '\.code() != 0' src -rl)
```
This is part of #2697