### PR TITLE
bcc_syms.cc: bug fix; identify VDSO using 'name' vs. 'path'

### DIFF
--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -238,7 +238,7 @@ ProcSyms::Module::Module(const char *name, const char *path,
   // Other symbol files
   if (bcc_is_valid_perf_map(path_.c_str()) == 1)
     type_ = ModuleType::PERF_MAP;
-  else if (bcc_elf_is_vdso(path_.c_str()) == 1)
+  else if (bcc_elf_is_vdso(name_.c_str()) == 1)
     type_ = ModuleType::VDSO;
 
   // Will be stored later


### PR DESCRIPTION
Correctly identify VDSO using 'name' vs. 'path'.
Use of path incorrectly compares `/proc/<pid>/root[vdso]` with `[vdso]`.

Signed-off-by: Pete Stevenson <jps@pixielabs.ai>