### PR TITLE
Use /sys/kernel/tracing when debugfs is not available

### DIFF
--- a/src/cc/common.cc
+++ b/src/cc/common.cc
@@ -211,6 +211,19 @@ static inline field_kind_t _get_field_kind(std::string const& line,
   return field_kind_t::regular;
 }
 
+#define DEBUGFS_TRACEFS "/sys/kernel/debug/tracing"
+#define TRACEFS "/sys/kernel/tracing"
+
+std::string tracefs_path() {
+  static bool use_debugfs = access(DEBUGFS_TRACEFS, F_OK) == 0;
+  return use_debugfs ? DEBUGFS_TRACEFS : TRACEFS;
+}
+
+std::string tracepoint_format_file(std::string const& category,
+                                   std::string const& event) {
+  return tracefs_path() + "/events/" + category + "/" + event + "/format";
+}
+
 std::string parse_tracepoint(std::istream &input, std::string const& category,
                              std::string const& event) {
   std::string tp_struct = "struct tracepoint__" + category + "__" + event + " {\n";

--- a/src/cc/common.h
+++ b/src/cc/common.h
@@ -39,6 +39,11 @@ std::vector<int> get_possible_cpus();
 
 std::string get_pid_exe(pid_t pid);
 
+std::string tracefs_path();
+
+std::string tracepoint_format_file(std::string const& category,
+                                   std::string const& event);
+
 std::string parse_tracepoint(std::istream &input, std::string const& category,
                              std::string const& event);
 }  // namespace ebpf

--- a/src/cc/frontends/clang/tp_frontend_action.cc
+++ b/src/cc/frontends/clang/tp_frontend_action.cc
@@ -53,8 +53,7 @@ TracepointTypeVisitor::TracepointTypeVisitor(ASTContext &C, Rewriter &rewriter)
 
 string TracepointTypeVisitor::GenerateTracepointStruct(
     SourceLocation loc, string const& category, string const& event) {
-  string format_file = "/sys/kernel/debug/tracing/events/" +
-    category + "/" + event + "/format";
+  string format_file = tracepoint_format_file(category, event);
   ifstream input(format_file.c_str());
   if (!input)
     return "";

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -44,7 +44,10 @@ def _get_num_open_probes():
     global _num_open_probes
     return _num_open_probes
 
-TRACEFS = "/sys/kernel/debug/tracing"
+DEBUGFS = "/sys/kernel/debug"
+TRACEFS = os.path.join(DEBUGFS, "tracing")
+if not os.path.exists(TRACEFS):
+    TRACEFS = "/sys/kernel/tracing"
 
 # Debug flags
 
@@ -686,7 +689,7 @@ class BPF(object):
 
     @staticmethod
     def get_kprobe_functions(event_re):
-        blacklist_file = "%s/../kprobes/blacklist" % TRACEFS
+        blacklist_file = "%s/kprobes/blacklist" % DEBUGFS
         try:
             with open(blacklist_file, "rb") as blacklist_f:
                 blacklist = set([line.rstrip().split()[1] for line in blacklist_f])


### PR DESCRIPTION
Tracefs might be available as /sys/kernel/tracing and not /sys/kernel/debug/tracing. This commit makes bcc check whether /sys/kernel/debug/tracing exists and use /sys/kernel/tracing if not.