### PR TITLE
usdt: support xmm registers as args for x64

### DIFF
--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -166,6 +166,22 @@ private:
     X64_REG_14,
     X64_REG_15,
     X64_REG_RIP,
+    X64_REG_XMM0,
+    X64_REG_XMM1,
+    X64_REG_XMM2,
+    X64_REG_XMM3,
+    X64_REG_XMM4,
+    X64_REG_XMM5,
+    X64_REG_XMM6,
+    X64_REG_XMM7,
+    X64_REG_XMM8,
+    X64_REG_XMM9,
+    X64_REG_XMM10,
+    X64_REG_XMM11,
+    X64_REG_XMM12,
+    X64_REG_XMM13,
+    X64_REG_XMM14,
+    X64_REG_XMM15,
   };
 
   struct RegInfo {

--- a/src/cc/usdt/usdt_args.cc
+++ b/src/cc/usdt/usdt_args.cc
@@ -69,7 +69,13 @@ bool Argument::assign_to_local(std::ostream &stream,
   }
 
   if (!deref_offset_) {
-    tfm::format(stream, "%s = ctx->%s;", local_name, *base_register_name_);
+    if(base_register_name_->substr(0,3) == "xmm") {
+      // TODO: When we can read xmm registers from BPF, update this to read
+      // the actual value
+      tfm::format(stream, "%s = 0;", local_name);
+    } else {
+      tfm::format(stream, "%s = ctx->%s;", local_name, *base_register_name_);
+    }
     // Put a compiler barrier to prevent optimization
     // like llvm SimplifyCFG SinkThenElseCodeToEnd
     // Volatile marking is not sufficient to prevent such optimization.
@@ -532,6 +538,23 @@ const std::unordered_map<std::string, ArgumentParser_x64::RegInfo>
         {"r15w", {X64_REG_15, 2}}, {"r15b", {X64_REG_15, 1}},
 
         {"rip", {X64_REG_RIP, 8}},
+
+        {"xmm0", {X64_REG_XMM0, 16}},
+        {"xmm1", {X64_REG_XMM1, 16}},
+        {"xmm2", {X64_REG_XMM2, 16}},
+        {"xmm3", {X64_REG_XMM3, 16}},
+        {"xmm4", {X64_REG_XMM4, 16}},
+        {"xmm5", {X64_REG_XMM5, 16}},
+        {"xmm6", {X64_REG_XMM6, 16}},
+        {"xmm7", {X64_REG_XMM7, 16}},
+        {"xmm8", {X64_REG_XMM8, 16}},
+        {"xmm9", {X64_REG_XMM9, 16}},
+        {"xmm10", {X64_REG_XMM10, 16}},
+        {"xmm11", {X64_REG_XMM11, 16}},
+        {"xmm12", {X64_REG_XMM12, 16}},
+        {"xmm13", {X64_REG_XMM13, 16}},
+        {"xmm14", {X64_REG_XMM14, 16}},
+        {"xmm15", {X64_REG_XMM15, 16}},
 };
 
 void ArgumentParser_x64::reg_to_name(std::string *norm, Register reg) {
@@ -590,6 +613,56 @@ void ArgumentParser_x64::reg_to_name(std::string *norm, Register reg) {
   case X64_REG_RIP:
     *norm = "ip";
     break;
+
+  case X64_REG_XMM0:
+    *norm = "xmm0";
+    break;
+  case X64_REG_XMM1:
+    *norm = "xmm1";
+    break;
+  case X64_REG_XMM2:
+    *norm = "xmm2";
+    break;
+  case X64_REG_XMM3:
+    *norm = "xmm3";
+    break;
+  case X64_REG_XMM4:
+    *norm = "xmm4";
+    break;
+  case X64_REG_XMM5:
+    *norm = "xmm5";
+    break;
+  case X64_REG_XMM6:
+    *norm = "xmm6";
+    break;
+  case X64_REG_XMM7:
+    *norm = "xmm7";
+    break;
+  case X64_REG_XMM8:
+    *norm = "xmm8";
+    break;
+  case X64_REG_XMM9:
+    *norm = "xmm9";
+    break;
+  case X64_REG_XMM10:
+    *norm = "xmm10";
+    break;
+  case X64_REG_XMM11:
+    *norm = "xmm11";
+    break;
+  case X64_REG_XMM12:
+    *norm = "xmm12";
+    break;
+  case X64_REG_XMM13:
+    *norm = "xmm13";
+    break;
+  case X64_REG_XMM14:
+    *norm = "xmm14";
+    break;
+  case X64_REG_XMM15:
+    *norm = "xmm15";
+    break;
+
   }
 }
 


### PR DESCRIPTION
Support for using xmm registers for USDT args was added to systemtap in
early 2021 (commit 04c99d0d0267f574fa60044c96933b0dd3846aa1 added xmm0-7
and eaa15b047688175a94e3ae796529785a3a0af208 added xmm8-15). As a result
these registers are showing up in probe descriptors on Fedora.

pthread_start probe description on Ubuntu 20.04:
```
  stapsdt              0x00000052       NT_STAPSDT (SystemTap probe descriptors)
    Provider: libpthread
    Name: pthread_start
    Location: 0x00000000000095e9, Base: 0x000000000001922c, Semaphore: 0x0000000000000000
    Arguments: 8@%rax 8@1600(%rax) 8@1608(%rax)
```

And in the Fedora test container:

```
  stapsdt              0x00000053       NT_STAPSDT (SystemTap probe descriptors)
    Provider: libpthread
    Name: pthread_start
    Location: 0x0000000000009280, Base: 0x0000000000016cbc, Semaphore: 0x0000000000000000
    Arguments: 8@%xmm0 8@1600(%rax) 8@1608(%rax)
```

bcc doesn't recognize these registers so it's unable to generate code to fetch arguments which use these registers for storage. Add support for XMM0-15.

This should fix `lib/uthreads.py` test, which uses `pthread_start` and therefore fails to generate program on Fedora.

Signed-off-by: Dave Marchevsky <davemarchevsky@fb.com>