### PR TITLE
tools/vfsstat: Use vfs_fsync_range instead of vfs_fsync

### DIFF
--- a/tools/vfsstat.py
+++ b/tools/vfsstat.py
@@ -65,11 +65,11 @@ void do_create(struct pt_regs *ctx) { stats_increment(S_CREATE); }
 """
 
 bpf_text_kfunc = """
-KFUNC_PROBE(vfs_read)   { stats_increment(S_READ); return 0; }
-KFUNC_PROBE(vfs_write)  { stats_increment(S_WRITE); return 0; }
-KFUNC_PROBE(vfs_fsync)  { stats_increment(S_FSYNC); return 0; }
-KFUNC_PROBE(vfs_open)   { stats_increment(S_OPEN); return 0; }
-KFUNC_PROBE(vfs_create) { stats_increment(S_CREATE); return 0; }
+KFUNC_PROBE(vfs_read)         { stats_increment(S_READ); return 0; }
+KFUNC_PROBE(vfs_write)        { stats_increment(S_WRITE); return 0; }
+KFUNC_PROBE(vfs_fsync_range)  { stats_increment(S_FSYNC); return 0; }
+KFUNC_PROBE(vfs_open)         { stats_increment(S_OPEN); return 0; }
+KFUNC_PROBE(vfs_create)       { stats_increment(S_CREATE); return 0; }
 """
 
 is_support_kfunc = BPF.support_kfunc()
@@ -81,11 +81,11 @@ else:
 
 b = BPF(text=bpf_text)
 if not is_support_kfunc:
-    b.attach_kprobe(event="vfs_read",   fn_name="do_read")
-    b.attach_kprobe(event="vfs_write",  fn_name="do_write")
-    b.attach_kprobe(event="vfs_fsync",  fn_name="do_fsync")
-    b.attach_kprobe(event="vfs_open",   fn_name="do_open")
-    b.attach_kprobe(event="vfs_create", fn_name="do_create")
+    b.attach_kprobe(event="vfs_read",         fn_name="do_read")
+    b.attach_kprobe(event="vfs_write",        fn_name="do_write")
+    b.attach_kprobe(event="vfs_fsync_range",  fn_name="do_fsync")
+    b.attach_kprobe(event="vfs_open",         fn_name="do_open")
+    b.attach_kprobe(event="vfs_create",       fn_name="do_create")
 
 # stat column labels and indexes
 stat_types = {


### PR DESCRIPTION
As reported in #3913, vfs_fsync is never triggered when fsync is called.
Use vfscount can reveal that:

    sudo python3 ./vfscount.py
    Tracing... Ctrl-C to end.
    ^C
    ADDR             FUNC                          COUNT
    ffffffff8ad23621 b'vfs_writev'                     2
    ffffffff8ad29df1 b'vfs_getattr_nosec'             55
    ffffffff8ad20401 b'vfs_open'                      58
    ffffffff8ad2a7b1 b'vfs_statx'                     91
    ffffffff8ad641d1 b'vfs_fsync_range'             1802
    ffffffff8ad22111 b'vfs_read'                    1900
    ffffffff8ad22551 b'vfs_write'                   3752

Let's use vfs_fsync_range instead to trace fsync operations.

Closes #3913.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>