### PR TITLE
bcc: Use bpf_probe_read_{kernel|user} functions if they are available

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -90,7 +90,7 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   std::vector<clang::ParmVarDecl *> fn_args_;
   std::set<clang::Expr *> visited_;
   std::string current_fn_;
-  bool has_overlap_kuaddr_;
+  std::string probe_read_kernel_fn_;
 };
 
 // Do a depth-first search to rewrite all pointers that need to be probed
@@ -130,7 +130,7 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   std::list<int> ptregs_returned_;
   const clang::Stmt *addrof_stmt_;
   bool is_addrof_;
-  bool has_overlap_kuaddr_;
+  std::string probe_read_kernel_fn_;
 };
 
 // A helper class to the frontend action, walks the decls


### PR DESCRIPTION
As suggested in https://lore.kernel.org/bpf/YslAxaryvm%2FMfGbq@ofant/ and
in other messages of that mailing list thread, BCC tools should use the
newer bpf_probe_read_{kernel|user} functions whenever possible, rather than
bpf_probe_read().

The main reason is that bpf_probe_read() is unreliable in the systems where
kernel and user address spaces can overlap, e.g. on s390x. See commit
6ae08ae3dea2 ("bpf: Add probe_read_{user, kernel} and probe_read_{user, kernel}_str helpers")
in the mainline kernel for more info.

Let us just use bpf_probe_read_kernel() and bpf_probe_read_user(), if they
are available in the kernel, and only try bpf_probe_read() as a fallback.

This fixes the following problem among other things. On RISC-V, execsnoop
tool failed to run because the BPF verifier rejected the relevant program:

>   root@riscv64-test: # /usr/share/bcc/tools/execsnoop
> 
>   bpf: Failed to load program: Invalid argument
>   0: (bf) r6 = r1
>   1: (79) r8 = *(u64 *)(r6 +88)
>   [...]
>   56: (85) call bpf_probe_read#4
>   unknown func bpf_probe_read#4
> 
>   processed 57 insns (limit 1000000) max_states_per_insn 0 total_states 1 peak_states 1 mark_read 1
> 
>   Traceback (most recent call last):
>     File "/usr/share/bcc/tools/execsnoop", line 229, in <module>
>       b.attach_kprobe(event=execve_fnname, fn_name="syscall__execve")
>     File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 837, in attach_kprobe
>       fn = self.load_func(fn_name, BPF.KPROBE)
>     File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 522, in load_func
>       raise Exception("Failed to load BPF program %s: %s" %
>   Exception: Failed to load BPF program b'syscall__execve': Invalid argument

This was because BCC incorrectly used a call to bpf_probe_read() in the BPF
program, while bpf_probe_read_kernel() should have been used.