### PR TITLE
tools: Flush stdout explicitly in event loop

### DIFF
--- a/tools/compactsnoop.py
+++ b/tools/compactsnoop.py
@@ -18,6 +18,7 @@ from bcc import BPF
 import argparse
 import platform
 from datetime import datetime, timedelta
+import sys
 
 # arguments
 examples = """examples:
@@ -389,6 +390,8 @@ def print_event(cpu, data, size):
             sym = b.ksym(addr, show_offset=True)
             print("\t%s" % sym)
         print("")
+
+    sys.stdout.flush()
 
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event, page_cnt=64)

--- a/tools/drsnoop.py
+++ b/tools/drsnoop.py
@@ -20,6 +20,7 @@ import argparse
 from datetime import datetime, timedelta
 import os
 import math
+import sys
 
 # symbols
 kallsyms = "/proc/kallsyms"
@@ -223,6 +224,8 @@ def print_event(cpu, data, size):
         print("%10d" % K(event.vm_stat[NR_FREE_PAGES]))
     else:
         print("")
+
+    sys.stdout.flush()
 
 
 # loop with callback to print_event

--- a/tools/hardirqs.py
+++ b/tools/hardirqs.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from bcc import BPF
 from time import sleep, strftime
 import argparse
+import sys
 
 # arguments
 examples = """examples:
@@ -247,6 +248,8 @@ while (1):
         for k, v in sorted(dist.items(), key=lambda dist: dist[1].value):
             print("%-26s %11d" % (k.name.decode('utf-8', 'replace'), v.value / factor))
     dist.clear()
+
+    sys.stdout.flush()
 
     countdown -= 1
     if exiting or countdown == 0:

--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -420,6 +420,7 @@ def print_event(mounts, umounts, parent, cpu, data, size):
                 print('{:16} {:<7} {:<7} {:<11} {}'.format(
                     syscall['comm'].decode('utf-8', 'replace'), syscall['tgid'],
                     syscall['pid'], syscall['mnt_ns'], call))
+        sys.stdout.flush()
     except KeyError:
         # This might happen if we lost an event.
         pass

--- a/tools/softirqs.py
+++ b/tools/softirqs.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 from bcc import BPF
 from time import sleep, strftime
 import argparse
+import sys
 
 # arguments
 examples = """examples:
@@ -174,6 +175,8 @@ while (1):
         for k, v in sorted(dist.items(), key=lambda dist: dist[1].value):
             print("%-16s %11d" % (vec_to_name(k.vec), v.value / factor))
     dist.clear()
+
+    sys.stdout.flush()
 
     countdown -= 1
     if exiting or countdown == 0:

--- a/tools/syncsnoop.py
+++ b/tools/syncsnoop.py
@@ -15,6 +15,7 @@
 
 from __future__ import print_function
 from bcc import BPF
+import sys
 
 # load BPF program
 b = BPF(text="""
@@ -40,6 +41,7 @@ print("%-18s %s" % ("TIME(s)", "CALL"))
 def print_event(cpu, data, size):
     event = b["events"].event(data)
     print("%-18.9f sync()" % (float(event.ts) / 1000000))
+    sys.stdout.flush()
 
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event)


### PR DESCRIPTION
When redirect output of hardirqs/softirqs to a file, line buffering (_IOLBF) switched to full buffering (_IOFBF), it may take dozens of seconds to see last output. hardirqs/softirqs write relatively less chars than other tools (such as biosnoop/opensnoop) each second, buffer filling causes poor real-time. For example:

```
/usr/share/bcc/tools/hardirqs -CT 1 > hardirqs.out
```
```
tail -f hardirqs.out

First Output
<after 30s>
Second Output
<after 34s>
Third Output
...
```

As ttysnoop/memleak/biolatpcts, this patch use stdout.flush() to flush stdout explicitly in event loop.

xxxsnoop tools (compactsnoop/drsnoop/mountsnoop/syncsnoop) with low frequency usually, also flush them.