### PR TITLE
tools/sslsniff: trace extra libraries

### DIFF
--- a/man/man8/sslsniff.8
+++ b/man/man8/sslsniff.8
@@ -4,6 +4,7 @@ sslsniff \- Print data passed to OpenSSL, GnuTLS or NSS. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B sslsniff [-h] [-p PID] [-u UID] [-x] [-c COMM] [-o] [-g] [-n] [-d]
 .B [--hexdump] [--max-buffer-size SIZE] [-l] [--handshake]
+.B [--extra-lib EXTRA_LIB]
 .SH DESCRIPTION
 sslsniff prints data sent to write/send and read/recv functions of
 OpenSSL, GnuTLS and NSS, allowing us to read plain text content before
@@ -52,6 +53,10 @@ Show function latency in ms.
 .TP
 \--handshake
 Show handshake latency, enabled only if latency option is on.
+.TP
+\--extra-lib EXTRA_LIB
+Consist type of the library and library path separated by colon. Supported
+library types are: openssl, gnutls, nss. Can be specified multiple times.
 .SH EXAMPLES
 .TP
 Print all calls to SSL write/send and read/recv system-wide:
@@ -65,6 +70,10 @@ Print only OpenSSL calls issued by user with UID 1000
 Print SSL handshake event and latency for all traced functions:
 #
 .B sslsniff -l --handshake
+.TP
+Print only calls to OpenSSL from /some/path/libssl.so
+.B sslsniff --no-openssl --no-gnutls --no-nss --extra-lib
+.B openssl:/some/path/libssl.so
 .SH FIELDS
 .TP
 FUNC

--- a/tools/sslsniff_example.txt
+++ b/tools/sslsniff_example.txt
@@ -160,12 +160,18 @@ READ/RECV    0.000049464        nginx            7081    1      0.004
 
 ----- END DATA -----
 
+Tracing few extra libraries (useful for docker containers and other isolated
+apps)
+
+# ./sslsniff.py --extra-lib openssl:/var/lib/docker/overlay2/l/S4EMHE/lib/libssl.so.1.1
+
+
 
 USAGE message:
 
 usage: sslsniff.py [-h] [-p PID] [-u UID] [-x] [-c COMM] [-o] [-g] [-n] [-d]
                    [--hexdump] [--max-buffer-size MAX_BUFFER_SIZE] [-l]
-                   [--handshake]
+                   [--handshake] [--extra-lib EXTRA_LIB]
 
 Sniff SSL data
 
@@ -186,6 +192,11 @@ optional arguments:
   -l, --latency         show function latency
   --handshake           show SSL handshake latency, enabled only if latency
                         option is on. 
+  --extra-lib EXTRA_LIB
+                        Intercept calls from extra library
+                        (format: lib_type:lib_path)
+
+
 
 examples:
     ./sslsniff              # sniff OpenSSL and GnuTLS functions
@@ -199,3 +210,4 @@ examples:
     ./sslsniff -x           # show process UID and TID
     ./sslsniff -l           # show function latency
     ./sslsniff -l --handshake  # show SSL handshake latency
+    ./sslsniff --extra-lib openssl:/path/libssl.so.1.1 # sniff extra library


### PR DESCRIPTION
This adds `--extra-lib` flag, which might be quite useful if an application is using custom TLS libraries that is shipped with application or in case of containerized applications. Also want to mention that bcc can determine path to the library [automatically by inspecting](https://github.com/iovisor/bcc/blob/e83019bdf6c400b589e69c7d18092e38088f89a8/src/cc/bcc_proc.c#L419) `/proc/$pid/maps` (if pid has been specified), but this not always works. For example, if application hasn't been started yet (and you need to trace launching process), if you want to trace multiple processes at the same time, or if application hasn't loaded that library at that time.

This flag can specified multiple times (which allows to provide list of libraries), for example:

```
./sslsniff --extra-lib openssl:/path/to/libssl.so --extra-lib nss:/path/to/libnspr4.so --extra-lib gnutils:/path/to/libgnutls.so
```
Also tracing of system wide libraries could be disabled (using flags that already implemented in `./sslsniff`), so it would be possible to just trace calls for specified libraries.