### PR TITLE
extern BPF_TABLE_PINNED to include an optional flags argument

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -170,8 +170,17 @@ struct _name##_table_t __##_name
 #define BPF_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries) \
 BPF_F_TABLE(_table_type, _key_type, _leaf_type, _name, _max_entries, 0)
 
-#define BPF_TABLE_PINNED(_table_type, _key_type, _leaf_type, _name, _max_entries, _pinned) \
-BPF_TABLE(_table_type ":" _pinned, _key_type, _leaf_type, _name, _max_entries)
+#define BPF_TABLE_PINNED7(_table_type, _key_type, _leaf_type, _name, _max_entries, _pinned, _flags) \
+  BPF_F_TABLE(_table_type ":" _pinned, _key_type, _leaf_type, _name, _max_entries, _flags)
+
+#define BPF_TABLE_PINNED6(_table_type, _key_type, _leaf_type, _name, _max_entries, _pinned) \
+  BPF_F_TABLE(_table_type ":" _pinned, _key_type, _leaf_type, _name, _max_entries, 0)
+
+#define BPF_TABLE_PINNEDX(_1, _2, _3, _4, _5, _6, _7, NAME, ...) NAME
+
+// Define a pinned table with optional flags argument
+#define BPF_TABLE_PINNED(...) \
+  BPF_TABLE_PINNEDX(__VA_ARGS__, BPF_TABLE_PINNED7, BPF_TABLE_PINNED6)(__VA_ARGS__)
 
 // define a table same as above but allow it to be referenced by other modules
 #define BPF_TABLE_PUBLIC(_table_type, _key_type, _leaf_type, _name, _max_entries) \

--- a/tests/cc/test_pinned_table.cc
+++ b/tests/cc/test_pinned_table.cc
@@ -47,7 +47,7 @@ TEST_CASE("test pinned table", "[pinned_table]") {
   // test table access
   {
     const std::string BPF_PROGRAM = R"(
-      BPF_TABLE_PINNED("hash", u64, u64, ids, 1024, "/sys/fs/bpf/test_pinned_table");
+      BPF_TABLE_PINNED("hash", u64, u64, ids, 0, "/sys/fs/bpf/test_pinned_table", BPF_F_NO_PREALLOC);
     )";
 
     ebpf::BPF bpf;


### PR DESCRIPTION
BPF_TABLE_PINNED has a feature to create a map and pin it if
the pinned map doesn't exist. Some maps, e.g., bpf_sk_storage map,
requires a non-zero flag for map creation. This patch extended
the BPF_TABLE_PINNED map to include an optional flags argument
for any pinned map which my require a non-zero flags.

Signed-off-by: Yonghong Song <yhs@fb.com>