### PR TITLE
libbpf-tools/runqlen: Fix a run queue occupancy count issue with ‘-C’

### DIFF
--- a/libbpf-tools/runqlen.c
+++ b/libbpf-tools/runqlen.c
@@ -171,12 +171,13 @@ static struct hist zero;
 
 static void print_runq_occupancy(struct runqlen_bpf__bss *bss)
 {
-	__u64 samples, idle = 0, queued = 0;
 	struct hist hist;
 	int slot, i = 0;
 	float runqocc;
 
 	do {
+		__u64 samples, idle = 0, queued = 0;
+
 		hist = bss->hists[i];
 		bss->hists[i] = zero;
 		for (slot = 0; slot < MAX_SLOTS; slot++) {


### PR DESCRIPTION
When use -O -C for count run queue occupancy for each CPU separately,
the first cpu statistics are correct; however, the data used by the
subsequent cpus are on top of the accumulation of the previous cpu data,
but not really separate-CPU statistics.

This is because the variables used for calculation are defined outside
the calculation loop body, resulting in the value of each variable being
accumulated on the basis of the previous calculation.

So put them into the loop body  to fix it.

Signed-off-by: Hailong Liu <liuhailong@linux.alibaba.com>