### PR TITLE
profile-manpage: Add missing flag "-C" in the SYNOPSIS section of the man page

### DIFF
--- a/man/man8/offwaketime.8
+++ b/man/man8/offwaketime.8
@@ -2,7 +2,7 @@
 .SH NAME
 offwaketime \- Summarize blocked time by off-CPU stack + waker stack. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B offwaketime [\-h] [\-p PID | \-t TID | \-u | \-k] [\-U | \-K] [\-f] [\-\-stack-storage-size STACK_STORAGE_SIZE] [\-m MIN_BLOCK_TIME] [\-M MAX_BLOCK_TIME] [\-\-state STATE] [duration]
+.B offwaketime [\-h] [\-p PID | \-t TID | \-u | \-k] [\-U | \-K] [\-d] [\-f] [\-\-stack-storage-size STACK_STORAGE_SIZE] [\-m MIN_BLOCK_TIME] [\-M MAX_BLOCK_TIME] [\-\-state STATE] [duration]
 .SH DESCRIPTION
 This program shows kernel stack traces and task names that were blocked and
 "off-CPU", along with the stack traces and task names for the threads that woke
@@ -54,6 +54,9 @@ Show stacks from user space only (no kernel space stacks).
 .TP
 \-K
 Show stacks from kernel space only (no user space stacks).
+.TP
+\-d, --delimited
+insert delimiter between kernel/user stacks
 .TP
 \-\-stack-storage-size STACK_STORAGE_SIZE
 Change the number of unique stack traces that can be stored and displayed.

--- a/man/man8/profile.8
+++ b/man/man8/profile.8
@@ -3,7 +3,7 @@
 profile \- Profile CPU usage by sampling stack traces. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B profile [\-adfh] [\-p PID | \-L TID] [\-U | \-K] [\-F FREQUENCY | \-c COUNT]
-.B [\-\-stack\-storage\-size COUNT] [\-\-cgroupmap CGROUPMAP] [\-\-mntnsmap MAPPATH] [duration]
+.B [\-\-stack\-storage\-size COUNT] [\-C CPU] [\-\-cgroupmap CGROUPMAP] [\-\-mntnsmap MAPPATH] [duration]
 .SH DESCRIPTION
 This is a CPU profiler. It works by taking samples of stack traces at timed
 intervals. It will help you understand and quantify CPU usage: which code is

--- a/man/man8/swapin.8
+++ b/man/man8/swapin.8
@@ -3,6 +3,12 @@
 swapin \- Count swapins by process. Uses BCC/eBPF.
 .SH SYNOPSIS
 .B swapin
+.TP
+.BR \-h ", " \-\-help\fR
+show this help message and exit
+.TP
+.BR \-T ", " \-\-notime\fR
+do not show the timestamp (HH:MM:SS)
 .SH DESCRIPTION
 This tool counts swapins by process, to show which process is affected by
 swapping (if swap devices are in use). This can explain a significant source

--- a/tools/swapin_example.txt
+++ b/tools/swapin_example.txt
@@ -30,6 +30,27 @@ gnome-shell      2239   2496
 While tracing, this showed that PID 2239 (gnome-shell) and PID 4536 (chrome)
 suffered over ten thousand swapins.
 
+#swapin.py -T
+Counting swap ins. Ctrl-C to end.
+COMM             PID    COUNT
+b'firefox'       60965  4
+
+COMM             PID    COUNT
+b'IndexedDB #1'  60965  1
+b'firefox'       60965  2
+
+COMM             PID    COUNT
+b'StreamTrans #9' 60965  1
+b'firefox'       60965  3
+
+COMM             PID    COUNT
+
+COMM             PID    COUNT
+b'sssd_kcm'      3605   384
+[--]
+
+While tracing along with -T flag, it does not show timestamp.
+
 
 
 USAGE:


### PR DESCRIPTION
-C CPU is missing in the SYNOPSIS section of the man page