### PR TITLE
tools/llcstat: Add TID info support

### DIFF
--- a/libbpf-tools/llcstat.bpf.c
+++ b/libbpf-tools/llcstat.bpf.c
@@ -3,36 +3,43 @@
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
+#include "maps.bpf.h"
 #include "llcstat.h"
 
 #define MAX_ENTRIES	10240
 
+const volatile bool targ_per_thread = false;
+
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, MAX_ENTRIES);
-	__type(key, u64);
-	__type(value, struct info);
+	__type(key, struct key_info);
+	__type(value, struct value_info);
 } infos SEC(".maps");
 
 static __always_inline
 int trace_event(__u64 sample_period, bool miss)
 {
-	u64 pid = bpf_get_current_pid_tgid();
-	u32 cpu = bpf_get_smp_processor_id();
-	struct info *infop, info = {};
-	u64 key = pid << 32 | cpu;
+	struct key_info key = {};
+	struct value_info *infop, zero = {};
 
-	infop = bpf_map_lookup_elem(&infos, &key);
-	if (!infop) {
-		bpf_get_current_comm(info.comm, sizeof(info.comm));
-		infop = &info;
-	}
+	u64 pid_tgid = bpf_get_current_pid_tgid();
+	key.cpu = bpf_get_smp_processor_id();
+	key.pid = pid_tgid >> 32;
+	if (targ_per_thread)
+		key.tid = (u32)pid_tgid;
+	else
+		key.tid = key.pid;
+
+	infop = bpf_map_lookup_or_try_init(&infos, &key, &zero);
+	if (!infop)
+		return 0;
 	if (miss)
 		infop->miss += sample_period;
 	else
 		infop->ref += sample_period;
-	if (infop == &info)
-		bpf_map_update_elem(&infos, &key, infop, 0);
+	bpf_get_current_comm(infop->comm, sizeof(infop->comm));
+
 	return 0;
 }
 

--- a/libbpf-tools/llcstat.h
+++ b/libbpf-tools/llcstat.h
@@ -4,10 +4,16 @@
 
 #define TASK_COMM_LEN	16
 
