### PR TITLE
riscv:fix user_regs_struct macro issue

### DIFF
--- a/src/cc/export/helpers.h
+++ b/src/cc/export/helpers.h
@@ -1363,17 +1363,19 @@ int bpf_usdt_readarg_p(int argc, struct pt_regs *ctx, void *buf, u64 len) asm("l
 #define PT_REGS_SP(x) ((x)->regs[29])
 #define PT_REGS_IP(x) ((x)->cp0_epc)
 #elif defined(bpf_target_riscv64)
-#define PT_REGS_PARM1(x) ((x)->a0)
-#define PT_REGS_PARM2(x) ((x)->a1)
-#define PT_REGS_PARM3(x) ((x)->a2)
-#define PT_REGS_PARM4(x) ((x)->a3)
-#define PT_REGS_PARM5(x) ((x)->a4)
-#define PT_REGS_PARM6(x) ((x)->a5)
-#define PT_REGS_RET(x) ((x)->ra)
-#define PT_REGS_FP(x) ((x)->s0) /* Works only with CONFIG_FRAME_POINTER */
-#define PT_REGS_RC(x) ((x)->a0)
-#define PT_REGS_SP(x) ((x)->sp)
-#define PT_REGS_IP(x) ((x)->pc)
+/* riscv64 provides struct user_pt_regs instead of struct pt_regs to userspace */
+#define __PT_REGS_CAST(x) ((const struct user_regs_struct *)(x))
+#define PT_REGS_PARM1(x) (__PT_REGS_CAST(x)->a0)
+#define PT_REGS_PARM2(x) (__PT_REGS_CAST(x)->a1)
+#define PT_REGS_PARM3(x) (__PT_REGS_CAST(x)->a2)
+#define PT_REGS_PARM4(x) (__PT_REGS_CAST(x)->a3)
+#define PT_REGS_PARM5(x) (__PT_REGS_CAST(x)->a4)
+#define PT_REGS_PARM6(x) (__PT_REGS_CAST(x)->a5)
+#define PT_REGS_RET(x) (__PT_REGS_CAST(x)->ra)
+#define PT_REGS_FP(x) (__PT_REGS_CAST(x)->s0) /* Works only with CONFIG_FRAME_POINTER */
+#define PT_REGS_RC(x) (__PT_REGS_CAST(x)->a0)
+#define PT_REGS_SP(x) (__PT_REGS_CAST(x)->sp)
+#define PT_REGS_IP(x) (__PT_REGS_CAST(x)->pc)
 #else
 #error "bcc does not support this platform yet"
 #endif


### PR DESCRIPTION
Fix #4110 . With this patch, running tools/cachestat on riscv64 can get the expected result.

```
$ sudo ./cachestat 
    HITS   MISSES  DIRTIES HITRATIO   BUFFERS_MB  CACHED_MB
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
     618        0        0  100.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
     607        0        0  100.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
       0        0        0    0.00%           52       5869
^C       0        0        0    0.00%           52       5869
Detaching...
```

Signed-off-by: Mingzheng Xing <xingmingzheng@iscas.ac.cn>