### PR TITLE
biolatency, biolatpcts, biosnoop, biotop: Build fix for v5.17+

### DIFF
--- a/tools/biolatpcts.py
+++ b/tools/biolatpcts.py
@@ -72,9 +72,9 @@ void kprobe_blk_account_io_done(struct pt_regs *ctx, struct request *rq, u64 now
         if (!rq->__START_TIME_FIELD__)
                 return;
 
-        if (!rq->rq_disk ||
-            rq->rq_disk->major != __MAJOR__ ||
-            rq->rq_disk->first_minor != __MINOR__)
+        if (!rq->__RQ_DISK__ ||
+            rq->__RQ_DISK__->major != __MAJOR__ ||
+            rq->__RQ_DISK__->first_minor != __MINOR__)
                 return;
 
         cmd_flags = rq->cmd_flags;
@@ -141,6 +141,11 @@ else:
 bpf_source = bpf_source.replace('__START_TIME_FIELD__', start_time_field)
 bpf_source = bpf_source.replace('__MAJOR__', str(major))
 bpf_source = bpf_source.replace('__MINOR__', str(minor))
+
+if BPF.kernel_struct_has_field(b'request', b'rq_disk'):
+    bpf_source = bpf_source.replace('__RQ_DISK__', 'rq_disk')
+else:
+    bpf_source = bpf_source.replace('__RQ_DISK__', 'q->disk')
 
 bpf = BPF(text=bpf_source)
 if BPF.get_kprobe_functions(b'__blk_account_io_done'):

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -125,7 +125,7 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
         data.pid = valp->pid;
         data.sector = req->__sector;
         bpf_probe_read_kernel(&data.name, sizeof(data.name), valp->name);
-        struct gendisk *rq_disk = req->rq_disk;
+        struct gendisk *rq_disk = req->__RQ_DISK__;
         bpf_probe_read_kernel(&data.disk_name, sizeof(data.disk_name),
                        rq_disk->disk_name);
     }
@@ -156,6 +156,10 @@ if args.queue:
     bpf_text = bpf_text.replace('##QUEUE##', '1')
 else:
     bpf_text = bpf_text.replace('##QUEUE##', '0')
+if BPF.kernel_struct_has_field(b'request', b'rq_disk'):
+    bpf_text = bpf_text.replace('__RQ_DISK__', 'rq_disk')
+else:
+    bpf_text = bpf_text.replace('__RQ_DISK__', 'q->disk')
 if debug or args.ebpf:
     print(bpf_text)
     if args.ebpf:

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -129,8 +129,8 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
 
     // setup info_t key
     struct info_t info = {};
-    info.major = req->rq_disk->major;
-    info.minor = req->rq_disk->first_minor;
+    info.major = req->__RQ_DISK__->major;
+    info.minor = req->__RQ_DISK__->first_minor;
 /*
  * The following deals with a kernel version change (in mainline 4.7, although
  * it may be backported to earlier kernels) with how block request write flags
@@ -173,6 +173,11 @@ int trace_req_completion(struct pt_regs *ctx, struct request *req)
 if args.ebpf:
     print(bpf_text)
     exit()
+
+if BPF.kernel_struct_has_field(b'request', b'rq_disk'):
+    bpf_text = bpf_text.replace('__RQ_DISK__', 'rq_disk')
+else:
+    bpf_text = bpf_text.replace('__RQ_DISK__', 'q->disk')
 
 b = BPF(text=bpf_text)
 if BPF.get_kprobe_functions(b'__blk_account_io_start'):


### PR DESCRIPTION
During 5.17 dev cycle, the kernel dropped request->rq_disk. It can now be
accessed through request->q->disk. Fix the python ones in tools/. There are
more usages in other places which need to be fixed too.

Signed-off-by: Tejun Heo <tj@kernel.org>