### PR TITLE
libbpf-tools: fix fentry prog in tcprtt

### DIFF
--- a/libbpf-tools/tcprtt.bpf.c
+++ b/libbpf-tools/tcprtt.bpf.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Wenbo Zhang
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_endian.h>
 #include "tcprtt.h"
@@ -56,7 +57,7 @@ int BPF_PROG(tcp_rcv, struct sock *sk)
 	if (!histp)
 		return 0;
 	ts = (struct tcp_sock *)(sk);
-	srtt = ts->srtt_us >> 3;
+	srtt = BPF_CORE_READ(ts, srtt_us) >> 3;
 	if (targ_ms)
 		srtt /= 1000U;
 	slot = log2l(srtt);

--- a/libbpf-tools/tcprtt.c
+++ b/libbpf-tools/tcprtt.c
@@ -249,7 +249,7 @@ int main(int argc, char **argv)
 	obj->rodata->targ_daddr = env.raddr;
 	obj->rodata->targ_ms = env.milliseconds;
 
-	if (!fentry_exists("tcp_rcv_established", NULL))
+	if (fentry_exists("tcp_rcv_established", NULL))
 		bpf_program__set_autoload(obj->progs.tcp_rcv_kprobe, false);
 	else
 		bpf_program__set_autoload(obj->progs.tcp_rcv, false);


### PR DESCRIPTION
 This commit fixes judgement if tcp_rcv_established fentry exists and fentry prog by introducing BPF_CORE_READ.

 Signed-off-by: chendotjs <chendotjs@gmail.com>