### PR TITLE
Convert oomkill to CO-RE

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -31,6 +31,7 @@
 /mountsnoop
 /numamove
 /offcputime
+/oomkill
 /opensnoop
 /readahead
 /runqlat

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -42,6 +42,7 @@ APPS = \
 	mountsnoop \
 	numamove \
 	offcputime \
+	oomkill \
 	opensnoop \
 	readahead \
 	runqlat \

--- a/libbpf-tools/oomkill.bpf.c
+++ b/libbpf-tools/oomkill.bpf.c
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL
+/* Copyright (c) 2022 The Inspektor Gadget authors */
+#include <linux/oom.h>
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+#include "oomkill.h"
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(u32));
+} events SEC(".maps");
+
+SEC("kprobe/oom_kill_process")
+void BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *unused)
+{
+	struct task_struct *victim;
+	struct task_struct *task;
+	struct event event = {};
+
+	task = (struct task_struct *) bpf_get_current_task();
+	victim = BPF_CORE_READ(oc, chosen);
+
+	event.tpid = bpf_get_current_pid_tgid() >> 32;
+	event.kpid = BPF_CORE_READ(victim, tgid);
+	event.pages = BPF_CORE_READ(oc, totalpages);
+	bpf_get_current_comm(&event.tcomm, sizeof(event.tcomm));
+	bpf_probe_read_kernel(&event.kcomm, sizeof(event.kcomm),
+			      BPF_CORE_READ(victim, comm));
+
+	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event,
+			      sizeof(event));
+}
+
+/*
+ * This eBPF core program is based on bcc oomkill BPF code from iovisor
+ * oomkill.py file.
+ * This file was under Apache-2.0 license, I would have liked to stick with this
+ * to respect its history but I need to be able to call GPL-only functions.
+ */
+char _license[] SEC("license") = "GPL";

--- a/libbpf-tools/oomkill.c
+++ b/libbpf-tools/oomkill.c
@@ -1,0 +1,155 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/*
+ * Copyright (c) 2022 The Inspektor Gadget authors
+ *
+ * Based on oomkill(8) from BCC by Brendan Gregg.
+ * 01-February-2022 Francis Laniel created this.
+ */
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "oomkill.h"
+#include "oomkill.skel.h"
+#include "trace_helpers.h"
+
+#define PERF_BUFFER_PAGES	16
+#define PERF_POLL_TIMEOUT_MS	100
+#define warn(...) fprintf(stderr, __VA_ARGS__)
+
+static volatile sig_atomic_t exiting = 0;
+static volatile int proc_loadavg_fd;
+
+const char *argp_program_version = "oomkill 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] =
+"Monitor when OOM killer is triggered and kills a process.\n"
+"\n"
+"USAGE: oomkill\n"
+"\n";
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+{
+	char time_string[9];
+	struct event *event;
+	char avgline[64];
+	struct tm *tm;
+	time_t tloc;
+
+	event = data;
+
+	time(&tloc);
+	tm = localtime(&tloc);
+	strftime(time_string, sizeof(time_string), "%H:%M:%S", tm);
+
+	if (read(proc_loadavg_fd, avgline, sizeof(avgline)) == -1) {
+		perror("Problem reading /proc/loadvg:");
+
+		return;
+	}
+
+	printf("%s Triggered by PID %d (\"%s\"), OOM kill of PID %d (\"%s\"), %llu pages, loadavg: %s\n",
+		time_string, event->tpid, event->tcomm, event->kpid,
+		event->kcomm, event->pages, avgline);
+}
+
+static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+}
+
+int main(int argc, char **argv)
+{
+	struct oomkill_bpf *obj;
+	struct perf_buffer *pb;
+	int ret;
+	int err;
+
+	ret = EXIT_SUCCESS;
+
+	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
+	proc_loadavg_fd = open("/proc/loadavg", O_RDONLY);
+	if (proc_loadavg_fd == -1) {
+		perror("Problem opening /proc/loadavg:");
+
+		return EXIT_FAILURE;
+	}
+
+	obj = oomkill_bpf__open();
+	if (!obj) {
+		warn("Failed to open BPF object\n");
+
+		return EXIT_FAILURE;
+	}
+
+	err = oomkill_bpf__load(obj);
+	if (err) {
+		warn("Failed to load BPF object: %d\n", err);
+
+		ret = EXIT_FAILURE;
+
+		goto cleanup;
+	}
+
+	err = oomkill_bpf__attach(obj);
+	if (err) {
+		warn("Failed to attach BPF programs: %d\n", err);
+
+		ret = EXIT_FAILURE;
+
+		goto cleanup;
+	}
+
+	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), PERF_BUFFER_PAGES,
+			      handle_event, handle_lost_events, NULL, NULL);
+	if (!pb) {
+		err = -errno;
+		warn("Failed to open perf buffer: %d\n", err);
+
+		ret = EXIT_FAILURE;
+
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		perror("Cannot set signal handler:");
+
+		ret = EXIT_FAILURE;
+
+		goto cleanup_everything;
+	}
+
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && errno != EINTR) {
+			perror("Error polling perf buffer:");
+
+			ret = EXIT_FAILURE;
+
+			goto cleanup_everything;
+		}
+
+		ret = EXIT_SUCCESS;
+	}
+cleanup_everything:
+	perf_buffer__free(pb);
+cleanup:
+	close(proc_loadavg_fd);
+	oomkill_bpf__destroy(obj);
+
+	return ret;
+}

--- a/libbpf-tools/oomkill.h
+++ b/libbpf-tools/oomkill.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#ifndef __OOMKILL_H
+#define __OOMKILL_H
+
+#define TASK_COMM_LEN	16
+
+struct event {
+	__u32 tpid;
+	__u32 kpid;
+	__u64 pages;
+	char tcomm[TASK_COMM_LEN];
+	char kcomm[TASK_COMM_LEN];
+};
+
+#endif /* __OOMKILL_H */


### PR DESCRIPTION
Hi.


I am adding `oomkill` to `inspektor-gadget` and I translated the BCC version of it to CO-RE (kinvolk/inspektor-gadget#484).
Since I get `oomkill` from BCC, I thought it would be fair to give you back the CO-RE version of it.

Normally, the output should be the same as the BCC version:

```bash
root@minikube:/# ldd oomkill 
        linux-vdso.so.1 (0x00007ffe4eb24000)
        libelf.so.1 => /lib/x86_64-linux-gnu/libelf.so.1 (0x00007fee49e5d000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fee49e41000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fee49c4f000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fee49ece000)
root@minikube:/# ./oomkill &
[1] 51491
root@minikube:/# perl -e 'while (1) { $a .= "A" x 1024; }' 
14:35:20 Triggered by PID 2387 ("kube-controller"), OOM kill of PID 51546 ("perl"), 718152 pages, loadavg: 1.33 0.80 0.59 3/417 51546

Killed
root@minikube:/#
```

If you see any way to improve this patch, feel free to share.

Best regards.