### PR TITLE
Revert "[test] Fix Wrapper script to properly handle arguments"

### DIFF
--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -32,11 +32,11 @@ function ns_run() {
   sudo ip netns exec $ns ethtool -K eth0 tx off
   sudo ip addr add dev $ns.out 172.16.1.1/24
   sudo ip link set $ns.out up
-  sudo --preserve-env=PYTHONPATH,PYTHON_TEST_LOGFILE,LD_LIBRARY_PATH ip netns exec $ns $cmd "$@"
+  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd \"$@\""
   return $?
 }
 function sudo_run() {
-  sudo --preserve-env=PYTHONPATH,PYTHON_TEST_LOGFILE,LD_LIBRARY_PATH $cmd "$@"
+  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd \"$@\""
   return $?
 }
 function simple_run() {

--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -32,27 +32,27 @@ function ns_run() {
   sudo ip netns exec $ns ethtool -K eth0 tx off
   sudo ip addr add dev $ns.out 172.16.1.1/24
   sudo ip link set $ns.out up
-  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd \"$@\""
+  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd $1 $2"
   return $?
 }
 function sudo_run() {
-  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd \"$@\""
+  sudo bash -c "PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd $1 $2"
   return $?
 }
 function simple_run() {
-  PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd "$@"
+  PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd $1 $2
   return $?
 }
 
 case $kind in
   namespace)
-    ns_run "$@"
+    ns_run $@
     ;;
   sudo)
-    sudo_run "$@"
+    sudo_run $@
     ;;
   simple)
-    simple_run "$@"
+    simple_run $@
     ;;
   *)
     echo "Invalid kind $kind"


### PR DESCRIPTION
This reverts commit 770a590e879dcc831bb68c4cc2b3fc1c1ee81674.

Now that "cc tests" are passing, the python section of "all tests" is
failing. Those tests run using wrapper.sh, so let's try reverting some
recent changes to see if that helps.