### PR TITLE
libbpf-tools: add oomkill tool

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -31,6 +31,7 @@
 /mountsnoop
 /numamove
 /offcputime
+/oomkill
 /opensnoop
 /readahead
 /runqlat

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -42,6 +42,7 @@ APPS = \
 	mountsnoop \
 	numamove \
 	offcputime \
+	oomkill \
 	opensnoop \
 	readahead \
 	runqlat \

--- a/libbpf-tools/oomkill.bpf.c
+++ b/libbpf-tools/oomkill.bpf.c
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2022 Jingxiang Zeng
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#include "oomkill.h"
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(u32));
+} events SEC(".maps");
+
+SEC("kprobe/oom_kill_process")
+int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
+{
+	struct data_t data;
+
+	data.fpid = bpf_get_current_pid_tgid() >> 32;
+	data.tpid = BPF_CORE_READ(oc, chosen, tgid);
+	data.pages = BPF_CORE_READ(oc, totalpages);
+	bpf_get_current_comm(&data.fcomm, sizeof(data.fcomm));
+	bpf_probe_read_kernel(&data.tcomm, sizeof(data.tcomm), BPF_CORE_READ(oc, chosen, comm));
+	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &data, sizeof(data));
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/oomkill.c
+++ b/libbpf-tools/oomkill.c
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2022 Jingxiang Zeng
+//
+// Based on oomkill(8) from BCC by Brendan Gregg.
+// 13-Jan-2022   Jingxiang Zeng   Created this.
+#include <argp.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+#include "oomkill.skel.h"
+#include "oomkill.h"
+#include "trace_helpers.h"
+
+#define PERF_POLL_TIMEOUT_MS	100
+
+static volatile sig_atomic_t exiting = 0;
+
+const char *argp_program_version = "oomkill 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+
+static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+{
+	FILE *f;
+	char buf[256];
+	int n;
+	struct tm *tm;
+	char ts[32];
+	time_t t;
+	struct data_t *e = data;
+
+	f = fopen("/proc/loadavg", "r");
+	if (f) {
+		memset(buf, 0 , sizeof(buf));
+		n = fread(buf, 1, sizeof(buf), f);
+		fclose(f);
+	}
+	time(&t);
+	tm = localtime(&t);
+	strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+	
+	if (n)
+		printf("%s Triggered by PID %d (\"%s\"), OOM kill of PID %d (\"%s\"), %lld pages, loadavg: %s\n",
+			ts, e->fpid, e->fcomm, e->tpid, e->tcomm, e->pages, buf);
+	else
+		printf("%s Triggered by PID %d (\"%s\"), OOM kill of PID %d (\"%s\"), %lld pages\n",
+                        ts, e->fpid, e->fcomm, e->tpid, e->tcomm, e->pages);
+}
+
+static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	printf("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+int main(int argc, char **argv)
+{
+	struct perf_buffer *pb = NULL;
+	struct oomkill_bpf *obj;
+	int err;
+
+	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+	libbpf_set_print(libbpf_print_fn);
+
+	obj = oomkill_bpf__open_and_load();
+	if (!obj) {
+		fprintf(stderr, "failed to load and open BPF object\n");
+		return 1;
+	}
+
+	err = oomkill_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+
+	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), 64,
+			      handle_event, handle_lost_events, NULL, NULL);
+	if (!pb) {
+		err = -errno;
+		fprintf(stderr, "failed to open perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		fprintf(stderr, "can't set signal handler: %d\n", err);
+		err = 1;
+		goto cleanup;
+	}
+
+	printf("Tracing OOM kills... Ctrl-C to stop.\n");
+
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && err != -EINTR) {
+			fprintf(stderr, "error polling perf buffer: %d\n", err);
+			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
+	}
+
+cleanup:
+	perf_buffer__free(pb);
+	oomkill_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/libbpf-tools/oomkill.h
+++ b/libbpf-tools/oomkill.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __OOMKILL_H
+#define __OOMKILL_H
+
+#define TASK_COMM_LEN 16
+
+struct data_t {
+	__u32 fpid;
+	__u32 tpid;
+	__u64 pages;
+	char fcomm[TASK_COMM_LEN];
+	char tcomm[TASK_COMM_LEN];
+};
+
+#endif /* __OOMKILL_H */


### PR DESCRIPTION
libbpf-tools: oomkill is a simple program that traces the Linux out-of-memory (OOM) killer

Total same as oomkill of bcc.

\#./oomkill 
Tracing OOM kills... Ctrl-C to stop.
11:41:47 Triggered by PID 636163 ("perf"), OOM kill of PID 636163 ("mysql"), 321382 pages, loadavg: 0.10 0.13 0.05 4/232 636418

The first line show that PID 321382, with process name "mysql", was OOM killed
when it reached 321382 pages (usually 4 Kbytes per page). This OOM kill
happened to be triggered by PID 636163, process name "perf", doing some memory
allocation.

More information can be exposed to users later through the oomkill tool.

Report bugs to https://github.com/iovisor/bcc/tree/master/libbpf-tools.