### PR TITLE
Build libbpf tools as part of fedora test run

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -128,6 +128,21 @@ jobs:
                    /bin/bash -c \
                    'mkdir -p /bcc/build && cd /bcc/build && \
                     cmake -DCMAKE_BUILD_TYPE=${TYPE} -DENABLE_LLVM_SHARED=ON -DRUN_LUA_TESTS=OFF .. && make -j9'"
+    - name: Run libbpf-tools build
+      env: ${{ matrix.env }}
+      run: |
+        /bin/bash -c \
+                   "docker run --privileged \
+                   --pid=host \
+                   -v $(pwd):/bcc \
+                   -v /sys/kernel/debug:/sys/kernel/debug:rw \
+                   -v /lib/modules:/lib/modules:ro \
+                   -v /usr/src:/usr/src:ro \
+                   -v /usr/include/linux:/usr/include/linux:ro \
+                   bcc-docker \
+                   /bin/bash -c \
+                   'cd /bcc/libbpf-tools && make -j9'"
+
     - name: Run bcc's cc tests
       env: ${{ matrix.env }}
       # tests are wrapped with `script` as a hack to get a TTY as github actions doesn't provide this

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -38,6 +38,7 @@ RUN dnf -y install \
 	iputils \
 	net-tools \
 	hostname \
-	iproute
+	iproute \
+	bpftool
 
 RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1


### PR DESCRIPTION
This makes no attempt to CMake-ify `libbpf-tools/Makefile`, so the build happens as a separate step

There's currently nothing using the generated executables to test, but ostensibly the `tests/python/test_tools_smoke.py` could be extended to do so. May be worth merging independently as there are lots of outstanding libbpf-tools PRs and quick feedback on whether build succeeds would be useful

Why fedora only? Installing `linux-tools-generic` package on Ubuntu, which contains `bpftool` causes problems since Ubuntu's `/usr/sbin/bpftool` is a script wrapper which tries to ensure that the installed bpftool (located in `/usr/lib/linux-tools/...`) kernel version matches the running kernel. Normally a useful thing to check. Also bpftools on 18.04 and 20.04 are too old to gen skel. All can be worked around, but needs some thought.