### PR TITLE
libbpf-tools: fix dev_t type issue

### DIFF
--- a/libbpf-tools/biolatency.bpf.c
+++ b/libbpf-tools/biolatency.bpf.c
@@ -16,7 +16,8 @@ const volatile bool targ_per_disk = false;
 const volatile bool targ_per_flag = false;
 const volatile bool targ_queued = false;
 const volatile bool targ_ms = false;
-const volatile dev_t targ_dev = -1;
+const volatile bool filter_dev = false;
+const volatile __u32 targ_dev = 0;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_CGROUP_ARRAY);
@@ -51,9 +52,9 @@ int trace_rq_start(struct request *rq, int issue)
 
 	u64 ts = bpf_ktime_get_ns();
 
-	if (targ_dev != -1) {
+	if (filter_dev) {
 		struct gendisk *disk = BPF_CORE_READ(rq, rq_disk);
-		dev_t dev;
+		u32 dev;
 
 		dev = disk ? MKDEV(BPF_CORE_READ(disk, major),
 				BPF_CORE_READ(disk, first_minor)) : 0;

--- a/libbpf-tools/biolatency.c
+++ b/libbpf-tools/biolatency.c
@@ -278,6 +278,7 @@ int main(int argc, char **argv)
 			fprintf(stderr, "invaild partition name: not exist\n");
 			goto cleanup;
 		}
+		obj->rodata->filter_dev = true;
 		obj->rodata->targ_dev = partition->dev;
 	}
 	obj->rodata->targ_per_disk = env.per_disk;

--- a/libbpf-tools/biopattern.bpf.c
+++ b/libbpf-tools/biopattern.bpf.c
@@ -6,12 +6,13 @@
 #include "biopattern.h"
 #include "maps.bpf.h"
 
-const volatile dev_t targ_dev = -1;
+const volatile bool filter_dev = false;
+const volatile __u32 targ_dev = 0;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 64);
-	__type(key, dev_t);
+	__type(key, u32);
 	__type(value, struct counter);
 	__uint(map_flags, BPF_F_NO_PREALLOC);
 } counters SEC(".maps");
@@ -22,9 +23,9 @@ int handle__block_rq_complete(struct trace_event_raw_block_rq_complete *ctx)
 	sector_t sector = ctx->sector;
 	struct counter *counterp, zero = {};
 	u32 nr_sector = ctx->nr_sector;
-	dev_t dev = ctx->dev;
+	u32 dev = ctx->dev;
 
-	if (targ_dev != -1 && targ_dev != dev)
+	if (filter_dev && targ_dev != dev)
 		return 0;
 
 	counterp = bpf_map_lookup_or_try_init(&counters, &dev, &zero);

--- a/libbpf-tools/biopattern.c
+++ b/libbpf-tools/biopattern.c
@@ -195,6 +195,7 @@ int main(int argc, char **argv)
 			fprintf(stderr, "invaild partition name: not exist\n");
 			goto cleanup;
 		}
+		obj->rodata->filter_dev = true;
 		obj->rodata->targ_dev = partition->dev;
 	}
 

--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -10,7 +10,8 @@
 
 const volatile bool filter_cg = false;
 const volatile bool targ_queued = false;
-const volatile dev_t targ_dev = -1;
+const volatile bool filter_dev = false;
+const volatile __u32 targ_dev = 0;
 
 extern __u32 LINUX_KERNEL_VERSION __kconfig;
 
@@ -37,7 +38,7 @@ struct {
 struct stage {
 	u64 insert;
 	u64 issue;
-	dev_t dev;
+	__u32 dev;
 };
 
 struct {
@@ -95,7 +96,7 @@ int trace_rq_start(struct request *rq, bool insert)
 
 		stage.dev = disk ? MKDEV(BPF_CORE_READ(disk, major),
 				BPF_CORE_READ(disk, first_minor)) : 0;
-		if (targ_dev != -1 && targ_dev != stage.dev)
+		if (filter_dev && targ_dev != stage.dev)
 			return 0;
 		stagep = &stage;
 	}

--- a/libbpf-tools/biosnoop.c
+++ b/libbpf-tools/biosnoop.c
@@ -225,6 +225,8 @@ int main(int argc, char **argv)
 			fprintf(stderr, "invaild partition name: not exist\n");
 			goto cleanup;
 		}
