### PR TITLE
combine static libraries into `bcc`

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -71,13 +71,13 @@ endif()
 
 set(bcc_common_sources bcc_common.cc bpf_module.cc bcc_btf.cc exported_files.cc)
 if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 6 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 6)
-  set(bcc_common_sources ${bcc_common_sources} bcc_debug.cc)
+  list(APPEND bcc_common_sources bcc_debug.cc)
 endif()
 
 if(ENABLE_LLVM_NATIVECODEGEN)
-set(bcc_common_sources ${bcc_common_sources} bpf_module_rw_engine.cc)
+list(APPEND bcc_common_sources bpf_module_rw_engine.cc)
 else()
-set(bcc_common_sources ${bcc_common_sources} bpf_module_rw_engine_disabled.cc)
+list(APPEND bcc_common_sources bpf_module_rw_engine_disabled.cc)
 endif()
 
 set(bcc_table_sources table_storage.cc shared_table.cc bpffs_table.cc json_map_decl_visitor.cc)
@@ -87,29 +87,36 @@ set(bcc_common_headers libbpf.h perf_reader.h "${CMAKE_CURRENT_BINARY_DIR}/bcc_v
 set(bcc_table_headers file_desc.h table_desc.h table_storage.h)
 set(bcc_api_headers bcc_common.h bpf_module.h bcc_exception.h bcc_syms.h bcc_proc.h bcc_elf.h)
 if(LIBBPF_FOUND)
-  set(bcc_common_sources ${bcc_common_sources} libbpf.c perf_reader.c)
+  list(APPEND bcc_common_sources libbpf.c perf_reader.c)
 endif()
 
 if(ENABLE_CLANG_JIT)
+
+add_subdirectory(frontends)
+list(APPEND bcc_common_sources "${bcc_frontend_sources}")
+
+if(ENABLE_CPP_API)
+  add_subdirectory(api)
+  list(APPEND bcc_common_sources "${bcc_api_sources}")
+endif()
+
+if(ENABLE_USDT)
+  add_definitions(-DEXPORT_USDT)
+  list(APPEND bcc_api_headers bcc_usdt.h)
+  add_subdirectory(usdt)
+endif()
+
 add_library(bcc-shared SHARED
   link_all.cc ${bcc_common_sources} ${bcc_table_sources} ${bcc_sym_sources}
   ${bcc_util_sources})
 set_target_properties(bcc-shared PROPERTIES VERSION ${REVISION_LAST} SOVERSION 0)
 set_target_properties(bcc-shared PROPERTIES OUTPUT_NAME bcc)
 
-if(ENABLE_USDT)
-  add_definitions(-DEXPORT_USDT)
-  set(bcc_usdt_sources usdt/usdt.cc usdt/usdt_args.cc)
-  # else undefined
-endif()
-
-add_library(bcc-loader-static STATIC ${bcc_sym_sources} ${bcc_util_sources})
-target_link_libraries(bcc-loader-static elf z)
 add_library(bcc-static STATIC
-  ${bcc_common_sources} ${bcc_table_sources} ${bcc_util_sources} ${bcc_usdt_sources} ${bcc_sym_sources} ${bcc_util_sources})
+  ${bcc_common_sources} ${bcc_table_sources} ${bcc_usdt_sources} ${bcc_sym_sources} ${bcc_util_sources})
 set_target_properties(bcc-static PROPERTIES OUTPUT_NAME bcc)
 set(bcc-lua-static
-  ${bcc_common_sources} ${bcc_table_sources} ${bcc_sym_sources} ${bcc_util_sources})
+  ${bcc_common_sources} ${bcc_table_sources} ${bcc_usdt_sources} ${bcc_sym_sources} ${bcc_util_sources})
 
 set(bpf_sources libbpf.c perf_reader.c ${libbpf_sources} ${bcc_sym_sources} ${bcc_util_sources} ${bcc_usdt_sources})
 add_library(bpf-static STATIC ${bpf_sources})
