### PR TITLE
tools: Use u32 as pid field type

### DIFF
--- a/tools/bashreadline.py
+++ b/tools/bashreadline.py
@@ -38,7 +38,7 @@ bpf_text = """
 #include <linux/sched.h>
 
 struct str_t {
-    u64 pid;
+    u32 pid;
     char str[80];
 };
 
@@ -47,11 +47,9 @@ BPF_PERF_OUTPUT(events);
 int printret(struct pt_regs *ctx) {
     struct str_t data  = {};
     char comm[TASK_COMM_LEN] = {};
-    u32 pid;
     if (!PT_REGS_RC(ctx))
         return 0;
-    pid = bpf_get_current_pid_tgid() >> 32;
-    data.pid = pid;
+    data.pid = bpf_get_current_pid_tgid() >> 32;
     bpf_probe_read_user(&data.str, sizeof(data.str), (void *)PT_REGS_RC(ctx));
 
     bpf_get_current_comm(&comm, sizeof(comm));

--- a/tools/btrfsslower.py
+++ b/tools/btrfsslower.py
@@ -87,10 +87,10 @@ struct data_t {
     // XXX: switch some to u32's when supported
     u64 ts_us;
     u64 type;
-    u64 size;
+    u32 size;
     u64 offset;
     u64 delta_us;
-    u64 pid;
+    u32 pid;
     char task[TASK_COMM_LEN];
     char file[DNAME_INLINE_LEN];
 };
@@ -219,9 +219,11 @@ static int trace_return(struct pt_regs *ctx, int type)
         return 0;
 
     // populate output struct
-    u32 size = PT_REGS_RC(ctx);
-    struct data_t data = {.type = type, .size = size, .delta_us = delta_us,
-        .pid = pid};
+    struct data_t data = {};
+    data.type = type;
+    data.size = PT_REGS_RC(ctx);
+    data.delta_us = delta_us;
+    data.pid = pid;
     data.ts_us = ts / 1000;
     data.offset = valp->offset;
     bpf_get_current_comm(&data.task, sizeof(data.task));

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -100,7 +100,7 @@ struct temp_t {
 };
 
 struct data_t {
-    u64 pid;
+    u32 pid;
     u64 timestamp;
     u64 duration;
     char query[256];

--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -82,10 +82,10 @@ struct data_t {
     // XXX: switch some to u32's when supported
     u64 ts_us;
     u64 type;
-    u64 size;
+    u32 size;
     u64 offset;
     u64 delta_us;
-    u64 pid;
+    u32 pid;
     char task[TASK_COMM_LEN];
     char file[DNAME_INLINE_LEN];
 };
@@ -212,9 +212,11 @@ static int trace_return(struct pt_regs *ctx, int type)
         return 0;
 
     // populate output struct
-    u32 size = PT_REGS_RC(ctx);
-    struct data_t data = {.type = type, .size = size, .delta_us = delta_us,
-        .pid = pid};
+    struct data_t data = {};
+    data.type = type;
+    data.size = PT_REGS_RC(ctx);
+    data.delta_us = delta_us;
+    data.pid = pid;
     data.ts_us = ts / 1000;
     data.offset = valp->offset;
     bpf_get_current_comm(&data.task, sizeof(data.task));

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -46,14 +46,14 @@ bpf_text = """
 #include <linux/sched.h>
 
 struct val_t {
-   u64 pid;
+   u32 pid;
    int sig;
    int tpid;
    char comm[TASK_COMM_LEN];
 };
 
 struct data_t {
-   u64 pid;
+   u32 pid;
    int tpid;
    int sig;
    int ret;

--- a/tools/mdflush.py
+++ b/tools/mdflush.py
@@ -23,7 +23,7 @@ bpf_text="""
 #include <linux/bio.h>
 
 struct data_t {
-    u64 pid;
+    u32 pid;
     char comm[TASK_COMM_LEN];
     char disk[DISK_NAME_LEN];
 };
@@ -32,8 +32,7 @@ BPF_PERF_OUTPUT(events);
 int kprobe__md_flush_request(struct pt_regs *ctx, void *mddev, struct bio *bio)
 {
     struct data_t data = {};
-    u32 pid = bpf_get_current_pid_tgid() >> 32;
-    data.pid = pid;
+    data.pid = bpf_get_current_pid_tgid() >> 32;
     bpf_get_current_comm(&data.comm, sizeof(data.comm));
 /*
  * The following deals with kernel version changes (in mainline 4.14 and 5.12, although

--- a/tools/mysqld_qslower.py
+++ b/tools/mysqld_qslower.py
@@ -48,7 +48,7 @@ struct start_t {
 };
 
 struct data_t {
-    u64 pid;
+    u32 pid;
     u64 ts;
     u64 delta;
     char query[QUERY_MAX];

--- a/tools/nfsslower.py
+++ b/tools/nfsslower.py
@@ -86,7 +86,7 @@ struct data_t {
     u64 size;
     u64 offset;
     u64 delta_us;
-    u64 pid;
+    u32 pid;
     char task[TASK_COMM_LEN];
     char file[DNAME_INLINE_LEN];
 };

--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -116,8 +116,8 @@ bpf_text = """
 #define MAXBLOCK_US    MAXBLOCK_US_VALUEULL
 
 struct key_t {
-    u64 pid;
-    u64 tgid;
+    u32 pid;
+    u32 tgid;
     int user_stack_id;
     int kernel_stack_id;
     char name[TASK_COMM_LEN];

--- a/tools/runqlat.py
+++ b/tools/runqlat.py
@@ -74,12 +74,12 @@ bpf_text = """
 #include <linux/init_task.h>
 
 typedef struct pid_key {
-    u64 id;    // work around
+    u32 id;
     u64 slot;
 } pid_key_t;
 
 typedef struct pidns_key {
-    u64 id;    // work around
+    u32 id;
     u64 slot;
 } pidns_key_t;
 

--- a/tools/solisten.py
+++ b/tools/solisten.py
@@ -58,8 +58,8 @@ bpf_text = """
 // Common structure for UDP/TCP IPv4/IPv6
 struct listen_evt_t {
     u64 ts_us;
-    u64 pid;
-    u64 backlog;
+    u32 pid;
+    int backlog;
     u64 netns;
     u64 proto;    // familiy << 16 | type
     u64 lport;    // use only 16 bits

--- a/tools/xfsslower.py
+++ b/tools/xfsslower.py
@@ -81,7 +81,7 @@ struct data_t {
     u64 size;
     u64 offset;
     u64 delta_us;
-    u64 pid;
+    u32 pid;
     char task[TASK_COMM_LEN];
     char file[DNAME_INLINE_LEN];
 };

--- a/tools/zfsslower.py
+++ b/tools/zfsslower.py
@@ -81,10 +81,10 @@ struct data_t {
     // XXX: switch some to u32's when supported
     u64 ts_us;
     u64 type;
-    u64 size;
+    u32 size;
     u64 offset;
     u64 delta_us;
-    u64 pid;
+    u32 pid;
     char task[TASK_COMM_LEN];
     char file[DNAME_INLINE_LEN];
 };
@@ -182,9 +182,11 @@ static int trace_return(struct pt_regs *ctx, int type)
         return 0;
 
     // populate output struct
-    u32 size = PT_REGS_RC(ctx);
-    struct data_t data = {.type = type, .size = size, .delta_us = delta_us,
-        .pid = pid};
+    struct data_t data = {};
+    data.type = type;
+    data.size = PT_REGS_RC(ctx);
+    data.delta_us = delta_us;
+    data.pid = pid;
     data.ts_us = ts / 1000;
     data.offset = valp->offset;
     bpf_get_current_comm(&data.task, sizeof(data.task));


### PR DESCRIPTION
Some tools still use u64 as pid field type, this patch try to unify them.