### PR TITLE
tools: Fix bytes<->str mixing in python3

### DIFF
--- a/tools/btrfsdist.py
+++ b/tools/btrfsdist.py
@@ -231,7 +231,7 @@ while (1):
     if args.interval and (not args.notimestamp):
         print(strftime("%H:%M:%S:"))
 
-    dist.print_log2_hist(label, "operation")
+    dist.print_log2_hist(label, "operation", section_print_fn=bytes.decode)
     dist.clear()
 
     countdown -= 1

--- a/tools/hardirqs.py
+++ b/tools/hardirqs.py
@@ -241,7 +241,7 @@ while (1):
         print("%-8s\n" % strftime("%H:%M:%S"), end="")
 
     if args.dist:
-        dist.print_log2_hist(label, "hardirq")
+        dist.print_log2_hist(label, "hardirq", section_print_fn=bytes.decode)
     else:
         print("%-26s %11s" % ("HARDIRQ", "TOTAL_" + label))
         for k, v in sorted(dist.items(), key=lambda dist: dist[1].value):

--- a/tools/xfsdist.py
+++ b/tools/xfsdist.py
@@ -169,7 +169,7 @@ while (1):
     if args.interval and (not args.notimestamp):
         print(strftime("%H:%M:%S:"))
 
-    dist.print_log2_hist(label, "operation")
+    dist.print_log2_hist(label, "operation", section_print_fn=bytes.decode)
     dist.clear()
 
     countdown -= 1

--- a/tools/zfsdist.py
+++ b/tools/zfsdist.py
@@ -183,7 +183,7 @@ while (1):
     if args.interval and (not args.notimestamp):
         print(strftime("%H:%M:%S:"))
 
-    dist.print_log2_hist(label, "operation")
+    dist.print_log2_hist(label, "operation", section_print_fn=bytes.decode)
     dist.clear()
 
     countdown -= 1


### PR DESCRIPTION
As pr #986,  remove b'' prefix in section header.

For example, hardirq's section header prefixed with b'', use bytes.decode function remove it.

```
hardirq = b'virtio0-input.2'
     usecs               : count     distribution
         0 -> 1          : 1        |****************************************|
```