### PR TITLE
filetop: Add missing entry of -a in the SYNOPSIS section

### DIFF
--- a/man/man8/filetop.8
+++ b/man/man8/filetop.8
@@ -2,7 +2,7 @@
 .SH NAME
 filetop \- File reads and writes by filename and process. Top for files.
 .SH SYNOPSIS
-.B filetop [\-h] [\-C] [\-r MAXROWS] [\-s {reads,writes,rbytes,wbytes}] [\-p PID] [interval] [count]
+.B filetop [\-h] [\-a] [\-C] [\-r MAXROWS] [\-s {reads,writes,rbytes,wbytes}] [\-p PID] [interval] [count]
 .SH DESCRIPTION
 This is top for files.
 


### PR DESCRIPTION
Signed-off-by: Vaibhav Nagare <vnagare@redhat.com>

Man page before:
~~~
SYNOPSIS
       filetop [-h] [-C] [-r MAXROWS] [-s {reads,writes,rbytes,wbytes}] [-p PID] [interval] [count]
~~~

Man page now:
~~~
SYNOPSIS
       filetop [-h] [-a] [-C] [-r MAXROWS] [-s {reads,writes,rbytes,wbytes}] [-p PID] [interval] [count]
~~~