### PR TITLE
Fix warning of strncpy() size field.

### DIFF
--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -156,7 +156,7 @@ static int mntns_func(void *arg) {
     return -1;
   }
 
-  strncpy(libpath, lm->l_name, 1024);
+  strncpy(libpath, lm->l_name, sizeof(libpath) - 1);
   dlclose(dlhdl);
   dlhdl = NULL;
 


### PR DESCRIPTION
bcc/tests/cc/test_c_api.cc:159:10: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 1024 equals destination size [-Wstringop-truncation]
  159 |   strncpy(libpath, lm->l_name, 1024);
      |   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~