### PR TITLE
sync with libbpf + backport `struct bpf_create_map_attr`

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -404,7 +404,7 @@ int BPFModule::create_maps(std::map<std::string, std::pair<int, int>> &map_tids,
     }
 
     if (pinned_id <= 0) {
-      struct bpf_create_map_attr attr = {};
+      struct bcc_create_map_attr attr = {};
       attr.map_type = (enum bpf_map_type)map_type;
       attr.name = map_name;
       attr.key_size = key_size;

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -307,7 +307,7 @@ static uint64_t ptr_to_u64(void *ptr)
   return (uint64_t) (unsigned long) ptr;
 }
 
-static int libbpf_bpf_map_create(struct bpf_create_map_attr *create_attr)
+static int libbpf_bpf_map_create(struct bcc_create_map_attr *create_attr)
 {
   LIBBPF_OPTS(bpf_map_create_opts, p);
 
@@ -326,7 +326,7 @@ static int libbpf_bpf_map_create(struct bpf_create_map_attr *create_attr)
                         create_attr->value_size, create_attr->max_entries, &p);
 }
 
-int bcc_create_map_xattr(struct bpf_create_map_attr *attr, bool allow_rlimit)
+int bcc_create_map_xattr(struct bcc_create_map_attr *attr, bool allow_rlimit)
 {
   unsigned name_len = attr->name ? strlen(attr->name) : 0;
   char map_name[BPF_OBJ_NAME_LEN] = {};
@@ -383,7 +383,7 @@ int bcc_create_map(enum bpf_map_type map_type, const char *name,
                    int key_size, int value_size,
                    int max_entries, int map_flags)
 {
-  struct bpf_create_map_attr attr = {};
+  struct bcc_create_map_attr attr = {};
 
   attr.map_type = map_type;
   attr.name = name;

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -27,7 +27,23 @@
 extern "C" {
 #endif
 
-struct bpf_create_map_attr;
+struct bcc_create_map_attr {
+	const char *name;
+	enum bpf_map_type map_type;
+	__u32 map_flags;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 numa_node;
+	__u32 btf_fd;
+	__u32 btf_key_type_id;
+	__u32 btf_value_type_id;
+	__u32 map_ifindex;
+	union {
+		__u32 inner_map_fd;
+		__u32 btf_vmlinux_value_type_id;
+	};
+};
 struct bpf_load_program_attr;
 
 enum bpf_probe_attach_type {
@@ -44,7 +60,7 @@ struct bcc_perf_buffer_opts {
 int bcc_create_map(enum bpf_map_type map_type, const char *name,
                    int key_size, int value_size, int max_entries,
                    int map_flags);
-int bcc_create_map_xattr(struct bpf_create_map_attr *attr, bool allow_rlimit);
+int bcc_create_map_xattr(struct bcc_create_map_attr *attr, bool allow_rlimit);
 int bpf_update_elem(int fd, void *key, void *value, unsigned long long flags);
 int bpf_lookup_elem(int fd, void *key, void *value);
 int bpf_delete_elem(int fd, void *key);


### PR DESCRIPTION
Since https://github.com/libbpf/libbpf/commit/7e8d4234ac0b24492dd473a2ba80204e175b87df, this structure is gone from libbpf.

BCC uses it as a structure to pass around `bcc_create_map_xattr` and `libbpf_bpf_map_create`.
The alternative would be to modify both libbpf_bpf_map_create and bcc_create_map_xattr to take each arguments, which I am not sure it would be any better.
 Renamed the struct from `bpf_create_map_xattr` to `bcc_create_map_xattr` to better reflect this is a bcc-provided struct, not bpf anymore.
