### PR TITLE
[tests] fix python tests

### DIFF
--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -32,11 +32,11 @@ function ns_run() {
   sudo ip netns exec $ns ethtool -K eth0 tx off
   sudo ip addr add dev $ns.out 172.16.1.1/24
   sudo ip link set $ns.out up
-  sudo --preserve-env=PYTHONPATH,PYTHON_TEST_LOGFILE,LD_LIBRARY_PATH ip netns exec $ns $cmd "$@"
+  sudo --preserve-env=PYTHON_TEST_LOGFILE env PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd "$@"
   return $?
 }
 function sudo_run() {
-  sudo --preserve-env=PYTHONPATH,PYTHON_TEST_LOGFILE,LD_LIBRARY_PATH $cmd "$@"
+  sudo --preserve-env=PYTHON_TEST_LOGFILE env PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd "$@"
   return $?
 }
 function simple_run() {


### PR DESCRIPTION
Python tests are failing to import bcc module:
```
41: Test command: /bcc/build/tests/wrapper.sh "py_test_map_in_map" "sudo" "/bcc/tests/python/test_map_in_map.py"
41: Test timeout computed to be: 10000000
41: Traceback (most recent call last):
41:   File "/bcc/tests/python/test_map_in_map.py", line 9, in <module>
41:     from bcc import BPF
41: ModuleNotFoundError: No module named 'bcc'
41: Failed
41/41 Test #41: py_test_map_in_map ...............***Failed    0.03 sec
Traceback (most recent call last):
  File "/bcc/tests/python/test_map_in_map.py", line 9, in <module>
    from bcc import BPF
ModuleNotFoundError: No module named 'bcc'
Failed
```

This was caused by #4162 . `sudo` has a list of env variables that get reset
regardless of what is in `preserve-env` list. See https://github.com/sudo-project/sudo/blob/158facf6d5852ebc420adca5ff06135b18ee57b8/plugins/sudoers/env.c#L138

This patch uses the `env` command to set those env variables within the sudoed context.