### PR TITLE
tools/sslsniff: add handshake call trace

### DIFF
--- a/man/man8/sslsniff.8
+++ b/man/man8/sslsniff.8
@@ -51,7 +51,7 @@ Default value is 8 Kib, maximum possible value is a bit less than 32 Kib.
 Show function latency in ms.
 .TP
 \--handshake
-Trace SSL handshake calls.
+Show handshake latency, enabled only if latency option is on.
 .SH EXAMPLES
 .TP
 Print all calls to SSL write/send and read/recv system-wide:
@@ -89,7 +89,7 @@ TID
 Thread ID, displayed only if launched with -x.
 .TP
 LAT(ms)
-Function latency in ms, or N/A when in function entry.
+Function latency in ms.
 .SH SOURCE
 This is from bcc.
 .IP

--- a/man/man8/sslsniff.8
+++ b/man/man8/sslsniff.8
@@ -3,7 +3,7 @@
 sslsniff \- Print data passed to OpenSSL, GnuTLS or NSS. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B sslsniff [-h] [-p PID] [-u UID] [-x] [-c COMM] [-o] [-g] [-n] [-d]
-.B [--hexdump] [--max-buffer-size SIZE]
+.B [--hexdump] [--max-buffer-size SIZE] [-v]
 .SH DESCRIPTION
 sslsniff prints data sent to write/send and read/recv functions of
 OpenSSL, GnuTLS and NSS, allowing us to read plain text content before
@@ -46,6 +46,8 @@ Show data as hexdump instead of trying to decode it as UTF-8
 \-\-max-buffer-size SIZE
 Sets maximum buffer size of intercepted data. Longer values would be truncated.
 Default value is 8 Kib, maximum possible value is a bit less than 32 Kib.
+\-v, \-\-verbose
+Trace SSL handshake calls and show function latency in ms.
 .SH EXAMPLES
 .TP
 Print all calls to SSL write/send and read/recv system-wide:
@@ -77,6 +79,8 @@ UID of the process, displayed only if launched with -x.
 .TP
 TID
 Thread ID, displayed only if launched with -x.
+LATms
+Function latency in ms, or N/A when in function entry.
 .SH SOURCE
 This is from bcc.
 .IP

--- a/man/man8/sslsniff.8
+++ b/man/man8/sslsniff.8
@@ -3,7 +3,7 @@
 sslsniff \- Print data passed to OpenSSL, GnuTLS or NSS. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B sslsniff [-h] [-p PID] [-u UID] [-x] [-c COMM] [-o] [-g] [-n] [-d]
-.B [--hexdump] [--max-buffer-size SIZE] [-v]
+.B [--hexdump] [--max-buffer-size SIZE] [-l] [--handshake]
 .SH DESCRIPTION
 sslsniff prints data sent to write/send and read/recv functions of
 OpenSSL, GnuTLS and NSS, allowing us to read plain text content before
@@ -46,8 +46,12 @@ Show data as hexdump instead of trying to decode it as UTF-8
 \-\-max-buffer-size SIZE
 Sets maximum buffer size of intercepted data. Longer values would be truncated.
 Default value is 8 Kib, maximum possible value is a bit less than 32 Kib.
-\-v, \-\-verbose
-Trace SSL handshake calls and show function latency in ms.
+.TP
+\-l, \-\-latency
+Show function latency in ms.
+.TP
+\--handshake
+Trace SSL handshake calls.
 .SH EXAMPLES
 .TP
 Print all calls to SSL write/send and read/recv system-wide:
@@ -57,6 +61,10 @@ Print all calls to SSL write/send and read/recv system-wide:
 Print only OpenSSL calls issued by user with UID 1000
 #
 .B sslsniff -u 1000 --no-nss --no-gnutls
+.TP
+Print SSL handshake event and latency for all traced functions:
+#
+.B sslsniff -l --handshake
 .SH FIELDS
 .TP
 FUNC
@@ -79,7 +87,8 @@ UID of the process, displayed only if launched with -x.
 .TP
 TID
 Thread ID, displayed only if launched with -x.
-LATms
+.TP
+LAT(ms)
 Function latency in ms, or N/A when in function entry.
 .SH SOURCE
 This is from bcc.

--- a/tools/sslsniff_example.txt
+++ b/tools/sslsniff_example.txt
@@ -103,42 +103,58 @@ lot of characters that are not printable or even Unicode replacement
 characters.
 
 
-Function latency can be show by -l or --latency option, and SSL handshake calls
-can be trace by --handshake option. This is useful when analyzing SSL/TLS
-performance. Tracing output of "openssl s_client -connect example.com:443":
+Use -l or --latency option to show function latency, and show handshake latency
+by using both -l and --handshake. This is useful for SSL/TLS performance
+analysis. Tracing output of "echo | openssl s_client -connect example.com:443":
 
 # ./sslsniff.py -l --handshake
 FUNC         TIME(s)            COMM             PID     LEN    LAT(ms)
