### PR TITLE
bcc/tools: Add biopattern.py to identify disk access patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[bindsnoop](tools/bindsnoop.py): Trace IPv4 and IPv6 bind() system calls (bind()). [Examples](tools/bindsnoop_example.txt).
 - tools/[biolatency](tools/biolatency.py): Summarize block device I/O latency as a histogram. [Examples](tools/biolatency_example.txt).
 - tools/[biotop](tools/biotop.py): Top for disks: Summarize block device I/O by process. [Examples](tools/biotop_example.txt).
+- tools/[biopattern](tools/biopattern.py): Identify random/sequential disk access patterns. [Examples](tools/biopattern_example.txt).
 - tools/[biosnoop](tools/biosnoop.py): Trace block device I/O with PID and latency. [Examples](tools/biosnoop_example.txt).
 - tools/[bitesize](tools/bitesize.py): Show per process I/O size histogram. [Examples](tools/bitesize_example.txt).
 - tools/[bpflist](tools/bpflist.py): Display processes with active BPF programs and maps. [Examples](tools/bpflist_example.txt).

--- a/man/man8/biopattern.8
+++ b/man/man8/biopattern.8
@@ -1,0 +1,78 @@
+.TH biopattern 8  "2022-02-21" "USER COMMANDS"
+.SH NAME
+biopattern \- Identify random/sequential disk access patterns.
+.SH SYNOPSIS
+.B biopattern [\-h] [\-d DISK] [interval] [count]
+.SH DESCRIPTION
+This traces block device I/O (disk I/O), and prints ratio of random/sequential I/O
+for each disk or the specified disk either on Ctrl-C, or after a given interval in seconds.
+
+This works by tracing kernel tracepoint block:block_rq_complete.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+.SH OPTIONS
+.TP
+\-h
+Show help message and exit.
+.TP
+\-d
+Trace this disk only.
+.TP
+interval
+Print output every interval seconds, if any.
+.TP
+count
+Number of interval summaries.
+.SH EXAMPLES
+.TP
+Trace access patterns of all disks, and print a summary on Ctrl-C:
+#
+.B biopattern
+.TP
+Trace disk sdb only:
+#
+.B biopattern -d sdb
+.TP
+Print 1 second summaries, 10 times:
+#
+.B biopattern 1 10
+.SH FIELDS
+.TP
+TIME
+Time of the output, in HH:MM:SS format.
+.TP
+DISK
+Disk device name.
+.TP
+%RND
+Ratio of random I/O.
+.TP
+%SEQ
+Ratio of sequential I/O.
+.TP
+COUNT
+Number of I/O during the interval.
+.TP
+KBYTES
+Total Kbytes for these I/O, during the interval.
+.SH OVERHEAD
+Since block device I/O usually has a relatively low frequency (< 10,000/s),
+the overhead for this tool is expected to be low or negligible. For high IOPS
+storage systems, test and quantify before use.
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Rocky Xing
+.SH SEE ALSO
+biosnoop(8), biolatency(8), iostat(1)

