### PR TITLE
tools/trace: Decode bytes to str and remove explicit ctype cast

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -612,11 +612,15 @@ BPF_PERF_OUTPUT(%s);
                                        if t == 'K']
                 user_placeholders = [i for i, t in enumerate(self.types)
                                      if t == 'U']
+                string_placeholders = [i for i, t in enumerate(self.types)
+                                       if t == 's']
                 for kp in kernel_placeholders:
-                        values[kp] = bpf.ksym(values[kp], show_offset=True)
+                    values[kp] = bpf.ksym(values[kp], show_offset=True)
                 for up in user_placeholders:
-                        values[up] = bpf.sym(values[up], tgid,
-                                           show_module=True, show_offset=True)
+                    values[up] = bpf.sym(values[up], tgid,
+                                         show_module=True, show_offset=True)
+                for sp in string_placeholders:
+                    values[sp] = values[sp].decode('utf-8', 'replace')
                 return self.python_format % tuple(values)
 
         def print_aggregate_events(self):


### PR DESCRIPTION
- remove b'' by decoding all field values whose format specifier are 's'.
- remove explicit ctype cast.

```
# ./trace.py 'c:open "%s, %d", arg1, arg2'

PID     TID     COMM            FUNC             -
318915  318919  grpc_global_tim open             b'/etc/resolv.conf', 0
318915  318919  grpc_global_tim open             b'/etc/nsswitch.conf', 0
318915  318919  grpc_global_tim open             b'/etc/hosts', 0
```