### PR TITLE
libbpf-tools: Fix bio tools with 5.16 kernel

### DIFF
--- a/libbpf-tools/biosnoop.c
+++ b/libbpf-tools/biosnoop.c
@@ -223,6 +223,15 @@ int main(int argc, char **argv)
 	}
 	obj->rodata->targ_queued = env.queued;
 
+	if (fentry_exists("__blk_account_io_start", NULL)) {
+		err = bpf_program__set_attach_target(obj->progs.blk_account_io_start, 0,
+						     "__blk_account_io_start");
+		if (err) {
+			fprintf(stderr, "failed to set attach target: %d\n", err);
+			goto cleanup;
+		}
+	}
+
 	err = biosnoop_bpf__load(obj);
 	if (err) {
 		fprintf(stderr, "failed to load BPF object: %d\n", err);

--- a/libbpf-tools/biostacks.c
+++ b/libbpf-tools/biostacks.c
@@ -178,6 +178,17 @@ int main(int argc, char **argv)
 
 	obj->rodata->targ_ms = env.milliseconds;
 
+	if (fentry_exists("__blk_account_io_start", NULL)) {
+		err = bpf_program__set_attach_target(obj->progs.blk_account_io_start, 0,
+						     "__blk_account_io_start");
+		err = err ?: bpf_program__set_attach_target(obj->progs.blk_account_io_done, 0,
+						     "__blk_account_io_done");
+		if (err) {
+			fprintf(stderr, "failed to set attach target: %d\n", err);
+			goto cleanup;
+		}
+	}
+
 	err = biostacks_bpf__load(obj);
 	if (err) {
 		fprintf(stderr, "failed to load BPF object: %d\n", err);


### PR DESCRIPTION
The tools biosnoop and biostacks are broken due to kernel change ([0]).
blk_account_io_{start, done} were renamed to __blk_account_io_{start, done},
and the symbols gone from vmlinux BTF. Fix them by checking symbol existence.

  [0]: https://github.com/torvalds/linux/commit/be6bfe36db1795babe9d92178a47b2e02193cb0f

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>