### PR TITLE
libbpf-tools: Build and use lightweight bootstrap version of bpftool

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -3,7 +3,8 @@ OUTPUT := $(abspath .output)
 CLANG ?= clang
 LLVM_STRIP ?= llvm-strip
 BPFTOOL_SRC := $(abspath ./bpftool/src)
-BPFTOOL ?= $(OUTPUT)/bpftool/bpftool
+BPFTOOL_OUTPUT ?= $(abspath $(OUTPUT)/bpftool)
+BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
 LIBBPF_SRC := $(abspath ../src/cc/libbpf/src)
 LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
 INCLUDES := -I$(OUTPUT) -I../src/cc/libbpf/include/uapi
@@ -120,14 +121,13 @@ clean:
 	$(call msg,CLEAN)
 	$(Q)rm -rf $(OUTPUT) $(APPS) $(APP_ALIASES)
 
-$(OUTPUT) $(OUTPUT)/libbpf:
+$(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
 	$(call msg,MKDIR,$@)
 	$(Q)mkdir -p $@
 
-.PHONY: bpftool
-bpftool:
-	$(Q)mkdir -p $(OUTPUT)/bpftool
-	$(Q)$(MAKE) ARCH= CROSS_COMPILE=  OUTPUT=$(OUTPUT)/bpftool/ -C $(BPFTOOL_SRC)
+$(BPFTOOL): | $(BPFTOOL_OUTPUT)
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(MAKE) ARCH= CROSS_COMPILE=  OUTPUT=$(BPFTOOL_OUTPUT)/ -C $(BPFTOOL_SRC) bootstrap
 
 $(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) $(COMMON_OBJ) | $(OUTPUT)
 	$(call msg,BINARY,$@)
@@ -139,7 +139,7 @@ $(OUTPUT)/%.o: %.c $(wildcard %.h) $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,CC,$@)
 	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
 
-$(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) bpftool
+$(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
 	$(call msg,GEN-SKEL,$@)
 	$(Q)$(BPFTOOL) gen skeleton $< > $@
 


### PR DESCRIPTION
We need bpftool for skeleton generation only, let's build and use bootstrap
bpftool like libbpf-bootstrap does ([0]). This avoids the following errors
on old kernels:

    skeleton/pid_iter.bpf.c:35:10: error: incomplete definition of type 'struct bpf_link'
                    return BPF_CORE_READ((struct bpf_link *)ent, id);
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  [0]: https://github.com/libbpf/libbpf-bootstrap/pull/92

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>