### PR TITLE
Fix llvm and clang version for Ubuntu 20.04 in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -337,10 +337,10 @@ sudo apt-get update
 sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
   libllvm6.0 llvm-6.0-dev libclang-6.0-dev python zlib1g-dev libelf-dev libfl-dev python3-distutils
 
-# For Eoan (19.10) or Focal (20.04.1 LTS)
+# For Focal (20.04.1 LTS)
 sudo apt install -y bison build-essential cmake flex git libedit-dev \
-  libllvm7 llvm-7-dev libclang-7-dev python zlib1g-dev libelf-dev libfl-dev python3-distutils
-  
+  libllvm12 llvm-12-dev libclang-12-dev python zlib1g-dev libelf-dev libfl-dev python3-distutils
+
 # For Hirsute (21.04) or Impish (21.10)
 sudo apt install -y bison build-essential cmake flex git libedit-dev   libllvm11 llvm-11-dev libclang-11-dev python zlib1g-dev libelf-dev libfl-dev python3-distutils
 


### PR DESCRIPTION
Refer the INSTALL.md, when run `cmake .. && make` in Ubuntu 20.04, an error will be reported as follows:

```
/tmp/bcc/src/cc/bpf_module.cc: In member function 'virtual void ebpf::MyMemoryManager::notifyObjectLoaded(llvm::ExecutionEngine*, const llvm::object::ObjectFile&)':
/tmp/bcc/src/cc/bpf_module.cc:117:46: error: no matching function for call to 'llvm::object::SectionRef::getName() const'
  117 |       auto sec_name = section.get()->getName();
```

Change the version of llvm and clang from 7 to 10, another error will be reported as follows:
```
/usr/bin/ld: /usr/lib/llvm-10/lib/libclangCodeGen.a(BackendUtil.cpp.o): in function `(anonymous namespace)::EmitAssemblyHelper::EmitAssemblyWithNewPassManager(clang::BackendAction, std::unique_ptr<llvm::raw_pwrite_stream, std::default_delete<llvm::raw_pwrite_stream> >)':
(.text._ZN12_GLOBAL__N_118EmitAssemblyHelper30EmitAssemblyWithNewPassManagerEN5clang13BackendActionESt10unique_ptrIN4llvm17raw_pwrite_streamESt14default_deleteIS5_EE+0x1f15): undefined reference to `getPollyPluginInfo()'
collect2: error: ld returned 1 exit status
```

Then change the version of llvm and clang to 12, it can work. 