### PR TITLE
tools/funcinterval: fix delta will overflow

### DIFF
--- a/tools/funcinterval.py
+++ b/tools/funcinterval.py
@@ -98,12 +98,18 @@ int trace_func_entry(struct pt_regs *ctx)
 {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 index = 0, tgid = pid_tgid >> 32;
-    u64 *tsp, ts = bpf_ktime_get_ns(), delta;
 
     FILTER
+
+    u64 *tsp, ts = bpf_ktime_get_ns(), delta;
+
     tsp = start.lookup(&index);
     if (tsp == 0)
         goto out;
+
+    if (ts < *tsp) {
+        return 0;
+    }
 
     delta = ts - *tsp;
     FACTOR


### PR DESCRIPTION
when I use funcinterval to count the function interval in a multi-processor environment
the output is just like below：
```
Tracing uprobe function for "malloc"... Hit Ctrl-C to end.

               usecs                         : count     distribution
                   0 -> 1                    : 938325   |********************|
                   2 -> 3                    : 768838   |****************    |
                   4 -> 7                    : 120978   |**                  |
                   8 -> 15                   : 25217    |                    |
                  16 -> 31                   : 7111     |                    |
                  32 -> 63                   : 1940     |                    |
                  64 -> 127                  : 908      |                    |
                 128 -> 255                  : 644      |                    |
                 256 -> 511                  : 408      |                    |
                 512 -> 1023                 : 199      |                    |
                1024 -> 2047                 : 81       |                    |
                2048 -> 4095                 : 4        |                    |
                4096 -> 8191                 : 0        |                    |
                8192 -> 16383                : 0        |                    |
               16384 -> 32767                : 0        |                    |
               32768 -> 65535                : 0        |                    |
               65536 -> 131071               : 0        |                    |
              131072 -> 262143               : 0        |                    |
              262144 -> 524287               : 0        |                    |
              524288 -> 1048575              : 0        |                    |
             1048576 -> 2097151              : 0        |                    |
             2097152 -> 4194303              : 0        |                    |
             4194304 -> 8388607              : 0        |                    |
             8388608 -> 16777215             : 0        |                    |
            16777216 -> 33554431             : 0        |                    |
            33554432 -> 67108863             : 0        |                    |
            67108864 -> 134217727            : 0        |                    |
           134217728 -> 268435455            : 0        |                    |
           268435456 -> 536870911            : 0        |                    |
           536870912 -> 1073741823           : 0        |                    |
          1073741824 -> 2147483647           : 0        |                    |
          2147483648 -> 4294967295           : 0        |                    |
          4294967296 -> 8589934591           : 0        |                    |
          8589934592 -> 17179869183          : 0        |                    |
         17179869184 -> 34359738367          : 0        |                    |
         34359738368 -> 68719476735          : 0        |                    |
         68719476736 -> 137438953471         : 0        |                    |
        137438953472 -> 274877906943         : 0        |                    |
        274877906944 -> 549755813887         : 0        |                    |
        549755813888 -> 1099511627775        : 0        |                    |
       1099511627776 -> 2199023255551        : 0        |                    |
       2199023255552 -> 4398046511103        : 0        |                    |
       4398046511104 -> 8796093022207        : 0        |                    |
       8796093022208 -> 17592186044415       : 0        |                    |
      17592186044416 -> 35184372088831       : 0        |                    |
      35184372088832 -> 70368744177663       : 0        |                    |
      70368744177664 -> 140737488355327      : 0        |                    |
     140737488355328 -> 281474976710655      : 0        |                    |
     281474976710656 -> 562949953421311      : 0        |                    |
     562949953421312 -> 1125899906842623     : 0        |                    |
    1125899906842624 -> 2251799813685247     : 0        |                    |
    2251799813685248 -> 4503599627370495     : 0        |                    |
    4503599627370496 -> 9007199254740991     : 0        |                    |
    9007199254740992 -> 18014398509481983    : 0        |                    |
   18014398509481984 -> 36028797018963967    : 1780     |                    |
```
seem in multi-processor, function `bpf_ktime_get_ns` will get lower nanoseconds.