### PR TITLE
libbpf-tools/klockstat: print the lock info for max acq/hold times

### DIFF
--- a/libbpf-tools/klockstat.h
+++ b/libbpf-tools/klockstat.h
@@ -10,11 +10,13 @@ struct lock_stat {
 	__u64 acq_total_time;
 	__u64 acq_max_time;
 	__u64 acq_max_id;
+	__u64 acq_max_lock_ptr;
 	char acq_max_comm[TASK_COMM_LEN];
 	__u64 hld_count;
 	__u64 hld_total_time;
 	__u64 hld_max_time;
 	__u64 hld_max_id;
+	__u64 hld_max_lock_ptr;
 	char hld_max_comm[TASK_COMM_LEN];
 };
 


### PR DESCRIPTION
This is handy if you want to look at a specific lock:

```
$ sudo ./klockstat -d 5 -c down_ -n 2 -s 2 -S hld_total
Tracing mutex/sem lock events...  Hit Ctrl-C to end

                               Caller  Avg Wait    Count   Max Wait   Total Wait
                        down_read+0x5    155 ns    33052   115.5 us       5.1 ms
             kernfs_fop_readdir+0x115
                              Max PID 39643, COMM cadvisor, Lock kernfs_rwsem (0xffffffff89f87e00)

                               Caller  Avg Wait    Count   Max Wait   Total Wait
                        down_read+0x5    161 ns    14438    66.7 us       2.3 ms
           kernfs_iop_permission+0x27
                              Max PID 39643, COMM cadvisor, Lock kernfs_rwsem (0xffffffff89f87e00)

                               Caller  Avg Hold    Count   Max Hold   Total Hold
               down_read_killable+0x5    8.3 us     7751   373.9 us      64.3 ms
                     iterate_dir+0x52
                              Max PID 39643, COMM cadvisor, Lock no-ksym (0xffff9477eec5f1a8)

                               Caller  Avg Hold    Count   Max Hold   Total Hold
                down_read_trylock+0x5    2.1 us     4066    50.8 us       8.5 ms
             do_user_addr_fault+0x11c
                              Max PID 40402, COMM flb-pipeline, Lock no-ksym (0xffff9496c8231168)
```