### PR TITLE
libbpf-tools/klockstat: do not account locks with missing try_at

### DIFF
--- a/libbpf-tools/klockstat.bpf.c
+++ b/libbpf-tools/klockstat.bpf.c
@@ -175,6 +175,10 @@ static void account(struct lockholder_info *li)
 			bpf_get_current_comm(ls->acq_max_comm, TASK_COMM_LEN);
 	}
 
+	if (!li->try_at) {
+		return;
+	}
+
 	delta = li->acq_at - li->try_at;
 	__sync_fetch_and_add(&ls->acq_count, 1);
 	__sync_fetch_and_add(&ls->acq_total_time, delta);


### PR DESCRIPTION
This change prevents confusion from reporting unrealistic values:

```
                               Caller  Avg Hold    Count   Max Hold   Total Hold
              down_write_killable+0x5    5.4 m      5421   491.2 h      491.2 h
                do_mprotect_pkey+0xb2
              __x64_sys_mprotect+0x1b
                   do_syscall_64+0x3b
  entry_SYSCALL_64_after_hwframe+0x44
                              Max PID 1983644, COMM edgeworker/sbox
```