### PR TITLE
tools/trace: Fix TypeError when format string contains %K or %U

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -630,8 +630,8 @@ BPF_PERF_OUTPUT(%s);
                 event = ct.cast(data, ct.POINTER(self.python_struct)).contents
                 if self.name not in event.comm:
                     return
-                values = map(lambda i: getattr(event, "v%d" % i),
-                             range(0, len(self.values)))
+                values = list(map(lambda i: getattr(event, "v%d" % i),
+                             range(0, len(self.values))))
                 msg = self._format_message(bpf, event.tgid, values)
                 if self.msg_filter and self.msg_filter not in msg:
                     return


### PR DESCRIPTION
```
# ./trace.py 'smp_call_function_single "%K", arg1'

Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 234, in 'calling callback function'
  File "/usr/lib/python3.6/site-packages/bcc/table.py", line 982, in raw_cb_
    callback(cpu, data, size)
  File "trace.py", line 635, in print_event
    msg = self._format_message(bpf, event.tgid, values)
  File "trace.py", line 616, in _format_message
    values[kp] = bpf.ksym(values[kp], show_offset=True)
TypeError: 'map' object is not subscriptable
```