@@ -135,7 +142,7 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${llvm_lib_exclude_f
 
 # bcc_common_libs_for_a for archive libraries
 # bcc_common_libs_for_s for shared libraries
-set(bcc_common_libs clang_frontend
+set(bcc_common_libs
   -Wl,--whole-archive ${clang_libs} ${llvm_libs} -Wl,--no-whole-archive
   ${LIBELF_LIBRARIES})
 if (LIBLZMA_FOUND)
@@ -146,8 +153,7 @@ if (LIBDEBUGINFOD_FOUND)
 endif (LIBDEBUGINFOD_FOUND)
 set(bcc_common_libs_for_a ${bcc_common_libs})
 set(bcc_common_libs_for_s ${bcc_common_libs})
-set(bcc_common_libs_for_lua clang_frontend
-  ${clang_libs} ${llvm_libs} ${LIBELF_LIBRARIES})
+set(bcc_common_libs_for_lua ${clang_libs} ${llvm_libs} ${LIBELF_LIBRARIES})
 if(LIBBPF_FOUND)
   list(APPEND bcc_common_libs_for_a ${LIBBPF_LIBRARIES})
   list(APPEND bcc_common_libs_for_s ${LIBBPF_LIBRARIES})
@@ -158,29 +164,12 @@ else()
   list(APPEND bcc_common_libs_for_lua bpf-static)
 endif()
 
-if(ENABLE_CPP_API)
-  add_subdirectory(api)
-  list(APPEND bcc_common_libs_for_a api-static)
-  # Keep all API functions
-  list(APPEND bcc_common_libs_for_s -Wl,--whole-archive api-static -Wl,--no-whole-archive)
-endif()
-
-if(ENABLE_USDT)
-  list(APPEND bcc_api_headers bcc_usdt.h)
-  add_subdirectory(usdt)
-  list(APPEND bcc_common_libs_for_a usdt-static)
-  list(APPEND bcc_common_libs_for_s usdt-static)
-  list(APPEND bcc_common_libs_for_lua usdt-static)
-endif()
-
-add_subdirectory(frontends)
-
 # Link against LLVM libraries
 target_link_libraries(bcc-shared ${bcc_common_libs_for_s})
-target_link_libraries(bcc-static ${bcc_common_libs_for_a} bcc-loader-static)
+target_link_libraries(bcc-static ${bcc_common_libs_for_a})
 set(bcc-lua-static ${bcc-lua-static} ${bcc_common_libs_for_lua})
 
-install(TARGETS bcc-shared bcc-static bcc-loader-static bpf-static LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS bcc-shared bcc-static bpf-static LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${bcc_table_headers} DESTINATION include/bcc)
 install(FILES ${bcc_api_headers} DESTINATION include/bcc)
 install(DIRECTORY ${libbpf_uapi} DESTINATION include/bcc/compat/linux FILES_MATCHING PATTERN "*.h")

--- a/src/cc/api/CMakeLists.txt
+++ b/src/cc/api/CMakeLists.txt
@@ -1,3 +1,5 @@
-set(bcc_api_sources BPF.cc BPFTable.cc)
-add_library(api-static STATIC ${bcc_api_sources})
 install(FILES BPF.h BPFTable.h COMPONENT libbcc DESTINATION include/bcc)
+set(bcc_api_sources
+  "${CMAKE_CURRENT_SOURCE_DIR}/BPF.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/BPFTable.cc"
+  PARENT_SCOPE)

--- a/src/cc/frontends/CMakeLists.txt
+++ b/src/cc/frontends/CMakeLists.txt
@@ -2,3 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 
 add_subdirectory(clang)
+
+set(bcc_frontend_sources "${bcc_clang_frontend_sources}" PARENT_SCOPE)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)

--- a/src/cc/frontends/clang/CMakeLists.txt
+++ b/src/cc/frontends/clang/CMakeLists.txt
@@ -1,12 +1,17 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_DIR='\"${BCC_KERNEL_MODULES_DIR}\"'")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DKERNEL_MODULES_DIR='\"${BCC_KERNEL_MODULES_DIR}\"'" PARENT_SCOPE)
 if(DEFINED BCC_CUR_CPU_IDENTIFIER)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCUR_CPU_IDENTIFIER='\"${BCC_CUR_CPU_IDENTIFIER}\"'")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCUR_CPU_IDENTIFIER='\"${BCC_CUR_CPU_IDENTIFIER}\"'" PARENT_SCOPE)
 endif()
 if(DEFINED BCC_BACKUP_COMPILE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBCC_BACKUP_COMPILE='${BCC_BACKUP_COMPILE}'")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBCC_BACKUP_COMPILE='${BCC_BACKUP_COMPILE}'" PARENT_SCOPE)
 endif()
 
