### PR TITLE
tools/mdflush: Fix CI build failure

### DIFF
--- a/tools/mdflush.py
+++ b/tools/mdflush.py
@@ -15,8 +15,8 @@ from __future__ import print_function
 from bcc import BPF
 from time import strftime
 
-# load BPF program
-b = BPF(text="""
+# define BPF program
+bpf_text="""
 #include <uapi/linux/ptrace.h>
 #include <linux/sched.h>
 #include <linux/genhd.h>
@@ -36,14 +36,14 @@ int kprobe__md_flush_request(struct pt_regs *ctx, void *mddev, struct bio *bio)
     data.pid = pid;
     bpf_get_current_comm(&data.comm, sizeof(data.comm));
 /*
- * The following deals with a kernel version change (in mainline 4.14, although
+ * The following deals with kernel version changes (in mainline 4.14 and 5.12, although
  * it may be backported to earlier kernels) with how the disk name is accessed.
  * We handle both pre- and post-change versions here. Please avoid kernel
  * version tests like this as much as possible: they inflate the code, test,
  * and maintenance burden.
  */
 #ifdef bio_dev
-    struct gendisk *bi_disk = bio->bi_disk;
+    struct gendisk *bi_disk = bio->__BI_DISK__;
 #else
     struct gendisk *bi_disk = bio->bi_bdev->bd_disk;
 #endif
@@ -51,7 +51,15 @@ int kprobe__md_flush_request(struct pt_regs *ctx, void *mddev, struct bio *bio)
     events.perf_submit(ctx, &data, sizeof(data));
     return 0;
 }
-""")
+"""
+
+if BPF.kernel_struct_has_field('bio', 'bi_bdev') == 1:
+    bpf_text = bpf_text.replace('__BI_DISK__', 'bi_bdev->bd_disk')
+else:
+    bpf_text = bpf_text.replace('__BI_DISK__', 'bi_disk')
+
+# initialize BPF
+b = BPF(text=bpf_text)
 
 # header
 print("Tracing md flush requests... Hit Ctrl-C to end.")


### PR DESCRIPTION
CI failed due to the following error (in mdflush.py, bio->bi_disk not found). I guess CI runtime env (such as kernel version) had changed in recent days.

```
error: no member named 'bi_disk' in 'struct bio'
     struct gendisk *bi_disk = bio->bi_disk;
                              ~~~  ^
1 error generated.
Traceback (most recent call last):
   File "/bcc/tools/mdflush.py", line 54, in <module>
```

Before kernel 4.14, stay the same, just use bio->bi_bdev->bd_disk.
Since kernel 4.14, macro bio_dev begin to appear, which refers to bio->bi_disk. 
Since kernel 5.12, macro bio_dev has changed to bio->bi_bdev->bd_disk (bio->bi_bdev changed back). So, just use '#ifdef bio_dev' could not make the right choice under higher kernel version.

This patch try to fix this error. Please take a look. @davemarchevsky @yonghong-song 