### PR TITLE
tools/cpudist: Fix concurrency issue caused by idle threads & Exclude CPU idle time by default

### DIFF
--- a/man/man8/cpudist.8
+++ b/man/man8/cpudist.8
@@ -2,7 +2,7 @@
 .SH NAME
 cpudist \- On- and off-CPU task time as a histogram.
 .SH SYNOPSIS
-.B cpudist [\-h] [-O] [\-T] [\-m] [\-P] [\-L] [\-p PID] [interval] [count]
+.B cpudist [\-h] [-O] [\-T] [\-m] [\-P] [\-L] [\-p PID] [\-I] [interval] [count]
 .SH DESCRIPTION
 This measures the time a task spends on the CPU before being descheduled, and
 shows the times as a histogram. Tasks that spend a very short time on the CPU
@@ -14,6 +14,8 @@ Similarly, the tool can also measure the time a task spends off-CPU before it
 is scheduled again. This can be helpful in identifying long blocking and I/O
 operations, or alternatively very short descheduling times due to short-lived
 locks or timers.
+
+By default CPU idle time are excluded by simply excluding PID 0.
 
 This tool uses in-kernel eBPF maps for storing timestamps and the histogram,
 for efficiency. Despite this, the overhead of this tool may become significant
@@ -45,6 +47,9 @@ Print a histogram for each TID (pid from the kernel's perspective).
 \-p PID
 Only show this PID (filtered in kernel for efficiency).
 .TP
+\-I
+Include CPU idle time (by default these are excluded).
+.TP
 interval
 Output interval, in seconds.
 .TP
@@ -71,6 +76,10 @@ Print 1 second summaries, using milliseconds as units for the histogram, and inc
 Trace PID 185 only, 1 second summaries:
 #
 .B cpudist -p 185 1
+.TP
+Include CPU idle time:
+#
+.B cpudist -I
 .SH FIELDS
 .TP
 usecs

--- a/tools/cpudist_example.txt
+++ b/tools/cpudist_example.txt
@@ -6,6 +6,8 @@ that can indicate oversubscription (too many tasks for too few processors),
 overhead due to excessive context switching (e.g. a common shared lock for
 multiple threads), uneven workload distribution, too-granular tasks, and more.
 
+By default CPU idle time are excluded by simply excluding PID 0.
+
 Alternatively, the same options are available for summarizing task off-CPU
 time, which helps understand how often threads are being descheduled and how
 long they spend waiting for I/O, locks, timers, and other causes of suspension.
@@ -280,7 +282,7 @@ USAGE message:
 
 # ./cpudist.py -h
 
-usage: cpudist.py [-h] [-O] [-T] [-m] [-P] [-L] [-p PID] [interval] [count]
+usage: cpudist.py [-h] [-O] [-T] [-m] [-P] [-L] [-p PID] [-I] [interval] [count]
 
 Summarize on-CPU time per task as a histogram.
 
@@ -296,6 +298,7 @@ optional arguments:
   -P, --pids          print a histogram per process ID
   -L, --tids          print a histogram per thread ID
   -p PID, --pid PID   trace this PID only
+  -I, --include-idle  include CPU idle time
 
 examples:
     cpudist              # summarize on-CPU time as a histogram
@@ -304,3 +307,5 @@ examples:
     cpudist -mT 1        # 1s summaries, milliseconds, and timestamps
     cpudist -P           # show each PID separately
     cpudist -p 185       # trace PID 185 only
+    cpudist -I           # include CPU idle time
+


### PR DESCRIPTION
1. Fix concurrency issue caused by idle threads

Like #2804, #3740, pid as key not be suitable for multiple idle threads (pid = 0), which may lead to incorrect delta time.  Combines cpu and pid as unique key to avoid this issue.

2. Exclude CPU idle time by default

Currently, cpudist includes CPU idle time by default. When idle threads (pid = 0) mixed with other threads (pid != 0), the output of cpudist is not clear enough, CPU time distribution of idle threads are usually very large on a not busy system (hundreds of milliseconds, even > 1s). 

For example：
```
# ./cpudist.py -Tm 1

14:45:36
     msecs               : count     distribution
         0 -> 1          : 676      |****************************************|
         2 -> 3          : 18       |*                                       |
         4 -> 7          : 119      |*******                                 |
         8 -> 15         : 74       |****                                    |
        16 -> 31         : 52       |***                                     |
        32 -> 63         : 175      |**********                              |
        64 -> 127        : 34       |**                                      |
       128 -> 255        : 9        |                                        |
       256 -> 511        : 10       |                                        |
       512 -> 1023       : 11       |                                        |
      1024 -> 2047       : 3        |                                        |
      2048 -> 4095       : 36       |**                                      |

14:45:37
     msecs               : count     distribution
         0 -> 1          : 739      |****************************************|
         2 -> 3          : 12       |                                        |
         4 -> 7          : 115      |******                                  |
         8 -> 15         : 76       |****                                    |
        16 -> 31         : 46       |**                                      |
        32 -> 63         : 191      |**********                              |
        64 -> 127        : 39       |**                                      |
       128 -> 255        : 2        |                                        |
       256 -> 511        : 7        |                                        |
       512 -> 1023       : 18       |                                        |
```

As #2166,  exclude CPU idle time by default, simply check whether pid == 0.  Add option -I to include CPU idle time (same as before).

Also, runqlat excludes idle threads directly (#1741).

After excluding CPU idle time by default, for example, the output looks simple and clear:
```
# ./cpudist.py -Tm 1

14:48:02
     msecs               : count     distribution
         0 -> 1          : 519      |****************************************|
         2 -> 3          : 1        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 2        |                                        |

14:48:03
     msecs               : count     distribution
         0 -> 1          : 540      |****************************************|
         2 -> 3          : 1        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 2        |                                        |
```

@yonghong-song @brendangregg Please take a look this patch, thanks!