### PR TITLE
popen should be pclose

### DIFF
--- a/libbpf-tools/bashreadline.c
+++ b/libbpf-tools/bashreadline.c
@@ -132,7 +132,7 @@ cleanup:
 	if (line)
 		free(line);
 	if (fp)
-		fclose(fp);
+		pclose(fp);
 	return result;
 }
 


### PR DESCRIPTION
CentOS Stream 9:
`gcc (GCC) 11.2.1`, 
`clang version 13.0.0`, 
`LLVM version 13.0.0`,
`ldd (GNU libc) 2.34`

```
In function ‘find_readline_so’,
    inlined from ‘main’ at bashreadline.c:163:33:
bashreadline.c:135:17: warning: ‘fclose’ called on pointer returned from a mismatched allocation function [-Wmismatched-dealloc]
  135 |                 fclose(fp);
      |                 ^~~~~~~~~~
bashreadline.c: In function ‘main’:
bashreadline.c:119:14: note: returned from ‘popen’
  119 |         fp = popen("ldd /bin/bash", "r");
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```