### PR TITLE
tools/biolatency: Add disk filter support

### DIFF
--- a/man/man8/biolatency.8
+++ b/man/man8/biolatency.8
@@ -2,7 +2,7 @@
 .SH NAME
 biolatency \- Summarize block device I/O latency as a histogram.
 .SH SYNOPSIS
-.B biolatency [\-h] [\-F] [\-T] [\-Q] [\-m] [\-D] [\-e] [interval [count]]
+.B biolatency [\-h] [\-F] [\-T] [\-Q] [\-m] [\-D] [\-F] [\-e] [\-j] [\-d DISK] [interval [count]]
 .SH DESCRIPTION
 biolatency traces block device I/O (disk I/O), and records the distribution
 of I/O latency (time). This is printed as a histogram either on Ctrl-C, or
@@ -41,6 +41,9 @@ Print a histogram dictionary
 .TP
 \-e
 Show extension summary(total, average)
+.TP
+\-d DISK
+Trace this disk only
 .TP
 interval
 Output interval, in seconds.
@@ -108,6 +111,6 @@ Linux
 .SH STABILITY
 Unstable - in development.
 .SH AUTHOR
-Brendan Gregg
+Brendan Gregg, Rocky Xing
 .SH SEE ALSO
 biosnoop(8)

--- a/tools/biolatency_example.txt
+++ b/tools/biolatency_example.txt
@@ -352,24 +352,25 @@ The -j with -m prints a millisecond histogram dictionary. The `value_type` key i
 USAGE message:
 
 # ./biolatency -h
-usage: biolatency.py [-h] [-T] [-Q] [-m] [-D] [-F] [-j]
-                              [interval] [count]
+usage: biolatency.py [-h] [-T] [-Q] [-m] [-D] [-F] [-e] [-j] [-d DISK]
+                     [interval] [count]
 
 Summarize block device I/O latency as a histogram
 
 positional arguments:
-  interval            output interval, in seconds
-  count               number of outputs
+  interval              output interval, in seconds
+  count                 number of outputs
 
 optional arguments:
-  -h, --help          show this help message and exit
-  -T, --timestamp     include timestamp on output
-  -Q, --queued        include OS queued time in I/O time
-  -m, --milliseconds  millisecond histogram
-  -D, --disks         print a histogram per disk device
-  -F, --flags         print a histogram per set of I/O flags
-  -e, --extension     also show extension summary(total, average)
-  -j, --json          json output
+  -h, --help            show this help message and exit
+  -T, --timestamp       include timestamp on output
+  -Q, --queued          include OS queued time in I/O time
+  -m, --milliseconds    millisecond histogram
+  -D, --disks           print a histogram per disk device
+  -F, --flags           print a histogram per set of I/O flags
+  -e, --extension       summarize average/total value
+  -j, --json            json output
+  -d DISK, --disk DISK  Trace this disk only
 
 examples:
     ./biolatency                    # summarize block I/O latency as a histogram
@@ -380,3 +381,4 @@ examples:
     ./biolatency -F                 # show I/O flags separately
     ./biolatency -j                 # print a dictionary
     ./biolatency -e                 # show extension summary(total, average)
+    ./biolatency -d sdc             # Trace sdc only


### PR DESCRIPTION
Sometimes, I just want to focus on a specified disk rather than all disks or per-disk. Refer to libbpf-tools/biolatency, this patch try to add disk filter support.