### PR TITLE
Clean up several warn

### DIFF
--- a/src/cc/bpf_module_rw_engine.cc
+++ b/src/cc/bpf_module_rw_engine.cc
@@ -416,7 +416,7 @@ int BPFModule::annotate() {
       StructType *st = dyn_cast<StructType>(t);
 #else
     if (PointerType *pt = dyn_cast<PointerType>(gvar->getType())) {
-      StructType *st = dyn_cast<StructType>(pt->getElementType());
+      StructType *st = dyn_cast<StructType>(pt->getPointerElementType());
 #endif
       if (st) {
         if (st->getNumElements() < 2) continue;

--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -74,28 +74,29 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
   cflags->push_back("-isystem");
   cflags->push_back("/virtual/lib/clang/include");
 
-  // The include order from kernel top Makefile:
-  //
-  // # Use USERINCLUDE when you must reference the UAPI directories only.
-  // USERINCLUDE    := \
-  //                 -I$(srctree)/arch/$(SRCARCH)/include/uapi \
-  //                 -I$(objtree)/arch/$(SRCARCH)/include/generated/uapi \
-  //                 -I$(srctree)/include/uapi \
-  //                 -I$(objtree)/include/generated/uapi \
-  //                 -include $(srctree)/include/linux/kconfig.h
-  //
-  // # Use LINUXINCLUDE when you must reference the include/ directory.
-  // # Needed to be compatible with the O= option
-  // LINUXINCLUDE    := \
-  //                 -I$(srctree)/arch/$(SRCARCH)/include \
-  //                 -I$(objtree)/arch/$(SRCARCH)/include/generated \
-  //                 $(if $(building_out_of_srctree),-I$(srctree)/include) \
-  //                 -I$(objtree)/include \
-  //                 $(USERINCLUDE)
-  //
-  // Some distros such as openSUSE/SUSE and Debian splits the headers between
-  // source/ and build/. In this case, just $(srctree) is source/ and
-  // $(objtree) is build/.
+  /* The include order from kernel top Makefile:
+   *
+   * # Use USERINCLUDE when you must reference the UAPI directories only.
+   * USERINCLUDE    := \
+   *                 -I$(srctree)/arch/$(SRCARCH)/include/uapi \
+   *                 -I$(objtree)/arch/$(SRCARCH)/include/generated/uapi \
+   *                 -I$(srctree)/include/uapi \
+   *                 -I$(objtree)/include/generated/uapi \
+   *                 -include $(srctree)/include/linux/kconfig.h
+   *
+   * # Use LINUXINCLUDE when you must reference the include/ directory.
+   * # Needed to be compatible with the O= option
+   * LINUXINCLUDE    := \
+   *                 -I$(srctree)/arch/$(SRCARCH)/include \
+   *                 -I$(objtree)/arch/$(SRCARCH)/include/generated \
+   *                 $(if $(building_out_of_srctree),-I$(srctree)/include) \
+   *                 -I$(objtree)/include \
+   *                 $(USERINCLUDE)
+   *
+   * Some distros such as openSUSE/SUSE and Debian splits the headers between
+   * source/ and build/. In this case, just $(srctree) is source/ and
+   * $(objtree) is build/.
+   */
   if (has_source_dir_) {
     cflags->push_back("-Iarch/"+arch+"/include/");
     cflags->push_back("-I" + kdir_ + "/build/arch/"+arch+"/include/generated");

--- a/src/python/setup.py.in
+++ b/src/python/setup.py.in
@@ -1,6 +1,6 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
-from distutils.core import setup
+from setuptools import setup
 import os
 import sys
 


### PR DESCRIPTION
This patch will redeem several warn #4028.

1. Comment format
2. Deprecated PointerType::getElementType()
3. use setuptools

Signed-off-by: Paran Lee <p4ranlee@gmail.com>