-WRITE/SEND   0.000000000        openssl          3260509 0      N/A
-WRITE/SEND   0.593772992        openssl          3260509 0      593.773
-WRITE/SEND   0.593898479        openssl          3260509 1      N/A
+WRITE/SEND   0.000000000        openssl          10377   1      0.005
 ----- DATA -----
 
 
 ----- END DATA -----
 
-
-WRITE/SEND   0.593906849        openssl          3260509 1      0.008
-
-
-Change example.com to localhost server. It takes 0.7ms for server handshake
-and 1.3ms before secure connection is ready for 1st SSL_read or SSL_write.
-Note that latency field shows "N/A" at function entry.
+Trace localhost server instead of example.com. It takes 0.7ms for server
+handshake before secure connection is ready for initial SSL_read or SSL_write.
 
 # ./sslsniff.py -l --handshake
 FUNC         TIME(s)            COMM             PID     LEN    LAT(ms)
-WRITE/SEND   0.000000000        openssl          3260362 0      N/A
-HANDSHAKE    0.001318467        nginx            3260106 1      0.689
-WRITE/SEND   0.001339752        openssl          3260362 0      1.340
-WRITE/SEND   0.001452343        openssl          3260362 1      N/A
+HANDSHAKE    0.000000000        nginx            7081    1      0.699
+WRITE/SEND   0.000132180        openssl          14800   1      0.010
 ----- DATA -----
 
 
 ----- END DATA -----
 
+READ/RECV    0.000136583        nginx            7081    1      0.004
+----- DATA -----
 
-WRITE/SEND   0.001467280        openssl          3260362 1      0.015
-READ/RECV    0.001470071        nginx            3260106 1      0.003
+
+----- END DATA -----
+
+Tracing output of "echo | gnutls-cli -p 443 example.com":
+
+# ./sslsniff.py -l --handshake
+FUNC         TIME(s)            COMM             PID     LEN    LAT(ms)
+WRITE/SEND   0.000000000        gnutls-cli       43554   1      0.012
+----- DATA -----
+
+
+----- END DATA -----
+
+Tracing output of "echo | gnutls-cli -p 443 --insecure localhost":
+
+# ./sslsniff.py -l --handshake
+FUNC         TIME(s)            COMM             PID     LEN    LAT(ms)
+HANDSHAKE    0.000000000        nginx            7081    1      0.710
+WRITE/SEND   0.000045126        gnutls-cli       43752   1      0.014
+----- DATA -----
+
+
+----- END DATA -----
+
+READ/RECV    0.000049464        nginx            7081    1      0.004
 ----- DATA -----
 
 
@@ -168,7 +184,8 @@ optional arguments:
   --max-buffer-size MAX_BUFFER_SIZE
                         Size of captured buffer
   -l, --latency         show function latency
-  --handshake           trace SSL handshake calls
+  --handshake           show SSL handshake latency, enabled only if latency
+                        option is on. 
 
 examples:
     ./sslsniff              # sniff OpenSSL and GnuTLS functions
@@ -181,4 +198,4 @@ examples:
     ./sslsniff --hexdump    # show data as hex instead of trying to decode it as UTF-8
     ./sslsniff -x           # show process UID and TID
     ./sslsniff -l           # show function latency
-    ./sslsniff --handshake  # trace SSL handshake calls
+    ./sslsniff -l --handshake  # show SSL handshake latency

--- a/tools/sslsniff_example.txt
+++ b/tools/sslsniff_example.txt
@@ -103,10 +103,36 @@ lot of characters that are not printable or even Unicode replacement
 characters.
 
 
+SSL handshake calls can be trace by -v or --verbose option. SSL crypto is
+CPU-intensive workload in server side especially for RSA key (elliptic-curve
+key optimized a lot). This is useful when analyzing CPU crypto acceleration
+features, crypto algorithms or openssl async SSL framework.
+
+Tracing output of https server when running "echo | openssl s_client -connect
+localhost:443" in another shell client. It takes 0.7ms for RSA 2K key exchange
+and 1.3ms for the whole handshake phase before SSL_write or SSL_read calls.
+
+FUNC         TIME(s)            COMM             PID     LEN    LATms
+WRITE/SEND   0.000000000        openssl          2741676 0      N/A
+HANDSHAKE    0.001301212        nginx            2235928 1      0.701
+WRITE/SEND   0.001319484        openssl          2741676 0      1.319
+WRITE/SEND   0.001435668        openssl          2741676 1      N/A
+----- DATA -----
+0a
+----- END DATA -----
+
+
+WRITE/SEND   0.001446787        openssl          2741676 1      0.011
+READ/RECV    0.001451482        nginx            2235928 1      0.004
+----- DATA -----
+0a
+----- END DATA -----
+
+
 USAGE message:
 
 usage: sslsniff.py [-h] [-p PID] [-u UID] [-x] [-c COMM] [-o] [-g] [-n] [-d]
-                   [--hexdump] [--max-buffer-size MAX_BUFFER_SIZE]
+                   [--hexdump] [--max-buffer-size MAX_BUFFER_SIZE] [-v]
 
 Sniff SSL data
 
@@ -124,6 +150,7 @@ optional arguments:
                         UTF-8
   --max-buffer-size MAX_BUFFER_SIZE
                         Size of captured buffer
