### PR TITLE
[test][bionic] Force python3 and utf-8 encoding

### DIFF
--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -72,3 +72,4 @@ RUN wget -O ruby-install-0.7.0.tar.gz \
 
 RUN ruby-install --system ruby 2.6.0 -- --enable-dtrace
 RUN if [ ! -f "/usr/bin/python" ]; then ln -s /bin/python3 /usr/bin/python; fi
+RUN if [ ! -f "/usr/local/bin/python" ]; then ln -s /usr/bin/python3 /usr/local/bin/python; fi

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -265,7 +265,6 @@ class SmokeTests(TestCase):
         self.run_with_duration("offcputime.py 1")
 
     @skipUnless(kernel_version_ge(4,6), "requires kernel >= 4.6")
-    @mayFail("This fails on ubuntu 18.04 github actions environment")
     def test_offwaketime(self):
         self.run_with_duration("offwaketime.py 1")
 

--- a/tests/wrapper.sh.in
+++ b/tests/wrapper.sh.in
@@ -9,6 +9,7 @@ kind=$1; shift
 cmd=$1; shift
 
 PYTHONPATH=@CMAKE_BINARY_DIR@/src/python/bcc-python3
+PYTHONIOENCODING=utf-8
 LD_LIBRARY_PATH=@CMAKE_BINARY_DIR@:@CMAKE_BINARY_DIR@/src/cc
 
 ns=$name
@@ -32,15 +33,15 @@ function ns_run() {
   sudo ip netns exec $ns ethtool -K eth0 tx off
   sudo ip addr add dev $ns.out 172.16.1.1/24
   sudo ip link set $ns.out up
-  sudo --preserve-env=PYTHON_TEST_LOGFILE env PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd "$@"
+  sudo --preserve-env=PYTHON_TEST_LOGFILE env PYTHONIOENCODING=$PYTHONIOENCODING PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH ip netns exec $ns $cmd "$@"
   return $?
 }
 function sudo_run() {
-  sudo --preserve-env=PYTHON_TEST_LOGFILE env PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd "$@"
+  sudo --preserve-env=PYTHON_TEST_LOGFILE env PYTHONIOENCODING=$PYTHONIOENCODING PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd "$@"
   return $?
 }
 function simple_run() {
-  PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd "$@"
+  PYTHONIOENCODING=$PYTHONIOENCODING PYTHONPATH=$PYTHONPATH PYTHON_TEST_LOGFILE=$PYTHON_TEST_LOGFILE LD_LIBRARY_PATH=$LD_LIBRARY_PATH $cmd "$@"
   return $?
 }
 

--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # argdist   Trace a function and display a distribution of its
 #           parameter values as a histogram or frequency count.

--- a/tools/bashreadline.py
+++ b/tools/bashreadline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # bashreadline  Print entered bash commands from all running shells.
 #               For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/bindsnoop.py
+++ b/tools/bindsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # bindsnoop       Trace IPv4 and IPv6 binds()s.
 #               For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # biolatency    Summarize block device I/O latency as a histogram.

--- a/tools/biolatpcts.py
+++ b/tools/biolatpcts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # biolatpcts.py  Monitor IO latency distribution of a block device.
 #

--- a/tools/biopattern.py
+++ b/tools/biopattern.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # biopattern - Identify random/sequential disk access patterns.

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # biosnoop  Trace block device I/O and print details including issuing PID.

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # biotop  block device (disk) I/O by process.

--- a/tools/bitesize.py
+++ b/tools/bitesize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # bitehist.py   Block I/O size histogram.
 #               For Linux, uses BCC, eBPF. See .c file.

--- a/tools/bpflist.py
+++ b/tools/bpflist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # bpflist   Display processes currently using BPF programs and maps,
 #           pinned BPF programs and maps, and enabled probes.

--- a/tools/btrfsdist.py
+++ b/tools/btrfsdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # btrfsdist  Summarize btrfs operation latency.

--- a/tools/btrfsslower.py
+++ b/tools/btrfsslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # btrfsslower  Trace slow btrfs operations.

--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # cachestat     Count cache kernel function calls.
 #               For Linux, uses BCC, eBPF. See .c file.

--- a/tools/cachetop.py
+++ b/tools/cachetop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # cachetop      Count cache kernel function calls per processes

