### PR TITLE
examples: Fix disksnoop

### DIFF
--- a/examples/tracing/disksnoop.py
+++ b/examples/tracing/disksnoop.py
@@ -19,7 +19,7 @@ REQ_WRITE = 1		# from include/linux/blk_types.h
 # load BPF program
 b = BPF(text="""
 #include <uapi/linux/ptrace.h>
-#include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 
 BPF_HASH(start, struct request *);
 
@@ -46,7 +46,10 @@ void trace_completion(struct pt_regs *ctx, struct request *req) {
 if BPF.get_kprobe_functions(b'blk_start_request'):
         b.attach_kprobe(event="blk_start_request", fn_name="trace_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_start")
-b.attach_kprobe(event="blk_account_io_done", fn_name="trace_completion")
+if BPF.get_kprobe_functions(b'__blk_account_io_done'):
+    b.attach_kprobe(event="__blk_account_io_done", fn_name="trace_completion")
+else:
+    b.attach_kprobe(event="blk_account_io_done", fn_name="trace_completion")
 
 # header
 print("%-18s %-2s %-7s %8s" % ("TIME(s)", "T", "BYTES", "LAT(ms)"))


### PR DESCRIPTION
Kernel commit 24b83deb29b ("block: move struct request to blk-mq.h")
and be6bfe36db17 ("block: inline hot paths of blk_account_io_*()")
introduce changes which break disksnoop.

Like #3748 and #3877 but for disksnoop, this commit fixes those issues.

Closes #3825.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>