### PR TITLE
tools: Update tcpdrop error message when the probe fails

### DIFF
--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -200,7 +200,7 @@ if b.get_kprobe_functions(b"tcp_drop"):
     b.attach_kprobe(event="tcp_drop", fn_name="trace_tcp_drop")
 else:
     print("ERROR: tcp_drop() kernel function not found or traceable. "
-        "Older kernel versions not supported.")
+        "The kernel might be too old or the the function has been inlined.")
     exit()
 stack_traces = b.get_table("stack_traces")
 


### PR DESCRIPTION
When tcpdrop tool fails to attach a kprobe to tcp_drop() function, the
error message suggest that the running kernel is too old. However,
tcp_drop() is a relatively small static function, so nowadays, it's
more likely that it has been inlined.

Update the error message to avoid to confuse the user.

Signed-off-by: Jerome Marchand <jmarchan@redhat.com>