### PR TITLE
swapin: Fixed the spelling mistake of funciton to function

### DIFF
--- a/man/man8/biosnoop.8
+++ b/man/man8/biosnoop.8
@@ -28,7 +28,7 @@ CONFIG_BPF and bcc.
 Print usage message.
 .TP
 \-Q
-Include a column showing the time spent quueued in the OS.
+Include a column showing the time spent queued in the OS.
 .SH EXAMPLES
 .TP
 Trace all block device I/O and print a summary line per I/O:

--- a/man/man8/bitesize.8
+++ b/man/man8/bitesize.8
@@ -6,7 +6,7 @@ bitesize \- Summarize block device I/O size as a histogram \- Linux eBPF/bcc.
 .SH DESCRIPTION
 Show I/O distribution for requested block sizes, by process name.
 
-This works by tracing block:block_rq_issue and prints a historgram of I/O size.
+This works by tracing block:block_rq_issue and prints a histogram of I/O size.
 
 Since this uses BPF, only the root user can use this tool.
 .SH REQUIREMENTS

--- a/man/man8/mdflush.8
+++ b/man/man8/mdflush.8
@@ -1,4 +1,4 @@
-.TH pidpersec 8  "2016-02-13" "USER COMMANDS"
+.TH mdflush 8  "2016-02-13" "USER COMMANDS"
 .SH NAME
 mdflush \- Trace md flush events. Uses Linux eBPF/bcc.
 .SH SYNOPSIS

--- a/man/man8/offwaketime.8
+++ b/man/man8/offwaketime.8
@@ -2,7 +2,7 @@
 .SH NAME
 offwaketime \- Summarize blocked time by off-CPU stack + waker stack. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B offwaketime [\-h] [\-p PID | \-t TID | \-u | \-k] [\-U | \-K] [\-f] [\-\-stack-storage-size STACK_STORAGE_SIZE] [\-m MIN_BLOCK_TIME] [\-M MAX_BLOCK_TIME] [\-\-state STATE] [duration]
+.B offwaketime [\-h] [\-p PID | \-t TID | \-u | \-k] [\-U | \-K] [\-d] [\-f] [\-\-stack-storage-size STACK_STORAGE_SIZE] [\-m MIN_BLOCK_TIME] [\-M MAX_BLOCK_TIME] [\-\-state STATE] [duration]
 .SH DESCRIPTION
 This program shows kernel stack traces and task names that were blocked and
 "off-CPU", along with the stack traces and task names for the threads that woke
@@ -54,6 +54,9 @@ Show stacks from user space only (no kernel space stacks).
 .TP
 \-K
 Show stacks from kernel space only (no user space stacks).
+.TP
+\-d, --delimited
+insert delimiter between kernel/user stacks
 .TP
 \-\-stack-storage-size STACK_STORAGE_SIZE
 Change the number of unique stack traces that can be stored and displayed.

--- a/man/man8/profile.8
+++ b/man/man8/profile.8
@@ -3,7 +3,7 @@
 profile \- Profile CPU usage by sampling stack traces. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
 .B profile [\-adfh] [\-p PID | \-L TID] [\-U | \-K] [\-F FREQUENCY | \-c COUNT]
-.B [\-\-stack\-storage\-size COUNT] [\-\-cgroupmap CGROUPMAP] [\-\-mntnsmap MAPPATH] [duration]
+.B [\-\-stack\-storage\-size COUNT] [\-C CPU] [\-\-cgroupmap CGROUPMAP] [\-\-mntnsmap MAPPATH] [duration]
 .SH DESCRIPTION
 This is a CPU profiler. It works by taking samples of stack traces at timed
 intervals. It will help you understand and quantify CPU usage: which code is

--- a/man/man8/swapin.8
+++ b/man/man8/swapin.8
@@ -15,7 +15,7 @@ swapping (if swap devices are in use). This can explain a significant source
 of application latency, if it has began swapping due to memory pressure on
 the system.
 
-This works by tracing the swap_readpage() kernel funciton
+This works by tracing the swap_readpage() kernel function
 using dynamic instrumentation. This tool may need maintenance to keep working
 if that function changes in later kernels.
 

--- a/man/man8/swapin.8
+++ b/man/man8/swapin.8
@@ -3,6 +3,12 @@
 swapin \- Count swapins by process. Uses BCC/eBPF.
 .SH SYNOPSIS
 .B swapin
+.TP
+.BR \-h ", " \-\-help\fR
+show this help message and exit
+.TP
+.BR \-T ", " \-\-notime\fR
+do not show the timestamp (HH:MM:SS)
 .SH DESCRIPTION
 This tool counts swapins by process, to show which process is affected by
 swapping (if swap devices are in use). This can explain a significant source

--- a/man/man8/tcprtt.8
+++ b/man/man8/tcprtt.8
@@ -2,7 +2,7 @@
 .SH NAME
 tcprtt \- Trace TCP RTT of established connections. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B tcprtt [\-h] [\-T] [\-D] [\-m] [\-i INTERVAL] [\-d DURATION] [\-b] [\-B] [\-e] [\-4 | \-6]
+.B tcprtt [\-h] [\-T] [\-D] [\-m] [\-p LPORT] [\-P RPORT] [\-a LADDR] [\-A RADDR] [\-i INTERVAL] [\-d DURATION] [\-b] [\-B] [\-e] [\-4 | \-6]
 .SH DESCRIPTION
 This tool traces established connections RTT(round-trip time) to analyze the
 quality of network. This can be useful for general troubleshooting to

--- a/tools/swapin_example.txt
+++ b/tools/swapin_example.txt
@@ -30,6 +30,27 @@ gnome-shell      2239   2496
 While tracing, this showed that PID 2239 (gnome-shell) and PID 4536 (chrome)
 suffered over ten thousand swapins.
 
+#swapin.py -T
+Counting swap ins. Ctrl-C to end.
+COMM             PID    COUNT
+b'firefox'       60965  4
+
+COMM             PID    COUNT
+b'IndexedDB #1'  60965  1
+b'firefox'       60965  2
+
+COMM             PID    COUNT
+b'StreamTrans #9' 60965  1
+b'firefox'       60965  3
+
+COMM             PID    COUNT
+
+COMM             PID    COUNT
+b'sssd_kcm'      3605   384
+[--]
+
+While tracing along with -T flag, it does not show timestamp.
+
 
 
 USAGE:


### PR DESCRIPTION
Previously man page:
~~~
DESCRIPTION
       This  tool  counts  swapins by process, to show which process is affected by swapping (if swap de‐
       vices are in use). This can explain a significant source of application latency, if it  has  began
       swapping due to memory pressure on the system.

       This works by tracing the swap_readpage() kernel funciton using dynamic instrumentation. This tool
       may need maintenance to keep working if that function changes in later kernels.

       Since this uses BPF, only the root user can use this tool.
~~~

Now:
~~~
DESCRIPTION
       This  tool  counts swapins by process, to show which process is affected by swapping (if swap devices are in use). This can explain a significant source of application latency, if it has began swap‐
       ping due to memory pressure on the system.

       This works by tracing the swap_readpage() kernel function using dynamic instrumentation. This tool may need maintenance to keep working if that function changes in later kernels.

       Since this uses BPF, only the root user can use this tool.

~~~