### PR TITLE
Use page offsets to distinguish between locations

### DIFF
--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -175,6 +175,11 @@ bool Probe::usdt_getarg(std::ostream &stream, const std::string& probe_func) {
   if (arg_count == 0)
     return true;
 
+  uint64_t page_size = sysconf(_SC_PAGESIZE);
+  std::unordered_set<int> page_offsets;
+  for (Location &location : locations_)
+    page_offsets.insert(location.address_ % page_size);
+
   for (size_t arg_n = 0; arg_n < arg_count; ++arg_n) {
     std::string ctype = largest_arg_type(arg_n);
     std::string cptr = tfm::format("*((%s *)dest)", ctype);
@@ -193,15 +198,22 @@ bool Probe::usdt_getarg(std::ostream &stream, const std::string& probe_func) {
         return false;
       stream << "\n  return 0;\n}\n";
     } else {
-      stream << "  switch(PT_REGS_IP(ctx)) {\n";
+      if (page_offsets.size() == locations_.size())
+        tfm::format(stream, "  switch (PT_REGS_IP(ctx) %% 0x%xULL) {\n", page_size);
+      else
+        stream << "  switch (PT_REGS_IP(ctx)) {\n";
       for (Location &location : locations_) {
-        uint64_t global_address;
+        if (page_offsets.size() == locations_.size()) {
+          tfm::format(stream, "  case 0x%xULL: ", location.address_ % page_size);
+        } else {
+          uint64_t global_address;
 
-        if (!resolve_global_address(&global_address, location.bin_path_,
-                                    location.address_))
-          return false;
+          if (!resolve_global_address(&global_address, location.bin_path_,
+                                      location.address_))
+            return false;
 
-        tfm::format(stream, "  case 0x%xULL: ", global_address);
+          tfm::format(stream, "  case 0x%xULL: ", global_address);
+        }
         if (!location.arguments_[arg_n].assign_to_local(stream, cptr, location.bin_path_,
                                                         pid_))
           return false;


### PR DESCRIPTION
When attaching to a probe that is inlined multiple times without
specifying a pid (which is not always convenient, e.g. when a target
process is not running yet), the following exception occurs:

    Exception: can't generate USDT probe arguments; possible cause is missing pid when a probe in a shared object has multiple locations

This is because eBPF programs distinguish between different locations
by doing a switch on an instruction pointer, and in order to get full
probe addresses in presence of ASLR, one has to choose a specific
process and inspect its /proc/{pid}/maps.

However, since shared objects are page-aligned, when all of the probe
locations have different page offsets, these offsets uniquely identify
locations. Adjust Probe::usdt_getarg() to generate a switch on page
offset if this is the case.

If some locations have the same page offset, an instruction pointer
switch is used, so this patch does not fully lift the restriction.
However, it helps greatly with one-off investigations.

Signed-off-by: Ilya Leoshkevich <iii@linux.ibm.com>