### PR TITLE
Fix libbpf-tools/sigsnoop segment fault

### DIFF
--- a/libbpf-tools/sigsnoop.c
+++ b/libbpf-tools/sigsnoop.c
@@ -19,6 +19,7 @@
 #define PERF_BUFFER_PAGES	16
 #define PERF_POLL_TIMEOUT_MS	100
 #define warn(...) fprintf(stderr, __VA_ARGS__)
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
 static volatile sig_atomic_t exiting = 0;
 
@@ -165,7 +166,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	time(&t);
 	tm = localtime(&t);
 	strftime(ts, sizeof(ts), "%H:%M:%S", tm);
-	if (signal_name)
+	if (signal_name && e->sig < ARRAY_SIZE(sig_name))
 		printf("%-8s %-7d %-16s %-9s %-7d %-6d\n",
 		       ts, e->pid, e->comm, sig_name[e->sig], e->tpid, e->ret);
 	else


### PR DESCRIPTION
Running without -n:

```
  [rongtao@RT-NUC libbpf-tools]$ sudo ./sigsnoop
  TIME     PID     COMM             SIG       TPID    RESULT
  ...
  16:32:48 0       swapper/1        34        2658    0
  16:33:08 0       swapper/1        34        2658    0
```

Running with -n, access sig_name[34] cause SEGV, this patch fix it:

```
  [rongtao@RT-NUC libbpf-tools]$ sudo ./sigsnoop -n
  TIME     PID     COMM             SIG       TPID    RESULT
  ...
  16:42:58 0       swapper/5        KERNEL    2658    0
```