+		obj->rodata->filter_dev = true;
+		obj->rodata->targ_dev = partition->dev;
 	}
 	obj->rodata->targ_queued = env.queued;
 	obj->rodata->filter_cg = env.cg;

--- a/libbpf-tools/biostacks.bpf.c
+++ b/libbpf-tools/biostacks.bpf.c
@@ -11,7 +11,8 @@
 #define MAX_ENTRIES	10240
 
 const volatile bool targ_ms = false;
-const volatile dev_t targ_dev = -1;
+const volatile bool filter_dev = false;
+const volatile __u32 targ_dev = -1;
 
 struct internal_rqinfo {
 	u64 start_ts;
@@ -41,11 +42,11 @@ int trace_start(void *ctx, struct request *rq, bool merge_bio)
 {
 	struct internal_rqinfo *i_rqinfop = NULL, i_rqinfo = {};
 	struct gendisk *disk = BPF_CORE_READ(rq, rq_disk);
-	dev_t dev;
+	u32 dev;
 
 	dev = disk ? MKDEV(BPF_CORE_READ(disk, major),
 			BPF_CORE_READ(disk, first_minor)) : 0;
-	if (targ_dev != -1 && targ_dev != dev)
+	if (filter_dev && targ_dev != dev)
 		return 0;
 
 	if (merge_bio)

--- a/libbpf-tools/biostacks.c
+++ b/libbpf-tools/biostacks.c
@@ -168,6 +168,7 @@ int main(int argc, char **argv)
 			fprintf(stderr, "invaild partition name: not exist\n");
 			goto cleanup;
 		}
+		obj->rodata->filter_dev = true;
 		obj->rodata->targ_dev = partition->dev;
 	}
 

--- a/libbpf-tools/bitesize.bpf.c
+++ b/libbpf-tools/bitesize.bpf.c
@@ -8,7 +8,8 @@
 #include "bits.bpf.h"
 
 const volatile char targ_comm[TASK_COMM_LEN] = {};
-const volatile dev_t targ_dev = -1;
+const volatile bool filter_dev = false;
+const volatile __u32 targ_dev = 0;
 
 extern __u32 LINUX_KERNEL_VERSION __kconfig;
 
@@ -39,9 +40,9 @@ static int trace_rq_issue(struct request *rq)
 	struct hist *histp;
 	u64 slot;
 
-	if (targ_dev != -1) {
+	if (filter_dev) {
 		struct gendisk *disk = BPF_CORE_READ(rq, rq_disk);
-		dev_t dev;
+		u32 dev;
 
 		dev = disk ? MKDEV(BPF_CORE_READ(disk, major),
 				BPF_CORE_READ(disk, first_minor)) : 0;

--- a/libbpf-tools/bitesize.c
+++ b/libbpf-tools/bitesize.c
@@ -192,6 +192,7 @@ int main(int argc, char **argv)
 			fprintf(stderr, "invaild partition name: not exist\n");
 			goto cleanup;
 		}
+		obj->rodata->filter_dev = true;
 		obj->rodata->targ_dev = partition->dev;
 	}
 


### PR DESCRIPTION
The vmlinux.h uses u32 to define dev_t. But the user-space process uses
<sys/types.h> which uses 8 bytes for dev_t. When the libbpf uses mapped
memory to update .rodata, it might override other variable's value. We
should use u32 to fix it.

And also fix `biosnoop -d $dev-name` issue.

Signed-off-by: Wei Fu <fuweid89@gmail.com>