### PR TITLE
bcc: add method to close file descriptors

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1736,6 +1736,20 @@ class BPF(object):
     def donothing(self):
         """the do nothing exit handler"""
 
+
+    def close(self):
+        """close(self)
+
+        Closes all associated files descriptors. Attached BPF programs are not
+        detached.
+        """
+        for name, fn in list(self.funcs.items()):
+            os.close(fn.fd)
+            del self.funcs[name]
+        if self.module:
+            lib.bpf_module_destroy(self.module)
+            self.module = None
+
     def cleanup(self):
         # Clean up opened probes
         for k, v in list(self.kprobe_fds.items()):
@@ -1763,12 +1777,8 @@ class BPF(object):
         if self.tracefile:
             self.tracefile.close()
             self.tracefile = None
-        for name, fn in list(self.funcs.items()):
-            os.close(fn.fd)
-            del self.funcs[name]
-        if self.module:
-            lib.bpf_module_destroy(self.module)
-            self.module = None
+
+        self.close()
 
         # Clean up ringbuf
         if self._ringbuf_manager:


### PR DESCRIPTION
I have a long running process that attaches BPF programs to containers,
and I want those programs to stay attached after the BPF object goes out
of scope. After some time, the open file descriptors pile up and my
process starts failing since it cannot open new files.

This close() method allows me to create a BPF object, attach my
function, then close the associated file descriptors without detaching
the program.

Signed-off-by: Antonio Terceiro <antonio.terceiro@linaro.org>