### PR TITLE
Fixed 'getElementType() is deprecated' compile warning.

### DIFF
--- a/src/cc/bpf_module_rw_engine.cc
+++ b/src/cc/bpf_module_rw_engine.cc
@@ -410,7 +410,7 @@ int BPFModule::annotate() {
     table_names_[table.name] = id++;
     GlobalValue *gvar = mod_->getNamedValue(table.name);
     if (!gvar) continue;
-#if LLVM_MAJOR_VERSION >= 15
+#if LLVM_MAJOR_VERSION >= 14
     {
       Type *t = gvar->getValueType();
       StructType *st = dyn_cast<StructType>(t);


### PR DESCRIPTION
```
/home/rongtao/Git/bcc/src/cc/bpf_module_rw_engine.cc: In member function ‘int ebpf::BPFModule::annotate()’:
/home/rongtao/Git/bcc/src/cc/bpf_module_rw_engine.cc:419:63: warning: ‘llvm::Type* llvm::PointerType::getElementType() const’ is deprecated: Pointer element types are deprecated. You can *temporarily* use Type::getPointerElementType() instead [-Wdeprecated-declarations]
  419 |       StructType *st = dyn_cast<StructType>(pt->getElementType());
      |                                             ~~~~~~~~~~~~~~~~~~^~
In file included from /usr/include/llvm/IR/DataLayout.h:27,
                 from /usr/include/llvm/ExecutionEngine/ExecutionEngine.h:24,
                 from /usr/include/llvm/ExecutionEngine/MCJIT.h:17,
                 from /home/rongtao/Git/bcc/src/cc/bpf_module_rw_engine.cc:20:
/usr/include/llvm/IR/DerivedTypes.h:675:9: note: declared here
  675 |   Type *getElementType() const {
      |         ^~~~~~~~~~~~~~
```

See llvm: `[OpaquePtrs] Deprecate PointerType::getElementType()`
https://github.com/llvm/llvm-project/commit/184591aeeb5a531f2315c3d7cddcd199c87ecb2c
Belongs to release/14.x branch.