### PR TITLE
examples: Use pid as filter instead of tid and make some improvements for stacksnoop.py

### DIFF
--- a/examples/tracing/stacksnoop.py
+++ b/examples/tracing/stacksnoop.py
@@ -13,7 +13,6 @@
 from __future__ import print_function
 from bcc import BPF
 import argparse
-import ctypes as ct
 import time
 
 # arguments
@@ -79,13 +78,6 @@ b.attach_kprobe(event=function, fn_name="trace_stack")
 
 TASK_COMM_LEN = 16  # linux/sched.h
 
-class Data(ct.Structure):
-    _fields_ = [
-        ("stack_id", ct.c_ulonglong),
-        ("pid", ct.c_uint),
-        ("comm", ct.c_char * TASK_COMM_LEN),
-    ]
-
 matched = b.num_open_kprobes()
 if matched == 0:
     print("Function \"%s\" not found. Exiting." % function)
@@ -102,18 +94,18 @@ else:
     print("%-18s %s" % ("TIME(s)", "FUNCTION"))
 
 def print_event(cpu, data, size):
-    event = ct.cast(data, ct.POINTER(Data)).contents
+    event = b["events"].event(data)
 
     ts = time.time() - start_ts
 
     if verbose:
         print("%-18.9f %-12.12s %-6d %-3d %s" %
-              (ts, event.comm.decode(), event.pid, cpu, function))
+              (ts, event.comm.decode('utf-8', 'replace'), event.pid, cpu, function))
     else:
         print("%-18.9f %s" % (ts, function))
 
     for addr in stack_traces.walk(event.stack_id):
-        sym = b.ksym(addr, show_offset=offset)
+        sym = b.ksym(addr, show_offset=offset).decode('utf-8', 'replace')
         print("\t%s" % sym)
 
     print()

--- a/examples/tracing/stacksnoop.py
+++ b/examples/tracing/stacksnoop.py
@@ -18,9 +18,9 @@ import time
 
 # arguments
 examples = """examples:
-    ./stacksnoop ext4_sync_fs    # print kernel stack traces for ext4_sync_fs
-    ./stacksnoop -s ext4_sync_fs    # ... also show symbol offsets
-    ./stacksnoop -v ext4_sync_fs    # ... show extra columns
+    ./stacksnoop ext4_sync_fs           # print kernel stack traces for ext4_sync_fs
+    ./stacksnoop -s ext4_sync_fs        # ... also show symbol offsets
+    ./stacksnoop -v ext4_sync_fs        # ... show extra columns
     ./stacksnoop -p 185 ext4_sync_fs    # ... only when PID 185 is on-CPU
 """
 parser = argparse.ArgumentParser(
@@ -56,7 +56,7 @@ BPF_STACK_TRACE(stack_traces, 128);
 BPF_PERF_OUTPUT(events);
 
 void trace_stack(struct pt_regs *ctx) {
-    u32 pid = bpf_get_current_pid_tgid();
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
     FILTER
     struct data_t data = {};
     data.stack_id = stack_traces.get_stackid(ctx, 0),

--- a/examples/tracing/vfsreadlat.py
+++ b/examples/tracing/vfsreadlat.py
@@ -17,7 +17,6 @@
 
 from __future__ import print_function
 from bcc import BPF
-from ctypes import c_ushort, c_int, c_ulonglong
 from time import sleep
 from sys import argv
 


### PR DESCRIPTION
For examples/stacksnoop.py:
- Use pid as filter instead of tid, keep consistent with -p option of other tools.
- Make some improvements (remove ctypes & 'b' prefixes).