### PR TITLE
[test][sockhash/map] Fix the test to work with kernels >= 5.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,10 @@ CMAKE_DEPENDENT_OPTION(ENABLE_CPP_API "Enable C++ API" ON "ENABLE_USDT" OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+if(ENABLE_TESTS)
+  find_package(KernelHeaders)
+endif()
+
 if (CMAKE_USE_LIBBPF_PACKAGE)
   find_package(LibBpf)
 endif()

--- a/cmake/FindKernelHeaders.cmake
+++ b/cmake/FindKernelHeaders.cmake
@@ -1,0 +1,35 @@
+# Find the kernel headers for the running kernel release
+# This is used to find a "linux/version.h" matching the running kernel.
+
+execute_process(
+        COMMAND uname -r
+        OUTPUT_VARIABLE KERNEL_RELEASE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Find the headers
+find_path(KERNELHEADERS_DIR
+        include/linux/user.h
+        PATHS
+        # RedHat derivatives
+        /usr/src/kernels/${KERNEL_RELEASE}
+        # Debian derivatives
+        /usr/src/linux-headers-${KERNEL_RELEASE}
+        )
+
+message(STATUS "Kernel release: ${KERNEL_RELEASE}")
+message(STATUS "Kernel headers: ${KERNELHEADERS_DIR}")
+
+if (KERNELHEADERS_DIR)
+    set(KERNELHEADERS_INCLUDE_DIRS
+            ${KERNELHEADERS_DIR}/include/generated/uapi
+            CACHE PATH "Kernel headers include dirs"
+            )
+    set(KERNELHEADERS_FOUND 1 CACHE STRING "Set to 1 if kernel headers were found")
+    include_directories(${KERNELHEADERS_INCLUDE_DIRS})
+else (KERNELHEADERS_DIR)
+    set(KERNELHEADERS_FOUND 0 CACHE STRING "Set to 1 if kernel headers were found")
+endif (KERNELHEADERS_DIR)
+
+mark_as_advanced(KERNELHEADERS_FOUND)
+


### PR DESCRIPTION
Those tests have started to fail since kernel 5.15.
The restriction was lifted in https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=0c48eefae712c2fd91480346a07a1a9cd0f9470b

This diff makes the expected returned value to the call to `update_value` conditional
on the kernel version.

Tested on 5.15 (using a Ubuntu 22.04 host), which is representative of the kernel running in GH CI.
Also tested on Ubuntu 20.04 stock kernel:

```
$ docker run -ti \
                    --privileged \
                    --network=host \
                    --pid=host \
                    -v $(pwd):/bcc \
                    -v /sys/kernel/debug:/sys/kernel/debug:rw \
                    -v /lib/modules:/lib/modules:ro \
                    -v /usr/src:/usr/src:ro \
                    -e CTEST_OUTPUT_ON_FAILURE=1 \
                    bcc-docker-focal \
                    /bin/bash -c \
                    '/bcc/build/tests/wrapper.sh \
                        c_test_all sudo /bcc/build/tests/cc/test_libbcc "test sock*"'
===============================================================================
All tests passed (8 assertions in 2 test cases)

[22:40:55] chantra@focal:bcc git:(fix_sock_map_tests*) $ uname -a
Linux focal 5.4.0-122-generic #138-Ubuntu SMP Wed Jun 22 15:00:31 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```