### PR TITLE
libbpf-tools: tcpconnect: take source port into consideration

### DIFF
--- a/libbpf-tools/tcpconnect.h
+++ b/libbpf-tools/tcpconnect.h
@@ -14,12 +14,14 @@
 struct ipv4_flow_key {
 	__u32 saddr;
 	__u32 daddr;
+	__u16 sport;
 	__u16 dport;
 };
 
 struct ipv6_flow_key {
 	__u8 saddr[16];
 	__u8 daddr[16];
+	__u16 sport;
 	__u16 dport;
 };
 
@@ -37,6 +39,7 @@ struct event {
 	__u32 af; // AF_INET or AF_INET6
 	__u32 pid;
 	__u32 uid;
+	__u16 sport;
 	__u16 dport;
 };
 


### PR DESCRIPTION
Originally, the tcpconnect utility didn't display the source port when tracing
events and ignored it (intentionally) when counting new connections. Add a new
option -s (or --source-port) to display the source port when tracing, or to use
the source port as part of the key when counting connections. This option is
unset by default to provide the original output.

Signed-off-by: Anton Protopopov <a.s.protopopov@gmail.com>