### PR TITLE
Move BPF UAPI import into `bcc_bpf_uapi_inc.h`

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <linux/bpf.h>
 #include <linux/perf_event.h>
 #include <unistd.h>
 #include <cstdio>

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -23,10 +23,10 @@
 #include <string>
 
 #include "BPFTable.h"
+#include "bcc_bpf_uapi_inc.h"
 #include "bcc_exception.h"
 #include "bcc_syms.h"
 #include "bpf_module.h"
-#include "linux/bpf.h"
 #include "libbpf.h"
 #include "table_storage.h"
 

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -26,13 +26,13 @@
 #include <utility>
 #include <vector>
 
+#include "bcc_bpf_uapi_inc.h"
 #include "bcc_exception.h"
 #include "bcc_syms.h"
 #include "bpf_module.h"
 #include "libbpf.h"
 #include "perf_reader.h"
 #include "table_desc.h"
-#include "linux/bpf.h"
 
 namespace ebpf {
 

--- a/src/cc/bcc_bpf_uapi_inc.h
+++ b/src/cc/bcc_bpf_uapi_inc.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef HAVE_EXTERNAL_LIBBPF
+# include <bpf/uapi/linux/bpf.h>
+# include <bpf/uapi/linux/bpf_common.h>
+# include <bpf/uapi/linux/btf.h>
+#else
+# include <linux/bpf.h>
+# include <linux/bpf_common.h>
+# include <linux/btf.h>
+#endif

--- a/src/cc/bcc_btf.cc
+++ b/src/cc/bcc_btf.cc
@@ -17,8 +17,8 @@
 #include "bcc_btf.h"
 #include <stdarg.h>
 #include <string.h>
-#include "linux/btf.h"
 #include "libbpf.h"
+#include "bcc_bpf_uapi_inc.h"
 #include "bcc_libbpf_inc.h"
 #include <vector>
 #include <byteswap.h>

--- a/src/cc/bcc_syms.h
+++ b/src/cc/bcc_syms.h
@@ -21,7 +21,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-#include "linux/bpf.h"
+#include "bcc_bpf_uapi_inc.h"
 #include "bcc_proc.h"
 
 struct bcc_symbol {

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -16,7 +16,6 @@
 #include "bpf_module.h"
 
 #include <fcntl.h>
-#include <linux/bpf.h>
 #include <llvm-c/Transforms/IPO.h>
 #include <llvm/ExecutionEngine/MCJIT.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
@@ -50,6 +49,7 @@
 #include <iostream>
 #include <vector>
 
+#include "bcc_bpf_uapi_inc.h"
 #include "bcc_btf.h"
 #include "bcc_debug.h"
 #include "bcc_elf.h"

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <linux/bpf.h>
 #include <linux/version.h>
 #include <sys/utsname.h>
 #include <unistd.h>
@@ -29,6 +28,7 @@
 
 #include "frontend_action_common.h"
 #include "b_frontend_action.h"
+#include "bcc_bpf_uapi_inc.h"
 #include "bpf_module.h"
 #include "common.h"
 #include "loader.h"

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -30,7 +30,6 @@
 #include <utility>
 #include <vector>
 #include <iostream>
-#include <linux/bpf.h>
 
 #include <clang/Basic/FileManager.h>
 #include <clang/Basic/TargetInfo.h>
@@ -50,6 +49,7 @@
 
 #include <llvm/IR/Module.h>
 
+#include "bcc_bpf_uapi_inc.h"
 #include "bcc_exception.h"
 #include "bpf_module.h"
 #include "exported_files.h"

--- a/src/cc/frontends/clang/tp_frontend_action.cc
+++ b/src/cc/frontends/clang/tp_frontend_action.cc
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <linux/bpf.h>
 #include <linux/version.h>
 #include <sys/utsname.h>
 #include <unistd.h>
@@ -28,6 +27,7 @@
 #include <clang/Frontend/MultiplexConsumer.h>
 #include <clang/Rewrite/Core/Rewriter.h>
 
+#include "bcc_bpf_uapi_inc.h"
 #include "frontend_action_common.h"
 #include "tp_frontend_action.h"
 #include "common.h"

--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -22,8 +22,6 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
-#include <linux/bpf.h>
-#include <linux/bpf_common.h>
 #include <linux/if_packet.h>
 #include <linux/types.h>
 #include <linux/perf_event.h>
@@ -48,6 +46,7 @@
 #include <unistd.h>
 #include <linux/if_alg.h>
 
+#include "bcc_bpf_uapi_inc.h"
 #include "libbpf.h"
 #include "perf_reader.h"
 

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -18,10 +18,11 @@
 #ifndef LIBBPF_H
 #define LIBBPF_H
 
-#include "linux/bpf.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
+
+#include "bcc_bpf_uapi_inc.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cc/shared_table.cc
+++ b/src/cc/shared_table.cc
@@ -17,8 +17,8 @@
 #include <unistd.h>
 #include <iostream>
 
+#include "bcc_bpf_uapi_inc.h"
 #include "common.h"
-#include "linux/bpf.h"
 #include "table_storage.h"
 #include "table_storage_impl.h"
 


### PR DESCRIPTION
and conditionally include the headers either from linux-headers or from libbpf source if
`HAVE_EXTERNAL_LIBBPF` is defined.