+  -v, --verbose         trace SSL handshake calls.
 
 examples:
     ./sslsniff              # sniff OpenSSL and GnuTLS functions
@@ -135,3 +162,4 @@ examples:
     ./sslsniff --no-nss     # don't show NSS calls
     ./sslsniff --hexdump    # show data as hex instead of trying to decode it as UTF-8
     ./sslsniff -x           # show process UID and TID
+    ./sslsniff -v           # trace SSL handshake calls.

--- a/tools/sslsniff_example.txt
+++ b/tools/sslsniff_example.txt
@@ -103,36 +103,53 @@ lot of characters that are not printable or even Unicode replacement
 characters.
 
 
-SSL handshake calls can be trace by -v or --verbose option. SSL crypto is
-CPU-intensive workload in server side especially for RSA key (elliptic-curve
-key optimized a lot). This is useful when analyzing CPU crypto acceleration
-features, crypto algorithms or openssl async SSL framework.
+Function latency can be show by -l or --latency option, and SSL handshake calls
+can be trace by --handshake option. This is useful when analyzing SSL/TLS
+performance. Tracing output of "openssl s_client -connect example.com:443":
 
-Tracing output of https server when running "echo | openssl s_client -connect
-localhost:443" in another shell client. It takes 0.7ms for RSA 2K key exchange
-and 1.3ms for the whole handshake phase before SSL_write or SSL_read calls.
-
-FUNC         TIME(s)            COMM             PID     LEN    LATms
-WRITE/SEND   0.000000000        openssl          2741676 0      N/A
-HANDSHAKE    0.001301212        nginx            2235928 1      0.701
-WRITE/SEND   0.001319484        openssl          2741676 0      1.319
-WRITE/SEND   0.001435668        openssl          2741676 1      N/A
+# ./sslsniff.py -l --handshake
+FUNC         TIME(s)            COMM             PID     LEN    LAT(ms)
+WRITE/SEND   0.000000000        openssl          3260509 0      N/A
+WRITE/SEND   0.593772992        openssl          3260509 0      593.773
+WRITE/SEND   0.593898479        openssl          3260509 1      N/A
 ----- DATA -----
-0a
+
+
 ----- END DATA -----
 
 
-WRITE/SEND   0.001446787        openssl          2741676 1      0.011
-READ/RECV    0.001451482        nginx            2235928 1      0.004
+WRITE/SEND   0.593906849        openssl          3260509 1      0.008
+
+
+Change example.com to localhost server. It takes 0.7ms for server handshake
+and 1.3ms before secure connection is ready for 1st SSL_read or SSL_write.
+Note that latency field shows "N/A" at function entry.
+
+# ./sslsniff.py -l --handshake
+FUNC         TIME(s)            COMM             PID     LEN    LAT(ms)
+WRITE/SEND   0.000000000        openssl          3260362 0      N/A
+HANDSHAKE    0.001318467        nginx            3260106 1      0.689
+WRITE/SEND   0.001339752        openssl          3260362 0      1.340
+WRITE/SEND   0.001452343        openssl          3260362 1      N/A
 ----- DATA -----
-0a
+
+
+----- END DATA -----
+
+
+WRITE/SEND   0.001467280        openssl          3260362 1      0.015
+READ/RECV    0.001470071        nginx            3260106 1      0.003
+----- DATA -----
+
+
 ----- END DATA -----
 
 
 USAGE message:
 
 usage: sslsniff.py [-h] [-p PID] [-u UID] [-x] [-c COMM] [-o] [-g] [-n] [-d]
-                   [--hexdump] [--max-buffer-size MAX_BUFFER_SIZE] [-v]
+                   [--hexdump] [--max-buffer-size MAX_BUFFER_SIZE] [-l]
+                   [--handshake]
 
 Sniff SSL data
 
@@ -150,7 +167,8 @@ optional arguments:
                         UTF-8
   --max-buffer-size MAX_BUFFER_SIZE
                         Size of captured buffer
-  -v, --verbose         trace SSL handshake calls.
+  -l, --latency         show function latency
+  --handshake           trace SSL handshake calls
 
 examples:
     ./sslsniff              # sniff OpenSSL and GnuTLS functions
@@ -162,4 +180,5 @@ examples:
     ./sslsniff --no-nss     # don't show NSS calls
     ./sslsniff --hexdump    # show data as hex instead of trying to decode it as UTF-8
     ./sslsniff -x           # show process UID and TID
-    ./sslsniff -v           # trace SSL handshake calls.
+    ./sslsniff -l           # show function latency
+    ./sslsniff --handshake  # trace SSL handshake calls


### PR DESCRIPTION
Add verbose option to trace additional SSL_do_handshake calls before initial SSL_read or SSL_write, and a new LATms field to show function latency. This is useful for TLS performance analysis. Also correct the output to skip buffer display when it's not filled.

New tools (sslsnoop and ssllatency) are also added in bpftrace to further investigate inside TLS handshake routines for async SSL and cyprto functions.

The use case analysis is here: https://xutao323.github.io/2022/01/06/tls-acceleration-with-new-CPU.html