### PR TITLE
Implement bashreadline with libbpf.

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -1,4 +1,5 @@
 /.output
+/bashreadline
 /bindsnoop
 /biolatency
 /biopattern

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -16,6 +16,7 @@ $(error Architecture $(ARCH) is not supported yet. Please open an issue)
 endif
 
 APPS = \
+	bashreadline \
 	bindsnoop \
 	biolatency \
 	biopattern \

--- a/libbpf-tools/bashreadline.bpf.c
+++ b/libbpf-tools/bashreadline.bpf.c
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (c) 2021 Facebook */
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "bashreadline.h"
+
+#define TASK_COMM_LEN 16
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(__u32));
+} events SEC(".maps");
+
+SEC("uretprobe/readline")
+int BPF_KRETPROBE(printret, const void *ret) {
+	struct str_t data;
+	char comm[TASK_COMM_LEN];
+	u32 pid;
+
+	if (!ret)
+		return 0;
+
+	bpf_get_current_comm(&comm, sizeof(comm));
+	if (comm[0] != 'b' || comm[1] != 'a' || comm[2] != 's' || comm[3] != 'h' || comm[4] != 0 )
+		return 0;
+
+	pid = bpf_get_current_pid_tgid() >> 32;
+	data.pid = pid;
+	bpf_probe_read_user_str(&data.str, sizeof(data.str), ret);
+
+	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &data, sizeof(data));
+
+	return 0;
+};
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/bashreadline.c
+++ b/libbpf-tools/bashreadline.c
@@ -1,0 +1,215 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2021 Facebook */
+#include <argp.h>
+#include <stdio.h>
+#include <errno.h>
+#include <signal.h>
+#include <time.h>
+#include <unistd.h>
+#include <ctype.h>
+
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "bashreadline.h"
+#include "bashreadline.skel.h"
+#include "trace_helpers.h"
+#include "uprobe_helpers.h"
+
+#define PERF_BUFFER_PAGES	16
+#define PERF_POLL_TIMEOUT_MS	100
+#define warn(...) fprintf(stderr, __VA_ARGS__)
+
+static volatile sig_atomic_t exiting = 0;
+
+const char *argp_program_version = "bashreadline 1.0";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] =
+"Print entered bash commands from all running shells.\n"
+"\n"
+"USAGE: bashreadline [-s <path/to/libreadline.so>]\n"
+"\n"
+"EXAMPLES:\n"
+"    bashreadline\n"
+"    bashreadline -s /usr/lib/libreadline.so\n";
+
+static const struct argp_option opts[] = {
+	{ "shared", 's', "PATH", 0, "the location of libreadline.so library" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{},
+};
+
+static char *libreadline_path = NULL;
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	switch (key) {
+	case 's':
+		libreadline_path = strdup(arg);
+		if (libreadline_path == NULL)
+			return ARGP_ERR_UNKNOWN;
+		break;
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static void handle_event(void *ctx, int cpu, void *data, __u32 data_size)
+{
+	struct str_t *e = data;
+	struct tm *tm;
+	char ts[16];
+	time_t t;
+
+	time(&t);
+	tm = localtime(&t);
+	strftime(ts, sizeof(ts), "%H:%m:%S", tm);
+
+	printf("%-9s %-7d %s\n", ts, e->pid, e->str);
+}
+
+static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+}
+
+static char *find_readline_so()
+{
+	const char *bash_path = "/bin/bash";
+	FILE *fp;
+	off_t func_off;
+	char *line = NULL;
+	size_t line_sz = 0;
+	char path[128];
+	char *result = NULL;
+
+	func_off = get_elf_func_offset(bash_path, "readline");
+	if (func_off >= 0)
+		return strdup(bash_path);
+
+	/*
+	 * Try to find libreadline.so if readline is not defined in
+	 * bash itself.
+	 *
+	 * ldd will print a list of names of shared objects,
+	 * dependencies, and their paths.  The line for libreadline
+	 * would looks like
+	 *
+	 *      libreadline.so.8 => /usr/lib/libreadline.so.8 (0x00007b....)
+	 *
+	 * Here, it finds a line with libreadline.so and extracts the
+	 * path after the arrow, '=>', symbol.
+	 */
+	fp = popen("ldd /bin/bash", "r");
+	if (fp == NULL)
+		goto cleanup;
+	while (getline(&line, &line_sz, fp) >= 0) {
+		if (sscanf(line, "%*s => %127s", path) < 1)
+			continue;
+		if (strstr(line, "/libreadline.so")) {
+			result = strdup(path);
+			break;
+		}
+	}
+
+cleanup:
+	if (line)
+		free(line);
+	if (fp)
+		fclose(fp);
+	return result;
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct bashreadline_bpf *obj = NULL;
+	struct perf_buffer_opts pb_opts;
+	struct perf_buffer *pb = NULL;
+	char *readline_so_path;
+	off_t func_off;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	if (libreadline_path) {
+		readline_so_path = libreadline_path;
+	} else if ((readline_so_path = find_readline_so()) == NULL) {
+		warn("failed to find readline\n");
+		return 1;
+	}
+
+	err = bump_memlock_rlimit();
+	if (err) {
+		warn("failed to increase rlimit: %d\n", err);
+		goto cleanup;
+	}
+
+	obj = bashreadline_bpf__open_and_load();
+	if (!obj) {
+		warn("failed to open and load BPF object\n");
+		goto cleanup;
+	}
+
+	func_off = get_elf_func_offset(readline_so_path, "readline");
+	if (func_off < 0) {
+		warn("cound not find readline in %s\n", readline_so_path);
+		goto cleanup;
+	}
+
+	obj->links.printret = bpf_program__attach_uprobe(obj->progs.printret, true, -1,
+							 readline_so_path, func_off);
+	err = libbpf_get_error(obj->links.printret);
+	if (err) {
+		warn("failed to attach readline: %d\n", err);
+		goto cleanup;
+	}
+
+	pb_opts.sample_cb = handle_event;
+	pb_opts.lost_cb = handle_lost_events;
+	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), PERF_BUFFER_PAGES, &pb_opts);
+	err = libbpf_get_error(pb);
+	if (err) {
+		warn("failed to open perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		warn("can't set signal handler: %s\n", strerror(errno));
+		err = 1;
+		goto cleanup;
+	}
+
+	printf("%-9s %-7s %s\n", "TIME", "PID", "COMMAND");
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && errno != EINTR) {
+			warn("error polling perf buffer: %s\n", strerror(errno));
+			goto cleanup;
+		}
+		err = 0;
+	}
+
+cleanup:
+	if (readline_so_path)
+		free(readline_so_path);
+	perf_buffer__free(pb);
+	bashreadline_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/libbpf-tools/bashreadline.h
+++ b/libbpf-tools/bashreadline.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright (c) 2021 Facebook */
+#ifndef __BASHREADLINE_H
+#define __BASHREADLINE_H
+
+#define MAX_LINE_SIZE 80
+
+struct str_t {
+	__u32 pid;
+	char str[MAX_LINE_SIZE];
+};
+
+#endif /* __BASHREADLINE_H */


### PR DESCRIPTION
Bashreadline will print user inputs, returning from readline, of every
instance of bash shell.  Readline is in bash itself, linked
statically, for some devices, while others may link to libreadline.so.
This implementation finds the symbol in bash if possible. Or, it tries
to find libreadline.so using ldd if the symbol is not in bash.

Signed-off-by: Kui-Feng Lee <kuifeng@fb.com>