### PR TITLE
Conditionally rebuild container

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -1,0 +1,47 @@
+name: "Build/Push container"
+description: "Build a BCC CI container and push it when not a pull-request."
+
+inputs:
+  os_distro:
+    description: "OS Disctribution. Ex: ubuntu"
+    required: true
+  os_version:
+    description: "Version of the OS. Ex: 20.04"
+    required: true
+  os_nick:
+    description: "Nickname of the OS. Ex: focal"
+    required: true
+  registry:
+    description: "Registry where to push images"
+    default: ghcr.io
+  password:
+    description: "Password used to log into the docker registry."
+  push:
+    description: "Whether or not to push the build image"
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+    # Login against registry except on PR
+    # https://github.com/docker/login-action
+    - name: Log into registry ${{ inputs.registry }}
+      if: ${{ inputs.push == 'true' && github.event_name != 'pull_request' }}
+
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ github.actor }}
+        password: ${{ inputs.password }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        push: ${{ inputs.push == 'true' && github.event_name != 'pull_request' }}
+        build-args: |
+          VERSION=${{ inputs.os_version }}
+          SHORTNAME=${{ inputs.os_nick }}
+        file: docker/build/Dockerfile.${{ inputs.os_distro }}
+        tags: ${{ inputs.registry }}/${{ github.repository }}:${{ inputs.os_distro }}-${{ inputs.os_version }}
+

--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -30,19 +30,29 @@ jobs:
           RW_ENGINE_ENABLED: ON
     steps:
     - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          docker:
+            - 'docker/build/**'
     - name: System info
       run: |
         uname -a
         ip addr
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v2
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Pull and tag docker container
+    - name: Pull docker container
+      if: steps.changes.outputs.docker == 'false'
       run: |
         docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os.distro }}-${{ matrix.os.version }}
+    - name: Build docker container
+      if: steps.changes.outputs.docker == 'true'
+      uses: ./.github/actions/build-container
+      with:
+        os_distro: ${{ matrix.os.distro }}
+        os_version: ${{ matrix.os.version }}
+        os_nick: ${{ matrix.os.nick }}
+    - name: Tag docker container
+      run: |
         docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os.distro }}-${{ matrix.os.version }} bcc-docker
     - name: Run bcc build
       env: ${{ matrix.env }}
@@ -121,19 +131,29 @@ jobs:
           PYTHON_TEST_LOGFILE: critical.log
     steps:
     - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          docker:
+            - 'docker/build/**'
     - name: System info
       run: |
         uname -a
         ip addr
-    - name: Log into registry ${{ env.REGISTRY }}
-      uses: docker/login-action@v2
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Pull and tag docker container
+    - name: Pull docker container
+      if: steps.changes.outputs.docker == 'false'
       run: |
         docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os.distro }}-${{ matrix.os.version }}
+    - name: Build docker container
+      if: steps.changes.outputs.docker == 'true'
+      uses: ./.github/actions/build-container
+      with:
+        os_distro: ${{ matrix.os.distro }}
+        os_version: ${{ matrix.os.version }}
+        os_nick: ${{ matrix.os.nick }}
+    - name: Tag docker container
+      run: |
         docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os.distro }}-${{ matrix.os.version }} bcc-docker
     - name: Run bcc build
       env: ${{ matrix.env }}

--- a/.github/workflows/publish-build-containers.yml
+++ b/.github/workflows/publish-build-containers.yml
@@ -11,12 +11,6 @@ on:
     paths:
       - 'docker/build/**'
 
-
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
 jobs:
 
   publish_ghcr:
@@ -35,23 +29,11 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    # Login against registry except on PR
-    # https://github.com/docker/login-action
-    - name: Log into registry ${{ env.REGISTRY }}
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v2
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Build and push
-      uses: docker/build-push-action@v3
+      uses: ./.github/actions/build-container
       with:
-        push: ${{ github.event_name != 'pull_request' }}
-        build-args: |
-          VERSION=${{ matrix.os.version }}
-          SHORTNAME=${{ matrix.os.nick }}
-        file: docker/build/Dockerfile.${{ matrix.os.distro }}
-        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os.distro }}-${{ matrix.os.version }}
-
+        os_distro: ${{ matrix.os.distro }}
+        os_version: ${{ matrix.os.version }}
+        os_nick: ${{ matrix.os.nick }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        push: true

--- a/docker/build/Dockerfile.fedora
+++ b/docker/build/Dockerfile.fedora
@@ -56,8 +56,8 @@ RUN dnf -y install \
 	hostname \
 	iproute \
 	bpftool \
-    iperf \
-    netperf
+	iperf \
+	netperf
 
 RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1
 


### PR DESCRIPTION
When any Dockerfile is modified, we should rebuild the container before running the CI.
Failing to do so, we would need to:
1) land the docker file change in order to incorporate the change
2) land the charge that uses this new dockerfile change

This is cumbersome and it is hard to make sure that changes to the dockerfile are indeed correct.

This change conditionally pull the pre-built image if no dockerfile change happened. Otherwise
it reuses the "build_container" action to build the image.

A first commit will confirm that the old behaviour is unchanged. A subsequent commit will confirm that when a Dockerfile is modified, we rebuild the container.