### PR TITLE
Add rwengine=OFF test run, disable tests we expect to fail during it

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -15,8 +15,13 @@ jobs:
         env:
         - TYPE: Debug
           PYTHON_TEST_LOGFILE: critical.log
+          RW_ENGINE_ENABLED: ON
+        - TYPE: Debug
+          PYTHON_TEST_LOGFILE: critical.log
+          RW_ENGINE_ENABLED: OFF
         - TYPE: Release
           PYTHON_TEST_LOGFILE: critical.log
+          RW_ENGINE_ENABLED: ON
     steps:
     - uses: actions/checkout@v2
     - name: System info
@@ -43,7 +48,7 @@ jobs:
                    bcc-docker \
                    /bin/bash -c \
                    'mkdir -p /bcc/build && cd /bcc/build && \
-                    cmake -DCMAKE_BUILD_TYPE=${TYPE} .. && make -j9'"
+                    cmake -DCMAKE_BUILD_TYPE=${TYPE} -DENABLE_LLVM_NATIVECODEGEN=${RW_ENGINE_ENABLED} .. && make -j9'"
     - name: Run bcc's cc tests
       env: ${{ matrix.env }}
       # tests are wrapped with `script` as a hack to get a TTY as github actions doesn't provide this

--- a/src/cc/bcc_common.cc
+++ b/src/cc/bcc_common.cc
@@ -37,6 +37,10 @@ void * bpf_module_create_c_from_string(const char *text, unsigned flags, const c
   return mod;
 }
 
+bool bpf_module_rw_engine_enabled() {
+  return ebpf::bpf_module_rw_engine_enabled();
+}
+
 void bpf_module_destroy(void *program) {
   auto mod = static_cast<ebpf::BPFModule *>(program);
   if (!mod) return;

--- a/src/cc/bcc_common.h
+++ b/src/cc/bcc_common.h
@@ -30,6 +30,7 @@ void * bpf_module_create_c(const char *filename, unsigned flags, const char *cfl
 void * bpf_module_create_c_from_string(const char *text, unsigned flags, const char *cflags[],
                                        int ncflags, bool allow_rlimit,
                                        const char *dev_name);
+bool bpf_module_rw_engine_enabled();
 void bpf_module_destroy(void *program);
 char * bpf_module_license(void *program);
 unsigned bpf_module_kern_version(void *program);

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -26,6 +26,8 @@ lib.bpf_module_create_c.argtypes = [ct.c_char_p, ct.c_uint,
 lib.bpf_module_create_c_from_string.restype = ct.c_void_p
 lib.bpf_module_create_c_from_string.argtypes = [ct.c_char_p, ct.c_uint,
         ct.POINTER(ct.c_char_p), ct.c_int, ct.c_bool, ct.c_char_p]
+lib.bpf_module_rw_engine_enabled.restype = ct.c_bool
+lib.bpf_module_rw_engine_enabled.argtypes = None
 lib.bpf_module_destroy.restype = None
 lib.bpf_module_destroy.argtypes = [ct.c_void_p]
 lib.bpf_module_license.restype = ct.c_char_p

--- a/tests/cc/test_bpf_table.cc
+++ b/tests/cc/test_bpf_table.cc
@@ -21,7 +21,7 @@
 #include "BPF.h"
 #include "catch.hpp"
 
-TEST_CASE("test bpf table", "[bpf_table]") {
+TEST_CASE("test bpf table", ebpf::bpf_module_rw_engine_enabled() ? "[bpf_table]" : "[bpf_table][!mayfail]") {
   const std::string BPF_PROGRAM = R"(
     BPF_TABLE("hash", int, int, myhash, 128);
   )";
@@ -92,7 +92,7 @@ TEST_CASE("test bpf table", "[bpf_table]") {
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
-TEST_CASE("test bpf percpu tables", "[bpf_percpu_table]") {
+TEST_CASE("test bpf percpu tables", ebpf::bpf_module_rw_engine_enabled() ? "[bpf_percpu_table]" : "[bpf_percpu_table][!mayfail]") {
   const std::string BPF_PROGRAM = R"(
     BPF_PERCPU_HASH(myhash, int, u64, 128);
   )";

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -3,6 +3,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 
 from bcc import BPF
+from bcc.libbcc import lib
 import ctypes as ct
 from unittest import main, skipUnless, TestCase
 from utils import kernel_version_ge
@@ -143,6 +144,7 @@ int do_completion(struct pt_regs *ctx, struct request *req) {
         b = BPF(text=text, debug=0)
         fns = b.load_funcs(BPF.KPROBE)
 
+    @skipUnless(lib.bpf_module_rw_engine_enabled(), "requires enabled rwengine")
     def test_sscanf(self):
         text = """
 BPF_HASH(stats, int, struct { u64 a; u64 b; u64 c:36; u64 d:28; struct { u32 a; u32 b; } s; }, 10);
@@ -164,6 +166,7 @@ int foo(void *ctx) {
         self.assertEqual(l.s.a, 5)
         self.assertEqual(l.s.b, 6)
 
+    @skipUnless(lib.bpf_module_rw_engine_enabled(), "requires enabled rwengine")
     def test_sscanf_array(self):
         text = """
 BPF_HASH(stats, int, struct { u32 a[3]; u32 b; }, 10);
@@ -180,6 +183,7 @@ BPF_HASH(stats, int, struct { u32 a[3]; u32 b; }, 10);
         self.assertEqual(l.a[2], 3)
         self.assertEqual(l.b, 4)
 
+    @skipUnless(lib.bpf_module_rw_engine_enabled(), "requires enabled rwengine")
     def test_sscanf_string(self):
         text = """
 struct Symbol {


### PR DESCRIPTION
I noticed this the other day. Just pushing this PR up to get signal from GH actions. On my local box, running the tests with this commit results in these failures:

```
The following tests FAILED:                                                                                                                                                                  
          3 - test_libbcc (Failed)                                                            
         16 - py_test_clang (Failed)                                                          
```