### PR TITLE
tools/cpudist: Fix warning introduced by recent change

### DIFF
--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -178,7 +178,7 @@ if args.pids or args.tids:
         section = "tid"
     storage_str += "BPF_HISTOGRAM(dist, pid_key_t, MAX_PID);"
     store_str += """
-    pid_key_t key = {.id = ' + pid + ', .slot = bpf_log2l(delta)};
+    pid_key_t key = {.id = """ + pid + """, .slot = bpf_log2l(delta)};
     dist.increment(key);
     """
 else:


### PR DESCRIPTION
With #4131 included, running the tool with -L reports the following warning:

    /virtual/main.c:57:28: warning: multi-character character constant [-Wmultichar]
        pid_key_t key = {.id = ' + pid + ', .slot = bpf_log2l(delta)};
                               ^
    /virtual/main.c:57:28: warning: character constant too long for its type
    2 warnings generated.

The `pid` part should not be treated as string literal. Fix it.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>