-struct info {
+struct value_info {
 	__u64 ref;
 	__u64 miss;
 	char comm[TASK_COMM_LEN];
+};
+
+struct key_info {
+	__u32 cpu;
+	__u32 pid;
+	__u32 tid;
 };
 
 #endif /* __LLCSTAT_H */

--- a/man/man8/llcstat.8
+++ b/man/man8/llcstat.8
@@ -28,6 +28,9 @@ Print usage message.
 \-c SAMPLE_PERIOD
 Sample one in this many cache reference and cache miss events.
 .TP
+\-t
+Summarize cache references and misses by PID/TID
+.TP
 duration
 Duration to trace, in seconds.
 .SH EXAMPLES

--- a/tools/llcstat.py
+++ b/tools/llcstat.py
@@ -15,6 +15,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
 # 19-Oct-2016   Teng Qin   Created this.
+# 20-Jun-2022   YeZhengMao Added tid info.
 
 from __future__ import print_function
 import argparse
@@ -30,6 +31,10 @@ parser.add_argument(
     help="Sample one in this many number of cache reference / miss events")
 parser.add_argument(
     "duration", nargs="?", default=10, help="Duration, in seconds, to run")
+parser.add_argument(
+    "-t", "--tid", action="store_true",
+    help="Summarize cache references and misses by PID/TID"
+)
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
 args = parser.parse_args()
@@ -41,7 +46,8 @@ bpf_text="""
 
 struct key_t {
     int cpu;
-    int pid;
+    u32 pid;
+    u32 tid;
     char name[TASK_COMM_LEN];
 };
 
@@ -49,8 +55,10 @@ BPF_HASH(ref_count, struct key_t);
 BPF_HASH(miss_count, struct key_t);
 
 static inline __attribute__((always_inline)) void get_key(struct key_t* key) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
     key->cpu = bpf_get_smp_processor_id();
-    key->pid = bpf_get_current_pid_tgid() >> 32;
+    key->pid = pid_tgid >> 32;
+    key->tid = GET_TID ? (u32)pid_tgid : key->pid;
     bpf_get_current_comm(&(key->name), sizeof(key->name));
 }
 
@@ -72,6 +80,8 @@ int on_cache_ref(struct bpf_perf_event_data *ctx) {
     return 0;
 }
 """
+
+bpf_text = bpf_text.replace("GET_TID", "1" if args.tid else "0")
 
 if args.ebpf:
     print(bpf_text)
@@ -98,22 +108,42 @@ except KeyboardInterrupt:
 
 miss_count = {}
 for (k, v) in b.get_table('miss_count').items():
-    miss_count[(k.pid, k.cpu, k.name)] = v.value
+    if args.tid:
+        miss_count[(k.pid, k.tid, k.cpu, k.name)] = v.value
+    else:
+        miss_count[(k.pid, k.cpu, k.name)] = v.value
 
-print('PID      NAME             CPU     REFERENCE         MISS    HIT%')
+header_text = 'PID      '
+format_text = '{:<8d} '
+if args.tid:
+    header_text += 'TID      '
+    format_text += '{:<8d} '
+
+header_text += 'NAME             CPU     REFERENCE         MISS    HIT%'
+format_text += '{:<16s} {:<4d} {:>12d} {:>12d} {:>6.2f}%'
+
+print(header_text)
 tot_ref = 0
 tot_miss = 0
 for (k, v) in b.get_table('ref_count').items():
     try:
-        miss = miss_count[(k.pid, k.cpu, k.name)]
+        if args.tid:
+            miss = miss_count[(k.pid, k.tid, k.cpu, k.name)]
+        else:
+            miss = miss_count[(k.pid, k.cpu, k.name)]
     except KeyError:
         miss = 0
     tot_ref += v.value
     tot_miss += miss
     # This happens on some PIDs due to missed counts caused by sampling
     hit = (v.value - miss) if (v.value >= miss) else 0
-    print('{:<8d} {:<16s} {:<4d} {:>12d} {:>12d} {:>6.2f}%'.format(
-        k.pid, k.name.decode('utf-8', 'replace'), k.cpu, v.value, miss,
-        (float(hit) / float(v.value)) * 100.0))
+    if args.tid:
+        print(format_text.format(
+            k.pid, k.tid, k.name.decode('utf-8', 'replace'), k.cpu, v.value, miss,
+            (float(hit) / float(v.value)) * 100.0))
+    else:
+        print(format_text.format(
+            k.pid, k.name.decode('utf-8', 'replace'), k.cpu, v.value, miss,
+            (float(hit) / float(v.value)) * 100.0))
 print('Total References: {} Total Misses: {} Hit Rate: {:.2f}%'.format(
     tot_ref, tot_miss, (float(tot_ref - tot_miss) / float(tot_ref)) * 100.0))

--- a/tools/llcstat_example.txt
+++ b/tools/llcstat_example.txt
@@ -38,6 +38,21 @@ some degree by chance. Overall it should make sense. But for low counts,
 you might find a case where -- by chance -- a process has been tallied with
 more misses than references, which would seem impossible.
 
+# ./llcstat.py 10 -t
+Running for 10 seconds or hit Ctrl-C to end.
+PID      TID      NAME             CPU     REFERENCE         MISS    HIT%
+170843   170845   docker           12           2700         1200  55.56%
+298670   298670   kworker/15:0     15            500            0 100.00%
+170254   170254   kworker/11:1     11           2500          400  84.00%
+1046952  1046953  git              0            2600         1100  57.69%
+170843   170849   docker           15           1000          400  60.00%
+1027373  1027382  node             8            3500         2500  28.57%
+0        0        swapper/7        7          173000         4200  97.57%
+1028217  1028217  node             14          15600        22400   0.00%
+[...]
+Total References: 7139900 Total Misses: 1413900 Hit Rate: 80.20%
+
+This shows each TID`s cache hit rate during the 10 seconds run period.
 
 USAGE message:
 
@@ -54,3 +69,4 @@ positional arguments:
     -c SAMPLE_PERIOD, --sample_period SAMPLE_PERIOD
                           Sample one in this many number of cache reference
                           and miss events
+    -t, --tid             Summarize cache references and misses by PID/TID


### PR DESCRIPTION
The tools/llcstat only collect info pre-process, sometimes, I just want to focus on per-thread rather than per-process.
This patch tries to add tid info support.