### PR TITLE
Refix test_bcc_fedora CI failure

### DIFF
--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -33,7 +33,9 @@ RUN dnf -y install \
 	python3 \
 	python3-pip
 
-RUN ln -s $(readlink /usr/bin/python3) /usr/bin/python
+RUN if [[ ! -e /usr/bin/python && -e /usr/bin/python3 ]]; then \
+        ln -s $(readlink /usr/bin/python3) /usr/bin/python; \
+    fi
 
 RUN dnf -y install \
 	procps \


### PR DESCRIPTION
Aha, test_bcc_fedora CI failed again, due to fedora image had been changed recently, /usr/bin/python comes back!

```
Step 5/7 : RUN ln -s $(readlink /usr/bin/python3) /usr/bin/python
 ---> Running in 039641fabbda
ln: failed to create symbolic link '/usr/bin/python': File exists
The command '/bin/sh -c ln -s $(readlink /usr/bin/python3) /usr/bin/python' returned a non-zero code: 1
```

This patch try to fix it. @davemarchevsky please take a look, thanks.