### PR TITLE
Add support to enable sanitizer + fix mem leak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+if(CMAKE_SANITIZE_TYPE)
+    add_compile_options(-fsanitize=${CMAKE_SANITIZE_TYPE})
+    add_link_options(-fsanitize=${CMAKE_SANITIZE_TYPE})
+endif()
+
+
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "path to install" FORCE)
 endif()

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -179,6 +179,9 @@ BPFModule::~BPFModule() {
         return;
       delete[] info.start_;
     });
+    for (auto &section : sections_) {
+      delete[] std::get<0>(section.second);
+    }
   }
 
   engine_.reset();


### PR DESCRIPTION
First diff add support to enable building bcc with sanitizer enabled.

The second diff fixes a leak in BPFModule and use the result of the sanitizer run to confirm the leak is gone.