### PR TITLE
Add systemtap header and ruby to fedora docker

### DIFF
--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -27,7 +27,8 @@ RUN dnf -y install \
 	luajit-devel \
 	python3-devel \
 	libstdc++ \
-	libstdc++-devel
+	libstdc++-devel \
+	systemtap-sdt-devel
 
 RUN dnf -y install \
 	python3 \
@@ -46,3 +47,12 @@ RUN dnf -y install \
 	bpftool
 
 RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1
+
+RUN wget -O ruby-install-0.7.0.tar.gz \
+         https://github.com/postmodern/ruby-install/archive/v0.7.0.tar.gz && \
+    tar -xzvf ruby-install-0.7.0.tar.gz && \
+    cd ruby-install-0.7.0/ && \
+    make install
+
+RUN ruby-install --system ruby 2.6.0 -- --enable-dtrace
+


### PR DESCRIPTION
The fedora USDT tests are failing because 1) ruby isn't installed on fedora by default, and 2) fedora's ruby doesn't (didn't) have USDTs when it was installed by default. So let's manually build it with USDTs.