-add_library(clang_frontend STATIC loader.cc b_frontend_action.cc tp_frontend_action.cc kbuild_helper.cc ../../common.cc)
+set(bcc_clang_frontend_sources
+  "${CMAKE_CURRENT_SOURCE_DIR}/loader.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/b_frontend_action.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/tp_frontend_action.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/kbuild_helper.cc"
+  PARENT_SCOPE)

--- a/src/cc/usdt/CMakeLists.txt
+++ b/src/cc/usdt/CMakeLists.txt
@@ -1,1 +1,4 @@
-add_library(usdt-static STATIC usdt_args.cc usdt.cc)
+set(bcc_usdt_sources
+  "${CMAKE_CURRENT_SOURCE_DIR}/usdt_args.cc"
+  "${CMAKE_CURRENT_SOURCE_DIR}/usdt.cc"
+  PARENT_SCOPE)


### PR DESCRIPTION
When linking BCC statically to a program, some symbols are missing
(output truncated, longer output at the bottom of this message):
```
undefined symbol: ebpf::BPF::get_syscall_fnname(...
undefined symbol: ebpf::BPF::init(...
undefined symbol: ebpf::BPF::~BPF(...
undefined symbol: ebpf::BPF::attach_kprobe(...
undefined symbol: ebpf::BPFTable::BPFTable(...
undefined symbol: ebpf::BPFModule::BPFModule(...
undefined symbol: ebpf::BPF::detach_kprobe(...
undefined symbol: ebpf::ProgFuncInfo::get_func(...
undefined symbol: ebpf::ProgFuncInfo::for_each_func(...
undefined symbol: ebpf::ClangLoader::~ClangLoader(...
undefined symbol: ebpf::ProgFuncInfo::func_name[abi:cxx11](...
undefined symbol: ebpf::ProgFuncInfo::get_func(...
undefined symbol: ebpf::ClangLoader::ClangLoader(...
undefined symbol: ebpf::ProgFuncInfo::add_func(...
undefined symbol: ebpf::ClangLoader::parse(...
```

Running `nm --demangle --defined-only -g` on `libbcc.a` confirms those
symbols are not defined by that library.

After looking at the `bcc` repository and build directory, I've found a
file named `libapi-static.a` and `libclang_frontend.a`, which do contain
the necessary symbols.  These libraries don't get installed by `make
install`, though.

Double checking `src/cc/api/CMakeLists.txt` and
`src/cc/frontends/clang/CMakeLists.txt` confirms that the corresponding
targets `api-static` and `clang_frontend` are never scheduled for
installation.

After manually installing these files and linking against them, the
linker errors go away.

This patch originally made the necessary changes to `CMakeLists.txt` so
that the targets get installed under the names `libbcc_api.a` and
`libbcc_clang_frontend.a`. Later it was decided that the libraries
should be merged together into `libbcc`, which the final form of the
patch does.

FWIW, these are the build flags passed to `cmake` when building `bcc`
(shared libraries are disabled):
```
cmake
  -DENABLE_CLANG_JIT=ON
  -DENABLE_CPP_API=ON
  -DENABLE_EXAMPLES=OFF
  -DENABLE_LLVM_NATIVECODEGEN=ON
  -DENABLE_LLVM_SHARED=OFF
  -DENABLE_MAN=ON
  -DENABLE_RTTI=OFF
  -DENABLE_TESTS=OFF
  -DENABLE_USDT=ON
  -DPYTHON_ONLY=OFF
  -DRUN_LUA_TESTS=OFF
  -DBUILD_SHARED_LIBS=OFF
  -DCMAKE_BUILD_TYPE=Release
  -DCMAKE_CXX_STANDARD:STRING="20"
  -DCMAKE_INSTALL_PREFIX:PATH=/usr/local
  ..
