### PR TITLE
libbpf-tools: Remove map flag BPF_F_NO_PREALLOC

### DIFF
--- a/libbpf-tools/biolatency.bpf.c
+++ b/libbpf-tools/biolatency.bpf.c
@@ -35,7 +35,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct request *);
 	__type(value, u64);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } start SEC(".maps");
 
 static struct hist initial_hist;
@@ -45,7 +44,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct hist_key);
 	__type(value, struct hist);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } hists SEC(".maps");
 
 static __always_inline

--- a/libbpf-tools/biopattern.bpf.c
+++ b/libbpf-tools/biopattern.bpf.c
@@ -14,7 +14,6 @@ struct {
 	__uint(max_entries, 64);
 	__type(key, u32);
 	__type(value, struct counter);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } counters SEC(".maps");
 
 SEC("tracepoint/block/block_rq_complete")

--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -36,7 +36,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct request *);
 	__type(value, struct piddata);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } infobyreq SEC(".maps");
 
 struct stage {

--- a/libbpf-tools/biostacks.bpf.c
+++ b/libbpf-tools/biostacks.bpf.c
@@ -28,7 +28,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct request *);
 	__type(value, struct internal_rqinfo);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } rqinfos SEC(".maps");
 
 struct {
@@ -36,7 +35,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct rqinfo);
 	__type(value, struct hist);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } hists SEC(".maps");
 
 static struct hist zero;

--- a/libbpf-tools/bitesize.bpf.c
+++ b/libbpf-tools/bitesize.bpf.c
@@ -22,7 +22,6 @@ struct {
 	__uint(max_entries, 10240);
 	__type(key, struct hist_key);
 	__type(value, struct hist);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } hists SEC(".maps");
 
 static struct hist initial_hist;

--- a/libbpf-tools/numamove.bpf.c
+++ b/libbpf-tools/numamove.bpf.c
@@ -9,7 +9,6 @@ struct {
 	__uint(max_entries, 10240);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } start SEC(".maps");
 
 __u64 latency = 0;

--- a/libbpf-tools/readahead.bpf.c
+++ b/libbpf-tools/readahead.bpf.c
@@ -13,7 +13,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } in_readahead SEC(".maps");
 
 struct {
@@ -21,7 +20,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct page *);
 	__type(value, u64);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } birth SEC(".maps");
 
 struct hist hist = {};

--- a/libbpf-tools/syscount.bpf.c
+++ b/libbpf-tools/syscount.bpf.c
@@ -28,7 +28,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, u32);
 	__type(value, u64);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } start SEC(".maps");
 
 struct {
@@ -36,7 +35,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, u32);
 	__type(value, struct data_t);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } data SEC(".maps");
 
 static __always_inline

--- a/libbpf-tools/tcpconnect.bpf.c
+++ b/libbpf-tools/tcpconnect.bpf.c
@@ -26,7 +26,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, u32);
 	__type(value, struct sock *);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } sockets SEC(".maps");
 
 struct {
@@ -34,7 +33,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct ipv4_flow_key);
 	__type(value, u64);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } ipv4_count SEC(".maps");
 
 struct {
@@ -42,7 +40,6 @@ struct {
 	__uint(max_entries, MAX_ENTRIES);
 	__type(key, struct ipv6_flow_key);
 	__type(value, u64);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
 } ipv6_count SEC(".maps");
 
 struct {


### PR DESCRIPTION
Using hash maps with BPF_F_NO_PREALLOC flag triggers a warning ([0]), and according
to kernel [commit 94dacdbd5d2d](https://github.com/torvalds/linux/commit/94dacdbd5d2d),
this may cause deadlocks. Remove the flag from libbpf tools.

  [0]: https://github.com/torvalds/linux/blob/v5.18/kernel/bpf/verifier.c#L11972-L12000

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>