### PR TITLE
libbpf-tools: Use __u16 for bindsnoop protocol.

### DIFF
--- a/libbpf-tools/bindsnoop.bpf.c
+++ b/libbpf-tools/bindsnoop.bpf.c
@@ -6,7 +6,6 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_endian.h>
 #include "bindsnoop.h"
-#include "maps.bpf.h"
 
 #define MAX_ENTRIES	10240
 #define MAX_PORTS	1024

--- a/libbpf-tools/bindsnoop.h
+++ b/libbpf-tools/bindsnoop.h
@@ -11,8 +11,8 @@ struct bind_event {
 	__u32 bound_dev_if;
 	int ret;
 	__u16 port;
+	__u16 proto;
 	__u8 opts;
-	__u8 proto;
 	__u8 ver;
 	char task[TASK_COMM_LEN];
 };


### PR DESCRIPTION
Hi.


I was playing with CO-RE version of `bindsnoop` and I figured out the protocol is stored in an `__u8`.
Nothing really serious but sadly this can not suffice to store some protocol (like `MPTCP`).
So, I preferred to open a PR suggesting this change or at least make people aware of it.


Best regards.