### PR TITLE
Update the tracefs path.

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -205,7 +205,7 @@ This is a macro that instruments the tracepoint defined by *category*:*event*.
 The tracepoint name is `<category>:<event>`.
 The probe function name is `tracepoint__<category>__<event>`.
 
-Arguments are available in an ```args``` struct, which are the tracepoint arguments. One way to list these is to cat the relevant format file under /sys/kernel/debug/tracing/events/*category*/*event*/format.
+Arguments are available in an ```args``` struct, which are the tracepoint arguments. One way to list these is to cat the relevant format file under /sys/kernel/tracing/events/*category*/*event*/format.
 
 The ```args``` struct can be used in place of ``ctx`` in each functions requiring a context as an argument. This includes notably [perf_submit()](#3-perf_submit).
 
@@ -213,7 +213,7 @@ For example:
 
 ```C
 TRACEPOINT_PROBE(random, urandom_read) {
-    // args is from /sys/kernel/debug/tracing/events/random/urandom_read/format
+    // args is from /sys/kernel/tracing/events/random/urandom_read/format
     bpf_trace_printk("%d\\n", args->got_bits);
     return 0;
 }
@@ -676,7 +676,7 @@ Syntax: ```int bpf_trace_printk(const char *fmt, ...)```
 
 Return: 0 on success
 
-A simple kernel facility for printf() to the common trace_pipe (/sys/kernel/debug/tracing/trace_pipe). This is ok for some quick examples, but has limitations: 3 args max, 1 %s only, and trace_pipe is globally shared, so concurrent programs will have clashing output. A better interface is via BPF_PERF_OUTPUT(). Note that calling this helper is made simpler than the original kernel version, which has ```fmt_size``` as the second parameter.
+A simple kernel facility for printf() to the common trace_pipe (/sys/kernel/tracing/trace_pipe). This is ok for some quick examples, but has limitations: 3 args max, 1 %s only, and trace_pipe is globally shared, so concurrent programs will have clashing output. A better interface is via BPF_PERF_OUTPUT(). Note that calling this helper is made simpler than the original kernel version, which has ```fmt_size``` as the second parameter.
 
 Examples in situ:
 [search /examples](https://github.com/iovisor/bcc/search?q=bpf_trace_printk+path%3Aexamples&type=Code),
@@ -1663,7 +1663,7 @@ bpf_text = """
 #include <uapi/linux/ptrace.h>
 
 struct urandom_read_args {
-    // from /sys/kernel/debug/tracing/events/random/urandom_read/format
+    // from /sys/kernel/tracing/events/random/urandom_read/format
     u64 __unused__;
     u32 got_bits;
     u32 pool_left;
@@ -1930,7 +1930,7 @@ b.detach_kretprobe(event="__page_cache_alloc", fn_name="trace_func_return")
 
 Syntax: ```BPF.trace_print(fmt="fields")```
 
-This method continually reads the globally shared /sys/kernel/debug/tracing/trace_pipe file and prints its contents. This file can be written to via BPF and the bpf_trace_printk() function, however, that method has limitations, including a lack of concurrent tracing support. The BPF_PERF_OUTPUT mechanism, covered earlier, is preferred.
+This method continually reads the globally shared /sys/kernel/tracing/trace_pipe file and prints its contents. This file can be written to via BPF and the bpf_trace_printk() function, however, that method has limitations, including a lack of concurrent tracing support. The BPF_PERF_OUTPUT mechanism, covered earlier, is preferred.
 
 Arguments:
 
@@ -1954,7 +1954,7 @@ Examples in situ:
 
 Syntax: ```BPF.trace_fields(nonblocking=False)```
 
-This method reads one line from the globally shared /sys/kernel/debug/tracing/trace_pipe file and returns it as fields. This file can be written to via BPF and the bpf_trace_printk() function, however, that method has limitations, including a lack of concurrent tracing support. The BPF_PERF_OUTPUT mechanism, covered earlier, is preferred.
+This method reads one line from the globally shared /sys/kernel/tracing/trace_pipe file and returns it as fields. This file can be written to via BPF and the bpf_trace_printk() function, however, that method has limitations, including a lack of concurrent tracing support. The BPF_PERF_OUTPUT mechanism, covered earlier, is preferred.
 
 Arguments:
 

--- a/docs/tutorial_bcc_python_developer.md
+++ b/docs/tutorial_bcc_python_developer.md
@@ -34,7 +34,7 @@ There are six things to learn from this:
 
 1. ```void *ctx```: ctx has arguments, but since we aren't using them here, we'll just cast it to ```void *```.
 
-1. ```bpf_trace_printk()```: A simple kernel facility for printf() to the common trace_pipe (/sys/kernel/debug/tracing/trace_pipe). This is ok for some quick examples, but has limitations: 3 args max, 1 %s only, and trace_pipe is globally shared, so concurrent programs will have clashing output. A better interface is via BPF_PERF_OUTPUT(), covered later.
+1. ```bpf_trace_printk()```: A simple kernel facility for printf() to the common trace_pipe (/sys/kernel/tracing/trace_pipe). This is ok for some quick examples, but has limitations: 3 args max, 1 %s only, and trace_pipe is globally shared, so concurrent programs will have clashing output. A better interface is via BPF_PERF_OUTPUT(), covered later.
 
 1. ```return 0;```: Necessary formality (if you want to know why, see [#139](https://github.com/iovisor/bcc/issues/139)).
 
@@ -460,7 +460,7 @@ from bcc import BPF
 # load BPF program
 b = BPF(text="""
 TRACEPOINT_PROBE(random, urandom_read) {
-    // args is from /sys/kernel/debug/tracing/events/random/urandom_read/format
+    // args is from /sys/kernel/tracing/events/random/urandom_read/format
     bpf_trace_printk("%d\\n", args->got_bits);
     return 0;
 }
@@ -484,7 +484,7 @@ Things to learn:
 1. ```args->got_bits```: ```args``` is auto-populated to be a structure of the tracepoint arguments. The comment above says where you can see that structure. Eg:
 
 ```
-# cat /sys/kernel/debug/tracing/events/random/urandom_read/format
+# cat /sys/kernel/tracing/events/random/urandom_read/format
 name: urandom_read
 ID: 972
 format:

--- a/examples/cpp/CGroupTest.cc
+++ b/examples/cpp/CGroupTest.cc
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  std::ifstream pipe("/sys/kernel/debug/tracing/trace_pipe");
+  std::ifstream pipe("/sys/kernel/tracing/trace_pipe");
   std::string line;
 
   std::cout << "Started tracing open event, hit Ctrl-C to terminate." << std::endl;

--- a/examples/cpp/HelloWorld.cc
+++ b/examples/cpp/HelloWorld.cc
@@ -26,7 +26,7 @@ int main() {
     return 1;
   }
 
-  std::ifstream pipe("/sys/kernel/debug/tracing/trace_pipe");
+  std::ifstream pipe("/sys/kernel/tracing/trace_pipe");
   std::string line;
   std::string clone_fnname = bpf.get_syscall_fnname("clone");
 

--- a/examples/tracing/urandomread-explicit.py
+++ b/examples/tracing/urandomread-explicit.py
@@ -24,7 +24,7 @@ bpf_text = """
 #include <uapi/linux/ptrace.h>
 
 struct urandom_read_args {
-    // from /sys/kernel/debug/tracing/events/random/urandom_read/format
+    // from /sys/kernel/tracing/events/random/urandom_read/format
     u64 __unused__;
     u32 got_bits;
     u32 pool_left;

--- a/examples/tracing/urandomread.py
+++ b/examples/tracing/urandomread.py
@@ -18,7 +18,7 @@ from bcc.utils import printb
 # load BPF program
 b = BPF(text="""
 TRACEPOINT_PROBE(random, urandom_read) {
-    // args is from /sys/kernel/debug/tracing/events/random/urandom_read/format
+    // args is from /sys/kernel/tracing/events/random/urandom_read/format
     bpf_trace_printk("%d\\n", args->got_bits);
     return 0;
 }

--- a/examples/usdt_sample/usdt_sample.md
+++ b/examples/usdt_sample/usdt_sample.md
@@ -522,7 +522,7 @@ bpf_trace_printk("inputString: '%s'", inputString);
 ```
 
 ```bash
-$ sudo tail -f /sys/kernel/debug/tracing/trace
+$ sudo tail -f /sys/kernel/tracing/trace
 ...
  usdt_sample_app-2439214 [001] d... 635079.194883: bpf_trace_printk: inputString: 'usdt_8'
  usdt_sample_app-2439214 [001] d... 635079.295102: bpf_trace_printk: inputString: 'usdt_17'

--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -1055,7 +1055,7 @@ bool kprobe_exists(const char *name)
 	FILE *f;
 	int ret;
 
-	f = fopen("/sys/kernel/debug/tracing/available_filter_functions", "r");
+	f = fopen("/sys/kernel/tracing/available_filter_functions", "r");
 	if (!f)
 		goto slow_path;
 

--- a/libbpf-tools/trace_helpers.h
+++ b/libbpf-tools/trace_helpers.h
@@ -85,7 +85,7 @@ bool fentry_can_attach(const char *name, const char *mod);
  * uses a certain function name before attaching.
  *
  * It is achieved by scaning
- * 	/sys/kernel/debug/tracing/available_filter_functions
+ * 	/sys/kernel/tracing/available_filter_functions
  * If this file does not exist, it fallbacks to parse /proc/kallsyms,
  * which is slower.
  */

--- a/man/man8/reset-trace.8
+++ b/man/man8/reset-trace.8
@@ -14,7 +14,7 @@ Make sure no other tracing sessions are active. This tool might stop them from
 functioning (perhaps ungracefully).
 
 This specifically clears the state in at least the following files in
-/sys/kernel/debug/tracing: kprobe_events, uprobe_events, trace_pipe.
+/sys/kernel/tracing: kprobe_events, uprobe_events, trace_pipe.
 Other tracing facilities (ftrace) are checked, and if not in an expected state,
 a note is printed. All tracing files can be reset with \-F for force, but this
 will interfere with any other running tracing sessions (eg, ftrace).

--- a/src/cc/compat/linux/virtual_bpf.h
+++ b/src/cc/compat/linux/virtual_bpf.h
@@ -1604,17 +1604,17 @@ union bpf_attr {
  * 	Description
  * 		This helper is a "printk()-like" facility for debugging. It
  * 		prints a message defined by format *fmt* (of size *fmt_size*)
- * 		to file *\/sys/kernel/debug/tracing/trace* from DebugFS, if
+ * 		to file *\/sys/kernel/tracing/trace* from DebugFS, if
  * 		available. It can take up to three additional **u64**
  * 		arguments (as an eBPF helpers, the total number of arguments is
  * 		limited to five).
  *
  * 		Each time the helper is called, it appends a line to the trace.
- * 		Lines are discarded while *\/sys/kernel/debug/tracing/trace* is
- * 		open, use *\/sys/kernel/debug/tracing/trace_pipe* to avoid this.
+ * 		Lines are discarded while *\/sys/kernel/tracing/trace* is
+ * 		open, use *\/sys/kernel/tracing/trace_pipe* to avoid this.
  * 		The format of the trace is customizable, and the exact output
  * 		one will get depends on the options set in
- * 		*\/sys/kernel/debug/tracing/trace_options* (see also the
+ * 		*\/sys/kernel/tracing/trace_options* (see also the
  * 		*README* file under the same directory). However, it usually
  * 		defaults to something like:
  *

--- a/src/cc/frontends/clang/tp_frontend_action.cc
+++ b/src/cc/frontends/clang/tp_frontend_action.cc
@@ -53,7 +53,7 @@ TracepointTypeVisitor::TracepointTypeVisitor(ASTContext &C, Rewriter &rewriter)
 
 string TracepointTypeVisitor::GenerateTracepointStruct(
     SourceLocation loc, string const& category, string const& event) {
-  string format_file = "/sys/kernel/debug/tracing/events/" +
+  string format_file = "/sys/kernel/tracing/events/" +
     category + "/" + event + "/format";
   ifstream input(format_file.c_str());
   if (!input)

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -1098,7 +1098,7 @@ static int create_probe_event(char *buf, const char *ev_name,
   char ev_alias[256];
   bool is_kprobe = strncmp("kprobe", event_type, 6) == 0;
 
-  snprintf(buf, PATH_MAX, "/sys/kernel/debug/tracing/%s_events", event_type);
+  snprintf(buf, PATH_MAX, "/sys/kernel/tracing/%s_events", event_type);
   kfd = open(buf, O_WRONLY | O_APPEND, 0);
   if (kfd < 0) {
     fprintf(stderr, "%s: open(%s): %s\n", __func__, buf,
@@ -1143,7 +1143,7 @@ static int create_probe_event(char *buf, const char *ev_name,
     goto error;
   }
   close(kfd);
-  snprintf(buf, PATH_MAX, "/sys/kernel/debug/tracing/events/%ss/%s",
+  snprintf(buf, PATH_MAX, "/sys/kernel/tracing/events/%ss/%s",
            event_type, ev_alias);
   return 0;
 error:
@@ -1186,10 +1186,10 @@ static int bpf_attach_probe(int progfd, enum bpf_probe_attach_type attach_type,
       }
       if (access(fname, F_OK) == -1) {
         // Deleting kprobe event with incorrect name.
-        kfd = open("/sys/kernel/debug/tracing/kprobe_events",
+        kfd = open("/sys/kernel/tracing/kprobe_events",
                    O_WRONLY | O_APPEND, 0);
         if (kfd < 0) {
-          fprintf(stderr, "open(/sys/kernel/debug/tracing/kprobe_events): %s\n",
+          fprintf(stderr, "open(/sys/kernel/tracing/kprobe_events): %s\n",
                   strerror(errno));
           return -1;
         }
@@ -1257,7 +1257,7 @@ static int bpf_detach_probe(const char *ev_name, const char *event_type)
    * the %s_bcc_%d line in [k,u]probe_events. If the event is not found,
    * it is safe to skip the cleaning up process (write -:... to the file).
    */
-  snprintf(buf, sizeof(buf), "/sys/kernel/debug/tracing/%s_events", event_type);
+  snprintf(buf, sizeof(buf), "/sys/kernel/tracing/%s_events", event_type);
   fp = fopen(buf, "r");
   if (!fp) {
     fprintf(stderr, "open(%s): %s\n", buf, strerror(errno));
@@ -1282,7 +1282,7 @@ static int bpf_detach_probe(const char *ev_name, const char *event_type)
   if (!found_event)
     return 0;
 
-  snprintf(buf, sizeof(buf), "/sys/kernel/debug/tracing/%s_events", event_type);
+  snprintf(buf, sizeof(buf), "/sys/kernel/tracing/%s_events", event_type);
   kfd = open(buf, O_WRONLY | O_APPEND, 0);
   if (kfd < 0) {
     fprintf(stderr, "open(%s): %s\n", buf, strerror(errno));
@@ -1326,7 +1326,7 @@ int bpf_attach_tracepoint(int progfd, const char *tp_category,
   char buf[256];
   int pfd = -1;
 
-  snprintf(buf, sizeof(buf), "/sys/kernel/debug/tracing/events/%s/%s",
+  snprintf(buf, sizeof(buf), "/sys/kernel/tracing/events/%s/%s",
            tp_category, tp_name);
   if (bpf_attach_tracing_event(progfd, buf, -1 /* PID */, &pfd) == 0)
     return pfd;

--- a/src/lua/README.md
+++ b/src/lua/README.md
@@ -119,7 +119,7 @@ See `examples/lua` directory.
 
 ### Helpers
 
-* `print(...)` is a wrapper for `bpf_trace_printk`, the output is captured in `cat /sys/kernel/debug/tracing/trace_pipe`
+* `print(...)` is a wrapper for `bpf_trace_printk`, the output is captured in `cat /sys/kernel/tracing/trace_pipe`
 * `bit.*` library **is** supported (`lshift, rshift, arshift, bnot, band, bor, bxor`)
 * `math.*` library *partially* supported (`log2, log, log10`)
 * `ffi.cast()` is implemented (including structures and arrays)

--- a/src/lua/bcc/tracerpipe.lua
+++ b/src/lua/bcc/tracerpipe.lua
@@ -15,7 +15,7 @@ limitations under the License.
 ]]
 local TracerPipe = class("TracerPipe")
 
-TracerPipe.static.TRACEFS = "/sys/kernel/debug/tracing"
+TracerPipe.static.TRACEFS = "/sys/kernel/tracing"
 TracerPipe.static.fields = "%s+(.-)%-(%d+)%s+%[(%d+)%]%s+(....)%s+([%d%.]+):.-:%s+(.+)"
 
 function TracerPipe:close()

--- a/src/lua/bpf/bpf.lua
+++ b/src/lua/bpf/bpf.lua
@@ -1461,7 +1461,7 @@ local bpf_map_mt = {
 
 -- Linux tracing interface
 local function trace_check_enabled(path)
-	path = path or '/sys/kernel/debug/tracing'
+	path = path or '/sys/kernel/tracing'
 	if S.statfs(path) then return true end
 	return nil, 'debugfs not accessible: "mount -t debugfs nodev /sys/kernel/debug"? missing sudo?'
 end
@@ -1487,7 +1487,7 @@ local tracepoint_mt = {
 -- Open tracepoint
 local function tracepoint_open(path, pid, cpu, group_fd)
 	-- Open tracepoint and compile tracepoint type
-	local tp = assert(S.perf_tracepoint('/sys/kernel/debug/tracing/events/'..path))
+	local tp = assert(S.perf_tracepoint('/sys/kernel/tracing/events/'..path))
 	local tp_type = assert(cdef.tracepoint_type(path))
 	-- Open tracepoint reader and create interface
 	local reader = assert(S.perf_attach_tracepoint(tp, pid, cpu, group_fd))
@@ -1621,7 +1621,7 @@ return setmetatable({
 	end,
 	tracelog = function(path)
 		assert(trace_check_enabled())
-		path = path or '/sys/kernel/debug/tracing/trace_pipe'
+		path = path or '/sys/kernel/tracing/trace_pipe'
 		return io.open(path, 'r')
 	end,
 	ntoh = builtins.ntoh, hton = builtins.hton,

--- a/src/lua/bpf/cdef.lua
+++ b/src/lua/bpf/cdef.lua
@@ -266,7 +266,7 @@ end
 
 function M.tracepoint_type(tp)
 	-- Read tracepoint format string
-	local fp = assert(io.open('/sys/kernel/debug/tracing/events/'..tp..'/format', 'r'))
+	local fp = assert(io.open('/sys/kernel/tracing/events/'..tp..'/format', 'r'))
 	local fmt = fp:read '*a'
 	fp:close()
 	-- Parse struct fields

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -44,7 +44,7 @@ def _get_num_open_probes():
     global _num_open_probes
     return _num_open_probes
 
-TRACEFS = "/sys/kernel/debug/tracing"
+TRACEFS = "/sys/kernel/tracing"
 
 # Debug flags
 
@@ -1009,7 +1009,7 @@ class BPF(object):
         provided regular expression.
 
         To obtain a list of kernel tracepoints, use the tplist tool or cat the
-        file /sys/kernel/debug/tracing/available_events.
+        file /sys/kernel/tracing/available_events.
 
         Examples:
             BPF(text).attach_tracepoint(tp="sched:sched_switch", fn_name="on_switch")

--- a/tools/bpflist.py
+++ b/tools/bpflist.py
@@ -42,7 +42,7 @@ counts = {}
 def parse_probes(typ):
     if args.verbosity > 1:
         print("open %ss:" % typ)
-    for probe in open("/sys/kernel/debug/tracing/%s_events" % typ):
+    for probe in open("/sys/kernel/tracing/%s_events" % typ):
         # Probes opened by bcc have a specific pattern that includes the pid
         # of the requesting process.
         match = re.search('_bcc_(\\d+)\\s', probe)

--- a/tools/opensnoop_example.txt
+++ b/tools/opensnoop_example.txt
@@ -6,7 +6,7 @@ Example output:
 
 # ./opensnoop
 PID    COMM      FD ERR PATH
-17326  <...>      7   0 /sys/kernel/debug/tracing/trace_pipe
+17326  <...>      7   0 /sys/kernel/tracing/trace_pipe
 1576   snmpd      9   0 /proc/net/dev
 1576   snmpd     11   0 /proc/net/if_inet6
 1576   snmpd     11   0 /proc/sys/net/ipv4/neigh/eth0/retrans_time_ms

--- a/tools/reset-trace.sh
+++ b/tools/reset-trace.sh
@@ -23,7 +23,7 @@
 # 20-Jul-2014	Brendan Gregg	Created this.
 # 18-Oct-2016      "      "     Updated for bcc use.
 
-tracing=/sys/kernel/debug/tracing
+tracing=/sys/kernel/tracing
 opt_force=0; opt_verbose=0; opt_quiet=0
 
 function usage {

--- a/tools/reset-trace_example.txt
+++ b/tools/reset-trace_example.txt
@@ -11,7 +11,7 @@ WARNING: Make sure no other tracing sessions are active, as it will likely
 stop them from functioning (perhaps ungracefully).
 
 This specifically clears the state in at least the following files in
-/sys/kernel/debug/tracing: kprobe_events, uprobe_events, trace_pipe.
+/sys/kernel/tracing: kprobe_events, uprobe_events, trace_pipe.
 Other tracing facilities (ftrace) are checked, and if not in an expected state,
 a note is printed. All tracing files can be reset with -F for force, but this
 will interfere with any other running tracing sessions (eg, ftrace).
@@ -29,16 +29,16 @@ You can use -v to see what it does:
 # ./reset-trace.sh -v
 Resetting tracing state...
 
-Checking /sys/kernel/debug/tracing/kprobe_events
-Checking /sys/kernel/debug/tracing/uprobe_events
-Checking /sys/kernel/debug/tracing/trace
-Checking /sys/kernel/debug/tracing/current_tracer
-Checking /sys/kernel/debug/tracing/set_ftrace_filter
-Checking /sys/kernel/debug/tracing/set_graph_function
-Checking /sys/kernel/debug/tracing/set_ftrace_pid
-Checking /sys/kernel/debug/tracing/events/enable
-Checking /sys/kernel/debug/tracing/tracing_thresh
-Checking /sys/kernel/debug/tracing/tracing_on
+Checking /sys/kernel/tracing/kprobe_events
+Checking /sys/kernel/tracing/uprobe_events
+Checking /sys/kernel/tracing/trace
+Checking /sys/kernel/tracing/current_tracer
+Checking /sys/kernel/tracing/set_ftrace_filter
+Checking /sys/kernel/tracing/set_graph_function
+Checking /sys/kernel/tracing/set_ftrace_pid
+Checking /sys/kernel/tracing/events/enable
+Checking /sys/kernel/tracing/tracing_thresh
+Checking /sys/kernel/tracing/tracing_on
 
 Done.
 
@@ -134,9 +134,9 @@ state. Using reset-trace:
 # ./reset-trace.sh -v
 Resetting tracing state...
 
-Checking /sys/kernel/debug/tracing/kprobe_events
-Checking /sys/kernel/debug/tracing/uprobe_events
-Needed to reset /sys/kernel/debug/tracing/uprobe_events
+Checking /sys/kernel/tracing/kprobe_events
+Checking /sys/kernel/tracing/uprobe_events
+Needed to reset /sys/kernel/tracing/uprobe_events
 uprobe_events, before (line enumerated):
      1	p:uprobes/p__bin_bash_0xa2540 /bin/bash:0x00000000000a2540
      2	p:uprobes/p__bin_bash_0x21220 /bin/bash:0x0000000000021220
@@ -157,14 +157,14 @@ uprobe_events, before (line enumerated):
    317	p:uprobes/p__bin_bash_0x4a930 /bin/bash:0x000000000004a930
 uprobe_events, after (line enumerated):
 
-Checking /sys/kernel/debug/tracing/trace
-Checking /sys/kernel/debug/tracing/current_tracer
-Checking /sys/kernel/debug/tracing/set_ftrace_filter
-Checking /sys/kernel/debug/tracing/set_graph_function
-Checking /sys/kernel/debug/tracing/set_ftrace_pid
-Checking /sys/kernel/debug/tracing/events/enable
-Checking /sys/kernel/debug/tracing/tracing_thresh
-Checking /sys/kernel/debug/tracing/tracing_on
+Checking /sys/kernel/tracing/trace
+Checking /sys/kernel/tracing/current_tracer
+Checking /sys/kernel/tracing/set_ftrace_filter
+Checking /sys/kernel/tracing/set_graph_function
+Checking /sys/kernel/tracing/set_ftrace_pid
+Checking /sys/kernel/tracing/events/enable
+Checking /sys/kernel/tracing/tracing_thresh
+Checking /sys/kernel/tracing/tracing_on
 
 Done.
 
@@ -174,7 +174,7 @@ from uprobe_events.
 Here's the same situation, but without the verbose option:
 
 # ./reset-trace.sh
-Needed to reset /sys/kernel/debug/tracing/uprobe_events
+Needed to reset /sys/kernel/tracing/uprobe_events
 #
 
 And again with quiet:
@@ -186,19 +186,19 @@ And again with quiet:
 Here is an example of reset-trace detecting an unrelated tracing session:
 
 # ./reset-trace.sh 
-Noticed unrelated tracing file /sys/kernel/debug/tracing/set_ftrace_filter isn't set as expected. Not resetting (-F to force, -v for verbose).
+Noticed unrelated tracing file /sys/kernel/tracing/set_ftrace_filter isn't set as expected. Not resetting (-F to force, -v for verbose).
 
 And verbose:
 
 # ./reset-trace.sh -v
 Resetting tracing state...
 
-Checking /sys/kernel/debug/tracing/kprobe_events
-Checking /sys/kernel/debug/tracing/uprobe_events
-Checking /sys/kernel/debug/tracing/trace
-Checking /sys/kernel/debug/tracing/current_tracer
-Checking /sys/kernel/debug/tracing/set_ftrace_filter
-Noticed unrelated tracing file /sys/kernel/debug/tracing/set_ftrace_filter isn't set as expected. Not resetting (-F to force, -v for verbose).
+Checking /sys/kernel/tracing/kprobe_events
+Checking /sys/kernel/tracing/uprobe_events
+Checking /sys/kernel/tracing/trace
+Checking /sys/kernel/tracing/current_tracer
+Checking /sys/kernel/tracing/set_ftrace_filter
+Noticed unrelated tracing file /sys/kernel/tracing/set_ftrace_filter isn't set as expected. Not resetting (-F to force, -v for verbose).
 Contents of set_ftrace_filter is (line enumerated):
      1	tcp_send_mss
      2	tcp_sendpage
@@ -215,11 +215,11 @@ Contents of set_ftrace_filter is (line enumerated):
     13	tcp_send_window_probe
     14	tcp_send_probe0
 Expected "".
-Checking /sys/kernel/debug/tracing/set_graph_function
-Checking /sys/kernel/debug/tracing/set_ftrace_pid
-Checking /sys/kernel/debug/tracing/events/enable
-Checking /sys/kernel/debug/tracing/tracing_thresh
-Checking /sys/kernel/debug/tracing/tracing_on
+Checking /sys/kernel/tracing/set_graph_function
+Checking /sys/kernel/tracing/set_ftrace_pid
+Checking /sys/kernel/tracing/events/enable
+Checking /sys/kernel/tracing/tracing_thresh
+Checking /sys/kernel/tracing/tracing_on
 
 Done.
 

--- a/tools/tplist.py
+++ b/tools/tplist.py
@@ -15,7 +15,7 @@ import sys
 
 from bcc import USDT
 
-trace_root = "/sys/kernel/debug/tracing"
+trace_root = "/sys/kernel/tracing"
 event_root = os.path.join(trace_root, "events")
 
 parser = argparse.ArgumentParser(

--- a/tools/ttysnoop_example.txt
+++ b/tools/ttysnoop_example.txt
@@ -54,9 +54,9 @@ console:
 
 # ./ttysnoop /dev/console
 Oct 16 01:32:06 bgregg-xenial-bpf-i-xxx kernel: [780087.407428] bash (9888): drop_caches: 1
-Oct 16 01:32:38 bgregg-xenial-bpf-i-xxx snmpd[2708]: Cannot statfs /sys/kernel/debug/tracing: Permission denied
-Oct 16 01:33:32 bgregg-xenial-bpf-i-xxx snmpd[2708]: Cannot statfs /sys/kernel/debug/tracing: Permission denied
-Oct 16 01:34:26 bgregg-xenial-bpf-i-xxx snmpd[2708]: Cannot statfs /sys/kernel/debug/tracing: Permission denied
+Oct 16 01:32:38 bgregg-xenial-bpf-i-xxx snmpd[2708]: Cannot statfs /sys/kernel/tracing: Permission denied
+Oct 16 01:33:32 bgregg-xenial-bpf-i-xxx snmpd[2708]: Cannot statfs /sys/kernel/tracing: Permission denied
+Oct 16 01:34:26 bgregg-xenial-bpf-i-xxx snmpd[2708]: Cannot statfs /sys/kernel/tracing: Permission denied
 ^C
 
 Neat!


### PR DESCRIPTION
The tracefs is mounted at `/sys/kernel/tracing` after 4.1 kernel. For backward compatibility, when mounting the debugfs file system, the tracefs file system will be automatically mounted at `/sys/kernel/debug/tracing`; But when CONFIG_TRACEFS_DISABLE_AUTOMOUNT is enabled, the automount wouldn't happen and the `/sys/kernel/debug/tracing` is not exist.