### PR TITLE
[python][test] change traced syscall from clone to execve

### DIFF
--- a/tests/python/test_percpu.py
+++ b/tests/python/test_percpu.py
@@ -7,6 +7,8 @@ import unittest
 from bcc import BPF
 import multiprocessing
 
+MONITORED_SYSCALL="execve"
+
 class TestPercpu(unittest.TestCase):
 
     def setUp(self):
@@ -38,7 +40,7 @@ class TestPercpu(unittest.TestCase):
         """
         bpf_code = BPF(text=test_prog1)
         stats_map = bpf_code.get_table("stats")
-        event_name = bpf_code.get_syscall_fnname("clone")
+        event_name = bpf_code.get_syscall_fnname(MONITORED_SYSCALL)
         bpf_code.attach_kprobe(event=event_name, fn_name="hello_world")
         ini = stats_map.Leaf()
         for i in range(0, multiprocessing.cpu_count()):
@@ -70,7 +72,7 @@ class TestPercpu(unittest.TestCase):
         """
         bpf_code = BPF(text=test_prog1)
         stats_map = bpf_code.get_table("stats")
-        event_name = bpf_code.get_syscall_fnname("clone")
+        event_name = bpf_code.get_syscall_fnname(MONITORED_SYSCALL)
         bpf_code.attach_kprobe(event=event_name, fn_name="hello_world")
         ini = stats_map.Leaf()
         for i in range(0, multiprocessing.cpu_count()):
@@ -108,7 +110,7 @@ class TestPercpu(unittest.TestCase):
         bpf_code = BPF(text=test_prog2)
         stats_map = bpf_code.get_table("stats",
                 reducer=lambda x,y: stats_map.sLeaf(x.c1+y.c1))
-        event_name = bpf_code.get_syscall_fnname("clone")
+        event_name = bpf_code.get_syscall_fnname(MONITORED_SYSCALL)
         bpf_code.attach_kprobe(event=event_name, fn_name="hello_world")
         ini = stats_map.Leaf()
         for i in ini:


### PR DESCRIPTION
Fixes #4203

The issue goes into more details as to why this change is needed. The TL;DR is
that the implementation of `os.popen` change somewhere between python 3.9 and
3.10 and depending on which version of python is used, either `fork/clone` is
called, or `vfork`.

In both cases, we are going to end up calling `execve`. This change switches
the syscall traced from `clone` to `execve`.

At the same time, it is now a constant that can be used across the tests.

Test plan:
Before https://gist.github.com/chantra/d37f3daa969bdbc07862dc11f8384a38
After https://gist.github.com/chantra/2860e9812f00eaa0758ccdb5d3192689