### PR TITLE
libbpf-tools/klockstat: Remove compilation warnings and consequent se…

### DIFF
--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -10,13 +10,13 @@
  *     when '-s' > 1 (otherwise it's cluttered).
  * - does not reset stats each interval by default. Can request with -R.
  */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <argp.h>
 #include <errno.h>
 #include <signal.h>
 #include <stdio.h>
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>


### PR DESCRIPTION
…gfault

There are compilation warnings and consequent segfault.
Relocate the definition of _GNU_SOURCE to the top of the header to fix it.

klockstat.c:404:12: warning: implicit declaration of function ‘reallocarray’; did you mean ‘realloc’? [-Wimplicit-function-declaration]
		stats = reallocarray(stats, stats_sz, sizeof(void *));
						^~~~~~~~~~~~
						realloc
klockstat.c:404:10: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
		stats = reallocarray(stats, stats_sz, sizeof(void *));

Signed-off-by: Eunseon Lee <es.lee@lge.com>