### PR TITLE
biolatpcts: Use block_rq_complete TP instead of kprobing blk_account_io_done()

### DIFF
--- a/examples/tracing/biolatpcts.py
+++ b/examples/tracing/biolatpcts.py
@@ -19,37 +19,36 @@ BPF_PERCPU_ARRAY(lat_100ms, u64, 100);
 BPF_PERCPU_ARRAY(lat_1ms, u64, 100);
 BPF_PERCPU_ARRAY(lat_10us, u64, 100);
 
-void kprobe_blk_account_io_done(struct pt_regs *ctx, struct request *rq, u64 now)
+RAW_TRACEPOINT_PROBE(block_rq_complete)
 {
+        // TP_PROTO(struct request *rq, blk_status_t error, unsigned int nr_bytes)
+        struct request *rq = (void *)ctx->args[0];
         unsigned int cmd_flags;
         u64 dur;
         size_t base, slot;
 
         if (!rq->io_start_time_ns)
-                return;
+                return 0;
 
-        dur = now - rq->io_start_time_ns;
+        dur = bpf_ktime_get_ns() - rq->io_start_time_ns;
 
         slot = min_t(size_t, div_u64(dur, 100 * NSEC_PER_MSEC), 99);
         lat_100ms.increment(slot);
         if (slot)
-                return;
+                return 0;
 
         slot = min_t(size_t, div_u64(dur, NSEC_PER_MSEC), 99);
         lat_1ms.increment(slot);
         if (slot)
-                return;
+                return 0;
 
         slot = min_t(size_t, div_u64(dur, 10 * NSEC_PER_USEC), 99);
         lat_10us.increment(slot);
+        return 0;
 }
 """
 
 bpf = BPF(text=bpf_source)
-if BPF.get_kprobe_functions(b'__blk_account_io_done'):
-    bpf.attach_kprobe(event="__blk_account_io_done", fn_name="kprobe_blk_account_io_done")
-else:
-    bpf.attach_kprobe(event="blk_account_io_done", fn_name="kprobe_blk_account_io_done")
 
 cur_lat_100ms = bpf['lat_100ms']
 cur_lat_1ms = bpf['lat_1ms']


### PR DESCRIPTION
Depending on the inlining decisions made by the compiler, neither blk_account_io_done() or __blk_account_io_done() may be kprobable. Side step the whole thing by attaching to the block_rq_complete tracepoint. It'd be probably a good idea to update other users kprobing blk_account_io_done().