### PR TITLE
bcc/tools: fix -u <int> flag for execsnoop. UID of 0 always fails.

### DIFF
--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -213,7 +213,7 @@ int do_ret_sys_execve(struct pt_regs *ctx)
 
 bpf_text = bpf_text.replace("MAXARG", args.max_args)
 
-if args.uid:
+if isinstance(args.uid, int):
     bpf_text = bpf_text.replace('UID_FILTER',
         'if (uid != %s) { return 0; }' % args.uid)
 else:


### PR DESCRIPTION
https://github.com/iovisor/bcc/blob/b1d87968aceed0a905f1ce32ac8c8d010a07d5e8/tools/execsnoop.py#L216-L220

This clause fails when `args.uid` is `0`. [parse_uid()](https://github.com/iovisor/bcc/blob/b1d87968aceed0a905f1ce32ac8c8d010a07d5e8/tools/execsnoop.py#L33) returns int.