### PR TITLE
docker: Run tests on ubuntu-20.04 as well

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   test_bcc:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [{version: "18.04", nick: bionic}, {version: "20.04", nick: focal}]
         env:
         - TYPE: Debug
           PYTHON_TEST_LOGFILE: critical.log
@@ -25,7 +25,10 @@ jobs:
         ip addr
     - name: Build docker container with all deps
       run: |
-        docker build -t bcc-docker -f Dockerfile.tests .
+        docker build \
+        --build-arg UBUNTU_VERSION=${{ matrix.os.version }} \
+        --build-arg UBUNTU_SHORTNAME=${{ matrix.os.nick }} \
+        -t bcc-docker -f Dockerfile.tests .
     - name: Run bcc build
       env: ${{ matrix.env }}
       run: |
@@ -88,7 +91,7 @@ jobs:
 
     - uses: actions/upload-artifact@v1
       with:
-        name: critical-tests-${{ matrix.env['TYPE'] }}-${{ matrix.os }}
+        name: critical-tests-${{ matrix.env['TYPE'] }}-${{ matrix.os.version }}
         path: tests/python/critical.log
 
 # To debug weird issues, you can add this step to be able to SSH to the test environment

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -71,3 +71,4 @@ RUN wget -O ruby-install-0.7.0.tar.gz \
     make install
 
 RUN ruby-install --system ruby 2.6.0 -- --enable-dtrace
+RUN if [ ! -f "/usr/bin/python" ]; then ln -s /bin/python3 /usr/bin/python; fi

--- a/tests/python/test_tools_memleak.py
+++ b/tests/python/test_tools_memleak.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import tempfile
 
-TOOLS_DIR = "../../tools/"
+TOOLS_DIR = "/bcc/tools/"
 
 
 class cfg:

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -9,7 +9,7 @@ import re
 from unittest import main, skipUnless, TestCase
 from utils import mayFail, kernel_version_ge
 
-TOOLS_DIR = "../../tools/"
+TOOLS_DIR = "/bcc/tools/"
 
 def _helpful_rc_msg(rc, allow_early, kill):
     s = "rc was %d\n" % rc

--- a/tests/python/test_uprobes.py
+++ b/tests/python/test_uprobes.py
@@ -56,13 +56,14 @@ int count(struct pt_regs *ctx) {
     return 0;
 }"""
         b = bcc.BPF(text=text)
-        b.attach_uprobe(name="/usr/bin/python", sym="main", fn_name="count")
-        b.attach_uretprobe(name="/usr/bin/python", sym="main", fn_name="count")
-        with os.popen("/usr/bin/python -V") as f:
+        pythonpath = "/usr/bin/python3"
+        b.attach_uprobe(name=pythonpath, sym="main", fn_name="count")
+        b.attach_uretprobe(name=pythonpath, sym="main", fn_name="count")
+        with os.popen(pythonpath + " -V") as f:
             pass
         self.assertGreater(b["stats"][ctypes.c_int(0)].value, 0)
-        b.detach_uretprobe(name="/usr/bin/python", sym="main")
-        b.detach_uprobe(name="/usr/bin/python", sym="main")
+        b.detach_uretprobe(name=pythonpath, sym="main")
+        b.detach_uprobe(name=pythonpath, sym="main")
 
     def test_mount_namespace(self):
         text = """


### PR DESCRIPTION
Move bcc-test github action's `matrix.os` to indicate the OS to run in
the container, not the test runner itself (just pin the latter to
ubuntu-20.04).

Also, fixup some tests that were failing when trying to run on 20.04
manually.