### PR TITLE
[ci] Install netperf and iperf

### DIFF
--- a/.github/workflows/publish-build-containers.yml
+++ b/.github/workflows/publish-build-containers.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    paths:
+      - 'docker/build/**'
+
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -44,7 +48,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v3
       with:
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         build-args: |
           VERSION=${{ matrix.os.version }}
           SHORTNAME=${{ matrix.os.nick }}

--- a/docker/build/Dockerfile.fedora
+++ b/docker/build/Dockerfile.fedora
@@ -51,7 +51,9 @@ RUN dnf -y install \
 	net-tools \
 	hostname \
 	iproute \
-	bpftool
+	bpftool \
+    iperf \
+    netperf
 
 RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1
 

--- a/docker/build/Dockerfile.ubuntu
+++ b/docker/build/Dockerfile.ubuntu
@@ -59,7 +59,8 @@ RUN apt-get update && apt-get install -y \
       iputils-ping \
       bridge-utils \
       libtinfo5 \
-      libtinfo-dev && \
+      libtinfo-dev \
+      iperf netperf && \
       apt-get -y clean
 
 RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1


### PR DESCRIPTION
Some tests need those binaries to run. Currently those tests are allowed to
fail and we are possibly losing signal.
Once those packages are in the container image, we will be able to enforce
running those test and having them succeed.