### PR TITLE
tools/memleak: support user-space tracing without a PID

### DIFF
--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -5,7 +5,7 @@
 #
 # USAGE: memleak [-h] [-p PID] [-t] [-a] [-o OLDER] [-c COMMAND]
 #                [--combined-only] [--wa-missing-free] [-s SAMPLE_RATE]
-#                [-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE] [-O OBJ]
+#                [-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE] [-O OBJ] [--percpu] [-K]
 #                [interval] [count]
 #
 # Licensed under the Apache License, Version 2.0 (the "License")
@@ -52,10 +52,10 @@ EXAMPLES:
         every 10 seconds for outstanding allocations
 ./memleak -c "./allocs"
         Run the specified command and trace its allocations
-./memleak
+./memleak -K
         Trace allocations in kernel mode and display a summary of outstanding
         allocations every 5 seconds
-./memleak -o 60000
+./memleak -K -o 60000
         Trace allocations in kernel mode and display a summary of outstanding
         allocations that are at least one minute (60 seconds) old
 ./memleak -s 5
@@ -73,7 +73,7 @@ parser = argparse.ArgumentParser(description=description,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=examples)
 parser.add_argument("-p", "--pid", type=int, default=-1,
-        help="the PID to trace; if not specified, trace kernel allocs")
+        help="the PID to trace")
 parser.add_argument("-t", "--trace", action="store_true",
         help="print trace messages for each alloc/free call")
 parser.add_argument("interval", nargs="?", default=5, type=int,
@@ -104,12 +104,14 @@ parser.add_argument("--ebpf", action="store_true",
         help=argparse.SUPPRESS)
 parser.add_argument("--percpu", default=False, action="store_true",
         help="trace percpu allocations")
+parser.add_argument("-K", "--kernel-trace", action="store_true",
+        help="trace kernel allocs", default=False)
 
 args = parser.parse_args()
 
 pid = args.pid
 command = args.command
-kernel_trace = (pid == -1 and command is None)
+kernel_trace = args.kernel_trace
 trace_all = args.trace
 interval = args.interval
 min_age_ns = 1e6 * args.older
@@ -135,11 +137,13 @@ struct alloc_info_t {
         u64 size;
         u64 timestamp_ns;
         int stack_id;
+        int pid;
 };
 
 struct combined_alloc_info_t {
         u64 total_size;
         u64 number_of_allocs;
+        int pid;
 };
 
 BPF_HASH(sizes, u64);
@@ -151,6 +155,7 @@ BPF_HASH(combined_allocs, u64, struct combined_alloc_info_t, 10240);
 static inline void update_statistics_add(u64 stack_id, u64 sz) {
         struct combined_alloc_info_t *existing_cinfo;
         struct combined_alloc_info_t cinfo = {0};
+        u64 pid = bpf_get_current_pid_tgid();
 
         existing_cinfo = combined_allocs.lookup(&stack_id);
         if (existing_cinfo != 0)
@@ -158,6 +163,7 @@ static inline void update_statistics_add(u64 stack_id, u64 sz) {
 
         cinfo.total_size += sz;
         cinfo.number_of_allocs += 1;
+        cinfo.pid = pid;
 
         combined_allocs.update(&stack_id, &cinfo);
 }
@@ -212,6 +218,7 @@ static inline int gen_alloc_exit2(struct pt_regs *ctx, u64 address) {
         if (address != 0) {
                 info.timestamp_ns = bpf_ktime_get_ns();
                 info.stack_id = stack_traces.get_stackid(ctx, STACK_FLAGS);
+                info.pid = pid;
                 allocs.update(&address, &info);
                 update_statistics_add(info.stack_id, info.size);
         }
@@ -510,7 +517,7 @@ def print_outstanding():
                         stack = list(stack_traces.walk(info.stack_id))
                         combined = []
                         for addr in stack:
-                                combined.append(('0x'+format(addr, '016x')+'\t').encode('utf-8') + bpf.sym(addr, pid,
+                                combined.append(('0x'+format(addr, '016x')+'\t').encode('utf-8') + bpf.sym(addr, info.pid,
                                         show_module=True, show_offset=True))
                         alloc_info[info.stack_id] = Allocation(combined,
                                                                info.size)
@@ -534,7 +541,7 @@ def print_outstanding_combined():
                 try:
                         trace = []
                         for addr in stack_traces.walk(stack_id.value):
-                                sym = bpf.sym(addr, pid,
+                                sym = bpf.sym(addr, info.pid,
                                                       show_module=True,
                                                       show_offset=True)
                                 trace.append(sym)

--- a/tools/memleak_example.txt
+++ b/tools/memleak_example.txt
@@ -60,10 +60,10 @@ Attaching to pid 5193, Ctrl+C to quit.
 
 
 When using the -p switch, memleak traces the libc allocations of a particular
-process. Without this switch, kernel allocations are traced instead.
+process. To trace kernel allocations the -K switch can be used instead.
 For example:
 
-# ./memleak
+# ./memleak -K
 Attaching to kernel allocators, Ctrl+C to quit.
 ...
         248 bytes in 4 allocations from stack
@@ -151,7 +151,7 @@ memleak keeps misjudging memory leak on the complicated environment which has
 the action of free in hard/soft irq.
 Add workaround to alleviate misjudgments when free is missing:
 
-# ./memleak --wa-missing-free
+# ./memleak -K --wa-missing-free
 Attaching to kernel allocators, Ctrl+C to quit.
 ...
         248 bytes in 4 allocations from stack
@@ -172,7 +172,7 @@ USAGE message:
 # ./memleak -h
 usage: memleak.py [-h] [-p PID] [-t] [-a] [-o OLDER] [-c COMMAND]
                   [--combined-only] [--wa-missing-free] [-s SAMPLE_RATE]
-                  [-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE] [-O OBJ]
+                  [-T TOP] [-z MIN_SIZE] [-Z MAX_SIZE] [-O OBJ] [--percpu] [-K]
                   [interval] [count]
 
 Trace outstanding memory allocations that weren't freed.
@@ -184,21 +184,17 @@ positional arguments:
   interval              interval in seconds to print outstanding allocations
   count                 number of times to print the report before exiting
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  -p PID, --pid PID     the PID to trace; if not specified, trace kernel
-                        allocs
+  -p PID, --pid PID     the PID to trace
   -t, --trace           print trace messages for each alloc/free call
-  -a, --show-allocs     show allocation addresses and sizes as well as call
-                        stacks
+  -a, --show-allocs     show allocation addresses and sizes as well as call stacks
   -o OLDER, --older OLDER
-                        prune allocations younger than this age in
-                        milliseconds
+                        prune allocations younger than this age in milliseconds
   -c COMMAND, --command COMMAND
                         execute and trace the specified command
   --combined-only       show combined allocation statistics only
-  --wa-missing-free     Workaround to alleviate misjudgments when free is
-                        missing
+  --wa-missing-free     Workaround to alleviate misjudgments when free is missing
   -s SAMPLE_RATE, --sample-rate SAMPLE_RATE
                         sample every N-th allocation to decrease the overhead
   -T TOP, --top TOP     display only this many top allocating stacks (by size)
@@ -207,6 +203,8 @@ optional arguments:
   -Z MAX_SIZE, --max-size MAX_SIZE
                         capture only allocations smaller than this size
   -O OBJ, --obj OBJ     attach to allocator functions in the specified object
+  --percpu              trace percpu allocations
+  -K, --kernel-trace    trace kernel allocs
 
 EXAMPLES:
 
@@ -220,10 +218,10 @@ EXAMPLES:
         every 10 seconds for outstanding allocations
 ./memleak -c "./allocs"
         Run the specified command and trace its allocations
-./memleak
+./memleak -K
         Trace allocations in kernel mode and display a summary of outstanding
         allocations every 5 seconds
-./memleak -o 60000
+./memleak -K -o 60000
         Trace allocations in kernel mode and display a summary of outstanding
         allocations that are at least one minute (60 seconds) old
 ./memleak -s 5


### PR DESCRIPTION
Sometimes it is useful to attach user probes before starting a process
(e.g. see https://github.com/iovisor/bcc/issues/3834), however memleak
currently requires a PID in order to enable user-space probing.

This change adds a new option `--kernel-trace` to explicitly enable
kernel tracing, and allow user-space tracing without providing a PID.

In order to do this, a stack's PID need to be stored in the BPF map, in
order to be able to later resolve symbols correctly.