### PR TITLE
Check whether cargo exists and disable the blazesym feature.

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -18,7 +18,12 @@ ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' \
 			 | sed 's/riscv64/riscv/' | sed 's/loongarch.*/loongarch/')
 BTFHUB_ARCHIVE ?= $(abspath btfhub-archive)
 ifeq ($(ARCH),x86)
+CARGO ?= $(shell which cargo)
+ifeq ($(strip $(CARGO)),)
+USE_BLAZESYM ?= 0
+else
 USE_BLAZESYM ?= 1
+endif
 endif
 
 ifeq ($(wildcard $(ARCH)/),)


### PR DESCRIPTION
See https://github.com/iovisor/bcc/pull/4223, Instead of having this change, maybe we can check whether cargo exists and disable the blazesym feature if not. @chenhengqi 

Like we do in libbpf-bootstrap:
https://github.com/libbpf/libbpf-bootstrap/blob/938651fcef787f3885b7c32792851f8423bf8421/examples/c/Makefile#L24-L32