### PR TITLE
libbpf-tools: fix kernel version checks

### DIFF
--- a/libbpf-tools/biolatency.bpf.c
+++ b/libbpf-tools/biolatency.bpf.c
@@ -86,7 +86,7 @@ int block_rq_insert(u64 *ctx)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION <= KERNEL_VERSION(5, 10, 0))
+	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0))
 		return trace_rq_start((void *)ctx[1], false);
 	else
 		return trace_rq_start((void *)ctx[0], false);
@@ -103,7 +103,7 @@ int block_rq_issue(u64 *ctx)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION <= KERNEL_VERSION(5, 10, 0))
+	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0))
 		return trace_rq_start((void *)ctx[1], true);
 	else
 		return trace_rq_start((void *)ctx[0], true);

--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -130,7 +130,7 @@ int BPF_PROG(block_rq_insert)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION > KERNEL_VERSION(5, 10, 0))
+	if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 11, 0))
 		return trace_rq_start((void *)ctx[0], true);
 	else
 		return trace_rq_start((void *)ctx[1], true);
@@ -147,7 +147,7 @@ int BPF_PROG(block_rq_issue)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION > KERNEL_VERSION(5, 10, 0))
+	if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 11, 0))
 		return trace_rq_start((void *)ctx[0], false);
 	else
 		return trace_rq_start((void *)ctx[1], false);

--- a/libbpf-tools/bitesize.bpf.c
+++ b/libbpf-tools/bitesize.bpf.c
@@ -86,7 +86,7 @@ int BPF_PROG(block_rq_issue)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION > KERNEL_VERSION(5, 10, 0))
+	if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 11, 0))
 		return trace_rq_issue((void *)ctx[0]);
 	else
 		return trace_rq_issue((void *)ctx[1]);


### PR DESCRIPTION
Several existing kernel version checks are intended to distinguish
5.11+ kernels vs 5.10 and earlier, but as written, 5.10.1+ kernels
will take the wrong path. Update the checks to match the intent
expressed in their accompanying comments.

Signed-off-by: Connor O'Brien <connoro@google.com>