### PR TITLE
bcc/usdt: fix parse double-reg-indirect addressing mode in arguments …

### DIFF
--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -127,8 +127,7 @@ class ArgumentParser_aarch64 : public ArgumentParser {
  private:
   bool parse_register(ssize_t pos, ssize_t &new_pos, std::string &reg_name);
   bool parse_size(ssize_t pos, ssize_t &new_pos, optional<int> *arg_size);
-  bool parse_mem(ssize_t pos, ssize_t &new_pos, std::string &reg_name,
-                 optional<int> *offset);
+  bool parse_mem(ssize_t pos, ssize_t &new_pos, Argument *dest);
 
  public:
   bool parse(Argument *dest);


### PR DESCRIPTION
…on AArch64

For bpftrace testcase usdt_args.c, it will generates usdt arguments
as follow:
> stapsdt              0x00000036       NT_STAPSDT (SystemTap probe descriptors)
>    Provider: usdt_args
>    Name: index_8
>    Location: 0x0000000000400724, Base: 0x0000000000400810, Semaphore: 0x0000000000000000
>    Arguments: -1@[x0, x1]

Such double-reg-indirect addressing mode is not supported yet, so
bpftrace will report such error:
> Parse error:
>     -1@[x0, x1]
> -----------^
> ERROR: couldn't get argument 0 for ./usdt_args:usdt_args:index_8

This patch fixed it.

Signed-off-by: Qiao Ma <mqaio@linux.alibaba.com>