### PR TITLE
libbpf-tools/klockstat update

### DIFF
--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -598,6 +598,7 @@ int main(int argc, char **argv)
 			warn("print_stats error, aborting.\n");
 			break;
 		}
+		fflush(stdout);
 	}
 
 	printf("Exiting trace of mutex/sem locks\n");


### PR DESCRIPTION
A couple of updates of klockstat in libbpf-tools.  The most important change is the per-thread mode (`-P` option) to track lock wait/hold stats for each task.  Also changed time format to have units.

```
$ sudo klockstat -n 5 -d 3 -P
Tracing mutex/sem lock events...  Hit Ctrl-C to end


                Tid              Comm  Avg Wait    Count   Max Wait   Total Wait
               8428   IPDL Background    4.8 us      213   379.0 us       1.0 ms
               8369    IPC I/O Parent    2.0 us      889   194.5 us       1.8 ms
             139151     IPC I/O Child    2.0 us      929   148.0 us       1.8 ms
               8400    GLXVsyncThread    3.1 us      182    25.9 us     559.9 us
             139148       Web Content    1.5 us     1013    24.0 us       1.5 ms

                Tid              Comm  Avg Hold    Count   Max Hold   Total Hold
             366280    kworker/u16:32   21.5 us     1760    31.1 ms      37.9 ms
               1056         in:imklog    4.0 ms      760    17.9 ms       3.0 s 
             377600         klockstat    1.0 ms      180     2.9 ms     188.6 ms
               5436            chrome   50.8 us       13   490.8 us     660.1 us
               2916       gnome-shell    4.4 us     1182   451.8 us       5.2 ms
Exiting trace of mutex/sem locks
```