### PR TITLE
bcc/tools: Allow trace.py to trace golang functions

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -110,7 +110,7 @@ class Probe(object):
                 #                                          opt. signature
                 #                               probespec       |      rest
                 #                               ---------  ----------   --
-                (spec, sig, rest) = re.match(r'([^ \t\(]+)(\([^\(]*\))?(.*)',
+                (spec, sig, rest) = re.match(r'([^ \t]+)(\([^\(]*\))?(.*)',
                                              text).groups()
 
                 self._parse_spec(spec)


### PR DESCRIPTION
Golang function symbols can contain `(`, which is excluded
by the original implementation. Thus oolang function symbol like:

    example.com/some-project/foo.(*Bar).Buz

is not allowed. Let's remove this constraint. Now we can do:

    trace 'p:/path/to/binary:example.com/some-project/foo.(*Bar).Buz "%llx", arg1'

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>