### PR TITLE
Remove executable permission for 'funcinterval.8'.

### DIFF
--- a/man/man8/funcinterval.8
+++ b/man/man8/funcinterval.8
@@ -8,7 +8,7 @@ This tool times interval between the same function as a histogram.
 
 eBPF/bcc is very suitable for platform performance tuning.
 By funclatency, we can profile specific functions to know how latency
-this function costs. However, sometimes performance drop is not about the 
+this function costs. However, sometimes performance drop is not about the
 latency of function but the interval between function calls.
 funcinterval is born for this purpose.
 


### PR DESCRIPTION
Remove executable permission for 'funcinterval.8'.