### PR TITLE
reallocarray: eliminate compilation warnings

### DIFF
--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -3,6 +3,7 @@
  *
  * Based on klockstat from BCC by Jiri Olsa and others
  * 2021-10-26   Barret Rhoden   Created this.
+ * 07-Jan-2022  Rong Tao        Eliminate compilation warnings of reallocarray.
  */
 /* Differences from BCC python tool:
  * - can specify a lock by ksym name, using '-L'
@@ -14,6 +15,9 @@
 #include <errno.h>
 #include <signal.h>
 #include <stdio.h>
+#ifndef __USE_GNU                                                                                                            
+#define __USE_GNU
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>

--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -3,7 +3,6 @@
  *
  * Based on klockstat from BCC by Jiri Olsa and others
  * 2021-10-26   Barret Rhoden   Created this.
- * 07-Jan-2022  Rong Tao        Eliminate compilation warnings of reallocarray.
  */
 /* Differences from BCC python tool:
  * - can specify a lock by ksym name, using '-L'
@@ -15,8 +14,8 @@
 #include <errno.h>
 #include <signal.h>
 #include <stdio.h>
-#ifndef __USE_GNU                                                                                                            
-#define __USE_GNU
+#ifndef _GNU_SOURCE                                                                                                            
+#define _GNU_SOURCE
 #endif
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
compile warning 

```bash
  CC       klockstat.o
klockstat.c: In function ‘print_stats’:
klockstat.c:396:12: warning: implicit declaration of function ‘reallocarray’; did you mean ‘realloc’? [-Wimplicit-function-declaration]
    stats = reallocarray(stats, stats_sz, sizeof(void *));
            ^~~~~~~~~~~~
            realloc
klockstat.c:396:10: warning: assignment to ‘struct stack_stat **’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
    stats = reallocarray(stats, stats_sz, sizeof(void *));
          ^
  BINARY   klockstat
```