### PR TITLE
libbpf-tools: Allow runq tools to run on old kernels

### DIFF
--- a/libbpf-tools/runqlat.bpf.c
+++ b/libbpf-tools/runqlat.bpf.c
@@ -42,8 +42,7 @@ struct {
 	__type(value, struct hist);
 } hists SEC(".maps");
 
-static __always_inline
-int trace_enqueue(u32 tgid, u32 pid)
+static int trace_enqueue(u32 tgid, u32 pid)
 {
 	u64 ts;
 
@@ -53,11 +52,11 @@ int trace_enqueue(u32 tgid, u32 pid)
 		return 0;
 
 	ts = bpf_ktime_get_ns();
-	bpf_map_update_elem(&start, &pid, &ts, 0);
+	bpf_map_update_elem(&start, &pid, &ts, BPF_ANY);
 	return 0;
 }
 
-static __always_inline unsigned int pid_namespace(struct task_struct *task)
+static unsigned int pid_namespace(struct task_struct *task)
 {
 	struct pid *pid;
 	unsigned int level;
@@ -75,27 +74,7 @@ static __always_inline unsigned int pid_namespace(struct task_struct *task)
 	return inum;
 }
 
-SEC("tp_btf/sched_wakeup")
-int BPF_PROG(sched_wakeup, struct task_struct *p)
-{
-	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
-		return 0;
-
-	return trace_enqueue(p->tgid, p->pid);
-}
-
-SEC("tp_btf/sched_wakeup_new")
-int BPF_PROG(sched_wakeup_new, struct task_struct *p)
-{
-	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
-		return 0;
-
-	return trace_enqueue(p->tgid, p->pid);
-}
-
-SEC("tp_btf/sched_switch")
-int BPF_PROG(sched_swith, bool preempt, struct task_struct *prev,
-	struct task_struct *next)
+static int handle_switch(bool preempt, struct task_struct *prev, struct task_struct *next)
 {
 	struct hist *histp;
 	u64 *tsp, slot;
@@ -106,9 +85,9 @@ int BPF_PROG(sched_swith, bool preempt, struct task_struct *prev,
 		return 0;
 
 	if (get_task_state(prev) == TASK_RUNNING)
-		trace_enqueue(prev->tgid, prev->pid);
+		trace_enqueue(BPF_CORE_READ(prev, tgid), BPF_CORE_READ(prev, pid));
 
-	pid = next->pid;
+	pid = BPF_CORE_READ(next, pid);
 
 	tsp = bpf_map_lookup_elem(&start, &pid);
 	if (!tsp)
@@ -118,7 +97,7 @@ int BPF_PROG(sched_swith, bool preempt, struct task_struct *prev,
 		goto cleanup;
 
 	if (targ_per_process)
-		hkey = next->tgid;
+		hkey = BPF_CORE_READ(next, tgid);
 	else if (targ_per_thread)
 		hkey = pid;
 	else if (targ_per_pidns)
@@ -143,6 +122,54 @@ int BPF_PROG(sched_swith, bool preempt, struct task_struct *prev,
 cleanup:
 	bpf_map_delete_elem(&start, &pid);
 	return 0;
+}
+
+SEC("tp_btf/sched_wakeup")
+int BPF_PROG(sched_wakeup, struct task_struct *p)
+{
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
+	return trace_enqueue(p->tgid, p->pid);
+}
+
+SEC("tp_btf/sched_wakeup_new")
+int BPF_PROG(sched_wakeup_new, struct task_struct *p)
+{
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
+	return trace_enqueue(p->tgid, p->pid);
+}
+
+SEC("tp_btf/sched_switch")
+int BPF_PROG(sched_switch, bool preempt, struct task_struct *prev, struct task_struct *next)
+{
+	return handle_switch(preempt, prev, next);
+}
+
+SEC("raw_tp/sched_wakeup")
+int BPF_PROG(handle_sched_wakeup, struct task_struct *p)
+{
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
+	return trace_enqueue(BPF_CORE_READ(p, tgid), BPF_CORE_READ(p, pid));
+}
+
+SEC("raw_tp/sched_wakeup_new")
+int BPF_PROG(handle_sched_wakeup_new, struct task_struct *p)
+{
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
+	return trace_enqueue(BPF_CORE_READ(p, tgid), BPF_CORE_READ(p, pid));
+}
+
+SEC("raw_tp/sched_switch")
+int BPF_PROG(handle_sched_switch, bool preempt, struct task_struct *prev, struct task_struct *next)
+{
+	return handle_switch(preempt, prev, next);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/runqlat.c
+++ b/libbpf-tools/runqlat.c
@@ -221,6 +221,16 @@ int main(int argc, char **argv)
 	obj->rodata->targ_tgid = env.pid;
 	obj->rodata->filter_cg = env.cg;
 
+	if (probe_tp_btf("sched_wakeup")) {
+		bpf_program__set_autoload(obj->progs.handle_sched_wakeup, false);
+		bpf_program__set_autoload(obj->progs.handle_sched_wakeup_new, false);
+		bpf_program__set_autoload(obj->progs.handle_sched_switch, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.sched_wakeup, false);
+		bpf_program__set_autoload(obj->progs.sched_wakeup_new, false);
+		bpf_program__set_autoload(obj->progs.sched_switch, false);
+	}
+
 	err = runqlat_bpf__load(obj);
 	if (err) {
 		fprintf(stderr, "failed to load BPF object: %d\n", err);

--- a/libbpf-tools/runqslower.c
+++ b/libbpf-tools/runqslower.c
@@ -167,6 +167,16 @@ int main(int argc, char **argv)
 	obj->rodata->targ_pid = env.tid;
 	obj->rodata->min_us = env.min_us;
 
+	if (probe_tp_btf("sched_wakeup")) {
+		bpf_program__set_autoload(obj->progs.handle_sched_wakeup, false);
+		bpf_program__set_autoload(obj->progs.handle_sched_wakeup_new, false);
+		bpf_program__set_autoload(obj->progs.handle_sched_switch, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.sched_wakeup, false);
+		bpf_program__set_autoload(obj->progs.sched_wakeup_new, false);
+		bpf_program__set_autoload(obj->progs.sched_switch, false);
+	}
+
 	err = runqslower_bpf__load(obj);
 	if (err) {
 		fprintf(stderr, "failed to load BPF object: %d\n", err);

--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -1126,3 +1126,19 @@ bool module_btf_exists(const char *mod)
 	}
 	return false;
 }
+
+bool probe_tp_btf(const char *name)
+{
+	LIBBPF_OPTS(bpf_prog_load_opts, opts, .expected_attach_type = BPF_TRACE_RAW_TP);
+	struct bpf_insn insns[] = {
+		{ .code = BPF_ALU64 | BPF_MOV | BPF_K, .dst_reg = BPF_REG_0, .imm = 0 },
+		{ .code = BPF_JMP | BPF_EXIT },
+	};
+	int fd, insn_cnt = sizeof(insns) / sizeof(struct bpf_insn);
+
+	opts.attach_btf_id = libbpf_find_vmlinux_btf_id(name, BPF_TRACE_RAW_TP);
+	fd = bpf_prog_load(BPF_PROG_TYPE_TRACING, NULL, "GPL", insns, insn_cnt, &opts);
+	if (fd >= 0)
+		close(fd);
+	return fd >= 0;
+}

--- a/libbpf-tools/trace_helpers.h
+++ b/libbpf-tools/trace_helpers.h
@@ -94,4 +94,6 @@ bool kprobe_exists(const char *name);
 bool vmlinux_btf_exists(void);
 bool module_btf_exists(const char *mod);
 
+bool probe_tp_btf(const char *name);
+
 #endif /* __TRACE_HELPERS_H */


### PR DESCRIPTION
Currently, runqlat and runqslower rely on tp_btf feature (requires kernel v5.5+).
This makes them failed to run on old kernels. Add a probe to detect whether the
target kernel has tp_btf support and fallback to raw tracepoint if not.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>