--- a/tools/capable.py
+++ b/tools/capable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # capable   Trace security capabilitiy checks (cap_capable()).

--- a/tools/compactsnoop.py
+++ b/tools/compactsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # compactsnoop  Trace compact zone and print details including issuing PID.

--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # cpudist   Summarize on- and off-CPU time per task as a histogram.

--- a/tools/cpuunclaimed.py
+++ b/tools/cpuunclaimed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # cpuunclaimed   Sample CPU run queues and calculate unclaimed idle CPU.

--- a/tools/criticalstat.py
+++ b/tools/criticalstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # criticalstat  Trace long critical sections (IRQs or preemption disabled)

--- a/tools/dbslower.py
+++ b/tools/dbslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # dbslower      Trace MySQL and PostgreSQL queries slower than a threshold.
 #

--- a/tools/dbstat.py
+++ b/tools/dbstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # dbstat        Display a histogram of MySQL and PostgreSQL query latencies.
 #

--- a/tools/dcsnoop.py
+++ b/tools/dcsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # dcsnoop   Trace directory entry cache (dcache) lookups.

--- a/tools/dcstat.py
+++ b/tools/dcstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # dcstat   Directory entry cache (dcache) stats.

--- a/tools/deadlock.py
+++ b/tools/deadlock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # deadlock  Detects potential deadlocks (lock order inversions)
 #           on a running process. For Linux, uses BCC, eBPF.

--- a/tools/dirtop.py
+++ b/tools/dirtop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # dirtop  file reads and writes by directory.

--- a/tools/drsnoop.py
+++ b/tools/drsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # drsnoop  Trace direct reclaim and print details including issuing PID.

--- a/tools/execsnoop.py
+++ b/tools/execsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # execsnoop Trace new processes via exec() syscalls.

--- a/tools/exitsnoop.py
+++ b/tools/exitsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 from __future__ import print_function
 

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # ext4dist  Summarize ext4 operation latency.

--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # ext4slower  Trace slow ext4 operations.

--- a/tools/filelife.py
+++ b/tools/filelife.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # filelife    Trace the lifespan of short-lived files.

--- a/tools/fileslower.py
+++ b/tools/fileslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # fileslower  Trace slow synchronous file reads and writes.

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # filetop  file reads and writes by process.

--- a/tools/funccount.py
+++ b/tools/funccount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # funccount Count functions, tracepoints, and USDT probes.

--- a/tools/funcinterval.py
+++ b/tools/funcinterval.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # funcinterval   Time interval between the same function, tracepoint

--- a/tools/funclatency.py
+++ b/tools/funclatency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # funclatency   Time functions and print latency as a histogram.

--- a/tools/funcslower.py
+++ b/tools/funcslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # funcslower  Trace slow kernel or user function calls.

--- a/tools/gethostlatency.py
+++ b/tools/gethostlatency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # gethostlatency  Show latency for getaddrinfo/gethostbyname[2] calls.
 #                 For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/hardirqs.py
+++ b/tools/hardirqs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # hardirqs  Summarize hard IRQ (interrupt) event time.

--- a/tools/inject.py
+++ b/tools/inject.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # This script generates a BPF program with structure inspired by trace.py. The
 # generated program operates on PID-indexed stacks. Generally speaking,

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # killsnoop Trace signals issued by the kill() syscall.

--- a/tools/klockstat.py
+++ b/tools/klockstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # klockstat traces lock events and display locks statistics.
 #

--- a/tools/llcstat.py
+++ b/tools/llcstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # llcstat.py Summarize cache references and cache misses by PID.
 #            Cache reference and cache miss are corresponding events defined in

--- a/tools/mdflush.py
+++ b/tools/mdflush.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # mdflush  Trace md flush events.

--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # memleak   Trace and display outstanding allocations to detect
 #           memory leaks in user-mode processes and the kernel.

--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # mountsnoop Trace mount() and umount syscalls.
 #            For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/mysqld_qslower.py
+++ b/tools/mysqld_qslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # mysqld_qslower    MySQL server queries slower than a threshold.
 #                   For Linux, uses BCC, BPF. Embedded C.

--- a/tools/netqtop.py
+++ b/tools/netqtop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import print_function
 from bcc import BPF

