### PR TITLE
Add rwsem support to klockstat

### DIFF
--- a/libbpf-tools/klockstat.bpf.c
+++ b/libbpf-tools/klockstat.bpf.c
@@ -13,7 +13,7 @@
 
 const volatile pid_t targ_tgid = 0;
 const volatile pid_t targ_pid = 0;
-struct mutex *const volatile targ_lock = NULL;
+void *const volatile targ_lock = NULL;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
@@ -72,7 +72,7 @@ static bool tracing_task(u64 task_id)
 	return true;
 }
 
-static void lock_contended(void *ctx, struct mutex *lock)
+static void lock_contended(void *ctx, void *lock)
 {
 	u64 task_id;
 	struct lockholder_info li[1] = {0};
@@ -107,7 +107,7 @@ static void lock_contended(void *ctx, struct mutex *lock)
 	bpf_map_update_elem(&lockholder_map, &tl, li, BPF_ANY);
 }
 
-static void lock_aborted(struct mutex *lock)
+static void lock_aborted(void *lock)
 {
 	u64 task_id;
 	struct task_lock tl = {};
@@ -122,7 +122,7 @@ static void lock_aborted(struct mutex *lock)
 	bpf_map_delete_elem(&lockholder_map, &tl);
 }
 
-static void lock_acquired(struct mutex *lock)
+static void lock_acquired(void *lock)
 {
 	u64 task_id;
 	struct lockholder_info *li;
@@ -188,7 +188,7 @@ static void account(struct lockholder_info *li)
 	}
 }
 
-static void lock_released(struct mutex *lock)
+static void lock_released(void *lock)
 {
 	u64 task_id;
 	struct lockholder_info *li;

--- a/libbpf-tools/klockstat.bpf.c
+++ b/libbpf-tools/klockstat.bpf.c
@@ -151,7 +151,8 @@ static void account(struct lockholder_info *li)
 	/*
 	 * Multiple threads may have the same stack_id.  Even though we are
 	 * holding the lock, dynamically allocated mutexes can have the same
-	 * callgraph but represent different locks.  They will be accounted as
+	 * callgraph but represent different locks.  Also, a rwsem can be held
+	 * by multiple readers at the same time.  They will be accounted as
 	 * the same lock, which is what we want, but we need to use atomics to
 	 * avoid corruption, especially for the total_time variables.
 	 */
@@ -271,6 +272,119 @@ int BPF_PROG(mutex_lock_killable_exit, struct mutex *lock, long ret)
 
 SEC("fentry/mutex_unlock")
 int BPF_PROG(mutex_unlock, struct mutex *lock)
+{
+	lock_released(lock);
+	return 0;
+}
+
+SEC("fentry/down_read")
+int BPF_PROG(down_read, struct rw_semaphore *lock)
+{
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("fexit/down_read")
+int BPF_PROG(down_read_exit, struct rw_semaphore *lock, long ret)
+{
+	lock_acquired(lock);
+	return 0;
+}
+
+SEC("fexit/down_read_trylock")
+int BPF_PROG(down_read_trylock_exit, struct rw_semaphore *lock, long ret)
+{
+	if (ret == 1) {
+		lock_contended(ctx, lock);
+		lock_acquired(lock);
+	}
+	return 0;
+}
+
+SEC("fentry/down_read_interruptible")
+int BPF_PROG(down_read_interruptible, struct rw_semaphore *lock)
+{
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("fexit/down_read_interruptible")
+int BPF_PROG(down_read_interruptible_exit, struct rw_semaphore *lock, long ret)
+{
+	if (ret)
+		lock_aborted(lock);
+	else
+		lock_acquired(lock);
+	return 0;
+}
+
+SEC("fentry/down_read_killable")
+int BPF_PROG(down_read_killable, struct rw_semaphore *lock)
+{
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("fexit/down_read_killable")
+int BPF_PROG(down_read_killable_exit, struct rw_semaphore *lock, long ret)
+{
+	if (ret)
+		lock_aborted(lock);
+	else
+		lock_acquired(lock);
+	return 0;
+}
+
+SEC("fentry/up_read")
+int BPF_PROG(up_read, struct rw_semaphore *lock)
+{
+	lock_released(lock);
+	return 0;
+}
+
+SEC("fentry/down_write")
+int BPF_PROG(down_write, struct rw_semaphore *lock)
+{
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("fexit/down_write")
+int BPF_PROG(down_write_exit, struct rw_semaphore *lock, long ret)
+{
+	lock_acquired(lock);
+	return 0;
+}
+
+SEC("fexit/down_write_trylock")
+int BPF_PROG(down_write_trylock_exit, struct rw_semaphore *lock, long ret)
+{
+	if (ret == 1) {
+		lock_contended(ctx, lock);
+		lock_acquired(lock);
+	}
+	return 0;
+}
+
+SEC("fentry/down_write_killable")
+int BPF_PROG(down_write_killable, struct rw_semaphore *lock)
+{
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("fexit/down_write_killable")
+int BPF_PROG(down_write_killable_exit, struct rw_semaphore *lock, long ret)
+{
+	if (ret)
+		lock_aborted(lock);
+	else
+		lock_acquired(lock);
+	return 0;
+}
+
+SEC("fentry/up_write")
+int BPF_PROG(up_write, struct rw_semaphore *lock)
 {
 	lock_released(lock);
 	return 0;


### PR DESCRIPTION
Hello,

This PR adds rwsem support to libbpf-tools/klockstat.  For kernel lock debugging, I found it useful to track rwsem as well as mutex.  This doesn't distinguish read and write to rwsem in the logic but users can see it in the caller info.

Example:
```
$ sudo klockstat -n 3 -s 3
Tracing mutex/rwsem lock events...  Hit Ctrl-C to end
^C

                               Caller  Avg Wait    Count   Max Wait   Total Wait
                       mutex_lock+0x5      1422      791      15628      1125030
                  do_epoll_wait+0x1ce
            do_epoll_pwait.part.0+0xc
                              Max PID 2441, COMM murdockd

                               Caller  Avg Wait    Count   Max Wait   Total Wait
                       mutex_lock+0x5      1699      465      14471       790264
                  do_epoll_wait+0x1ce
            __x64_sys_epoll_wait+0x60
                              Max PID 1864873, COMM svw_NetThreadEv

                               Caller  Avg Wait    Count   Max Wait   Total Wait
                       mutex_lock+0x5      1559      144       2106       224575
                      pipe_write+0x47
                 new_sync_write+0x199
                              Max PID 2441, COMM murdockd

                               Caller  Avg Hold    Count   Max Hold   Total Hold
                down_read_trylock+0x5   1888876        5    9109738      9444384
                   trylock_super+0x16
           __writeback_inodes_wb+0x8d
                              Max PID 3744442, COMM kworker/u145:6

                               Caller  Avg Hold    Count   Max Hold   Total Hold
                       mutex_lock+0x5   2350695       15    2593128     35260434
        bpf_tracing_prog_attach+0x34b
        bpf_raw_tracepoint_open+0x1c4
                              Max PID 3748530, COMM klockstat

                               Caller  Avg Hold    Count   Max Hold   Total Hold
                       mutex_lock+0x5   2510333        8    2590270     20082666
       bpf_trampoline_link_prog+0x18b
        bpf_tracing_prog_attach+0x1e8
                              Max PID 3748530, COMM klockstat
Exiting trace of mutex/rwsem locks
```