### PR TITLE
libbpf-tools: Fix biopattern with recent tracepoint change

### DIFF
--- a/libbpf-tools/core_fixes.bpf.h
+++ b/libbpf-tools/core_fixes.bpf.h
@@ -17,6 +17,15 @@ struct task_struct___x {
 	unsigned int __state;
 } __attribute__((preserve_access_index));
 
+static __always_inline __s64 get_task_state(void *task)
+{
+	struct task_struct___x *t = task;
+
+	if (bpf_core_field_exists(t->__state))
+		return BPF_CORE_READ(t, __state);
+	return BPF_CORE_READ((struct task_struct *)task, state);
+}
+
 /**
  * commit 309dca309fc3 ("block: store a block_device pointer in struct bio")
  * adds a new member bi_bdev which is a pointer to struct block_device
@@ -27,15 +36,6 @@ struct bio___x {
 	struct block_device *bi_bdev;
 } __attribute__((preserve_access_index));
 
-static __always_inline __s64 get_task_state(void *task)
-{
-	struct task_struct___x *t = task;
-
-	if (bpf_core_field_exists(t->__state))
-		return BPF_CORE_READ(t, __state);
-	return BPF_CORE_READ((struct task_struct *)task, state);
-}
-
 static __always_inline struct gendisk *get_gendisk(void *bio)
 {
 	struct bio___x *b = bio;
@@ -43,6 +43,28 @@ static __always_inline struct gendisk *get_gendisk(void *bio)
 	if (bpf_core_field_exists(b->bi_bdev))
 		return BPF_CORE_READ(b, bi_bdev, bd_disk);
 	return BPF_CORE_READ((struct bio *)bio, bi_disk);
+}
+
+/**
+ * commit d5869fdc189f ("block: introduce block_rq_error tracepoint")
+ * adds a new tracepoint block_rq_error and it shares the same arguments
+ * with tracepoint block_rq_complete. As a result, the kernel BTF now has
+ * a `struct trace_event_raw_block_rq_completion` instead of
+ * `struct trace_event_raw_block_rq_complete`.
+ * see:
+ *     https://github.com/torvalds/linux/commit/d5869fdc189f
+ */
+struct trace_event_raw_block_rq_completion___x {
+	dev_t dev;
+	sector_t sector;
+	unsigned int nr_sector;
+} __attribute__((preserve_access_index));
+
+static __always_inline bool has_block_rq_completion()
+{
+	if (bpf_core_type_exists(struct trace_event_raw_block_rq_completion___x))
+		return true;
+	return false;
 }
 
 #endif /* __CORE_FIXES_BPF_H */


### PR DESCRIPTION
After kernel commit d5869fdc189f ("block: introduce block_rq_error tracepoint"),
tracepoint block_rq_complete now shares the same argument struct as
`struct trace_event_raw_block_rq_completion` with tracepoint block_rq_error.
Because of that, now biopattern is broken because `struct trace_event_raw_block_rq_complete`
is disappeared from kernel BTF. Fix it by checking type existence.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>