### PR TITLE
libbpf-tools: Fix dropped request->rq_disk for kernel 5.17+

### DIFF
--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -15,6 +15,10 @@ const volatile __u32 targ_dev = 0;
 
 extern __u32 LINUX_KERNEL_VERSION __kconfig;
 
+struct request_queue___x {
+	struct gendisk *disk;
+} __attribute__((preserve_access_index));
+
 struct {
 	__uint(type, BPF_MAP_TYPE_CGROUP_ARRAY);
 	__type(key, u32);
@@ -92,7 +96,13 @@ int trace_rq_start(struct request *rq, bool insert)
 
 	stagep = bpf_map_lookup_elem(&start, &rq);
 	if (!stagep) {
-		struct gendisk *disk = BPF_CORE_READ(rq, rq_disk);
+		struct request_queue___x *q = (void *)BPF_CORE_READ(rq, q);
+		struct gendisk *disk;
+
+		if (bpf_core_field_exists(q->disk))
+			disk = BPF_CORE_READ(q, disk);
+		else
+			disk = BPF_CORE_READ(rq, rq_disk);
 
 		stage.dev = disk ? MKDEV(BPF_CORE_READ(disk, major),
 				BPF_CORE_READ(disk, first_minor)) : 0;


### PR DESCRIPTION
Since 5.17, The Linux kernel has dropped request->rq_disk, use request->q->disk instead. tools/bioxxx had been fixed not long ago, this patch try to fix libbpf-tools/bioxxx.