### PR TITLE
libbpf-tools/runqlen: fix variable type

### DIFF
--- a/libbpf-tools/runqlen.c
+++ b/libbpf-tools/runqlen.c
@@ -29,7 +29,7 @@ struct env {
 	bool runqocc;
 	bool timestamp;
 	time_t interval;
-	bool freq;
+	int freq;
 	int times;
 	bool verbose;
 } env = {


### PR DESCRIPTION
switch the variable type of freq from bool to int depending on usage.

Signed-off-by: Eunseon Lee <es.lee@lge.com>