### PR TITLE
tools: Unify PID column width (at most 7 chars)

### DIFF
--- a/tools/bashreadline.py
+++ b/tools/bashreadline.py
@@ -68,11 +68,11 @@ b = BPF(text=bpf_text)
 b.attach_uretprobe(name=name, sym="readline", fn_name="printret")
 
 # header
-print("%-9s %-6s %s" % ("TIME", "PID", "COMMAND"))
+print("%-9s %-7s %s" % ("TIME", "PID", "COMMAND"))
 
 def print_event(cpu, data, size):
     event = b["events"].event(data)
-    print("%-9s %-6d %s" % (strftime("%H:%M:%S"), event.pid,
+    print("%-9s %-7d %s" % (strftime("%H:%M:%S"), event.pid,
                             event.str.decode('utf-8', 'replace')))
 
 b["events"].open_perf_buffer(print_event)

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -180,7 +180,7 @@ else:
     b.attach_kprobe(event="blk_account_io_done", fn_name="trace_req_completion")
 
 # header
-print("%-11s %-14s %-6s %-9s %-1s %-10s %-7s" % ("TIME(s)", "COMM", "PID",
+print("%-11s %-14s %-7s %-9s %-1s %-10s %-7s" % ("TIME(s)", "COMM", "PID",
     "DISK", "T", "SECTOR", "BYTES"), end="")
 if args.queue:
     print("%7s " % ("QUE(ms)"), end="")
@@ -210,7 +210,7 @@ def print_event(cpu, data, size):
     if not disk_name:
         disk_name = '<unknown>'
 
-    print("%-11.6f %-14.14s %-6s %-9s %-1s %-10s %-7s" % (
+    print("%-11.6f %-14.14s %-7s %-9s %-1s %-10s %-7s" % (
         delta / 1000000, event.name.decode('utf-8', 'replace'), event.pid,
         disk_name, rwflg, event.sector, event.len), end="")
     if args.queue:

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -216,7 +216,7 @@ while 1:
         print()
     with open(loadavg) as stats:
         print("%-8s loadavg: %s" % (strftime("%H:%M:%S"), stats.read()))
-    print("%-6s %-16s %1s %-3s %-3s %-8s %5s %7s %6s" % ("PID", "COMM",
+    print("%-7s %-16s %1s %-3s %-3s %-8s %5s %7s %6s" % ("PID", "COMM",
         "D", "MAJ", "MIN", "DISK", "I/O", "Kbytes", "AVGms"))
 
     # by-PID output
@@ -234,7 +234,7 @@ while 1:
 
         # print line
         avg_ms = (float(v.us) / 1000) / v.io
-        print("%-6d %-16s %1s %-3d %-3d %-8s %5s %7s %6.2f" % (k.pid,
+        print("%-7d %-16s %1s %-3d %-3d %-8s %5s %7s %6.2f" % (k.pid,
             k.name.decode('utf-8', 'replace'), "W" if k.rwflag else "R",
             k.major, k.minor, diskname, v.io, v.bytes / 1024, avg_ms))
 

--- a/tools/btrfsslower.py
+++ b/tools/btrfsslower.py
@@ -310,7 +310,7 @@ def print_event(cpu, data, size):
             type, event.size, event.offset, event.delta_us,
             event.file.decode('utf-8', 'replace')))
         return
-    print("%-8s %-14.14s %-6s %1s %-7s %-8d %7.2f %s" % (strftime("%H:%M:%S"),
+    print("%-8s %-14.14s %-7d %1s %-7s %-8d %7.2f %s" % (strftime("%H:%M:%S"),
         event.task.decode('utf-8', 'replace'), event.pid, type, event.size,
         event.offset / 1024, float(event.delta_us) / 1000,
         event.file.decode('utf-8', 'replace')))
@@ -336,7 +336,7 @@ else:
         print("Tracing btrfs operations")
     else:
         print("Tracing btrfs operations slower than %d ms" % min_ms)
-    print("%-8s %-14s %-6s %1s %-7s %-8s %7s %s" % ("TIME", "COMM", "PID", "T",
+    print("%-8s %-14s %-7s %1s %-7s %-8s %7s %s" % ("TIME", "COMM", "PID", "T",
         "BYTES", "OFF_KB", "LAT(ms)", "FILENAME"))
 
 # read events

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -212,7 +212,7 @@ start = BPF.monotonic_time()
 
 def print_event(cpu, data, size):
     event = bpf["events"].event(data)
-    print("%-14.6f %-6d %8.3f %s" % (
+    print("%-14.6f %-7d %8.3f %s" % (
         float(event.timestamp - start) / 1000000000,
         event.pid, float(event.duration) / 1000000, event.query))
 
@@ -223,7 +223,7 @@ else:
     print("Tracing database queries for pids %s slower than %d ms..." %
         (', '.join(map(str, args.pids)), args.threshold))
 
-print("%-14s %-6s %8s %s" % ("TIME(s)", "PID", "MS", "QUERY"))
+print("%-14s %-7s %8s %s" % ("TIME(s)", "PID", "MS", "QUERY"))
 
 bpf["events"].open_perf_buffer(print_event, page_cnt=64)
 while True:

--- a/tools/dcsnoop.py
+++ b/tools/dcsnoop.py
@@ -148,13 +148,13 @@ start_ts = time.time()
 
 def print_event(cpu, data, size):
     event = b["events"].event(data)
-    print("%-11.6f %-6d %-16s %1s %s" % (
+    print("%-11.6f %-7d %-16s %1s %s" % (
             time.time() - start_ts, event.pid,
             event.comm.decode('utf-8', 'replace'), mode_s[event.type],
             event.filename.decode('utf-8', 'replace')))
 
 # header
-print("%-11s %-6s %-16s %1s %s" % ("TIME(s)", "PID", "COMM", "T", "FILE"))
+print("%-11s %-7s %-16s %1s %s" % ("TIME(s)", "PID", "COMM", "T", "FILE"))
 
 b["events"].open_perf_buffer(print_event, page_cnt=64)
 while 1:

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -236,7 +236,7 @@ if args.timestamp:
     print("%-8s" % ("TIME(s)"), end="")
 if args.print_uid:
     print("%-6s" % ("UID"), end="")
-print("%-16s %-6s %-6s %3s %s" % ("PCOMM", "PID", "PPID", "RET", "ARGS"))
+print("%-16s %-7s %-7s %3s %s" % ("PCOMM", "PID", "PPID", "RET", "ARGS"))
 
 class EventType(object):
     EVENT_ARG = 0
@@ -290,7 +290,7 @@ def print_event(cpu, data, size):
             ppid = event.ppid if event.ppid > 0 else get_ppid(event.pid)
             ppid = b"%d" % ppid if ppid > 0 else b"?"
             argv_text = b' '.join(argv[event.pid]).replace(b'\n', b'\\n')
-            printb(b"%-16s %-6d %-6s %3d %s" % (event.comm, event.pid,
+            printb(b"%-16s %-7d %-7s %3d %s" % (event.comm, event.pid,
                    ppid, event.retval, argv_text))
         try:
             del(argv[event.pid])

--- a/tools/filelife.py
+++ b/tools/filelife.py
@@ -118,12 +118,12 @@ b.attach_kprobe(event="security_inode_create", fn_name="trace_create")
 b.attach_kprobe(event="vfs_unlink", fn_name="trace_unlink")
 
 # header
-print("%-8s %-6s %-16s %-7s %s" % ("TIME", "PID", "COMM", "AGE(s)", "FILE"))
+print("%-8s %-7s %-16s %-7s %s" % ("TIME", "PID", "COMM", "AGE(s)", "FILE"))
 
 # process event
 def print_event(cpu, data, size):
     event = b["events"].event(data)
-    print("%-8s %-6d %-16s %-7.2f %s" % (strftime("%H:%M:%S"), event.pid,
+    print("%-8s %-7d %-16s %-7.2f %s" % (strftime("%H:%M:%S"), event.pid,
         event.comm.decode('utf-8', 'replace'), float(event.delta) / 1000,
         event.fname.decode('utf-8', 'replace')))
 

--- a/tools/mdflush.py
+++ b/tools/mdflush.py
@@ -55,12 +55,12 @@ int kprobe__md_flush_request(struct pt_regs *ctx, void *mddev, struct bio *bio)
 
 # header
 print("Tracing md flush requests... Hit Ctrl-C to end.")
-print("%-8s %-6s %-16s %s" % ("TIME", "PID", "COMM", "DEVICE"))
+print("%-8s %-7s %-16s %s" % ("TIME", "PID", "COMM", "DEVICE"))
 
 # process event
 def print_event(cpu, data, size):
     event = b["events"].event(data)
-    print("%-8s %-6d %-16s %s" % (strftime("%H:%M:%S"), event.pid,
+    print("%-8s %-7d %-16s %s" % (strftime("%H:%M:%S"), event.pid,
         event.comm.decode('utf-8', 'replace'),
         event.disk.decode('utf-8', 'replace')))
 

--- a/tools/mysqld_qslower.py
+++ b/tools/mysqld_qslower.py
@@ -108,7 +108,7 @@ b = BPF(text=bpf_text, usdt_contexts=[u])
 # header
 print("Tracing MySQL server queries for PID %d slower than %s ms..." % (pid,
     min_ms_text))
-print("%-14s %-6s %8s %s" % ("TIME(s)", "PID", "MS", "QUERY"))
+print("%-14s %-7s %8s %s" % ("TIME(s)", "PID", "MS", "QUERY"))
 
 # process event
 start = 0
@@ -117,7 +117,7 @@ def print_event(cpu, data, size):
     event = b["events"].event(data)
     if start == 0:
         start = event.ts
-    print("%-14.6f %-6d %8.3f %s" % (float(event.ts - start) / 1000000000,
+    print("%-14.6f %-7d %8.3f %s" % (float(event.ts - start) / 1000000000,
         event.pid, float(event.delta) / 1000000, event.query))
 
 # loop with callback to print_event

--- a/tools/sslsniff.py
+++ b/tools/sslsniff.py
@@ -343,7 +343,7 @@ if args.extra_lib:
 
 
 # header
-header = "%-12s %-18s %-16s %-7s %-6s" % ("FUNC", "TIME(s)", "COMM", "PID", "LEN")
+header = "%-12s %-18s %-16s %-7s %-7s" % ("FUNC", "TIME(s)", "COMM", "PID", "LEN")
 
 if args.extra:
     header += " %-7s %-7s" % ("UID", "TID")

--- a/tools/swapin.py
+++ b/tools/swapin.py
@@ -74,11 +74,11 @@ while 1:
 
     if not args.notime:
         print(strftime("%H:%M:%S"))
-    print("%-16s %-6s %s" % ("COMM", "PID", "COUNT"))
+    print("%-16s %-7s %s" % ("COMM", "PID", "COUNT"))
     counts = b.get_table("counts")
     for k, v in sorted(counts.items(),
 		       key=lambda counts: counts[1].value):
-        print("%-16s %-6d %d" % (k.comm, k.pid, v.value))
+        print("%-16s %-7d %d" % (k.comm, k.pid, v.value))
     counts.clear()
     print()
 

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -384,12 +384,12 @@ def print_ipv4_event(cpu, data, size):
         printb(b"%-6d" % event.uid, nl="")
     dest_ip = inet_ntop(AF_INET, pack("I", event.daddr)).encode()
     if args.lport:
-        printb(b"%-6d %-12.12s %-2d %-16s %-6d %-16s %-6d %s" % (event.pid,
+        printb(b"%-7d %-12.12s %-2d %-16s %-6d %-16s %-6d %s" % (event.pid,
             event.task, event.ip,
             inet_ntop(AF_INET, pack("I", event.saddr)).encode(), event.lport,
             dest_ip, event.dport, print_dns(dest_ip)))
     else:
-        printb(b"%-6d %-12.12s %-2d %-16s %-16s %-6d %s" % (event.pid,
+        printb(b"%-7d %-12.12s %-2d %-16s %-16s %-6d %s" % (event.pid,
             event.task, event.ip,
             inet_ntop(AF_INET, pack("I", event.saddr)).encode(),
             dest_ip, event.dport, print_dns(dest_ip)))
@@ -405,12 +405,12 @@ def print_ipv6_event(cpu, data, size):
         printb(b"%-6d" % event.uid, nl="")
     dest_ip = inet_ntop(AF_INET6, event.daddr).encode()
     if args.lport:
-        printb(b"%-6d %-12.12s %-2d %-16s %-6d %-16s %-6d %s" % (event.pid,
+        printb(b"%-7d %-12.12s %-2d %-16s %-6d %-16s %-6d %s" % (event.pid,
             event.task, event.ip,
             inet_ntop(AF_INET6, event.saddr).encode(), event.lport,
             dest_ip, event.dport, print_dns(dest_ip)))
     else:
-        printb(b"%-6d %-12.12s %-2d %-16s %-16s %-6d %s" % (event.pid,
+        printb(b"%-7d %-12.12s %-2d %-16s %-16s %-6d %s" % (event.pid,
             event.task, event.ip,
             inet_ntop(AF_INET6, event.saddr).encode(),
             dest_ip, event.dport, print_dns(dest_ip)))
@@ -532,10 +532,10 @@ else:
     if args.print_uid:
         print("%-6s" % ("UID"), end="")
     if args.lport:
-        print("%-6s %-12s %-2s %-16s %-6s %-16s %-6s" % ("PID", "COMM", "IP", "SADDR",
+        print("%-7s %-12s %-2s %-16s %-6s %-16s %-6s" % ("PID", "COMM", "IP", "SADDR",
             "LPORT", "DADDR", "DPORT"), end="")
     else:
-        print("%-6s %-12s %-2s %-16s %-16s %-6s" % ("PID", "COMM", "IP", "SADDR",
+        print("%-7s %-12s %-2s %-16s %-16s %-6s" % ("PID", "COMM", "IP", "SADDR",
             "DADDR", "DPORT"), end="")
     if args.dns:
         print(" QUERY")

--- a/tools/tcpconnlat.py
+++ b/tools/tcpconnlat.py
@@ -231,13 +231,13 @@ def print_ipv4_event(cpu, data, size):
             start_ts = event.ts_us
         print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
     if args.lport:
-        print("%-6d %-12.12s %-2d %-16s %-6d %-16s %-5d %.2f" % (event.pid,
+        print("%-7d %-12.12s %-2d %-16s %-6d %-16s %-5d %.2f" % (event.pid,
             event.task.decode('utf-8', 'replace'), event.ip,
             inet_ntop(AF_INET, pack("I", event.saddr)), event.lport,
             inet_ntop(AF_INET, pack("I", event.daddr)), event.dport,
             float(event.delta_us) / 1000))
     else:
-        print("%-6d %-12.12s %-2d %-16s %-16s %-5d %.2f" % (event.pid,
+        print("%-7d %-12.12s %-2d %-16s %-16s %-5d %.2f" % (event.pid,
             event.task.decode('utf-8', 'replace'), event.ip,
             inet_ntop(AF_INET, pack("I", event.saddr)),
             inet_ntop(AF_INET, pack("I", event.daddr)), event.dport,
@@ -251,13 +251,13 @@ def print_ipv6_event(cpu, data, size):
             start_ts = event.ts_us
         print("%-9.3f" % ((float(event.ts_us) - start_ts) / 1000000), end="")
     if args.lport:
-        print("%-6d %-12.12s %-2d %-16s %-6d %-16s %-5d %.2f" % (event.pid,
+        print("%-7d %-12.12s %-2d %-16s %-6d %-16s %-5d %.2f" % (event.pid,
             event.task.decode('utf-8', 'replace'), event.ip,
             inet_ntop(AF_INET6, event.saddr), event.lport,
             inet_ntop(AF_INET6, event.daddr),
             event.dport, float(event.delta_us) / 1000))
     else:
-        print("%-6d %-12.12s %-2d %-16s %-16s %-5d %.2f" % (event.pid,
+        print("%-7d %-12.12s %-2d %-16s %-16s %-5d %.2f" % (event.pid,
             event.task.decode('utf-8', 'replace'), event.ip,
             inet_ntop(AF_INET6, event.saddr), inet_ntop(AF_INET6, event.daddr),
             event.dport, float(event.delta_us) / 1000))
@@ -266,10 +266,10 @@ def print_ipv6_event(cpu, data, size):
 if args.timestamp:
     print("%-9s" % ("TIME(s)"), end="")
 if args.lport:
-    print("%-6s %-12s %-2s %-16s %-6s %-16s %-5s %s" % ("PID", "COMM",
+    print("%-7s %-12s %-2s %-16s %-6s %-16s %-5s %s" % ("PID", "COMM",
         "IP", "SADDR", "LPORT", "DADDR", "DPORT", "LAT(ms)"))
 else:
-    print("%-6s %-12s %-2s %-16s %-16s %-5s %s" % ("PID", "COMM", "IP",
+    print("%-7s %-12s %-2s %-16s %-16s %-5s %s" % ("PID", "COMM", "IP",
         "SADDR", "DADDR", "DPORT", "LAT(ms)"))
 
 # read events

--- a/tools/tcpretrans.py
+++ b/tools/tcpretrans.py
@@ -355,7 +355,7 @@ tcpstate[12] = 'NEW_SYN_RECV'
 # process event
 def print_ipv4_event(cpu, data, size):
     event = b["ipv4_events"].event(data)
-    print("%-8s %-6d %-2d %-20s %1s> %-20s" % (
+    print("%-8s %-7d %-2d %-20s %1s> %-20s" % (
         strftime("%H:%M:%S"), event.pid, event.ip,
         "%s:%d" % (inet_ntop(AF_INET, pack('I', event.saddr)), event.lport),
         type[event.type],
@@ -368,7 +368,7 @@ def print_ipv4_event(cpu, data, size):
 
 def print_ipv6_event(cpu, data, size):
     event = b["ipv6_events"].event(data)
-    print("%-8s %-6d %-2d %-20s %1s> %-20s" % (
+    print("%-8s %-7d %-2d %-20s %1s> %-20s" % (
         strftime("%H:%M:%S"), event.pid, event.ip,
         "%s:%d" % (inet_ntop(AF_INET6, event.saddr), event.lport),
         type[event.type],
@@ -415,7 +415,7 @@ if args.count:
 # read events
 else:
     # header
-    print("%-8s %-6s %-2s %-20s %1s> %-20s" % ("TIME", "PID", "IP",
+    print("%-8s %-7s %-2s %-20s %1s> %-20s" % ("TIME", "PID", "IP",
         "LADDR:LPORT", "T", "RADDR:RPORT"), end='')
     if args.sequence:
         print(" %-12s %-10s" % ("STATE", "SEQ"))

--- a/tools/tcptop.py
+++ b/tools/tcptop.py
@@ -281,14 +281,14 @@ while i != args.count and not exiting:
     ipv4_recv_bytes.clear()
 
     if ipv4_throughput:
-        print("%-6s %-12s %-21s %-21s %6s %6s" % ("PID", "COMM",
+        print("%-7s %-12s %-21s %-21s %6s %6s" % ("PID", "COMM",
             "LADDR", "RADDR", "RX_KB", "TX_KB"))
 
     # output
     for k, (send_bytes, recv_bytes) in sorted(ipv4_throughput.items(),
                                               key=lambda kv: sum(kv[1]),
                                               reverse=True):
-        print("%-6d %-12.12s %-21s %-21s %6d %6d" % (k.pid,
+        print("%-7d %-12.12s %-21s %-21s %6d %6d" % (k.pid,
             k.name,
             k.laddr + ":" + str(k.lport),
             k.daddr + ":" + str(k.dport),
@@ -308,14 +308,14 @@ while i != args.count and not exiting:
 
     if ipv6_throughput:
         # more than 80 chars, sadly.
-        print("\n%-6s %-12s %-32s %-32s %6s %6s" % ("PID", "COMM",
+        print("\n%-7s %-12s %-32s %-32s %6s %6s" % ("PID", "COMM",
             "LADDR6", "RADDR6", "RX_KB", "TX_KB"))
 
     # output
     for k, (send_bytes, recv_bytes) in sorted(ipv6_throughput.items(),
                                               key=lambda kv: sum(kv[1]),
                                               reverse=True):
-        print("%-6d %-12.12s %-32s %-32s %6d %6d" % (k.pid,
+        print("%-7d %-12.12s %-32s %-32s %6d %6d" % (k.pid,
             k.name,
             k.laddr + ":" + str(k.lport),
             k.daddr + ":" + str(k.dport),

--- a/tools/threadsnoop.py
+++ b/tools/threadsnoop.py
@@ -45,7 +45,7 @@ try:
 except Exception:
     b.attach_uprobe(name="c", sym="pthread_create", fn_name="do_entry")
 
-print("%-10s %-6s %-16s %s" % ("TIME(ms)", "PID", "COMM", "FUNC"))
+print("%-10s %-7s %-16s %s" % ("TIME(ms)", "PID", "COMM", "FUNC"))
 
 start_ts = 0
 
@@ -58,7 +58,7 @@ def print_event(cpu, data, size):
     func = b.sym(event.start, event.pid)
     if (func == "[unknown]"):
         func = hex(event.start)
-    print("%-10d %-6d %-16s %s" % ((event.ts - start_ts) / 1000000,
+    print("%-10d %-7d %-16s %s" % ((event.ts - start_ts) / 1000000,
         event.pid, event.comm, func))
 
 b["events"].open_perf_buffer(print_event)


### PR DESCRIPTION
The "kernel.pid_max" sysctl is now bumped to 4194304 by default, so 6 chars not enough for PID colume. Some tools use %6d, some use %7d. This patch try to unify PID column width by %7d (at most 7 chars).

```
# sysctl -a | grep pid_max
kernel.pid_max = 4194304
```