### PR TITLE
cachetop: Add missing entry of CMD in the FIELDS section

### DIFF
--- a/man/man8/cachetop.8
+++ b/man/man8/cachetop.8
@@ -52,6 +52,9 @@ Process ID of the process causing the cache activity.
 UID
 User ID of the process causing the cache activity.
 .TP
+CMD
+Name of the process.
+.TP
 HITS
 Number of page cache hits.
 .TP


### PR DESCRIPTION
Man page before:
~~~
FIELDS
       PID    Process ID of the process causing the cache activity.

       UID    User ID of the process causing the cache activity.

       HITS   Number of page cache hits.
~~~

Man page now:
~~~
FIELDS
       PID    Process ID of the process causing the cache activity.

       UID    User ID of the process causing the cache activity.

       CMD    Name of the process.
~~~