### PR TITLE
Add more hints for error kprobe.

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -828,7 +828,8 @@ class BPF(object):
                     failed += 1
                     probes.append(line)
             if failed == len(matches):
-                raise Exception("Failed to attach BPF program %s to kprobe %s" %
+                raise Exception("Failed to attach BPF program %s to kprobe %s"
+                                ", it's not traceable (either non-existing, inlined, or marked as \"notrace\")" %
                                 (fn_name, '/'.join(probes)))
             return
 
@@ -837,7 +838,8 @@ class BPF(object):
         ev_name = b"p_" + event.replace(b"+", b"_").replace(b".", b"_")
         fd = lib.bpf_attach_kprobe(fn.fd, 0, ev_name, event, event_off, 0)
         if fd < 0:
-            raise Exception("Failed to attach BPF program %s to kprobe %s" %
+            raise Exception("Failed to attach BPF program %s to kprobe %s"
+                            ", it's not traceable (either non-existing, inlined, or marked as \"notrace\")" %
                             (fn_name, event))
         self._add_kprobe_fd(ev_name, fn_name, fd)
         return self
@@ -860,7 +862,8 @@ class BPF(object):
                     failed += 1
                     probes.append(line)
             if failed == len(matches):
-                raise Exception("Failed to attach BPF program %s to kretprobe %s" %
+                raise Exception("Failed to attach BPF program %s to kretprobe %s"
+                                ", it's not traceable (either non-existing, inlined, or marked as \"notrace\")" %
                                 (fn_name, '/'.join(probes)))
             return
 
@@ -869,7 +872,8 @@ class BPF(object):
         ev_name = b"r_" + event.replace(b"+", b"_").replace(b".", b"_")
         fd = lib.bpf_attach_kprobe(fn.fd, 1, ev_name, event, 0, maxactive)
         if fd < 0:
-            raise Exception("Failed to attach BPF program %s to kretprobe %s" %
+            raise Exception("Failed to attach BPF program %s to kretprobe %s"
+                            ", it's not traceable (either non-existing, inlined, or marked as \"notrace\")" %
                             (fn_name, event))
         self._add_kprobe_fd(ev_name, fn_name, fd)
         return self


### PR DESCRIPTION
Add more hints for error kprobe.

 Before:
```
 $ sudo ./funccount.py -i 1 'xfs_f*'
 cannot attach kprobe, Invalid argument
 Failed to attach BPF program b'trace_count_62' to kprobe b'xfs_fs_eofblocks_from_user'
```

Like bpftrace tell more information

```
$ sudo bpftrace -e 'kprobe:xfs_fs_eofblocks_from_user {}'
stdin:1:1-34: WARNING: xfs_fs_eofblocks_from_user is not traceable (either non-existing, inlined, or marked as "notrace"); attaching to it will likely fail
kprobe:xfs_fs_eofblocks_from_user {}
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Attaching 1 probe...
cannot attach kprobe, Invalid argument
ERROR: Error attaching probe: 'kprobe:xfs_fs_eofblocks_from_user'
```

 After:

```
 $ sudo ./funccount.py -i 1 'xfs_f*'
 cannot attach kprobe, Invalid argument
 Failed to attach BPF program b'trace_count_10' to kprobe b'xfs_fs_eofblocks_from_user', it's not traceable (either non-existing, inlined, or marked as "notrace")
```

 In kernel:

```
 static inline int
 xfs_fs_eofblocks_from_user(...)
```