### PR TITLE
Fix a llvm compilation bug

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -24,6 +24,11 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Module.h>
+
+#if LLVM_MAJOR_VERSION >= 15
+#include <llvm/Pass.h>
+#endif
+
 #include <llvm/IR/Verifier.h>
 #include <llvm/Object/ObjectFile.h>
 #include <llvm/Object/ELFObjectFile.h>


### PR DESCRIPTION
llvm upstream patch https://reviews.llvm.org/D118652
did some header file cleanup and this breaks bcc with llvm15
with the following compilation error:

  /.../src/cc/bpf_module.cc: In member function ‘void ebpf::BPFModule::dump_ir(llvm::Module&)’:
  /.../src/cc/bpf_module.cc:231:39: error: no matching function for call to ‘llvm::legacy::PassManager::add(llvm::Module Pass*)’
   PM.add(createPrintModulePass(errs()));
                                       ^
  In file included from /.../src/cc/bpf_module.cc:25:
  /.../include/llvm/IR/LegacyPassManager.h:58:8: note: candidate: ‘virtual void llvm::legacy::PassManager::add(llvm::Pass*)’
     void add(Pass *P) override;
          ^~~
  /.../include/llvm/IR/LegacyPassManager.h:58:8: note:   no known conversion for argument 1 from ‘llvm::ModulePass*’ to ‘llvm::Pass*’

Adding the include path "llvm/Pass.h" in bpf_module.cc fixed the issue.

Signed-off-by: Yonghong Song <yhs@fb.com>