### PR TITLE
Fix test_bcc_fedora CI failure

### DIFF
--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -33,6 +33,8 @@ RUN dnf -y install \
 	python3 \
 	python3-pip
 
+RUN ln -s $(readlink /usr/bin/python3) /usr/bin/python
+
 RUN dnf -y install \
 	procps \
 	iputils \


### PR DESCRIPTION
```
timeout: failed to run command ‘/bcc/tools/argdist.py’: No such file or directory
...
```

The reason for test_bcc_fedora CI failure is that argdist.py and other tools use '#!/usr/bin/python' as interpreter, but /usr/bin/python does not exist in fedora:34 latest image (recently changed), only /usr/bin/python3 exists. Whereas, /usr/bin/python exists in ubuntu image, which refers to /usr/bin/python -> /bin/python3 -> python3.8.

This patch try to create a symbolic links (/usr/bin/python -> python3.9) when building BCC fedora image.

All checks have passed now, please take a look at it. @yonghong-song @davemarchevsky 