### PR TITLE
[Man Page]: Add missing entry of -T & -h in man page along with example

### DIFF
--- a/man/man8/swapin.8
+++ b/man/man8/swapin.8
@@ -3,6 +3,12 @@
 swapin \- Count swapins by process. Uses BCC/eBPF.
 .SH SYNOPSIS
 .B swapin
+.TP
+.BR \-h ", " \-\-help\fR
+show this help message and exit
+.TP
+.BR \-T ", " \-\-notime\fR
+do not show the timestamp (HH:MM:SS)
 .SH DESCRIPTION
 This tool counts swapins by process, to show which process is affected by
 swapping (if swap devices are in use). This can explain a significant source

--- a/tools/swapin_example.txt
+++ b/tools/swapin_example.txt
@@ -30,6 +30,27 @@ gnome-shell      2239   2496
 While tracing, this showed that PID 2239 (gnome-shell) and PID 4536 (chrome)
 suffered over ten thousand swapins.
 
+#swapin.py -T
+Counting swap ins. Ctrl-C to end.
+COMM             PID    COUNT
+b'firefox'       60965  4
+
+COMM             PID    COUNT
+b'IndexedDB #1'  60965  1
+b'firefox'       60965  2
+
+COMM             PID    COUNT
+b'StreamTrans #9' 60965  1
+b'firefox'       60965  3
+
+COMM             PID    COUNT
+
+COMM             PID    COUNT
+b'sssd_kcm'      3605   384
+[--]
+
+While tracing along with -T flag, it does not show timestamp.
+
 
 
 USAGE:


### PR DESCRIPTION
swapin: Adding missing entries of -T/ -h flag on the man page. The -T/ --notime flag does not show the timestamp (HH:MM:SS). In addition, -h/ --help shows the help message.

Signed-off-by: Vaibhav Nagare <nagarevaibhav@gmail.com>