### PR TITLE
biolatpcts: Build fixes on recent kernels

### DIFF
--- a/examples/tracing/biolatpcts.py
+++ b/examples/tracing/biolatpcts.py
@@ -11,6 +11,7 @@ from time import sleep
 
 bpf_source = """
 #include <linux/blk_types.h>
+#include <linux/blk-mq.h>
 #include <linux/blkdev.h>
 #include <linux/time64.h>
 
@@ -45,7 +46,10 @@ void kprobe_blk_account_io_done(struct pt_regs *ctx, struct request *rq, u64 now
 """
 
 bpf = BPF(text=bpf_source)
-bpf.attach_kprobe(event='blk_account_io_done', fn_name='kprobe_blk_account_io_done')
+if BPF.get_kprobe_functions(b'__blk_account_io_done'):
+    bpf.attach_kprobe(event="__blk_account_io_done", fn_name="kprobe_blk_account_io_done")
+else:
+    bpf.attach_kprobe(event="blk_account_io_done", fn_name="kprobe_blk_account_io_done")
 
 cur_lat_100ms = bpf['lat_100ms']
 cur_lat_1ms = bpf['lat_1ms']

--- a/tools/biolatpcts.py
+++ b/tools/biolatpcts.py
@@ -56,6 +56,7 @@ parser.add_argument('--verbose', '-v', action='count', default = 0)
 bpf_source = """
 #include <linux/blk_types.h>
 #include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 #include <linux/time64.h>
 
 BPF_PERCPU_ARRAY(rwdf_100ms, u64, 400);


### PR DESCRIPTION
* `struct request` definition recently moved from blkdev.h to blk-mq.h
  breaking both tools/biolatpcts and examples/tracing/biolatpcts. Fix them
  by also including blk-mq.h.

* blk_account_io_done() got split into two parts - inline condition checks
  and the actual accounting with the latter now done in
  __blk_account_io_done(). The kprobe attachment needs to be conditionalized
  to work across the change. tools/biolatpcts was already updated but
  examples/tracing/biolatpcts wasn't. Fix it.

Signed-off-by: Tejun Heo <tj@kernel.org>