### PR TITLE
libbpf-tools: fix tcpconnect build errors

### DIFF
--- a/libbpf-tools/tcpconnect.bpf.c
+++ b/libbpf-tools/tcpconnect.bpf.c
@@ -11,7 +11,7 @@
 #include "maps.bpf.h"
 #include "tcpconnect.h"
 
-SEC(".rodata") int filter_ports[MAX_PORTS];
+const volatile int filter_ports[MAX_PORTS];
 const volatile int filter_ports_len = 0;
 const volatile uid_t filter_uid = -1;
 const volatile pid_t filter_pid = 0;


### PR DESCRIPTION
With the latest clang and bpftool the build of tcpconnect fails as
follows (output patched a bit for readability):

    bpftool gen skeleton tcpconnect.bpf.o > tcpconnect.skel.h
    Error: Something is wrong for .rodata's variable #1: need offset 0, already at 4.

This happens because the filter_ports variable is declared using a ".rodata hack":

    SEC(".rodata") int filter_ports[MAX_PORTS]

This breaks with the recent clang, as the filter_ports variable is placed into
the '.rodata,aw' section. Older clang would put it into '.rodata,a' section
where all 'const volatile' variables are placed. The result is that the
filter_ports variable has a wrong offset of 0 in BTF_KIND_DATASEC.

To hack the hack we can declare the variable as

    SEC(".rodata") const int filter_ports[MAX_PORTS]

but, instead, we now can just declare it as

    const volatile int filter_ports[MAX_PORTS]

In fact, this was already done in a02663be ("libbpf-tools: update bpftool and
fix .rodata hack"), but a later commit f8ac3c6c ("libbpf-tools: fix tcpconnect
compile errors") reverted the change without any comments.

Signed-off-by: Anton Protopopov <a.s.protopopov@gmail.com>