### PR TITLE
drsnoop: Add missing entry of -v in the options section

### DIFF
--- a/man/man8/drsnoop.8
+++ b/man/man8/drsnoop.8
@@ -45,6 +45,9 @@ Total duration of trace in seconds.
 Only print processes where its name partially matches 'name'
 \-v verbose         
 Run in verbose mode. Will output system memory state
+.TP
+\-v
+show system memory state
 .SH EXAMPLES
 .TP
 Trace all direct reclaim events:


### PR DESCRIPTION
Man page before:
~~~
OPTIONS
       -h     Print usage message.

       -T     Include a timestamp column.

       -U     Show UID.

       -p PID Trace this process ID only (filtered in-kernel).

       -t TID Trace this thread ID only (filtered in-kernel).

       -u UID Trace this UID only (filtered in-kernel).

       -d DURATION
              Total duration of trace in seconds.

       -n name
              Only print processes where its name partially matches 'name' -v verbose  Run  in  verbose
              mode. Will output system memory state
~~~

Man page now:
~~~
OPTIONS
       -h     Print usage message.

       -T     Include a timestamp column.

       -U     Show UID.

       -p PID Trace this process ID only (filtered in-kernel).

       -t TID Trace this thread ID only (filtered in-kernel).

       -u UID Trace this UID only (filtered in-kernel).

       -d DURATION
              Total duration of trace in seconds.

       -n name
              Only print processes where its name partially matches 'name' -v verbose Run in verbose mode. Will output system memory state

       -v     show system memory state
~~~