### PR TITLE
exclude static functions __SCT__

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -737,6 +737,10 @@ class BPF(object):
                 # non-attachable.
                 elif fn.startswith(b'__perf') or fn.startswith(b'perf_'):
                     continue
+                # Exclude all static functions with prefix __SCT__, they are
+                # all non-attachable
+                elif fn.startswith(b'__SCT__'):
+                    continue
                 # Exclude all gcc 8's extra .cold functions
                 elif re.match(b'^.*\.cold(\.\d+)?$', fn):
                     continue


### PR DESCRIPTION
The functions with prefix __SCT__ are static functions that are not traceable. Hence removed__SCT__ prefix functions in bcc get_kprobe_functions().