### PR TITLE
tools/mdflush: include blkdev.h instead of genhd.h

### DIFF
--- a/tools/mdflush.py
+++ b/tools/mdflush.py
@@ -19,7 +19,7 @@ from time import strftime
 bpf_text="""
 #include <uapi/linux/ptrace.h>
 #include <linux/sched.h>
-#include <linux/genhd.h>
+#include <linux/blkdev.h>
 #include <linux/bio.h>
 
 struct data_t {


### PR DESCRIPTION
In recent kernels, i.e. since commit 322cbb50de71 ("block: remove
genhd.h"), genhd.h header has been removed and its content moved to
blkdev.h. Since genhd.h has been included in blkdev.h since forever,
including blkdev instead of genhd in the mdflush tool works for both
older and newer kernel.