### PR TITLE
bcc: Replace deprecated libbpf APIs

### DIFF
--- a/src/cc/bcc_btf.cc
+++ b/src/cc/bcc_btf.cc
@@ -597,7 +597,7 @@ int BTF::load(uint8_t *btf_sec, uintptr_t btf_sec_size,
     return -1;
   }
 
-  if (btf__load(btf)) {
+  if (btf__load_into_kernel(btf)) {
     btf__free(btf);
     warning("Loading .BTF section failed\n");
     return -1;


### PR DESCRIPTION
Several libbpf APIs used by BCC are deprecated, which causes
annoying compilation warnings. Update BCC to use the replacement
APIs. The code is mainly borrowed from libbpf itself.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>