### PR TITLE
[libbpf-tools] core_fixes: Add 'old' triple-under structs

### DIFF
--- a/libbpf-tools/core_fixes.bpf.h
+++ b/libbpf-tools/core_fixes.bpf.h
@@ -13,17 +13,24 @@
  * see:
  *     https://github.com/torvalds/linux/commit/2f064a59a1
  */
-struct task_struct___x {
+struct task_struct___new {
 	unsigned int __state;
+} __attribute__((preserve_access_index));
+
+struct task_struct___old {
+	volatile long state;
 } __attribute__((preserve_access_index));
 
 static __always_inline __s64 get_task_state(void *task)
 {
-	struct task_struct___x *t = task;
+	struct task_struct___new *t = task;
+	struct task_struct___old *o = task;
 
 	if (bpf_core_field_exists(t->__state))
 		return BPF_CORE_READ(t, __state);
-	return BPF_CORE_READ((struct task_struct *)task, state);
+	else if (bpf_core_field_exists(o->state))
+		return BPF_CORE_READ(o, state);
+	return 0;
 }
 
 /**
@@ -32,17 +39,24 @@ static __always_inline __s64 get_task_state(void *task)
  * see:
  *     https://github.com/torvalds/linux/commit/309dca309fc3
  */
-struct bio___x {
+struct bio___new {
 	struct block_device *bi_bdev;
+} __attribute__((preserve_access_index));
+
+struct bio___old {
+	struct gendisk *bi_disk;
 } __attribute__((preserve_access_index));
 
 static __always_inline struct gendisk *get_gendisk(void *bio)
 {
-	struct bio___x *b = bio;
+	struct bio___new *b = bio;
+	struct bio___old *c = bio;
 
 	if (bpf_core_field_exists(b->bi_bdev))
 		return BPF_CORE_READ(b, bi_bdev, bd_disk);
-	return BPF_CORE_READ((struct bio *)bio, bi_disk);
+	else if (bpf_core_field_exists(c->bi_disk))
+		return BPF_CORE_READ(c, bi_disk);
+	return NULL;
 }
 
 /**


### PR DESCRIPTION
Currently, `core_fixes.bpf.h` helper fns which deal with structs whose
fields changed after a specific commit contain a triple-underscore
struct definition which contains the new field, e.g.

```
struct task_struct___x {
        unsigned int __state;
} __attribute__((preserve_access_index));
```

This allows the `bpf_core_field_exists` and `BPF_CORE_READ` calls
dealing with the new field to compile even if the `vmlinux.h` the user
is compiling against contains the 'old' struct definition (`state`
instead of `__state` in the above example).

If the `vmlinux.h` the user is compiling against has the 'new' struct
def, currently `core_fixes.bpf.h` compilation will fail because the old
field definition (`state`) does not exist. Let's fix this by also having
a `___old` struct def, and returning NULL or 0 if neither old or new
fields exist.

Signed-off-by: Dave Marchevsky <davemarchevsky@fb.com>