### PR TITLE
libbpf-tools/opensnoop: remove unused variable and macro

### DIFF
--- a/libbpf-tools/opensnoop.bpf.c
+++ b/libbpf-tools/opensnoop.bpf.c
@@ -5,9 +5,6 @@
 #include <bpf/bpf_helpers.h>
 #include "opensnoop.h"
 
-#define TASK_RUNNING	0
-
-const volatile __u64 min_us = 0;
 const volatile pid_t targ_pid = 0;
 const volatile pid_t targ_tgid = 0;
 const volatile uid_t targ_uid = 0;


### PR DESCRIPTION
The variable min_us and macro TASK_RUNNING are not used, remove them.

Signed-off-by: Yuntao Wang <ytcoode@gmail.com>