### PR TITLE
[test] fix module search test

### DIFF
--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -14,6 +14,7 @@ else()
 endif()
 
 add_test(NAME c_test_static COMMAND ${TEST_WRAPPER} c_test_static sudo ${CMAKE_CURRENT_BINARY_DIR}/test_static)
+add_compile_options(-DCMAKE_CURRENT_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result -fPIC")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-result -fPIC")

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -34,6 +34,7 @@
 
 #include "catch.hpp"
 
+
 using namespace std;
 
 static pid_t spawn_child(void *, bool, bool, int (*)(void *));
@@ -495,7 +496,8 @@ struct mod_search {
 };
 
 TEST_CASE("searching for modules in /proc/[pid]/maps", "[c_api][!mayfail]") {
-  FILE *dummy_maps = fopen("dummy_proc_map.txt", "r");
+  std::string dummy_maps_path = CMAKE_CURRENT_BINARY_DIR + std::string("/dummy_proc_map.txt");
+  FILE *dummy_maps = fopen(dummy_maps_path.c_str(), "r");
   REQUIRE(dummy_maps != NULL);
 
   SECTION("name match") {


### PR DESCRIPTION
The test "searching for modules in /proc/[pid]/maps" was trying to load
`dummy_proc_map.txt` from the current directory.

When running in a container, the current directory is set to `/`.
One way around this in CI would be to use the argument `-w /bcc/build/tests/cc`
so we change current directory.
On the other hand, our CMakeLists.txt file already copy the dummy file to
CMAKE_CURRENT_BINARY_DIR. So we may as well use this.

This diff sets `CMAKE_CURRENT_BINARY_DIR` as a define flag at compilation and
we re-use this within the test itself to load the file properly.

Test:
```
$ docker run -ti \
                    --privileged \
                    --network=host \
                    --pid=host \
                    -v $(pwd):/bcc \
                    -v /sys/kernel/debug:/sys/kernel/debug:rw \
                    -v /lib/modules:/lib/modules:ro \
                    -v /usr/src:/usr/src:ro \
                    -e CTEST_OUTPUT_ON_FAILURE=1 \
                    bcc-docker-fedora \
                    /bin/bash -c \
                    '/bcc/build/tests/wrapper.sh \
                        c_test_all sudo /bcc/build/tests/cc/test_libbcc "searching for modules *"'
===============================================================================
All tests passed (15 assertions in 1 test case)
```

original failure:
```
-------------------------------------------------------------------------------
searching for modules in /proc/[pid]/maps
-------------------------------------------------------------------------------
/bcc/tests/cc/test_c_api.cc:497
...............................................................................

/bcc/tests/cc/test_c_api.cc:499: FAILED:
  REQUIRE( dummy_maps != __null )
with expansion:
  NULL != 0
```