### PR TITLE
riscv: initial ebpf support

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -1247,6 +1247,9 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #elif defined(__TARGET_ARCH_mips)
 #define bpf_target_mips
 #define bpf_target_defined
+#elif defined(__TARGET_ARCH_riscv64)
+#define bpf_target_riscv64
+#define bpf_target_defined
 #else
 #undef bpf_target_defined
 #endif
@@ -1263,6 +1266,8 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #define bpf_target_powerpc
 #elif defined(__mips__)
 #define bpf_target_mips
+#elif defined(__riscv) && (__riscv_xlen == 64)
+#define bpf_target_riscv64
 #endif
 #endif
 
@@ -1323,6 +1328,18 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #define PT_REGS_RC(x) ((x)->regs[2])
 #define PT_REGS_SP(x) ((x)->regs[29])
 #define PT_REGS_IP(x) ((x)->cp0_epc)
+#elif defined(bpf_target_riscv64)
+#define PT_REGS_PARM1(x) ((x)->a0)
+#define PT_REGS_PARM2(x) ((x)->a1)
+#define PT_REGS_PARM3(x) ((x)->a2)
+#define PT_REGS_PARM4(x) ((x)->a3)
+#define PT_REGS_PARM5(x) ((x)->a4)
+#define PT_REGS_PARM6(x) ((x)->a5)
+#define PT_REGS_RET(x) ((x)->ra)
+#define PT_REGS_FP(x) ((x)->fp) /* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_RC(x) ((x)->a0)
+#define PT_REGS_SP(x) ((x)->sp)
+#define PT_REGS_IP(x) ((x)->epc)
 #else
 #error "bcc does not support this platform yet"
 #endif

--- a/src/cc/frontends/clang/arch_helper.h
+++ b/src/cc/frontends/clang/arch_helper.h
@@ -23,6 +23,7 @@ typedef enum {
   BCC_ARCH_S390X,
   BCC_ARCH_ARM64,
   BCC_ARCH_MIPS,
+  BCC_ARCH_RISCV64,
   BCC_ARCH_X86
 } bcc_arch_t;
 
@@ -46,6 +47,8 @@ static void *run_arch_callback(arch_callback_t fn, bool for_syscall = false)
     return fn(BCC_ARCH_ARM64, for_syscall);
 #elif defined(__mips__)
     return fn(BCC_ARCH_MIPS, for_syscall);
+#elif defined(__riscv) && (__riscv_xlen == 64)
+    return fn(BCC_ARCH_RISCV64, for_syscall);
 #else
     return fn(BCC_ARCH_X86, for_syscall);
 #endif
@@ -64,6 +67,8 @@ static void *run_arch_callback(arch_callback_t fn, bool for_syscall = false)
     return fn(BCC_ARCH_ARM64, for_syscall);
   } else if (!strcmp(archenv, "mips")) {
     return fn(BCC_ARCH_MIPS, for_syscall);
+  } else if (!strcmp(archenv, "riscv64")) {
+    return fn(BCC_ARCH_RISCV64, for_syscall);
   } else {
     return fn(BCC_ARCH_X86, for_syscall);
   }

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -60,6 +60,9 @@ const char *calling_conv_regs_arm64[] = {"regs[0]", "regs[1]", "regs[2]",
 const char *calling_conv_regs_mips[] = {"regs[4]", "regs[5]", "regs[6]",
                                        "regs[7]", "regs[8]", "regs[9]"};
 
+const char *calling_conv_regs_riscv64[] = {"a0", "a1", "a2",
+                                       "a3", "a4", "a5"};
+
 void *get_call_conv_cb(bcc_arch_t arch, bool for_syscall)
 {
   const char **ret;
@@ -77,6 +80,9 @@ void *get_call_conv_cb(bcc_arch_t arch, bool for_syscall)
       break;
     case BCC_ARCH_MIPS:
       ret = calling_conv_regs_mips;
+      break;
+    case BCC_ARCH_RISCV64:
+      ret = calling_conv_regs_riscv64;
       break;
     default:
       if (for_syscall)

--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -66,6 +66,8 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
     arch = "powerpc";
   } else if (!arch.compare(0, 4, "mips")) {
     arch = "mips";
+  } else if (!arch.compare(0, 5, "riscv")) {
+    arch = "riscv";
   } else if (!arch.compare(0, 2, "sh")) {
     arch = "sh";
   }

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -360,6 +360,9 @@ void *get_clang_target_cb(bcc_arch_t arch, bool for_syscall)
     case BCC_ARCH_MIPS:
       ret = "mips64el-unknown-linux-gnuabi64";
       break;
+    case BCC_ARCH_RISCV64:
+      ret = "riscv64-unknown-linux-gnu";
+      break;
     default:
       ret = "x86_64-unknown-linux-gnu";
   }


### PR DESCRIPTION
This patch will fix issue #4081. It works on RISC-V 64 with the following kernel patch,
https://lore.kernel.org/lkml/20220703130924.57240-1-dlan@gentoo.org/

Signed-off-by: Yixun Lan <yixun.lan@gmail.com>
Co-authored-by: Mingzheng Xing <mingzheng.xing@gmail.com>