```

Linker errors:
```
+ /usr/local/bin/clang++ -pthread -fuse-ld=mold -static-libgcc -static /src/out/main.o -o /src/out/main /usr/local/lib/libbcc.a /usr/local/lib/libbcc_bpf.a /usr/local/lib/libbcc-loader-static.a /usr/local/lib/libclangFrontend.a /usr/local/lib/libclangSerialization.a /usr/local/lib/libclangDriver.a /usr/local/lib/libclangASTMatchers.a /usr/local/lib/libclangParse.a /usr/local/lib/libclangSema.a /usr/local/lib/libclangCodeGen.a /usr/local/lib/libclangAnalysis.a /usr/local/lib/libclangRewrite.a /usr/local/lib/libclangEdit.a /usr/local/lib/libclangIndex.a /usr/local/lib/libclangAST.a /usr/local/lib/libclangLex.a /usr/local/lib/libclangBasic.a /usr/local/lib/libclang.a /usr/local/lib/libLLVMBPFDisassembler.a /usr/local/lib/libLLVMBPFAsmParser.a /usr/local/lib/libLLVMBPFCodeGen.a /usr/local/lib/libLLVMBPFDesc.a /usr/local/lib/libLLVMBPFInfo.a /usr/local/lib/libLLVMCoverage.a /usr/local/lib/libLLVMX86Disassembler.a /usr/local/lib/libLLVMX86AsmParser.a /usr/local/lib/libLLVMX86CodeGen.a /usr/local/lib/libLLVMX86Desc.a /usr/local/lib/libLLVMX86Info.a /usr/local/lib/libLLVMOrcJIT.a /usr/local/lib/libLLVMMCJIT.a /usr/local/lib/libLLVMExecutionEngine.a /usr/local/lib/libLLVMRuntimeDyld.a /usr/local/lib/libLLVMOrcTargetProcess.a /usr/local/lib/libLLVMOption.a /usr/local/lib/libLLVMMCDisassembler.a /usr/local/lib/libLLVMLTO.a /usr/local/lib/libLLVMPasses.a /usr/local/lib/libLLVMCFGuard.a /usr/local/lib/libLLVMCoroutines.a /usr/local/lib/libLLVMObjCARCOpts.a /usr/local/lib/libLLVMipo.a /usr/local/lib/libLLVMVectorize.a /usr/local/lib/libLLVMLinker.a /usr/local/lib/libLLVMInstrumentation.a /usr/local/lib/libLLVMFrontendOpenMP.a /usr/local/lib/libLLVMGlobalISel.a /usr/local/lib/libLLVMMIRParser.a /usr/local/lib/libLLVMAsmPrinter.a /usr/local/lib/libLLVMSelectionDAG.a /usr/local/lib/libLLVMCodeGen.a /usr/local/lib/libLLVMIRReader.a /usr/local/lib/libLLVMAsmParser.a /usr/local/lib/libLLVMTarget.a /usr/local/lib/libLLVMScalarOpts.a /usr/local/lib/libLLVMInstCombine.a /usr/local/lib/libLLVMAggressiveInstCombine.a /usr/local/lib/libLLVMTransformUtils.a /usr/local/lib/libLLVMBitWriter.a /usr/local/lib/libLLVMAnalysis.a /usr/local/lib/libLLVMProfileData.a /usr/local/lib/libLLVMDebugInfoDWARF.a /usr/local/lib/libLLVMObject.a /usr/local/lib/libLLVMTextAPI.a /usr/local/lib/libLLVMMCParser.a /usr/local/lib/libLLVMMC.a /usr/local/lib/libLLVMDebugInfoCodeView.a /usr/local/lib/libLLVMBitReader.a /usr/local/lib/libLLVMCore.a /usr/local/lib/libLLVMRemarks.a /usr/local/lib/libLLVMBitstreamReader.a /usr/local/lib/libLLVMBinaryFormat.a /usr/local/lib/libLLVMTableGen.a /usr/local/lib/libLLVMSupport.a /usr/local/lib/libLLVMDemangle.a /usr/local/lib/libxml2.a /usr/local/lib/libncurses.a /usr/local/lib/libtinfo.a /usr/local/lib64/libbpf.a /usr/local/lib/libelf.a /usr/local/lib/libdw.a /usr/local/lib/libasm.a /usr/local/lib/libzstd.a /usr/local/lib/libz.a -ldl

...

