### PR TITLE
tools/syscount: Add TID filter support

### DIFF
--- a/man/man8/syscount.8
+++ b/man/man8/syscount.8
@@ -2,7 +2,7 @@
 .SH NAME
 syscount \- Summarize syscall counts and latencies.
 .SH SYNOPSIS
-.B syscount [-h] [-p PID] [-i INTERVAL] [-d DURATION] [-T TOP] [-x] [-e ERRNO] [-L] [-m] [-P] [-l]
+.B syscount [-h] [-p PID] [-t TID] [-i INTERVAL] [-d DURATION] [-T TOP] [-x] [-e ERRNO] [-L] [-m] [-P] [-l]
 .SH DESCRIPTION
 This tool traces syscall entry and exit tracepoints and summarizes either the
 number of syscalls of each type, or the number of syscalls per process. It can
@@ -19,6 +19,9 @@ Print usage message.
 .TP
 \-p PID
 Trace only this process.
+.TP
+\-t TID
+Trace only this thread.
 .TP
 \-i INTERVAL
 Print the summary at the specified interval (in seconds).

--- a/tools/syscount_example.txt
+++ b/tools/syscount_example.txt
@@ -141,18 +141,19 @@ rmdir                         1
 
 USAGE:
 # syscount -h
-usage: syscount.py [-h] [-p PID] [-i INTERVAL] [-T TOP] [-x] [-e ERRNO] [-L]
-                   [-m] [-P] [-l]
+usage: syscount.py [-h] [-p PID] [-t TID] [-i INTERVAL] [-d DURATION] [-T TOP]
+                   [-x] [-e ERRNO] [-L] [-m] [-P] [-l]
 
 Summarize syscall counts and latencies.
 
 optional arguments:
   -h, --help            show this help message and exit
   -p PID, --pid PID     trace only this pid
+  -t TID, --tid TID     trace only this tid
   -i INTERVAL, --interval INTERVAL
                         print summary at this interval (seconds)
   -d DURATION, --duration DURATION
-			total duration of trace, in seconds
+                        total duration of trace, in seconds
   -T TOP, --top TOP     print only the top syscalls by count or latency
   -x, --failures        trace only failed syscalls (return < 0)
   -e ERRNO, --errno ERRNO


### PR DESCRIPTION
For multi-threaded applications, such as MySQL, I just want to focus on syscall stats of a specified thread, rathan than all threads of the mysqld process (I am doing recently some performace optimizations on MySQL). This patch try to add tid filter (option -t) support.