### PR TITLE
tools/biolatency: Use '<unknown>' instead of empty disk name

### DIFF
--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -4,7 +4,7 @@
 # biolatency    Summarize block device I/O latency as a histogram.
 #       For Linux, uses BCC, eBPF.
 #
-# USAGE: biolatency [-h] [-T] [-Q] [-m] [-D] [-e] [interval] [count]
+# USAGE: biolatency [-h] [-T] [-Q] [-m] [-D] [-F] [-e] [-j] [interval] [count]
 #
 # Copyright (c) 2015 Brendan Gregg.
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -188,6 +188,12 @@ else:
 if not args.json:
     print("Tracing block device I/O... Hit Ctrl-C to end.")
 
+def disk_print(s):
+    disk = s.decode('utf-8', 'replace')
+    if not disk:
+        disk = "<unknown>"
+    return disk
+
 # see blk_fill_rwbs():
 req_opf = {
     0: "Read",
@@ -256,9 +262,8 @@ while (1):
 
         if args.flags:
             dist.print_json_hist(label, "flags", flags_print)
-
         else:
-            dist.print_json_hist(label)
+            dist.print_json_hist(label, "disk", disk_print)
 
     else:
         if args.timestamp:
@@ -267,7 +272,7 @@ while (1):
         if args.flags:
             dist.print_log2_hist(label, "flags", flags_print)
         else:
-            dist.print_log2_hist(label, "disk")
+            dist.print_log2_hist(label, "disk", disk_print)
         if args.extension:
             total = extension[0].total
             counts = extension[0].count

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -180,7 +180,7 @@ else:
     b.attach_kprobe(event="blk_account_io_done", fn_name="trace_req_completion")
 
 # header
-print("%-11s %-14s %-6s %-7s %-1s %-10s %-7s" % ("TIME(s)", "COMM", "PID",
+print("%-11s %-14s %-6s %-9s %-1s %-10s %-7s" % ("TIME(s)", "COMM", "PID",
     "DISK", "T", "SECTOR", "BYTES"), end="")
 if args.queue:
     print("%7s " % ("QUE(ms)"), end="")
@@ -206,10 +206,13 @@ def print_event(cpu, data, size):
 
     delta = float(event.ts) - start_ts
 
-    print("%-11.6f %-14.14s %-6s %-7s %-1s %-10s %-7s" % (
+    disk_name = event.disk_name.decode('utf-8', 'replace')
+    if not disk_name:
+        disk_name = '<unknown>'
+
+    print("%-11.6f %-14.14s %-6s %-9s %-1s %-10s %-7s" % (
         delta / 1000000, event.name.decode('utf-8', 'replace'), event.pid,
-        event.disk_name.decode('utf-8', 'replace'), rwflg, event.sector,
-        event.len), end="")
+        disk_name, rwflg, event.sector, event.len), end="")
     if args.queue:
         print("%7.2f " % (float(event.qdelta) / 1000000), end="")
     print("%7.2f" % (float(event.delta) / 1000000))


### PR DESCRIPTION
Sometimes, req->rq_disk is NULL, for example, scsi cmd with non-data requests. As a consequence, biosnoop/biolatency output show empty disk colume，which may be confusing.

Example 1 (biolatency):

```
disk = b''
     usecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 1        |****************************************|


disk = b'vda'
     usecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 0        |                                        |
       512 -> 1023       : 18       |************************                |
      1024 -> 2047       : 30       |****************************************|
      2048 -> 4095       : 2        |**                                      |
      4096 -> 8191       : 10       |*************                           |
```

Example 2 (biosnoop):

DISK colume and SECTOR colume with unassigned values. In actually, it was issued by block softirq (blk_done_softirq), req->rq_disk is NULL.

```
TIME(s)     COMM           PID    DISK    T SECTOR     BYTES  LAT(ms)
0.959516    ?              0              R 0          8         0.35
2.377032    jbd2/vda1-8    447    vda     W 4531168    61440     1.70
2.378106    jbd2/vda1-8    447    vda     W 4531288    4096      1.06
3.007478    ?              0              R 0          8         0.34
4.608320    kworker/u32:2  899558 vda     W 17650496   49152     1.10
5.055483    ?              0              R 0          8         0.33
```

I add an option -x to exclude requests with null disk. I am not sure whether it is reasonable or not. @yonghong-song  please help review this pr, thanks.