--- a/tools/nfsdist.py
+++ b/tools/nfsdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # nfsdist   Summarize NFS operation latency

--- a/tools/nfsslower.py
+++ b/tools/nfsslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # nfsslower     Trace slow NFS operations

--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # offcputime    Summarize off-CPU time by stack trace
 #               For Linux, uses BCC, eBPF.

--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # offwaketime   Summarize blocked time by kernel off-CPU stack + waker stack
 #               For Linux, uses BCC, eBPF.

--- a/tools/oomkill.py
+++ b/tools/oomkill.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # oomkill   Trace oom_kill_process(). For Linux, uses BCC, eBPF.
 #

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # opensnoop Trace open() syscalls.

--- a/tools/pidpersec.py
+++ b/tools/pidpersec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # pidpersec Count new processes (via fork).

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # profile  Profile CPU usage by sampling stack traces at a timed interval.

--- a/tools/readahead.py
+++ b/tools/readahead.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # readahead     Show performance of read-ahead cache

--- a/tools/runqlat.py
+++ b/tools/runqlat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # runqlat   Run queue (scheduler) latency as a histogram.

--- a/tools/runqlen.py
+++ b/tools/runqlen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # runqlen    Summarize scheduler run queue length as a histogram.

--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # runqslower    Trace long process scheduling delays.

--- a/tools/shmsnoop.py
+++ b/tools/shmsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # shmsnoop Trace shm*() syscalls.

--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # slabratetop  Summarize kmem_cache_alloc() calls.

--- a/tools/sofdsnoop.py
+++ b/tools/sofdsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # sofdsnoop traces file descriptors passed via socket

--- a/tools/softirqs.py
+++ b/tools/softirqs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # softirqs  Summarize soft IRQ (interrupt) event time.

--- a/tools/solisten.py
+++ b/tools/solisten.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # solisten      Trace TCP listen events
 #               For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/sslsniff.py
+++ b/tools/sslsniff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # sslsniff  Captures data on read/recv or write/send functions of OpenSSL,
 #           GnuTLS and NSS

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # stackcount    Count events and their stack traces.
 #               For Linux, uses BCC, eBPF.

--- a/tools/statsnoop.py
+++ b/tools/statsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # statsnoop Trace stat() syscalls.

--- a/tools/swapin.py
+++ b/tools/swapin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # swapin        Count swapins by process.

--- a/tools/syncsnoop.py
+++ b/tools/syncsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # syncsnoop Trace sync() syscall.

--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # syscount   Summarize syscall counts and latencies.
 #

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpaccept Trace TCP accept()s.

--- a/tools/tcpcong.py
+++ b/tools/tcpcong.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpcong  Measure tcp congestion control status duration.

--- a/tools/tcpconnect.py
+++ b/tools/tcpconnect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpconnect    Trace TCP connect()s.

--- a/tools/tcpconnlat.py
+++ b/tools/tcpconnlat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpconnlat    Trace TCP active connection latency (connect).

--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpdrop   Trace TCP kernel-dropped packets/segments.

--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcplife   Trace the lifespan of TCP sessions and summarize.

--- a/tools/tcpretrans.py
+++ b/tools/tcpretrans.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpretrans    Trace or count TCP retransmits and TLPs.

--- a/tools/tcprtt.py
+++ b/tools/tcprtt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcprtt    Summarize TCP RTT as a histogram. For Linux, uses BCC, eBPF.

--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # @lint-avoid-python-3-compatibility-imports
 #

--- a/tools/tcpsubnet.py
+++ b/tools/tcpsubnet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpsubnet   Summarize TCP bytes sent to different subnets.

--- a/tools/tcpsynbl.py
+++ b/tools/tcpsynbl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcpsynbl      Show TCP SYN backlog.

--- a/tools/tcptop.py
+++ b/tools/tcptop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # tcptop    Summarize TCP send/recv throughput by host.

--- a/tools/tcptracer.py
+++ b/tools/tcptracer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # tcpv4tracer   Trace TCP connections.
 #               For Linux, uses BCC, eBPF. Embedded C.

--- a/tools/threadsnoop.py
+++ b/tools/threadsnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # threadsnoop   List new thread creation.

