### PR TITLE
tools/memleak: fix print_outstanding_combined function

### DIFF
--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -538,7 +538,7 @@ def print_outstanding_combined():
                                                       show_module=True,
                                                       show_offset=True)
                                 trace.append(sym)
-                        trace = "\n\t\t".join(trace)
+                        trace = "\n\t\t".join(trace.decode())
                 except KeyError:
                         trace = "stack information lost"
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/share/bcc/tools/memleak", line 568, in <module> 
    print_outstanding_combined()
  File "share/bcc/tools/memleak", line 541, in print_outstanding_combined 
    trace = "\n\t\t".join(trace) 
TypeError: sequence item 0: expected str instance, bytes found
```
fix this.