### PR TITLE
Fix trace's print_event function

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -630,8 +630,8 @@ BPF_PERF_OUTPUT(%s);
                 event = ct.cast(data, ct.POINTER(self.python_struct)).contents
                 if self.name not in event.comm:
                     return
-                values = map(lambda i: getattr(event, "v%d" % i),
-                             range(0, len(self.values)))
+                values = [getattr(event, "v%d" % i)
+                          for i in range(len(self.values))]
                 msg = self._format_message(bpf, event.tgid, values)
                 if self.msg_filter and self.msg_filter not in msg:
                     return


### PR DESCRIPTION
Starting at Python3, map became a lazy operation, i.e., it is only evaluated when it is iterated over. Therefore, random acess via subscription is not possible anymore. print_event was generating the list of events using map, then passes the list of events to the helper function _format_message, which performs random access, resulting in:
```TypeError: 'map' object is not subscriptable```

Output before the change when running he following command and starting up `node` in a second shell:
```python
$ sudo $(which trace) 'u:pthread:pthread_create "%U", arg3' -T -C
TIME     CPU PID     TID     COMM            FUNC             -
Exception ignored on calling ctypes callback function: <function PerfEventArray._open_perf_buffer.<locals>.raw_cb_ at 0xffff81ff38b0>
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/bcc/table.py", line 982, in raw_cb_
    callback(cpu, data, size)
  File "/usr/share/bcc/tools/trace", line 635, in print_event
    msg = self._format_message(bpf, event.tgid, values)
  File "/usr/share/bcc/tools/trace", line 618, in _format_message
    values[up] = bpf.sym(values[up], tgid,
TypeError: 'map' object is not subscriptable
```

After the fix:
```bash
$ sudo $(which trace) 'u:pthread:pthread_create "%U", arg3' -T -C
TIME     CPU PID     TID     COMM            FUNC             -
21:23:42 1   5702    5702    node            pthread_create   b'node::BackgroundTaskRunner::DelayedTaskScheduler::Start()::{lambda(void*)#1}::_FUN(void*)+0x0 [libnode.so.64]'
21:23:42 1   5702    5702    node            pthread_create   b'[unknown] [libnode.so.64]'
21:23:42 1   5702    5702    node            pthread_create   b'[unknown] [libnode.so.64]'
21:23:42 1   5702    5702    node            pthread_create   b'[unknown] [libnode.so.64]'
21:23:42 1   5702    5702    node            pthread_create   b'[unknown] [libnode.so.64]'
21:23:43 1   5702    5702    node            pthread_create   b'[unknown] [libnode.so.64]'
21:23:43 1   5702    5702    node            pthread_create   b'[unknown] [libuv.so.1.0.0]'
21:23:43 1   5702    5702    node            pthread_create   b'[unknown] [libuv.so.1.0.0]'
21:23:43 1   5702    5702    node            pthread_create   b'[unknown] [libuv.so.1.0.0]'
21:23:43 1   5702    5702    node            pthread_create   b'[unknown] [libuv.so.1.0.0]'
```