### PR TITLE
filetop: Use dev and rdev as device ID

### DIFF
--- a/libbpf-tools/filetop.bpf.c
+++ b/libbpf-tools/filetop.bpf.c
@@ -44,7 +44,8 @@ static int probe_entry(struct pt_regs *ctx, struct file *file, size_t count, enu
 	if (regular_file_only && !S_ISREG(mode))
 		return 0;
 
-	key.dev = BPF_CORE_READ(file, f_inode, i_rdev);
+	key.dev = BPF_CORE_READ(file, f_inode, i_sb, s_dev);
+	key.rdev = BPF_CORE_READ(file, f_inode, i_rdev);
 	key.inode = BPF_CORE_READ(file, f_inode, i_ino);
 	key.pid = pid;
 	key.tid = tid;

--- a/libbpf-tools/filetop.h
+++ b/libbpf-tools/filetop.h
@@ -13,6 +13,7 @@ enum op {
 struct file_id {
 	__u64 inode;
 	__u32 dev;
+	__u32 rdev;
 	__u32 pid;
 	__u32 tid;
 };

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -67,6 +67,7 @@ bpf_text = """
 struct info_t {
     unsigned long inode;
     dev_t dev;
+    dev_t rdev;
     u32 pid;
     u32 name_len;
     char comm[TASK_COMM_LEN];
@@ -105,7 +106,8 @@ static int do_entry(struct pt_regs *ctx, struct file *file,
     struct info_t info = {
         .pid = pid,
         .inode = file->f_inode->i_ino,
-        .dev = file->f_inode->i_rdev,
+        .dev = file->f_inode->i_sb->s_dev,
+        .rdev = file->f_inode->i_rdev,
     };
     bpf_get_current_comm(&info.comm, sizeof(info.comm));
     info.name_len = d_name.len;


### PR DESCRIPTION
Different filesystems(partitions) can have files share the same inum.
And for regular files, inode->i_rdev is zero. So the combination of
inode->i_ino and inode->i_rdev is not enough to uniquely identify a file.
Let's use dev and rdev to identify a device. Closes #3824.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>