### PR TITLE
fix a llvm compilation error due to header file reshuffle

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -19,6 +19,9 @@
 #include <tuple>
 #include <vector>
 
+#if LLVM_MAJOR_VERSION >= 15
+#include <llvm/DebugInfo/DWARF/DWARFCompileUnit.h>
+#endif
 #include <llvm/DebugInfo/DWARF/DWARFContext.h>
 #include <llvm/DebugInfo/DWARF/DWARFDebugLine.h>
 #include <llvm/IR/Module.h>


### PR DESCRIPTION
llvm upstream https://reviews.llvm.org/D119723 removed
header file llvm/DebugInfo/DWARF/DWARFCompileUnit.h from
llvm/DebugInfo/DWARF/DWARFContext.h and this
caused bcc compilation failure:
```
  ...
  .../src/cc/bcc_debug.cc: In member function ‘void ebpf::SourceDebugger::dump()’:
  .../src/cc/bcc_debug.cc:186:69: error: no matching function for call to
   ‘llvm::DWARFContext::getLineTableForUnit(llvm::DWARFCompileUnit*&)’
     const DWARFLineTable *LineTable = DwarfCtx->getLineTableForUnit(CU);
                                                                     ^
  In file included from /home/yhs/work/bcc/src/cc/bcc_debug.cc:22:
  ...
```
Similar to fix in https://reviews.llvm.org/D119723, let us explicitly
add llvm/DebugInfo/DWARF/DWARFCompileUnit.h in the .cc file.

Signed-off-by: Yonghong Song <yhs@fb.com>