### PR TITLE
[test] Fix wrapper script to allow testing individual tests

### DIFF
--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -32,27 +32,27 @@ function ns_run() {
   sudo ip netns exec $ns ethtool -K eth0 tx off
   sudo ip addr add dev $ns.out 172.16.1.1/24
   sudo ip link set $ns.out up
-  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd $1 $2"
+  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd \"$@\""
   return $?
 }
 function sudo_run() {
-  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd $1 $2"
+  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd \"$@\""
   return $?
 }
 function simple_run() {
-  PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd $1 $2
+  PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd "$@"
   return $?
 }
 
 case $kind in
   namespace)
-    ns_run $@
+    ns_run "$@"
     ;;
   sudo)
-    sudo_run $@
+    sudo_run "$@"
     ;;
   simple)
-    simple_run $@
+    simple_run "$@"
     ;;
   *)
     echo "Invalid kind $kind"


### PR DESCRIPTION
When working on fixing individual tests, it is useful to be able to tell the test suite to only run that individual test.

The catch framework allows to do this. See https://github.com/catchorg/Catch2/blob/devel/docs/command-line.md#specifying-which-tests-to-run

When the wrapper was originally introduced, it used to pass the list of arguments to the tests as an array.

For some reasons, it got changed in https://github.com/iovisor/bcc/commit/7009b559f390292b1ee4b3970aca88b2272c52fd#diff-29e66e11b6682a5b66d214c108dd3c351a557bc884b64946af004e0e3195d209

This diff, re-introduces passing the list of arguments as an array (`$@`).

Also, it needs to be double-quoted in order to be able to handle space in test names.

Before:
```
$ docker run -ti \
                    --privileged \
                    --network=host \
                    --pid=host \
                    -v $(pwd):/bcc \
                    -v /sys/kernel/debug:/sys/kernel/debug:rw \
                    -v /lib/modules:/lib/modules:ro \
                    -v /usr/src:/usr/src:ro \
                    -e CTEST_OUTPUT_ON_FAILURE=1 \
                    bcc-docker \
                    /bin/bash -c \
                    '/bcc/build/tests/wrapper.sh \
                        c_test_all sudo /bcc/build/tests/cc/test_libbcc "test prob*"'
===============================================================================
No tests ran
```

After:
```
$ docker run -ti \
                    --privileged \
                    --network=host \
                    --pid=host \
                    -v $(pwd):/bcc \
                    -v /sys/kernel/debug:/sys/kernel/debug:rw \
                    -v /lib/modules:/lib/modules:ro \
                    -v /usr/src:/usr/src:ro \
                    -e CTEST_OUTPUT_ON_FAILURE=1 \
                    bcc-docker \
                    /bin/bash -c \
                    '/bcc/build/tests/wrapper.sh \
                        c_test_all sudo /bcc/build/tests/cc/test_libbcc "test prob*"'
===============================================================================
All tests passed (15 assertions in 2 test cases)

```

Also tested `namespace` and `simple` kinds:
```
$ docker run -ti \
                    --privileged \
                    --network=host \
                    --pid=host \
                    -v $(pwd):/bcc \
                    -v /sys/kernel/debug:/sys/kernel/debug:rw \
                    -v /lib/modules:/lib/modules:ro \
                    -v /usr/src:/usr/src:ro \
                    -e CTEST_OUTPUT_ON_FAILURE=1 \
                    bcc-docker \
                    /bin/bash -c \
                    '/bcc/build/tests/wrapper.sh \
                        c_test_all simple /bcc/build/tests/cc/test_libbcc "test prob*"'
===============================================================================
All tests passed (15 assertions in 2 test cases)

[16:08:12] chantra@focal:bcc git:(test_wrapper_fix) $ docker run -ti \
                    --privileged \
                    --network=host \
                    --pid=host \
                    -v $(pwd):/bcc \
                    -v /sys/kernel/debug:/sys/kernel/debug:rw \
                    -v /lib/modules:/lib/modules:ro \
                    -v /usr/src:/usr/src:ro \
                    -e CTEST_OUTPUT_ON_FAILURE=1 \
                    bcc-docker \
                    /bin/bash -c \
                    '/bcc/build/tests/wrapper.sh \
                        c_test_all namespace /bcc/build/tests/cc/test_libbcc "test prob*"'
Actual changes:
tx-checksumming: off
        tx-checksum-ip-generic: off
        tx-checksum-sctp: off
tcp-segmentation-offload: off
        tx-tcp-segmentation: off [requested on]
        tx-tcp-ecn-segmentation: off [requested on]
        tx-tcp-mangleid-segmentation: off [requested on]
        tx-tcp6-segmentation: off [requested on]
open(/sys/kernel/debug/tracing/uprobe_events): No such file or directory

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test_libbcc is a Catch v1.4.0 host application.
Run with -? for options

-------------------------------------------------------------------------------
test probing running Ruby process in namespaces
  in separate mount namespace
-------------------------------------------------------------------------------
/bcc/tests/cc/test_usdt_probes.cc:351
...............................................................................

/bcc/tests/cc/test_usdt_probes.cc:374: FAILED:
  REQUIRE( res.ok() )
with expansion:
  false

ioctl(PERF_EVENT_IOC_DISABLE) failed: Bad file descriptor
close perf event FD failed: Bad file descriptor
open(/sys/kernel/debug/tracing/uprobe_events): No such file or directory
Failed to detach all probes on destruction:
Failed to detach uprobe event p__proc_64889_root_usr_local_bin_ruby_0x453b0_64889: Unable to detach uprobe p__proc_64889_root_usr_local_bin_ruby_0x453b0_64889

open(/sys/kernel/debug/tracing/uprobe_events): No such file or directory
-------------------------------------------------------------------------------
test probing running Ruby process in namespaces
  in separate mount namespace and separate PID namespace
-------------------------------------------------------------------------------
/bcc/tests/cc/test_usdt_probes.cc:351
...............................................................................

/bcc/tests/cc/test_usdt_probes.cc:400: FAILED:
  REQUIRE( res.ok() )
with expansion:
  false

ioctl(PERF_EVENT_IOC_DISABLE) failed: Bad file descriptor
close perf event FD failed: Bad file descriptor
open(/sys/kernel/debug/tracing/uprobe_events): No such file or directory
Failed to detach all probes on destruction:
Failed to detach uprobe event p__proc_64891_root_usr_local_bin_ruby_0x453b0_64891: Unable to detach uprobe p__proc_64891_root_usr_local_bin_ruby_0x453b0_64891

===============================================================================
test cases:  2 |  1 passed | 1 failed as expected
assertions: 13 | 11 passed | 2 failed as expected

```