### PR TITLE
tools: Fix misuse of BPF.kernel_struct_has_field in bio* tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,25 @@ enable_testing()
 
 # populate submodules (libbpf)
 if(NOT CMAKE_USE_LIBBPF_PACKAGE)
+   execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR}
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                   RESULT_VARIABLE CONFIG_RESULT)
+   if(CONFIG_RESULT AND NOT CONFIG_RESULT EQUAL 0)
+     message(WARNING "Failed to add root source directory to safe.directory")
+   endif()
+   execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                   RESULT_VARIABLE CONFIG_RESULT)
+   if(CONFIG_RESULT AND NOT CONFIG_RESULT EQUAL 0)
+     message(WARNING "Failed to add libbpf source directory to safe.directory")
+   endif()
+   execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR}/libbpf-tools/bpftool
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                   RESULT_VARIABLE CONFIG_RESULT)
+   if(CONFIG_RESULT AND NOT CONFIG_RESULT EQUAL 0)
+     message(WARNING "Failed to add bpftool source directory to safe.directory")
+   endif()
+
    if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/src)
 	execute_process(COMMAND git submodule update --init --recursive
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -134,7 +134,7 @@ if args.disks:
     bpf_probe_read(&key.disk, sizeof(key.disk), __tmp);
     dist.atomic_increment(key);
     """
-    if BPF.kernel_struct_has_field(b'request', b'rq_disk'):
+    if BPF.kernel_struct_has_field(b'request', b'rq_disk') == 1:
         store_str += disks_str.replace('__RQ_DISK__', 'rq_disk')
     else:
         store_str += disks_str.replace('__RQ_DISK__', 'q->disk')

--- a/tools/biolatpcts.py
+++ b/tools/biolatpcts.py
@@ -142,7 +142,7 @@ bpf_source = bpf_source.replace('__START_TIME_FIELD__', start_time_field)
 bpf_source = bpf_source.replace('__MAJOR__', str(major))
 bpf_source = bpf_source.replace('__MINOR__', str(minor))
 
-if BPF.kernel_struct_has_field(b'request', b'rq_disk'):
+if BPF.kernel_struct_has_field(b'request', b'rq_disk') == 1:
     bpf_source = bpf_source.replace('__RQ_DISK__', 'rq_disk')
 else:
     bpf_source = bpf_source.replace('__RQ_DISK__', 'q->disk')

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -156,7 +156,7 @@ if args.queue:
     bpf_text = bpf_text.replace('##QUEUE##', '1')
 else:
     bpf_text = bpf_text.replace('##QUEUE##', '0')
-if BPF.kernel_struct_has_field(b'request', b'rq_disk'):
+if BPF.kernel_struct_has_field(b'request', b'rq_disk') == 1:
     bpf_text = bpf_text.replace('__RQ_DISK__', 'rq_disk')
 else:
     bpf_text = bpf_text.replace('__RQ_DISK__', 'q->disk')

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -194,7 +194,7 @@ if args.ebpf:
     print(bpf_text)
     exit()
 
-if BPF.kernel_struct_has_field(b'request', b'rq_disk'):
+if BPF.kernel_struct_has_field(b'request', b'rq_disk') == 1:
     bpf_text = bpf_text.replace('__RQ_DISK__', 'rq_disk')
 else:
     bpf_text = bpf_text.replace('__RQ_DISK__', 'q->disk')


### PR DESCRIPTION
BPF.kernel_struct_has_field possible return values: -1 (not support BTF), 1 (has a specified field), 0 (has no specified field).
This patch try to fix current flaws.