### PR TITLE
Fix warning: passing argument 4 of ‘btf_dump__new’ from incompatible …

### DIFF
--- a/libbpf-tools/ksnoop.c
+++ b/libbpf-tools/ksnoop.c
@@ -513,7 +513,6 @@ static int parse_trace(char *str, struct trace *trace)
 	char argname[MAX_NAME], membername[MAX_NAME];
 	char tracestr[MAX_STR], argdata[MAX_STR];
 	struct func *func = &trace->func;
-	struct btf_dump_opts opts = { };
 	char *arg, *saveptr;
 	int ret;
 
@@ -560,7 +559,7 @@ static int parse_trace(char *str, struct trace *trace)
 		      strerror(-ret));
 		return -ENOENT;
 	}
-	trace->dump = btf_dump__new(trace->btf, NULL, &opts, trace_printf);
+	trace->dump = btf_dump__new(trace->btf, trace_printf, NULL, NULL);
 	if (!trace->dump) {
 		ret = -errno;
 		p_err("could not create BTF dump : %s", strerror(-ret));


### PR DESCRIPTION
Fix:

```
…pointer type

ksnoop.c: In function ‘parse_trace’:
ksnoop.c:563:62: warning: passing argument 4 of ‘btf_dump__new’ from incompatible pointer type [-Wincompatible-pointer-types]
  563 |         trace->dump = btf_dump__new(trace->btf, NULL, &opts, trace_printf);
      |                                                              ^~~~~~~~~~~~
      |                                                              |
      |                                                              void (*)(void *, const char *, __va_list_tag *)
In file included from ksnoop.c:14:
/home/rongtao/Git/rtoax/bcc/libbpf-tools/.output/bpf/btf.h:247:71: note: expected ‘const struct btf_dump_opts *’ but argument is of type ‘void (*)(void *, const char *, __va_list_tag *)’
  247 |                                           const struct btf_dump_opts *opts);
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
```

when running

```bash
 ./ksnoop info ip_send_skb
Error: could not create BTF dump : Invalid argument
```

in libbpf:

```c
LIBBPF_API struct btf_dump *btf_dump__new(const struct btf *btf,
                      btf_dump_printf_fn_t printf_fn,
                      void *ctx,
                      const struct btf_dump_opts *opts);
```
