### PR TITLE
libbpf-tools/klockstat: no more rlimit bumping + add comment

### DIFF
--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -4,6 +4,12 @@
  * Based on klockstat from BCC by Jiri Olsa and others
  * 2021-10-26   Barret Rhoden   Created this.
  */
+/* Differences from BCC python tool:
+ * - can specify a lock by ksym name, using '-L'
+ * - tracks whichever task had the max time for acquire and hold, outputted
+ *     when '-s' > 1 (otherwise it's cluttered).
+ * - does not reset stats each interval by default. Can request with -R.
+ */
 #include <argp.h>
 #include <errno.h>
 #include <signal.h>
@@ -484,12 +490,7 @@ int main(int argc, char **argv)
 
 	sigaction(SIGINT, &sigact, 0);
 
-	err = bump_memlock_rlimit();
-	if (err) {
-		warn("failed to increase rlimit: %d\n", err);
-		err = 1;
-		goto cleanup;
-	}
+	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 
 	ksyms = ksyms__load();
 	if (!ksyms) {


### PR DESCRIPTION
The PR adding the libbpf-tools port of klockstat was sitting in a
mergeable state for some time. Meanwhile, libbpf stopped exposing
rlimit_memlock bumping API and now does the rlimit bump automatically if
necessary. So remove the bump_rlimit_memlock call and set libbpf strict
mode for this tool.

Also, add a comment (from @brho's PR summary in #3688) detailing the
differences in default behavior between the libbpf-tools and bcc-python
versions.

Signed-off-by: Dave Marchevsky <davemarchevsky@fb.com>