--- a/tools/biopattern.py
+++ b/tools/biopattern.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python
+# @lint-avoid-python-3-compatibility-imports
+#
+# biopattern - Identify random/sequential disk access patterns.
+#              For Linux, uses BCC, eBPF.
+#
+# Copyright (c) 2022 Rocky Xing.
+# Licensed under the Apache License, Version 2.0 (the "License")
+#
+# 21-Feb-2022   Rocky Xing   Created this.
+
+from __future__ import print_function
+from bcc import BPF
+from time import sleep, strftime
+import argparse
+import os
+
+examples = """examples:
+    ./biopattern            # show block device I/O pattern.
+    ./biopattern 1 10       # print 1 second summaries, 10 times
+    ./biopattern -d sdb     # show sdb only
+"""
+parser = argparse.ArgumentParser(
+    description="Show block device I/O pattern.",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("-d", "--disk", type=str,
+    help="Trace this disk only")
+parser.add_argument("interval", nargs="?", default=99999999,
+    help="Output interval in seconds")
+parser.add_argument("count", nargs="?", default=99999999,
+    help="Number of outputs")
+args = parser.parse_args()
+countdown = int(args.count)
+
+bpf_text="""
+struct counter {
+    u64 last_sector;
+    u64 bytes;
+    u32 sequential;
+    u32 random;
+};
+
+BPF_HASH(counters, u32, struct counter);
+
+TRACEPOINT_PROBE(block, block_rq_complete)
+{
+    struct counter *counterp;
+    struct counter zero = {};
+    u32 dev = args->dev;
+    u64 sector = args->sector;
+    u32 nr_sector = args->nr_sector;
+
+    DISK_FILTER
+
+    counterp = counters.lookup_or_try_init(&dev, &zero);
+    if (counterp == 0) {
+        return 0;
+    }
+
+    if (counterp->last_sector) {
+        if (counterp->last_sector == sector) {
+            __sync_fetch_and_add(&counterp->sequential, 1);
+        } else {
+            __sync_fetch_and_add(&counterp->random, 1);
+        }
+        __sync_fetch_and_add(&counterp->bytes, nr_sector * 512);
+    }
+    counterp->last_sector = sector + nr_sector;
+
+    return 0;
+}
+"""
+
+dev_minor_bits = 20
+
+def mkdev(major, minor):
+   return (major << dev_minor_bits) | minor
+
+
+partitions = {}
+
+with open("/proc/partitions", 'r') as f:
+    lines = f.readlines()
+    for line in lines[2:]:
+        words = line.strip().split()
+        major = int(words[0])
+        minor = int(words[1])
+        part_name = words[3]
+        partitions[mkdev(major, minor)] = part_name
+
+if args.disk is not None:
+    disk_path = os.path.join('/dev', args.disk)
+    if os.path.exists(disk_path) == False:
+        print("no such disk '%s'" % args.disk)
+        exit(1)
+
+    stat_info = os.stat(disk_path)
+    major = os.major(stat_info.st_rdev)
+    minor = os.minor(stat_info.st_rdev)
+    bpf_text = bpf_text.replace('DISK_FILTER',
+                                'if (dev != %s) { return 0; }' % mkdev(major, minor))
+else:
+    bpf_text = bpf_text.replace('DISK_FILTER', '')
+
+b = BPF(text=bpf_text)
+
+exiting = 0 if args.interval else 1
+counters = b.get_table("counters")
+
+print("%-9s %-7s %5s %5s %8s %10s" % 
+    ("TIME", "DISK", "%RND", "%SEQ", "COUNT", "KBYTES"))
+
+while True:
+    try:
+        sleep(int(args.interval))
+    except KeyboardInterrupt:
+        exiting = 1
+    
+    for k, v in counters.items():
+        total = v.random + v.sequential
+        if total == 0:
+            continue
+
+        part_name = partitions.get(k.value, "Unknown")
+
+        print("%-9s %-7s %5d %5d %8d %10d" % (
+            strftime("%H:%M:%S"),
+            part_name,
+            v.random * 100 / total,
+            v.sequential * 100 / total,
+            total,
+            v.bytes / 1024))
+
+    counters.clear()
+
+    countdown -= 1
+    if exiting or countdown == 0:
+        exit()
+

--- a/tools/biopattern_example.txt
+++ b/tools/biopattern_example.txt
@@ -1,0 +1,45 @@
+Demonstrations of biopattern, the Linux eBPF/bcc version.
+
+
+biopattern identifies random/sequential disk access patterns. Example:
+
+# ./biopattern.py
+TIME      DISK     %RND  %SEQ    COUNT     KBYTES
+22:03:51  vdb         0    99      788       3184
+22:03:51  Unknown     0   100        4          0
+22:03:51  vda        85    14       21        488
+[...]
+
+
+The -d option only print the matched disk.
+
+# ./biopattern.py -d vdb 1 10
+TIME      DISK     %RND  %SEQ    COUNT     KBYTES
+22:12:57  vdb         0    99      193        772
+22:12:58  vdb         0   100     1119       4476
+22:12:59  vdb         0   100     1126       4504
+22:13:00  vdb         0   100     1009       4036
+22:13:01  vdb         0   100      958       3832
+22:13:02  vdb         0    99      957       3856
+22:13:03  vdb         0   100     1130       4520
+22:13:04  vdb         0   100     1051       4204
+22:13:05  vdb         0   100     1158       4632
+[...]
+
+
+USAGE message:
+
+Show block device I/O pattern.
+
+positional arguments:
+  interval              Output interval in seconds
+  count                 Number of outputs
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -d DISK, --disk DISK  Trace this disk only
+
+examples:
+    ./biopattern            # show block device I/O pattern.
+    ./biopattern 1 10       # print 1 second summaries, 10 times
+    ./biopattern -d sdb     # show sdb only


### PR DESCRIPTION
Add biopattern.py (Based on libbpf-tools/biopattern) to identify random/sequential disk access patterns.

Example:
```
# ./biopattern.py -d vdb 1 10
TIME      DISK     %RND  %SEQ    COUNT     KBYTES
22:12:57  vdb         0    99      193        772
22:12:58  vdb         0   100     1119       4476
22:12:59  vdb         0   100     1126       4504
22:13:00  vdb         0   100     1009       4036
22:13:01  vdb         0   100      958       3832
22:13:02  vdb         0    99      957       3856
22:13:03  vdb         0   100     1130       4520
22:13:04  vdb         0   100     1051       4204
22:13:05  vdb         0   100     1158       4632
[...]
```

@yonghong-song @davemarchevsky please help review this pr, thanks.