### PR TITLE
bcc/usdt: Fix returning address of local temporary object

### DIFF
--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -66,6 +66,7 @@ public:
 
   int arg_size() const { return arg_size_.value_or(sizeof(void *)); }
   std::string ctype() const;
+  const char *ctype_name() const;
 
   const optional<std::string> &deref_ident() const { return deref_ident_; }
   const optional<std::string> &base_register_name() const {
@@ -228,7 +229,7 @@ class Probe {
   optional<uint64_t> attached_semaphore_;
   uint8_t mod_match_inode_only_;
 
-  std::string largest_arg_type(size_t arg_n);
+  const char *largest_arg_type(size_t arg_n);
 
   bool add_to_semaphore(int16_t val);
   bool resolve_global_address(uint64_t *global, const std::string &bin_path,
@@ -253,6 +254,10 @@ public:
   bool usdt_getarg(std::ostream &stream);
   bool usdt_getarg(std::ostream &stream, const std::string& probe_func);
   std::string get_arg_ctype(int arg_index) {
+    return largest_arg_type(arg_index);
+  }
+
+  const char *get_arg_ctype_name(int arg_index) {
     return largest_arg_type(arg_index);
   }
 

--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -149,7 +149,7 @@ bool Probe::disable() {
   return true;
 }
 
-std::string Probe::largest_arg_type(size_t arg_n) {
+const char *Probe::largest_arg_type(size_t arg_n) {
   Argument *largest = nullptr;
   for (Location &location : locations_) {
     Argument *candidate = &location.arguments_[arg_n];
@@ -159,7 +159,7 @@ std::string Probe::largest_arg_type(size_t arg_n) {
   }
 
   assert(largest);
-  return largest->ctype();
+  return largest->ctype_name();
 }
 
 bool Probe::usdt_getarg(std::ostream &stream) {
@@ -556,7 +556,7 @@ const char *bcc_usdt_get_probe_argctype(
 ) {
   USDT::Probe *p = static_cast<USDT::Context *>(ctx)->get(probe_name);
   if (p)
-    return p->get_arg_ctype(arg_index).c_str();
+    return p->get_arg_ctype_name(arg_index);
   return "";
 }
 
@@ -565,7 +565,7 @@ const char *bcc_usdt_get_fully_specified_probe_argctype(
 ) {
   USDT::Probe *p = static_cast<USDT::Context *>(ctx)->get(provider_name, probe_name);
   if (p)
-    return p->get_arg_ctype(arg_index).c_str();
+    return p->get_arg_ctype_name(arg_index);
   return "";
 }
 

--- a/src/cc/usdt/usdt_args.cc
+++ b/src/cc/usdt/usdt_args.cc
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cmath>
 #include <unordered_map>
 #include <regex>
 
@@ -31,6 +32,17 @@ Argument::~Argument() {}
 std::string Argument::ctype() const {
   const int s = arg_size() * 8;
   return (s < 0) ? tfm::format("int%d_t", -s) : tfm::format("uint%d_t", s);
+}
+
+static const char *type_names[][4] = {
+  { "int8_t", "int16_t", "int32_t", "int64_t" },
+  { "uint8_t", "uint16_t", "uint32_t", "uint64_t" },
+};
+
+const char *Argument::ctype_name() const {
+  const int s = arg_size();
+  const int r = log2(abs(s));
+  return s < 0 ? type_names[0][r] : type_names[1][r];
 }
 
 bool Argument::get_global_address(uint64_t *address, const std::string &binpath,


### PR DESCRIPTION
When compiling BCC with clang++, it reports the following warning:

    warning: returning address of local temporary object [-Wreturn-stack-address]

Fixes it by returning a statically allocated `const char *`.

Closes #3949.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>