### PR TITLE
[py] Add support for CGROUP_SOCKOPT program type

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -188,6 +188,7 @@ class BPFProgType:
     SK_MSG = 16
     RAW_TRACEPOINT = 17
     CGROUP_SOCK_ADDR = 18
+    CGROUP_SOCKOPT = 25
     TRACING = 26
     LSM = 29
 

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -2,7 +2,7 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 
-from bcc import BPF
+from bcc import BPF, BPFAttachType, BPFProgType
 from bcc.libbcc import lib
 import ctypes as ct
 from unittest import main, skipUnless, TestCase
@@ -54,6 +54,16 @@ int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
 """
         b = BPF(text=text, debug=0)
         fn = b.load_func("count_sched", BPF.KPROBE)
+
+    def test_load_cgroup_sockopt_prog(self):
+        text = """
+int sockopt(struct bpf_sockopt* ctx){
+
+    return 0;
+}
+"""
+        b = BPF(text=text, debug=0)
+        fn =  b.load_func("sockopt", BPFProgType.CGROUP_SOCKOPT, device = None, attach_type = BPFAttachType.CGROUP_SETSOCKOPT)
 
     def test_probe_read2(self):
         text = """


### PR DESCRIPTION
Testing: Added a new test to test_clang that loads a program of type `CGROUP_SOCKOPT`

```
16: .
16: ----------------------------------------------------------------------
16: Ran 84 tests in 83.695s
16:
16: OK (skipped=4)
16: 0
16/41 Test #16: py_test_clang ....................   Passed   84.14 sec
```