### PR TITLE
Suppress warning: '__HAVE_BUILTIN_BSWAP32__' macro redefined

### DIFF
--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -224,7 +224,7 @@ if args.ebpf:
     exit()
 
 # initialize BPF
-b = BPF(text=bpf_text)
+b = BPF(text=bpf_text, cflags=['-Wno-macro-redefined'])
 execve_fnname = b.get_syscall_fnname("execve")
 b.attach_kprobe(event=execve_fnname, fn_name="syscall__execve")
 b.attach_kretprobe(event=execve_fnname, fn_name="do_ret_sys_execve")


### PR DESCRIPTION
To supress these warnings.

```$sudo execsnoop-bpfcc
In file included from <built-in>:2:
In file included from /virtual/include/bcc/bpf.h:12:
In file included from /lib/modules/5.14.14/build/include/linux/types.h:6:
In file included from /lib/modules/5.14.14/build/include/uapi/linux/types.h:14:
In file included from /lib/modules/5.14.14/build/include/uapi/linux/posix_types.h:5:
In file included from /lib/modules/5.14.14/build/include/linux/stddef.h:5:
In file included from /lib/modules/5.14.14/build/include/uapi/linux/stddef.h:2:
In file included from /lib/modules/5.14.14/build/include/linux/compiler_types.h:80:
/lib/modules/5.14.14/build/include/linux/compiler-clang.h:41:9: warning: '__HAVE_BUILTIN_BSWAP32__' macro redefined [-Wmacro-redefined]
#define __HAVE_BUILTIN_BSWAP32__
        ^
<command line>:4:9: note: previous definition is here
#define __HAVE_BUILTIN_BSWAP32__ 1
        ^```