### PR TITLE
tools: Fix BCC bio tools with recent kernel change

### DIFF
--- a/tools/biolatpcts.py
+++ b/tools/biolatpcts.py
@@ -142,7 +142,10 @@ bpf_source = bpf_source.replace('__MAJOR__', str(major))
 bpf_source = bpf_source.replace('__MINOR__', str(minor))
 
 bpf = BPF(text=bpf_source)
-bpf.attach_kprobe(event="blk_account_io_done", fn_name="kprobe_blk_account_io_done")
+if BPF.get_kprobe_functions(b'__blk_account_io_done'):
+    bpf.attach_kprobe(event="__blk_account_io_done", fn_name="kprobe_blk_account_io_done")
+else:
+    bpf.attach_kprobe(event="blk_account_io_done", fn_name="kprobe_blk_account_io_done")
 
 # times are in usecs
 MSEC = 1000

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -163,12 +163,17 @@ if debug or args.ebpf:
 
 # initialize BPF
 b = BPF(text=bpf_text)
-b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
+if BPF.get_kprobe_functions(b'__blk_account_io_start'):
+    b.attach_kprobe(event="__blk_account_io_start", fn_name="trace_pid_start")
+else:
+    b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
-b.attach_kprobe(event="blk_account_io_done",
-    fn_name="trace_req_completion")
+if BPF.get_kprobe_functions(b'__blk_account_io_done'):
+    b.attach_kprobe(event="__blk_account_io_done", fn_name="trace_req_completion")
+else:
+    b.attach_kprobe(event="blk_account_io_done", fn_name="trace_req_completion")
 
 # header
 print("%-11s %-14s %-6s %-7s %-1s %-10s %-7s" % ("TIME(s)", "COMM", "PID",

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -175,12 +175,17 @@ if args.ebpf:
     exit()
 
 b = BPF(text=bpf_text)
-b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
+if BPF.get_kprobe_functions(b'__blk_account_io_start'):
+    b.attach_kprobe(event="__blk_account_io_start", fn_name="trace_pid_start")
+else:
+    b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
-b.attach_kprobe(event="blk_account_io_done",
-    fn_name="trace_req_completion")
+if BPF.get_kprobe_functions(b'__blk_account_io_done'):
+    b.attach_kprobe(event="__blk_account_io_done", fn_name="trace_req_completion")
+else:
+    b.attach_kprobe(event="blk_account_io_done", fn_name="trace_req_completion")
 
 print('Tracing... Output every %d secs. Hit Ctrl-C to end' % interval)
 


### PR DESCRIPTION
Several BCC bio tools are broken due to kernel change ([0]).
blk_account_io_{start, done} were renamed to __blk_account_io_{start, done},
and the symbols gone from /proc/kallsyms. Fix them by checking symbol existence.

  [0]: https://github.com/torvalds/linux/commit/be6bfe36db1795babe9d92178a47b2e02193cb0f

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>