### PR TITLE
[test][python] temptatively attach to blk_start_request probe.

### DIFF
--- a/tests/python/test_trace3.py
+++ b/tests/python/test_trace3.py
@@ -16,11 +16,13 @@ if len(sys.argv) > 1:
 
 
 class TestBlkRequest(TestCase):
-    @mayFail("This fails on github actions environment, and needs to be fixed")
     def setUp(self):
         b = BPF(arg1, arg2, debug=0)
         self.latency = b.get_table("latency", c_uint, c_ulong)
-        b.attach_kprobe(event="blk_start_request",
+        if BPF.get_kprobe_functions(b"blk_start_request"):
+            b.attach_kprobe(event="blk_start_request",
+                    fn_name="probe_blk_start_request")
+        b.attach_kprobe(event="blk_mq_start_request",
                 fn_name="probe_blk_start_request")
         b.attach_kprobe(event="blk_update_request",
                 fn_name="probe_blk_update_request")

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -209,8 +209,7 @@ else:
     b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
-else:
-    b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
+b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
 if BPF.get_kprobe_functions(b'__blk_account_io_done'):
     b.attach_kprobe(event="__blk_account_io_done", fn_name="trace_req_completion")
 else:


### PR DESCRIPTION
`blk_start_request` is gone since kernel 5. This patch is in the same vein as https://github.com/iovisor/bcc/pull/4124
except that we only conditionally attach to `blk_start_request` but attach also attach to
`blk_mq_start_request`.