### PR TITLE
test_bpf_table: Re-add deletion of 'bpf' module

### DIFF
--- a/tests/cc/test_bpf_table.cc
+++ b/tests/cc/test_bpf_table.cc
@@ -26,13 +26,13 @@ TEST_CASE("test bpf table", ebpf::bpf_module_rw_engine_enabled() ? "[bpf_table]"
     BPF_TABLE("hash", int, int, myhash, 128);
   )";
 
-  ebpf::BPF bpf;
+  auto bpf = std::make_unique<ebpf::BPF>();
   ebpf::StatusTuple res(0);
   std::vector<std::pair<std::string, std::string>> elements;
-  res = bpf.init(BPF_PROGRAM);
+  res = bpf->init(BPF_PROGRAM);
   REQUIRE(res.ok());
 
-  ebpf::BPFTable t = bpf.get_table("myhash");
+  ebpf::BPFTable t = bpf->get_table("myhash");
 
   // update element
   std::string value;
@@ -78,7 +78,8 @@ TEST_CASE("test bpf table", ebpf::bpf_module_rw_engine_enabled() ? "[bpf_table]"
   REQUIRE(res.ok());
   REQUIRE(elements.size() == 0);
 
-
+  // delete bpf_module, call to key/leaf printf/scanf must fail
+  bpf.reset();
 
   res = t.update_value("0x07", "0x42");
   REQUIRE(!res.ok());


### PR DESCRIPTION
This was removed in 6616092255f80fc0918e19e898f0abfe2e3c2840, presumably
because sanitizer complained.

Signed-off-by: Dave Marchevsky <davemarchevsky@fb.com>