### PR TITLE
Fix: Failed to load BPF program b'trace_read_return': Permission denied

### DIFF
--- a/tools/xfsslower.py
+++ b/tools/xfsslower.py
@@ -186,8 +186,11 @@ static int trace_return(struct pt_regs *ctx, int type)
 
     // populate output struct
     u32 size = PT_REGS_RC(ctx);
-    struct data_t data = {.type = type, .size = size, .delta_us = delta_us,
-        .pid = pid};
+    struct data_t data = {};
+    data.type = type;
+    data.size = size;
+    data.delta_us = delta_us;
+    data.pid = pid;
     data.ts_us = ts / 1000;
     data.offset = valp->offset;
     bpf_get_current_comm(&data.task, sizeof(data.task));


### PR DESCRIPTION
ENV

* centos-stream9
* kernel 5.14.0-105.el9.x86_64
* bcc: newest
* LLVM version 14.0.0

ERROR:

```
 $ sudo ./xfsslower.py
 [...]
 80: (07) r4 += -104
 ; bpf_perf_event_output(ctx, bpf_pseudo_fd(1, -2), CUR_CPU_IDENTIFIER, &data, sizeof(data));
 81: (bf) r1 = r6
 82: (18) r3 = 0xffffffff
 84: (b7) r5 = 96
 85: (85) call bpf_perf_event_output#25
 invalid indirect read from stack R4 off -104+92 size 96
 processed 82 insns (limit 1000000) max_states_per_insn 0 total_states 4 peak_states 4 mark_read 3

 Traceback (most recent call last):
   File "/home/rongtao/Git/rtoax/bcc/tools/./xfsslower.py", line 271, in <module>
     b.attach_kretprobe(event="xfs_file_read_iter", fn_name="trace_read_return")
   File "/usr/lib/python3.9/site-packages/bcc/__init__.py", line 868, in attach_kretprobe
     fn = self.load_func(fn_name, BPF.KPROBE)
   File "/usr/lib/python3.9/site-packages/bcc/__init__.py", line 522, in load_func
     raise Exception("Failed to load BPF program %s: %s" %
 Exception: Failed to load BPF program b'trace_read_return': Permission denied
```

Solve according to https://github.com/iovisor/bcc/issues/2623