### PR TITLE
Fix some redundant spaces in the INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -511,7 +511,7 @@ mkdir llvm-build
 
 cd llvm-build
 cmake3 -G "Unix Makefiles" -DLLVM_TARGETS_TO_BUILD="BPF;X86" \
-  -DCMAKE_BUILD_TYPE=Release ../llvm-10.0.10.src
+  -DCMAKE_BUILD_TYPE=Release ../llvm-10.0.0.src
 make
 sudo make install
 
@@ -528,8 +528,8 @@ or install from centos-release-scl
 ```
 yum install -y centos-release-scl
 yum-config-manager --enable rhel-server-rhscl-7-rpms
-yum install -y devtoolset-7 llvm-toolset-7 llvm-toolset-7-llvm-devel llvm-toolset-7-llvm-static llvm-toolset-7-clang-devel
-source scl_source enable devtoolset-7 llvm-toolset-7
+yum install -y devtoolset-7 llvm-toolset-10 llvm-toolset-10-llvm-devel llvm-toolset-10-llvm-static llvm-toolset-10-clang-devel
+source scl_source enable devtoolset-7 llvm-toolset-10
 ```
 
 For permanently enable scl environment, please check https://access.redhat.com/solutions/527703.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -341,8 +341,9 @@ sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
 sudo apt install -y bison build-essential cmake flex git libedit-dev \
   libllvm7 llvm-7-dev libclang-7-dev python zlib1g-dev libelf-dev libfl-dev python3-distutils
   
-# For Hirsute (21.04)  or Impish (21.10)
-sudo apt install -y bison build-essential cmake flex git libedit-dev   libllvm11 llvm-11-dev libclang-11-dev python zlib1g-dev libelf-dev libfl-dev python3-distutils
+# For Hirsute (21.04) or Impish (21.10)
+sudo apt install -y bison build-essential cmake flex git libedit-dev \
+  libllvm11 llvm-11-dev libclang-11-dev python zlib1g-dev libelf-dev libfl-dev python3-distutils
 
 # For other versions
 sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
@@ -387,7 +388,7 @@ mkdir bcc-build
 cd bcc-build/
 
 ## here llvm should always link shared library
-cmake ../bcc -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_LLVM_SHARED=1  
+cmake ../bcc -DCMAKE_INSTALL_PREFIX=/usr -DENABLE_LLVM_SHARED=1
 make -j10
 make install 
 
@@ -501,8 +502,8 @@ sudo yum install -y luajit luajit-devel  # for Lua support
 You could compile LLVM from source code
 
 ```
-curl  -LO  http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz
-curl  -LO  http://releases.llvm.org/7.0.1/cfe-7.0.1.src.tar.xz
+curl -LO http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz
+curl -LO http://releases.llvm.org/7.0.1/cfe-7.0.1.src.tar.xz
 tar -xf cfe-7.0.1.src.tar.xz
 tar -xf llvm-7.0.1.src.tar.xz
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -342,8 +342,7 @@ sudo apt install -y bison build-essential cmake flex git libedit-dev \
   libllvm7 llvm-7-dev libclang-7-dev python zlib1g-dev libelf-dev libfl-dev python3-distutils
   
 # For Hirsute (21.04) or Impish (21.10)
-sudo apt install -y bison build-essential cmake flex git libedit-dev \
-  libllvm11 llvm-11-dev libclang-11-dev python zlib1g-dev libelf-dev libfl-dev python3-distutils
+sudo apt install -y bison build-essential cmake flex git libedit-dev   libllvm11 llvm-11-dev libclang-11-dev python zlib1g-dev libelf-dev libfl-dev python3-distutils
 
 # For other versions
 sudo apt-get -y install bison build-essential cmake flex git libedit-dev \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -501,23 +501,23 @@ sudo yum install -y luajit luajit-devel  # for Lua support
 You could compile LLVM from source code
 
 ```
-curl -LO http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz
-curl -LO http://releases.llvm.org/7.0.1/cfe-7.0.1.src.tar.xz
-tar -xf cfe-7.0.1.src.tar.xz
-tar -xf llvm-7.0.1.src.tar.xz
+curl -LO http://releases.llvm.org/10.0.0/llvm-10.0.0.src.tar.xz
+curl -LO http://releases.llvm.org/10.0.0/cfe-10.0.0.src.tar.xz
+tar -xf cfe-10.0.0.src.tar.xz
+tar -xf llvm-10.0.0.src.tar.xz
 
 mkdir clang-build
 mkdir llvm-build
 
 cd llvm-build
 cmake3 -G "Unix Makefiles" -DLLVM_TARGETS_TO_BUILD="BPF;X86" \
-  -DCMAKE_BUILD_TYPE=Release ../llvm-7.0.1.src
+  -DCMAKE_BUILD_TYPE=Release ../llvm-10.0.10.src
 make
 sudo make install
 
 cd ../clang-build
 cmake3 -G "Unix Makefiles" -DLLVM_TARGETS_TO_BUILD="BPF;X86" \
-  -DCMAKE_BUILD_TYPE=Release ../cfe-7.0.1.src
+  -DCMAKE_BUILD_TYPE=Release ../cfe-10.0.0.src
 make
 sudo make install
 cd ..


### PR DESCRIPTION
Fix some redundant spaces in the INSTALL.md
some command line like : "curl  -LO  http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz" should be "curl -LO http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz".

And other:
When "make install bcc" in CentOS(7.X) system, we need the versions of llvm and clang to be greater than or equal to 10.0.0. Otherwise, an error will be reported as follows:
```
/tmp/bcc/src/cc/bpf_module.cc: In member function ‘virtual void ebpf::MyMemoryManager::notifyObjectLoaded(llvm::ExecutionEngine*, const llvm::object::ObjectFile&)’:
/tmp/bcc/src/cc/bpf_module.cc:108:46: error: no matching function for call to ‘llvm::object::SectionRef::getName() const’
       auto sec_name = section.get()->getName();
```
