### PR TITLE
Decode symname for exception message when symbol cannot be found

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -957,7 +957,8 @@ class BPF(object):
             ct.cast(None, ct.POINTER(bcc_symbol_option)),
             ct.byref(sym),
         ) < 0:
-            raise Exception("could not determine address of symbol %s" % symname)
+            raise Exception("could not determine address of symbol %s in %s"
+                            % (symname.decode(), module.decode()))
         new_addr = sym.offset + sym_off
         module_path = ct.cast(sym.module, ct.c_char_p).value
         lib.bcc_procutils_free(sym.module)


### PR DESCRIPTION
symname is kept as a byte-sring. As such, when the exception message is created, it generates something like:
```
could not determine address of symbol b'function__entry'
```
By decoding the symname variable, the user will get the following message instead:
```
could not determine address of symbol function__entry
```

I took it one step further and added the module to the error message. An example of the new message:
```
could not determine address of symbol function__entry in /usr/bin/python
```

This will make it more clear for users as well as hide the implementation detail of having byte-strings, which shouldn't be exposed to users who simply rely on the tool instead of coding it themselves.