### PR TITLE
libbpf-tools: Fix bio tools

### DIFF
--- a/libbpf-tools/biostacks.c
+++ b/libbpf-tools/biostacks.c
@@ -173,6 +173,18 @@ int main(int argc, char **argv)
 
 	obj->rodata->targ_ms = env.milliseconds;
 
+	if (fentry_can_attach("blk_account_io_start", NULL)) {
+		bpf_program__set_attach_target(obj->progs.blk_account_io_start, 0,
+					       "blk_account_io_start");
+		bpf_program__set_attach_target(obj->progs.blk_account_io_done, 0,
+					       "blk_account_io_done");
+	} else {
+		bpf_program__set_attach_target(obj->progs.blk_account_io_start, 0,
+					       "__blk_account_io_start");
+		bpf_program__set_attach_target(obj->progs.blk_account_io_done, 0,
+					       "__blk_account_io_done");
+	}
+
 	err = biostacks_bpf__load(obj);
 	if (err) {
 		fprintf(stderr, "failed to load BPF object: %d\n", err);


### PR DESCRIPTION
The tools biosnoop and biostacks are broken due to kernel change ([0]).
blk_account_io_{start, done} were renamed to \_\_blk_account_io_{start, done},
and the symbols gone from vmlinux BTF. Fix them by checking symbol existence.

  [0]: https://github.com/torvalds/linux/commit/be6bfe36db1795babe9d92178a47b2e02193cb0f