### PR TITLE
[ci] Enable running CI on Fedora 36

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [{distro: "fedora", version: "34", nick: "f34"}]
+        os: [{distro: "fedora", version: "34", nick: "f34"}, {distro: "fedora", version: "36", nick: "f36"}]
         env:
         - TYPE: Debug
           PYTHON_TEST_LOGFILE: critical.log


### PR DESCRIPTION
Fedora 34 is EOL since 2022-06-07: https://docs.fedoraproject.org/en-US/releases/eol/

This diff adds support for F36 (current release).