### PR TITLE
[test] Fix Wrapper script to properly handle arguments

### DIFF
--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -32,11 +32,11 @@ function ns_run() {
   sudo ip netns exec $ns ethtool -K eth0 tx off
   sudo ip addr add dev $ns.out 172.16.1.1/24
   sudo ip link set $ns.out up
-  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd \"$@\""
+  sudo --preserve-env=PYTHONPATH,PYTHON_TEST_LOGFILE,LD_LIBRARY_PATH ip netns exec $ns $cmd "$@"
   return $?
 }
 function sudo_run() {
-  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd \"$@\""
+  sudo --preserve-env=PYTHONPATH,PYTHON_TEST_LOGFILE,LD_LIBRARY_PATH $cmd "$@"
   return $?
 }
 function simple_run() {


### PR DESCRIPTION
In #4126 I solved one problem but essentially pushed it somewhere else.

Now the problem is that when multiple arguments are passed, they all end up
being within the same argument because they get wrapped within the double-quotes.

This is pretty much an escape-hell as we keep on passing the same arguments over
and over through functions and then within `bash -c`.

The reason for the `bash -c` bit is that it allows us to set some envirtonment variable used in the tests.
Those env var are set to the local environment values.

Instead of going an extra layer of indirection, we can tell `sudo` to preserve those
specific env var by using the `--preserve-env` argument this way, we do not have to
re-escape the arguments that are passed within the `bash -c` quoted arg.

Tests:

Confirm that this was not working before:
```
$ docker run -ti \
                    --privileged \
                    --network=host \
                    --pid=host \
                    -v $(pwd):/bcc \
                    -v /sys/kernel/debug:/sys/kernel/debug:rw \
                    -v /lib/modules:/lib/modules:ro \
                    -v /usr/src:/usr/src:ro \
                    -e CTEST_OUTPUT_ON_FAILURE=1 \
                    bcc-docker-focal \
                    /bin/bash -c \
                    '/bcc/build/tests/wrapper.sh \
                        c_test_all sudo /bcc/build/tests/cc/test_libbcc -s "test probing running Ruby*"'
test probing running Ruby*": -c: line 0: unexpected EOF while looking for matching `"'
test probing running Ruby*": -c: line 1: syntax error: unexpected end of file
Failed

```

and is fixed after the patch:

```
$ docker run -ti \
                    --privileged \
                    --network=host \
                    --pid=host \
                    -v $(pwd):/bcc \
                    -v /sys/kernel/debug:/sys/kernel/debug:rw \
                    -v /lib/modules:/lib/modules:ro \
                    -v /usr/src:/usr/src:ro \
                    -e CTEST_OUTPUT_ON_FAILURE=1 \
                    bcc-docker-focal \
                    /bin/bash -c \
                    '/bcc/build/tests/wrapper.sh \
                        c_test_all sudo /bcc/build/tests/cc/test_libbcc -s "test probing running Ruby*"'

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test_libbcc is a Catch v1.4.0 host application.
Run with -? for options

-------------------------------------------------------------------------------
test probing running Ruby process in namespaces
  in separate mount namespace
-------------------------------------------------------------------------------
/bcc/tests/cc/test_usdt_probes.cc:351
...............................................................................

/bcc/tests/cc/test_usdt_probes.cc:367:
PASSED:
  REQUIRE( res.msg() == "" )
with expansion:
  "" == ""

/bcc/tests/cc/test_usdt_probes.cc:368:
PASSED:
  REQUIRE( res.ok() )
with expansion:
  true

/bcc/tests/cc/test_usdt_probes.cc:371:
PASSED:
  REQUIRE( res.ok() )
with expansion:
  true

/bcc/tests/cc/test_usdt_probes.cc:374:
PASSED:
  REQUIRE( res.ok() )
with expansion:
  true

-------------------------------------------------------------------------------
test probing running Ruby process in namespaces
  in separate mount namespace and separate PID namespace
-------------------------------------------------------------------------------
/bcc/tests/cc/test_usdt_probes.cc:351
...............................................................................

/bcc/tests/cc/test_usdt_probes.cc:393:
PASSED:
  REQUIRE( res.msg() == "" )
with expansion:
  "" == ""

/bcc/tests/cc/test_usdt_probes.cc:394:
PASSED:
  REQUIRE( res.ok() )
with expansion:
  true

/bcc/tests/cc/test_usdt_probes.cc:397:
PASSED:
  REQUIRE( res.ok() )
with expansion:
  true

/bcc/tests/cc/test_usdt_probes.cc:400:
PASSED:
  REQUIRE( res.ok() )
with expansion:
  true

/bcc/tests/cc/test_usdt_probes.cc:405:
PASSED:
  REQUIRE( bcc_resolve_symname(module.c_str(), "rb_gc_mark", 0x0, ruby_pid, nullptr, &sym) == 0 )
with expansion:
  0 == 0

/bcc/tests/cc/test_usdt_probes.cc:406:
PASSED:
  REQUIRE( std::string(sym.module).find(pid_root, 1) == std::string::npos )
with expansion:
  18446744073709551615 (0xffffffffffffffff)
  ==
  18446744073709551615 (0xffffffffffffffff)

===============================================================================
All tests passed (10 assertions in 1 test case)
```