### PR TITLE
fix llvm15 compilation error

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -29,6 +29,9 @@
 #include <llvm/MC/MCInstrInfo.h>
 #include <llvm/MC/MCObjectFileInfo.h>
 #include <llvm/MC/MCRegisterInfo.h>
+#if LLVM_MAJOR_VERSION >= 15
+#include <llvm/MC/MCSubtargetInfo.h>
+#endif
 #if LLVM_MAJOR_VERSION >= 14
 #include <llvm/MC/TargetRegistry.h>
 #else

--- a/src/cc/bpf_module_rw_engine.cc
+++ b/src/cc/bpf_module_rw_engine.cc
@@ -401,7 +401,12 @@ int BPFModule::annotate() {
     GlobalValue *gvar = mod_->getNamedValue(table.name);
     if (!gvar) continue;
     if (PointerType *pt = dyn_cast<PointerType>(gvar->getType())) {
-      if (StructType *st = dyn_cast<StructType>(pt->getElementType())) {
+#if LLVM_MAJOR_VERSION >= 15
+      StructType *st = dyn_cast<StructType>(pt->getPointerElementType());
+#else
+      StructType *st = dyn_cast<StructType>(pt->getElementType());
+#endif
+      if (st) {
         if (st->getNumElements() < 2) continue;
         Type *key_type = st->elements()[0];
         Type *leaf_type = st->elements()[1];


### PR DESCRIPTION
With latest upstream llvm15, we have the following compilation
error:
```
  <...>/src/cc/bpf_module_rw_engine.cc: In member function ‘int ebpf::BPFModule::annotate()’:
  <...>/src/cc/bpf_module_rw_engine.cc:404:53: error: ‘class llvm::PointerType’ has no member named
  ‘getElementType’; did you mean ‘getArrayElementType’?
       if (StructType *st = dyn_cast<StructType>(pt->getElementType())) {
                                                     ^~~~~~~~~~~~~~
                                                     getArrayElementType

  In file included from /usr/include/c++/8/memory:80,
                   from /<...>/llvm-project/llvm/build/install/include/llvm/ADT/SmallVector.h:28,
                   from /<...>/llvm-project/llvm/build/install/include/llvm/ADT/MapVector.h:21,
                   from /<...>/llvm-project/llvm/build/install/include/llvm/DebugInfo/DWARF/DWARFContext.h:12,
                   from /<...>/src/cc/bcc_debug.cc:22:
  /usr/include/c++/8/bits/unique_ptr.h: In instantiation of ‘void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = llvm::MCSubtargetInfo]’:
  /usr/include/c++/8/bits/unique_ptr.h:277:17:   required from ‘std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = llvm::MCSubtargetInfo; _Dp = std::default_delete<llvm::MCSubtargetInfo>]’
  /<...>/src/cc/bcc_debug.cc:136:50:   required from here
  /usr/include/c++/8/bits/unique_ptr.h:79:16: error: invalid application of ‘sizeof’ to incomplete type ‘llvm::MCSubtargetInfo’
  static_assert(sizeof(_Tp)>0,
                ^~~~~~~~~~~
```
There are two problems here. The first compilation error is due to
  https://github.com/llvm/llvm-project/commit/d593cf79458a59d37e75c886a4fc3ac6a02b484d
where `PointerType->getElementType()` is removed.
The second error is due to https://reviews.llvm.org/D119244 which reshuffles
header files which removes `MCSubtargetInfo.h` from some header files used in bcc_debug.cc.

Signed-off-by: Yonghong Song <yhs@fb.com>