### PR TITLE
libbpf-tools/sigsnoop: Fix build warning

### DIFF
--- a/libbpf-tools/sigsnoop.c
+++ b/libbpf-tools/sigsnoop.c
@@ -37,7 +37,6 @@ static const char *sig_name[] = {
 	[4] = "SIGILL",
 	[5] = "SIGTRAP",
 	[6] = "SIGABRT",
-	[6] = "SIGIOT",
 	[7] = "SIGBUS",
 	[8] = "SIGFPE",
 	[9] = "SIGKILL",


### PR DESCRIPTION
SIGIOT is an alias of SIGABRT so it's assigned to the same number.
However it caused an error in my build setup like below:

    libbpf-tools/sigsnoop.c:40:8: error: initializer overrides prior
                                  initialization of this subobject
                                  [-Werror,-Winitializer-overrides]
            [6] = "SIGIOT",
                  ^~~~~~~~
    libbpf-tools/sigsnoop.c:39:8: note: previous initialization is here
            [6] = "SIGABRT",
                  ^~~~~~~~~
    1 error generated.

Anyway, it's gonna show only single entry.  So let's remove the other.