### PR TITLE
tools/syscount: Add syscall filter support

### DIFF
--- a/man/man8/syscount.8
+++ b/man/man8/syscount.8
@@ -2,7 +2,7 @@
 .SH NAME
 syscount \- Summarize syscall counts and latencies.
 .SH SYNOPSIS
-.B syscount [-h] [-p PID] [-t TID] [-i INTERVAL] [-d DURATION] [-T TOP] [-x] [-e ERRNO] [-L] [-m] [-P] [-l]
+.B syscount [-h] [-p PID] [-t TID] [-i INTERVAL] [-d DURATION] [-T TOP] [-x] [-e ERRNO] [-L] [-m] [-P] [-l] [--syscall SYSCALL]
 .SH DESCRIPTION
 This tool traces syscall entry and exit tracepoints and summarizes either the
 number of syscalls of each type, or the number of syscalls per process. It can
@@ -48,6 +48,9 @@ Summarize by process and not by syscall.
 List the syscalls recognized by the tool (hard-coded list). Syscalls beyond this
 list will still be displayed, as "[unknown: nnn]" where nnn is the syscall
 number.
+.TP
+\--syscall SYSCALL
+Trace this syscall only (use option -l to get all recognized syscalls).
 .SH EXAMPLES
 .TP
 Summarize all syscalls by syscall:
@@ -108,6 +111,6 @@ Linux
 .SH STABILITY
 Unstable - in development.
 .SH AUTHOR
-Sasha Goldshtein
+Sasha Goldshtein, Rocky Xing
 .SH SEE ALSO
 funccount(8), ucalls(8), argdist(8), trace(8), funclatency(8)

--- a/tools/syscount_example.txt
+++ b/tools/syscount_example.txt
@@ -139,10 +139,25 @@ unlink                        1
 rmdir                         1
 ^C
 
+Sometimes, you'd only care about a single syscall rather than all syscalls.
+Use the --syscall option for this; the following example also demonstrates
+the --syscall option, for printing at predefined intervals:
+
+# syscount --syscall stat -i 1
+Tracing syscall 'stat'... Ctrl+C to quit.
+[12:51:06]
+SYSCALL                   COUNT
+stat                        310
+
+[12:51:07]
+SYSCALL                   COUNT
+stat                        316
+^C
+
 USAGE:
 # syscount -h
 usage: syscount.py [-h] [-p PID] [-t TID] [-i INTERVAL] [-d DURATION] [-T TOP]
-                   [-x] [-e ERRNO] [-L] [-m] [-P] [-l]
+                   [-x] [-e ERRNO] [-L] [-m] [-P] [-l] [--syscall SYSCALL]
 
 Summarize syscall counts and latencies.
 
@@ -164,3 +179,5 @@ optional arguments:
                         microseconds)
   -P, --process         count by process and not by syscall
   -l, --list            print list of recognized syscalls and exit
+  --syscall SYSCALL     trace this syscall only (use option -l to get all
+                        recognized syscalls)


### PR DESCRIPTION
Sometimes, I'd only care about a single syscall rather than all syscalls. Use the --syscall option for this.

```
# syscount -i 1 -p $(pgrep -nx mysqld) --syscall fsync -L

Tracing syscall 'fsync'... Ctrl+C to quit.
[13:02:24]
SYSCALL                   COUNT        TIME (us)
fsync                       956      2448760.979

[13:02:25]
SYSCALL                   COUNT        TIME (us)
fsync                       979      2387591.025

[13:02:26]
SYSCALL                   COUNT        TIME (us)
fsync                       845      2488404.454
```

@yonghong-song Please take a look, thanks.