### PR TITLE
libbpf-tools: Fix klockstat when CONFIG_DEBUG_LOCK_ALLOC is set

### DIFF
--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -534,6 +534,21 @@ int main(int argc, char **argv)
 	obj->rodata->targ_pid = env.tid;
 	obj->rodata->targ_lock = lock_addr;
 
+	if (fentry_exists("mutex_lock_nested", NULL)) {
+		bpf_program__set_attach_target(obj->progs.mutex_lock, 0,
+					       "mutex_lock_nested");
+		bpf_program__set_attach_target(obj->progs.mutex_lock_exit, 0,
+					       "mutex_lock_nested");
+		bpf_program__set_attach_target(obj->progs.mutex_lock_interruptible, 0,
+					       "mutex_lock_interruptible_nested");
+		bpf_program__set_attach_target(obj->progs.mutex_lock_interruptible_exit, 0,
+					       "mutex_lock_interruptible_nested");
+		bpf_program__set_attach_target(obj->progs.mutex_lock_killable, 0,
+					       "mutex_lock_killable_nested");
+		bpf_program__set_attach_target(obj->progs.mutex_lock_killable_exit, 0,
+					       "mutex_lock_killable_nested");
+	}
+
 	err = klockstat_bpf__load(obj);
 	if (err) {
 		warn("failed to load BPF object\n");


### PR DESCRIPTION
When CONFIG_DEBUG_LOCK_ALLOC is set ([0]), mutex_lock, mutex_lock_interruptible
and mutex_lock_killable become macro defines and gone from ksyms. Let's use
the *_nested functions as tracing targets instead.

  [0]: https://github.com/torvalds/linux/blob/df0cc57e057f18e44dac8e6c18aba47ab53202f9/include/linux/mutex.h#L177-L209

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>