### PR TITLE
bcc: Allow specify wakeup_events for perf buffer

### DIFF
--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -35,6 +35,12 @@ enum bpf_probe_attach_type {
 	BPF_PROBE_RETURN
 };
 
+struct bcc_perf_buffer_opts {
+  int pid;
+  int cpu;
+  int wakeup_events;
+};
+
 int bcc_create_map(enum bpf_map_type map_type, const char *name,
                    int key_size, int value_size, int max_entries,
                    int map_flags);
@@ -106,6 +112,10 @@ int kernel_struct_has_field(const char *struct_name, const char *field_name);
 void * bpf_open_perf_buffer(perf_reader_raw_cb raw_cb,
                             perf_reader_lost_cb lost_cb, void *cb_cookie,
                             int pid, int cpu, int page_cnt);
+
+void * bpf_open_perf_buffer_opts(perf_reader_raw_cb raw_cb,
+                            perf_reader_lost_cb lost_cb, void *cb_cookie,
+                            int page_cnt, struct bcc_perf_buffer_opts *opts);
 
 /* attached a prog expressed by progfd to the device specified in dev_name */
 int bpf_attach_xdp(const char *dev_name, int progfd, uint32_t flags);

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -133,6 +133,16 @@ lib.kernel_struct_has_field.restype = ct.c_int
 lib.kernel_struct_has_field.argtypes = [ct.c_char_p, ct.c_char_p]
 lib.bpf_open_perf_buffer.restype = ct.c_void_p
 lib.bpf_open_perf_buffer.argtypes = [_RAW_CB_TYPE, _LOST_CB_TYPE, ct.py_object, ct.c_int, ct.c_int, ct.c_int]
+
+class bcc_perf_buffer_opts(ct.Structure):
+    _fields_ = [
+        ('pid', ct.c_int),
+        ('cpu', ct.c_int),
+        ('wakeup_events', ct.c_int),
+    ]
+
+lib.bpf_open_perf_buffer_opts.restype = ct.c_void_p
+lib.bpf_open_perf_buffer_opts.argtypes = [_RAW_CB_TYPE, _LOST_CB_TYPE, ct.py_object, ct.c_int, ct.POINTER(bcc_perf_buffer_opts)]
 lib.bpf_open_perf_event.restype = ct.c_int
 lib.bpf_open_perf_event.argtypes = [ct.c_uint, ct.c_ulonglong, ct.c_int, ct.c_int]
 lib.perf_reader_poll.restype = ct.c_int


### PR DESCRIPTION
This commit adds a new option `wakeup_events` to the open_perf_buffer API.
This provides an alternative to solve #3793.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>