### PR TITLE
bcc: Fix array type handling due to llvm changes

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -946,6 +946,9 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
             std::vector<std::string> perf_event;
 
             for (auto it = r->field_begin(); it != r->field_end(); ++it) {
+              // After LLVM commit aee49255074f
+              // (https://github.com/llvm/llvm-project/commit/aee49255074fd4ef38d97e6e70cbfbf2f9fd0fa7)
+              // array type change from `comm#char [16]` to `comm#char[16]`
               perf_event.push_back(it->getNameAsString() + "#" + it->getType().getAsString()); //"pid#u32"
             }
             fe_.perf_events_[name] = perf_event;

--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -227,8 +227,8 @@ def _get_event_class(event_map):
                    'unsigned __int128' : (ct.c_ulonglong * 2),
                    'void *'            : ct.c_void_p }
 
-    # handle array types e.g. "int [16] foo"
-    array_type = re.compile(r"(.+) \[([0-9]+)\]$")
+    # handle array types e.g. "int [16]" or "char[16]"
+    array_type = re.compile(r"([^ ]+) ?\[([0-9]+)\]$")
 
     fields = []
     num_fields = lib.bpf_perf_event_fields(event_map.bpf.module, event_map._name)


### PR DESCRIPTION
The llvm commit aee49255074f ([0]) changes array type
from `int [4]` to `int[4]` (with space removed), which
breaks the assumption in BCC. This commit fixes this
issue and adds a comment to the related code. While at
it, also remove execution permission of file `table.py`.

  [0]: https://github.com/llvm/llvm-project/commit/aee49255074fd4ef38d97e6e70cbfbf2f9fd0fa7

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>