### PR TITLE
fix arithmetic on a pointer to an incomplete type

### DIFF
--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -40,7 +40,74 @@ struct open_probe_t {
   std::vector<std::pair<int, int>>* per_cpu_fd;
 };
 
-class USDT;
+class BPF;
+
+class USDT {
+ public:
+  USDT(const std::string& binary_path, const std::string& provider,
+       const std::string& name, const std::string& probe_func);
+  USDT(pid_t pid, const std::string& provider, const std::string& name,
+       const std::string& probe_func);
+  USDT(const std::string& binary_path, pid_t pid, const std::string& provider,
+       const std::string& name, const std::string& probe_func);
+  USDT(const USDT& usdt);
+  USDT(USDT&& usdt) noexcept;
+
+  const std::string &binary_path() const { return binary_path_; }
+  pid_t pid() const { return pid_; }
+  const std::string &provider() const { return provider_; }
+  const std::string &name() const { return name_; }
+  const std::string &probe_func() const { return probe_func_; }
+
+  StatusTuple init();
+
+  bool operator==(const USDT& other) const;
+
+  std::string print_name() const {
+    return provider_ + ":" + name_ + " from binary " + binary_path_ + " PID " +
+           std::to_string(pid_) + " for probe " + probe_func_;
+  }
+
+  friend std::ostream& operator<<(std::ostream& out, const USDT& usdt) {
+    return out << usdt.provider_ << ":" << usdt.name_ << " from binary "
+               << usdt.binary_path_ << " PID " << usdt.pid_ << " for probe "
+               << usdt.probe_func_;
+  }
+
+  // When the kludge flag is set to 1 (default), we will only match on inode
+  // when searching for modules in /proc/PID/maps that might contain the
+  // tracepoint we're looking for.
+  // By setting this to 0, we will match on both inode and
+  // (dev_major, dev_minor), which is a more accurate way to uniquely
+  // identify a file, but may fail depending on the filesystem backing the
+  // target file (see bcc#2715)
+  //
+  // This hack exists because btrfs and overlayfs report different device
+  // numbers for files in /proc/PID/maps vs stat syscall. Don't use it unless
+  // you've had issues with inode collisions. Both btrfs and overlayfs are
+  // known to require inode-only resolution to accurately match a file.
+  //
+  // set_probe_matching_kludge(0) must be called before USDTs are submitted to
+  // BPF::init()
+  int set_probe_matching_kludge(uint8_t kludge);
+
+ private:
+  bool initialized_;
+
+  std::string binary_path_;
+  pid_t pid_;
+
+  std::string provider_;
+  std::string name_;
+  std::string probe_func_;
+
+  std::unique_ptr<void, std::function<void(void*)>> probe_;
+  std::string program_text_;
+
+  uint8_t mod_match_inode_only_;
+
+  friend class BPF;
+};
 
 class BPF {
  public:
@@ -347,73 +414,6 @@ class BPF {
   std::map<std::string, BPFPerfBuffer*> perf_buffers_;
   std::map<std::string, BPFPerfEventArray*> perf_event_arrays_;
   std::map<std::pair<uint32_t, uint32_t>, open_probe_t> perf_events_;
-};
-
-class USDT {
- public:
-  USDT(const std::string& binary_path, const std::string& provider,
-       const std::string& name, const std::string& probe_func);
-  USDT(pid_t pid, const std::string& provider, const std::string& name,
-       const std::string& probe_func);
-  USDT(const std::string& binary_path, pid_t pid, const std::string& provider,
-       const std::string& name, const std::string& probe_func);
-  USDT(const USDT& usdt);
-  USDT(USDT&& usdt) noexcept;
-
-  const std::string &binary_path() const { return binary_path_; }
-  pid_t pid() const { return pid_; }
-  const std::string &provider() const { return provider_; }
-  const std::string &name() const { return name_; }
-  const std::string &probe_func() const { return probe_func_; }
-
-  StatusTuple init();
-
-  bool operator==(const USDT& other) const;
-
-  std::string print_name() const {
-    return provider_ + ":" + name_ + " from binary " + binary_path_ + " PID " +
-           std::to_string(pid_) + " for probe " + probe_func_;
-  }
-
-  friend std::ostream& operator<<(std::ostream& out, const USDT& usdt) {
-    return out << usdt.provider_ << ":" << usdt.name_ << " from binary "
-               << usdt.binary_path_ << " PID " << usdt.pid_ << " for probe "
-               << usdt.probe_func_;
-  }
-
-  // When the kludge flag is set to 1 (default), we will only match on inode
-  // when searching for modules in /proc/PID/maps that might contain the
-  // tracepoint we're looking for.
-  // By setting this to 0, we will match on both inode and
-  // (dev_major, dev_minor), which is a more accurate way to uniquely
-  // identify a file, but may fail depending on the filesystem backing the
-  // target file (see bcc#2715)
-  //
-  // This hack exists because btrfs and overlayfs report different device
-  // numbers for files in /proc/PID/maps vs stat syscall. Don't use it unless
-  // you've had issues with inode collisions. Both btrfs and overlayfs are
-  // known to require inode-only resolution to accurately match a file.
-  //
-  // set_probe_matching_kludge(0) must be called before USDTs are submitted to
-  // BPF::init()
-  int set_probe_matching_kludge(uint8_t kludge);
-
- private:
-  bool initialized_;
-
-  std::string binary_path_;
-  pid_t pid_;
-
-  std::string provider_;
-  std::string name_;
-  std::string probe_func_;
-
-  std::unique_ptr<void, std::function<void(void*)>> probe_;
-  std::string program_text_;
-
-  uint8_t mod_match_inode_only_;
-
-  friend class BPF;
 };
 
 }  // namespace ebpf


### PR DESCRIPTION
When including `bcc/BPF.h` there's a compilation error regarding arithmetic on a pointer to an incomplete type 'ebpf::USDT'.

The fix is straightforward: swap the order of the class declarations in the `bcc/BPF.h` file, after which things compile successfully.

More details are described in the issue #4160