### PR TITLE
Skip test when missing binaries

### DIFF
--- a/tests/python/test_brb.py
+++ b/tests/python/test_brb.py
@@ -65,7 +65,7 @@ from ctypes import c_uint
 from netaddr import IPAddress, EUI
 from bcc import BPF
 from pyroute2 import IPRoute, NetNS, IPDB, NSPopen
-from utils import NSPopenWithCheck, mayFail
+from utils import NSPopenWithCheck, skipUnlessHasBinaries
 import sys
 from time import sleep
 from unittest import main, TestCase
@@ -147,7 +147,9 @@ class TestBPFSocket(TestCase):
         self.br1_rtr[c_uint(0)] = c_uint(self.nsrtr_eth0_out.index)
         self.br2_rtr[c_uint(0)] = c_uint(self.nsrtr_eth1_out.index)
 
-    @mayFail("If the 'iperf', 'netserver' and 'netperf' binaries are unavailable, this is allowed to fail.")
+    @skipUnlessHasBinaries(
+        ["arping", "iperf", "netperf", "netserver", "ping"],
+        "iperf and netperf packages must be installed.")
     def test_brb(self):
         try:
             b = BPF(src_file=arg1.encode(), debug=0)

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -2,6 +2,7 @@ from pyroute2 import NSPopen
 from distutils.spawn import find_executable
 import traceback
 import distutils.version
+import shutil
 
 import logging, os, sys
 
@@ -48,6 +49,23 @@ def mayFail(message):
                     raise err
                 else:
                     return res
+        return wrapper
+    return decorator
+
+# This is a decorator that will skip tests if any binary in the list is not in PATH.
+def skipUnlessHasBinaries(binaries, message):
+    def decorator(func):
+        def wrapper(self, *args, **kwargs):
+            missing = []
+            for binary in binaries:
+                if shutil.which(binary) is None:
+                    missing.append(binary)
+
+            if len(missing):
+                missing_binaries = ", ".join(missing)
+                self.skipTest(f"Missing binaries: {missing_binaries}. {message}")
+            else:
+                func(self, *args, **kwargs)
         return wrapper
     return decorator
 


### PR DESCRIPTION
Some tests are currently allowed to fail with @mayFail because some binaries may be missing.
The problem is that we cannot differenciate between a test failing because some tooling is missing,
or tests legitimately failing.

This diff creates a new decorator that will skip a test if some binaries are not
present, therefore, if the binaries are there and there is any issue, CI will fail.

It will generate a message similar to:
```
docker run -ti \
                    --privileged \
                    --network=host \
                    --pid=host \
                    -v $(pwd):/bcc \
                    -v /sys/kernel/debug:/sys/kernel/debug:rw \
                    -v /lib/modules:/lib/modules:ro \
                    -v /usr/src:/usr/src:ro \
                    -e CTEST_OUTPUT_ON_FAILURE=1 \
                    u34 \
                    /bin/bash -c \
                    '/bcc/build/tests/wrapper.sh "py_test_percpu" "sudo" "/bcc/tests/python/test_brb.py" test_brb.c -v'
test_brb (__main__.TestBPFSocket) ... skipped 'Missing binaries: neperf, neterver. iperf and netperf packages must be installed.'

----------------------------------------------------------------------
Ran 1 test in 0.000s

OK (skipped=1)
```

Depends on #4211