--- a/tools/tplist.py
+++ b/tools/tplist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # tplist    Display kernel tracepoints or USDT probes and their formats.
 #

--- a/tools/trace.py
+++ b/tools/trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # trace         Trace a function and print a trace message based on its
 #               parameters, with an optional filter.

--- a/tools/ttysnoop.py
+++ b/tools/ttysnoop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # ttysnoop   Watch live output from a tty or pts device.

--- a/tools/vfscount.py
+++ b/tools/vfscount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # vfscount  Count VFS calls ("vfs_*").

--- a/tools/vfsstat.py
+++ b/tools/vfsstat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # vfsstat   Count some VFS calls.

--- a/tools/virtiostat.py
+++ b/tools/virtiostat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # virtiostat    Show virtio devices input/output statistics.

--- a/tools/wakeuptime.py
+++ b/tools/wakeuptime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # wakeuptime    Summarize sleep to wakeup time by waker kernel stack
 #               For Linux, uses BCC, eBPF.

--- a/tools/xfsdist.py
+++ b/tools/xfsdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # xfsdist  Summarize XFS operation latency.

--- a/tools/xfsslower.py
+++ b/tools/xfsslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # xfsslower  Trace slow XFS operations.

--- a/tools/zfsdist.py
+++ b/tools/zfsdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # zfsdist  Summarize ZFS operation latency.

--- a/tools/zfsslower.py
+++ b/tools/zfsslower.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # @lint-avoid-python-3-compatibility-imports
 #
 # zfsslower  Trace slow ZFS operations.


### PR DESCRIPTION
bionic's /usr/bin/python is python2. Encoding and python2/python3 is.... complicated.
Those tests already run on py3 which is the default for Ubuntu Focal and Fedora 34.

This change symlinks /usr/local/bin/python to python3 within the Bionic container
and changes all tools to use "#!/usr/bin/env python" shebang instead of "#!/usr/bin/python"
which allows to use the default python set by the environment.

To add insult to injury. Python 3.6 still needs a bit of help to default to UTF-8
which can be achieved with the env var `PYTHONIOENCODING` to `utf-8`.
Since python 3.7, [UTF-8 mode is enabled by default when the locale is C or POSIX](https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep540).
Some more details about this problem can be found here: https://vstinner.github.io/posix-locale.html#misconfigured-locales-in-docker-images

Illustration:
```
root@bionic:/# locale
LANG=
LANGUAGE=
LC_CTYPE="POSIX"
LC_NUMERIC="POSIX"
LC_TIME="POSIX"
LC_COLLATE="POSIX"
LC_MONETARY="POSIX"
LC_MESSAGES="POSIX"
LC_PAPER="POSIX"
LC_NAME="POSIX"
LC_ADDRESS="POSIX"
LC_TELEPHONE="POSIX"
LC_MEASUREMENT="POSIX"
LC_IDENTIFICATION="POSIX"
LC_ALL=
root@bionic:/# python2
Python 2.7.17 (default, Jul  1 2022, 15:56:32)
[GCC 7.5.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> print("%s" % u'\xb7')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character u'\xb7' in position 0: ordinal not in range(128)
>>>
root@bionic:/# python3
Python 3.6.9 (default, Jun 29 2022, 11:45:57)
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> print("%s" % u'\xb7')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode character '\xb7' in position 0: ordinal not in range(128)
>>>
root@bionic:/# PYTHONIOENCODING=utf-8 python3
Python 3.6.9 (default, Jun 29 2022, 11:45:57)
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> print("%s" % u'\xb7')
·
```

On Focal:
```
root@focal:/# locale
LANG=
LANGUAGE=
LC_CTYPE="POSIX"
LC_NUMERIC="POSIX"
LC_TIME="POSIX"
LC_COLLATE="POSIX"
LC_MONETARY="POSIX"
LC_MESSAGES="POSIX"
LC_PAPER="POSIX"
LC_NAME="POSIX"
LC_ADDRESS="POSIX"
LC_TELEPHONE="POSIX"
LC_MEASUREMENT="POSIX"
LC_IDENTIFICATION="POSIX"
LC_ALL=
root@focal:/# python3
Python 3.8.10 (default, Jun 22 2022, 20:18:18)
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> print("%s" % u'\xb7')
·
```
