### PR TITLE
tools/biotop: Fix output format specifier

### DIFF
--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -259,7 +259,7 @@ while 1:
 
         # print line
         avg_ms = (float(v.us) / 1000) / v.io
-        print("%-7d %-16s %1s %-3d %-3d %-8s %5s %7s %6.2f" % (k.pid,
+        print("%-7d %-16s %1s %-3d %-3d %-8s %5s %7d %6.2f" % (k.pid,
             k.name.decode('utf-8', 'replace'), "W" if k.rwflag else "R",
             k.major, k.minor, diskname, v.io, v.bytes / 1024, avg_ms))
 


### PR DESCRIPTION
biotop output column 'Kbytes' looks not good. One example is as follows (first tow suffixed with .0, last one is 0.0078125):
```
PID     COMM             D MAJ MIN DISK       I/O  Kbytes  AVGms
941343  mysqld           W 253 0   vda       1262 56476.0   2.00
447     jbd2/vda1-8      W 253 0   vda        547  6712.0   0.89
0                        R 0   0   ?            1 0.0078125   0.34
```

This patch try to fix it by modifying output format specifier. Please have a look @davemarchevsky, thanks.