mold: error: undefined symbol: ebpf::BPF::get_syscall_fnname(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
>>> referenced by kprobe.cpp
>>>               /src/out/libkprobe.a(kprobe.cpp.o):(kprobe::kprobe(program&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&))

mold: error: undefined symbol: ebpf::BPF::init(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::vector<ebpf::USDT, std::allocator<ebpf::USDT> > const&)
>>> referenced by program.cpp
>>>               /src/out/libprogram.a(program.cpp.o):(program::program(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >))

mold: error: undefined symbol: ebpf::BPF::~BPF()
>>> referenced by program.cpp
>>>               /src/out/libprogram.a(program.cpp.o):(program::~program())

mold: error: undefined symbol: ebpf::BPF::attach_kprobe(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, bpf_probe_attach_type, int)
>>> referenced by kprobe.cpp
>>>               /src/out/libkprobe.a(kprobe.cpp.o):(kprobe::kprobe(program&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&))

mold: error: undefined symbol: ebpf::BPFTable::BPFTable(ebpf::TableDesc const&)
>>> referenced by program.cpp
>>>               /src/out/libprogram.a(program.cpp.o):(ebpf::BPF::get_table(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&))>>> referenced by program.cpp
>>>               /src/out/libprogram.a(program.cpp.o):(ebpf::BPF::get_table(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&))

mold: error: undefined symbol: ebpf::BPFModule::BPFModule(unsigned int, ebpf::TableStorage*, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, char const*)
>>> referenced by program.cpp
>>>               /src/out/libprogram.a(program.cpp.o):(ebpf::BPF::BPF(unsigned int, ebpf::TableStorage*, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool))

mold: error: undefined symbol: ebpf::BPF::detach_kprobe(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bpf_probe_attach_type)
>>> referenced by kprobe.cpp
>>>               /src/out/libkprobe.a(kprobe.cpp.o):(kprobe::detach())

mold: error: undefined symbol: ebpf::ProgFuncInfo::get_func(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::function_start(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const)>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::function_source(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const)>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::function_source_rewritten(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const)>>> referenced 2 more times

mold: error: undefined symbol: ebpf::ProgFuncInfo::for_each_func(std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ebpf::FuncInfo&)>)
>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::~BPFModule())>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::load_maps(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::tuple<unsigned char*, unsigned long, unsigned int>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::tuple<unsigned char*, unsigned long, unsigned int> > > >&))>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::finalize())>>> referenced 3 more times

mold: error: undefined symbol: ebpf::ClangLoader::~ClangLoader()
>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::load_cfile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, char const**, int))>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::load_cfile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, char const**, int))>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::load_includes(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&))>>> referenced 6 more times

mold: error: undefined symbol: ebpf::ProgFuncInfo::func_name[abi:cxx11](unsigned long)
>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::function_name(unsigned long) const)
mold: error: undefined symbol: ebpf::ProgFuncInfo::get_func(unsigned long)
>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::function_start(unsigned long) const)>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::function_size(unsigned long) const)
mold: error: undefined symbol: ebpf::ClangLoader::ClangLoader(llvm::LLVMContext*, unsigned int)
>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::load_cfile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, char const**, int))>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::load_includes(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&))>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::load_c(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const**, int))>>> referenced 1 more times

mold: error: undefined symbol: ebpf::ProgFuncInfo::add_func(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(std::_Function_handler<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ebpf::FuncInfo&), ebpf::BPFModule::finalize_prog_func_info()::$_4>::_M_invoke(std::_Any_data const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, ebpf::FuncInfo&))
mold: error: undefined symbol: ebpf::ClangLoader::parse(std::unique_ptr<llvm::Module, std::default_delete<llvm::Module> >*, ebpf::TableStorage&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, char const**, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, ebpf::ProgFuncInfo&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<int, std::tuple<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, int, int, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::less<int>, std::allocator<std::pair<int const, std::tuple<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, int, int, int, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > >&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > > >&)
>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::load_cfile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, char const**, int))>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::load_includes(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&))>>> referenced by bpf_module.cc
>>>               /usr/local/lib/libbcc.a(bpf_module.cc.o):(ebpf::BPFModule::load_c(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const**, int))>>> referenced 1 more times

clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
```