### PR TITLE
libbpf-tools: Fix a compiler warning on oomkill

### DIFF
--- a/libbpf-tools/oomkill.c
+++ b/libbpf-tools/oomkill.c
@@ -30,7 +30,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 {
 	FILE *f;
 	char buf[256];
-	int n;
+	int n = 0;
 	struct tm *tm;
 	char ts[32];
 	time_t t;


### PR DESCRIPTION
Current code shows the following warning because of n is not initialized if `f` is NULL.

```
oomkill.c: In function ‘handle_event’:
oomkill.c:49:12: warning: ‘n’ may be used uninitialized in this function [-Wmaybe-uniniti
alized]
   49 |         if (n)
      |            ^
```