### PR TITLE
use dwarf-4 in compilation flags

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -249,6 +249,7 @@ int ClangLoader::parse(unique_ptr<llvm::Module> *mod, TableStorage &ts,
     return -1;
 #if LLVM_MAJOR_VERSION >= 9
   flags_cstr.push_back("-g");
+  flags_cstr.push_back("-gdwarf-4");
 #else
   if (flags_ & DEBUG_SOURCE)
     flags_cstr.push_back("-g");


### PR DESCRIPTION
llvm14 changed the dwarf default to 5 and this breaks
debug=8 which intends to print out the source annotated
assembly code. For example, for biolatency.py with debug=8,
with llvm14 and latest llvm15, the following error will appear:
```
  error: invalid reference to or invalid content in .debug_str_offsets[.dwo]:
      insufficient space for 32 bit header prefix
```
Using dwarf-4 can work around the issue and source
annotated asm code can display properly:
```
  trace_req_start:
  ; struct request *req = ctx->di; // Line  37
     0:   79 11 70 00 00 00 00 00 r1 = *(u64 *)(r1 + 112)
     1:   7b 1a f8 ff 00 00 00 00 *(u64 *)(r10 - 8) = r1
  ; u64 ts = bpf_ktime_get_ns(); // Line  38
     2:   85 00 00 00 05 00 00 00 call 5
     3:   7b 0a f0 ff 00 00 00 00 *(u64 *)(r10 - 16) = r0
  ; bpf_map_update_elem((void *)bpf_pseudo_fd(1, -1), &req, &ts, BPF_ANY); // Line  39
     4:   18 11 00 00 ff ff ff ff 00 00 00 00 00 00 00 00 ld_pseudo       r1, 1, 4294967295
```
Since we are toward using object file based libbpf interface,
use dwarf-4 for now as after object file interface is used,
we can use standard llvm-objdump to dump source annotated
code.

Signed-off-by: Yonghong Song <yhs@fb.com>