### PR TITLE
libbpf-tools/klockstat: Fallback to kprobe if fentry is not available

### DIFF
--- a/libbpf-tools/klockstat.h
+++ b/libbpf-tools/klockstat.h
@@ -17,7 +17,7 @@ struct lock_stat {
 	__u64 hld_max_time;
 	__u64 hld_max_id;
 	__u64 hld_max_lock_ptr;
-	char hld_max_comm[TASK_COMM_LEN];
+		char hld_max_comm[TASK_COMM_LEN];
 };
 
 #endif /*__KLOCKSTAT_H */

--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -1008,10 +1008,8 @@ static bool fentry_try_attach(int id)
 
 	prog_fd = bpf_prog_load(BPF_PROG_TYPE_TRACING, "test", "GPL", insns,
 			sizeof(insns) / sizeof(struct bpf_insn), &opts);
-	if (prog_fd < 0) {
-		fprintf(stderr, "failed to try attaching to fentry: %s\n", error);
+	if (prog_fd < 0)
 		return false;
-	}
 
 	attach_fd = bpf_raw_tracepoint_open(NULL, prog_fd);
 	if (attach_fd >= 0)


### PR DESCRIPTION
If fentry is not available, let's fallback to kprobe instead. This would allows the tool to run on old kernels or architectures without BPF trampoline.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>

cc @namhyung @brho