### PR TITLE
libbpf-tools/bitesize: inline trace_rq_issue

### DIFF
--- a/libbpf-tools/bitesize.bpf.c
+++ b/libbpf-tools/bitesize.bpf.c
@@ -38,7 +38,7 @@ static __always_inline bool comm_allowed(const char *comm)
 	return true;
 }
 
-static int trace_rq_issue(struct request *rq)
+static __always_inline int trace_rq_issue(struct request *rq)
 {
 	struct hist_key hkey;
 	struct hist *histp;


### PR DESCRIPTION
When running with 5.10 kernel, bitesize fails verification as a result
of passing a modified ctx pointer into trace_rq_issue. Forcing the
compiler to inline trace_rq_issue fixes the problem.

Signed-off-by: Connor O'Brien <connoro@google.com>