### PR TITLE
Fix compilation warnings.

### DIFF
--- a/src/cc/bpf_module_rw_engine.cc
+++ b/src/cc/bpf_module_rw_engine.cc
@@ -54,7 +54,7 @@ static LoadInst *createLoad(IRBuilder<> &B, Value *addr, bool isVolatile = false
     return B.CreateLoad(dyn_cast<AllocaInst>(addr)->getAllocatedType(), addr, isVolatile);
   else
     return B.CreateLoad(addr->getType(), addr, isVolatile);
-#elif LLVM_MAJOR_VERSION >= 14
+#elif LLVM_MAJOR_VERSION >= 13
   return B.CreateLoad(addr->getType()->getPointerElementType(), addr, isVolatile);
 #else
   return B.CreateLoad(addr, isVolatile);
@@ -68,7 +68,7 @@ static Value *createInBoundsGEP(IRBuilder<> &B, Value *ptr, ArrayRef<Value *>idx
     return B.CreateInBoundsGEP(dyn_cast<GlobalValue>(ptr)->getValueType(), ptr, idxlist);
   else
     return B.CreateInBoundsGEP(ptr->getType(), ptr, idxlist);
-#elif LLVM_MAJOR_VERSION >= 14
+#elif LLVM_MAJOR_VERSION >= 13
   return B.CreateInBoundsGEP(ptr->getType()->getScalarType()->getPointerElementType(),
                              ptr, idxlist);
 #else


### PR DESCRIPTION
Compilation warnings:
  /home/rongtao/Git/IO-Visor/bcc/src/cc/bpf_module_rw_engine.cc:60:22: warning: ‘llvm::LoadInst* llvm::IRBuilderBase::CreateLoad(llvm::Value*, bool, const llvm::Twine&)’ is deprecated: Use the version that explicitly specifies the loaded type instead [-Wdeprecated-declarations]
     60 |   return B.CreateLoad(addr, isVolatile);
        |          ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
  /home/rongtao/Git/IO-Visor/bcc/src/cc/bpf_module_rw_engine.cc:75:29: warning: ‘llvm::Value* llvm::IRBuilderBase::CreateInBoundsGEP(llvm::Value*, llvm::ArrayRef<llvm::Value*>, const llvm::Twine&)’ is deprecated: Use the version with explicit element type instead [-Wdeprecated-declarations]
     75 |   return B.CreateInBoundsGEP(ptr, idxlist);
        |          ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~

See llvm-project [https://github.com/llvm/llvm-project/commit/f95d26006e0641385565774ca4b560cc72a84e2f](https://github.com/llvm/llvm-project/commit/f95d26006e0641385565774ca4b560cc72a84e2f)

  [IRBuilder] Deprecate CreateInBoundsGEP() without element type

llvm branch: release/13.x