### PR TITLE
update debian changelog for release v0.24.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+bcc (0.24.0-1) unstable; urgency=low
+
+  * Support for kernel up to 5.16
+  * bcc tools: update for trace.py, sslsniff.py, tcptop.py, hardirqs.py, etc.
+  * new libbpf tools: bashreadline
+  * allow specify wakeup_events for perf buffer
+  * support BPF_MAP_TYPE_{INODE, TASK}_STORAGE maps
+  * remove all deprecated libbpf function usage
+  * remove P4/B language support
+  * major test infra change, using github actions now
+  * doc update, bug fixes and other tools improvement
+
+ -- Yonghong Song <ys114321@gmail.com>  Wed, 14 Jan 2022 17:00:00 +0000
+
 bcc (0.23.0-1) unstable; urgency=low
 
   * Support for kernel up to 5.15


### PR DESCRIPTION
  * Support for kernel up to 5.16
  * bcc tools: update for trace.py, sslsniff.py, tcptop.py, hardirqs.py, etc.
  * new libbpf tools: bashreadline
  * allow specify wakeup_events for perf buffer
  * support BPF_MAP_TYPE_{INODE, TASK}_STORAGE maps
  * remove all deprecated libbpf function usage
  * remove P4/B language support
  * major test infra change, using github actions now
  * doc update, bug fixes and other tools improvement

Signed-off-by: Yonghong Song <yhs@fb.com>