### PR TITLE
libbpf-tools: improve fentry_exists check

### DIFF
--- a/libbpf-tools/cachestat.c
+++ b/libbpf-tools/cachestat.c
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
 	 * account_page_dirtied was renamed to folio_account_dirtied
 	 * in kernel commit 203a31516616 ("mm/writeback: Add __folio_mark_dirty()")
 	 */
-	if (fentry_exists("folio_account_dirtied", NULL)) {
+	if (fentry_can_attach("folio_account_dirtied", NULL)) {
 		err = bpf_program__set_attach_target(obj->progs.account_page_dirtied, 0,
 						     "folio_account_dirtied");
 		if (err) {

--- a/libbpf-tools/fsdist.c
+++ b/libbpf-tools/fsdist.c
@@ -233,7 +233,7 @@ static bool check_fentry()
 	for (i = 0; i < MAX_OP; i++) {
 		fn_name = fs_configs[fs_type].op_funcs[i];
 		module = fs_configs[fs_type].fs;
-		if (fn_name && !fentry_exists(fn_name, module)) {
+		if (fn_name && !fentry_can_attach(fn_name, module)) {
 			support_fentry = false;
 			break;
 		}

--- a/libbpf-tools/fsslower.c
+++ b/libbpf-tools/fsslower.c
@@ -201,7 +201,7 @@ static bool check_fentry()
 	for (i = 0; i < MAX_OP; i++) {
 		fn_name = fs_configs[fs_type].op_funcs[i];
 		module = fs_configs[fs_type].fs;
-		if (fn_name && !fentry_exists(fn_name, module)) {
+		if (fn_name && !fentry_can_attach(fn_name, module)) {
 			support_fentry = false;
 			break;
 		}

--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -534,7 +534,7 @@ int main(int argc, char **argv)
 	obj->rodata->targ_pid = env.tid;
 	obj->rodata->targ_lock = lock_addr;
 
-	if (fentry_exists("mutex_lock_nested", NULL)) {
+	if (fentry_can_attach("mutex_lock_nested", NULL)) {
 		bpf_program__set_attach_target(obj->progs.mutex_lock, 0,
 					       "mutex_lock_nested");
 		bpf_program__set_attach_target(obj->progs.mutex_lock_exit, 0,

--- a/libbpf-tools/solisten.c
+++ b/libbpf-tools/solisten.c
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
 
 	obj->rodata->target_pid = target_pid;
 
-	if (fentry_exists("inet_listen", NULL)) {
+	if (fentry_can_attach("inet_listen", NULL)) {
 		bpf_program__set_autoload(obj->progs.inet_listen_entry, false);
 		bpf_program__set_autoload(obj->progs.inet_listen_exit, false);
 	} else {

--- a/libbpf-tools/tcprtt.c
+++ b/libbpf-tools/tcprtt.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv)
 	obj->rodata->targ_daddr = env.raddr;
 	obj->rodata->targ_ms = env.milliseconds;
 
-	if (fentry_exists("tcp_rcv_established", NULL))
+	if (fentry_can_attach("tcp_rcv_established", NULL))
 		bpf_program__set_autoload(obj->progs.tcp_rcv_kprobe, false);
 	else
 		bpf_program__set_autoload(obj->progs.tcp_rcv, false);

--- a/libbpf-tools/tcpsynbl.c
+++ b/libbpf-tools/tcpsynbl.c
@@ -124,14 +124,14 @@ static void disable_all_progs(struct tcpsynbl_bpf *obj)
 static void set_autoload_prog(struct tcpsynbl_bpf *obj, int version)
 {
 	if (version == 4) {
-		if (fentry_exists("tcp_v4_syn_recv_sock", NULL))
+		if (fentry_can_attach("tcp_v4_syn_recv_sock", NULL))
 			bpf_program__set_autoload(obj->progs.tcp_v4_syn_recv, true);
 		else
 			bpf_program__set_autoload(obj->progs.tcp_v4_syn_recv_kprobe, true);
 	}
 
 	if (version == 6){
-		if (fentry_exists("tcp_v6_syn_recv_sock", NULL))
+		if (fentry_can_attach("tcp_v6_syn_recv_sock", NULL))
 			bpf_program__set_autoload(obj->progs.tcp_v6_syn_recv, true);
 		else
 			bpf_program__set_autoload(obj->progs.tcp_v6_syn_recv_kprobe, true);

--- a/libbpf-tools/trace_helpers.h
+++ b/libbpf-tools/trace_helpers.h
@@ -77,7 +77,7 @@ bool is_kernel_module(const char *name);
  * *mod* is a hint that indicates the *name* may reside in module BTF,
  * if NULL, it means *name* belongs to vmlinux.
  */
-bool fentry_exists(const char *name, const char *mod);
+bool fentry_can_attach(const char *name, const char *mod);
 
 /*
  * The name of a kernel function to be attached to may be changed between

--- a/libbpf-tools/vfsstat.c
+++ b/libbpf-tools/vfsstat.c
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
 	}
 
 	/* It fallbacks to kprobes when kernel does not support fentry. */
-	if (vmlinux_btf_exists() && fentry_exists("vfs_read", NULL)) {
+	if (vmlinux_btf_exists() && fentry_can_attach("vfs_read", NULL)) {
 		bpf_program__set_autoload(skel->progs.kprobe_vfs_read, false);
 		bpf_program__set_autoload(skel->progs.kprobe_vfs_write, false);
 		bpf_program__set_autoload(skel->progs.kprobe_vfs_fsync, false);


### PR DESCRIPTION
On architectures that lack support for fentry programs, tools should
fall back to using kprobes even if the kernel version is new enough to
include BPF_TRACE_FENTRY, but fentry_exists() cannot currently detect
this case.

Add an additional check verifying that attaching a BPF_TRACE_FENTRY
program can actually succeed.

Signed-off-by: Connor O'Brien <connoro@google.com>