### PR TITLE
bcc: Get rid of deprecated libbpf API btf__get_map_kv_tids()

### DIFF
--- a/src/cc/bcc_btf.h
+++ b/src/cc/bcc_btf.h
@@ -26,6 +26,7 @@
 #include "bpf_module.h"
 
 struct btf;
+struct btf_type;
 
 namespace btf_ext_vendored {
 


### PR DESCRIPTION
btf__get_map_kv_tids() is deprecated and causes annoying compilation warnings.
Reimplement it in BCC.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>