### PR TITLE
tools: include blk-mq.h in bio tools

### DIFF
--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -64,7 +64,7 @@ if args.flags and args.disks:
 # define BPF program
 bpf_text = """
 #include <uapi/linux/ptrace.h>
-#include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 
 typedef struct disk_key {
     char disk[DISK_NAME_LEN];

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -37,7 +37,7 @@ debug = 0
 # define BPF program
 bpf_text="""
 #include <uapi/linux/ptrace.h>
-#include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 
 // for saving the timestamp and __data_len of each request
 struct start_req_t {

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -54,7 +54,7 @@ diskstats = "/proc/diskstats"
 # load BPF program
 bpf_text = """
 #include <uapi/linux/ptrace.h>
-#include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 
 // for saving the timestamp and __data_len of each request
 struct start_req_t {


### PR DESCRIPTION
Kernel commit 24b83deb29b ("block: move struct request to blk-mq.h")
has moved struct request  from blkdev.h to blk-mq.h. It results in
several bio tools to fail with errors of the following type:

error: incomplete definition of type 'struct request'

Since blk-mq.h had always included blkdev.h. it is safe to simply
replace the inclusion of blkdev.h by blk-mq-h. It works on both older
and newer kernel.

Fixes: #3869

Signed-off-by: Jerome Marchand <jmarchan@redhat.com>