### PR TITLE
Fix: error adding symbols: DSO missing from command line

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -6,8 +6,8 @@ include_directories(${PROJECT_SOURCE_DIR}/src/cc)
 include_directories(${PROJECT_SOURCE_DIR}/src/cc/api)
 include_directories(${PROJECT_SOURCE_DIR}/src/cc/libbpf/include/uapi)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -shared")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -shared")
 
 option(INSTALL_CPP_EXAMPLES "Install C++ examples. Those binaries are statically linked and can take plenty of disk space" OFF)
 

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -16,8 +16,8 @@ endif()
 add_test(NAME c_test_static COMMAND ${TEST_WRAPPER} c_test_static sudo ${CMAKE_CURRENT_BINARY_DIR}/test_static)
 add_compile_options(-DCMAKE_CURRENT_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result -fPIC")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-result -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result -fPIC -shared")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-result -fPIC -shared")
 
 if(ENABLE_USDT)
 set(TEST_LIBBCC_SOURCES


### PR DESCRIPTION
Compile error:
```
 $ cmake ..
 $ make
 ...
 [ 37%] Linking CXX executable CGroupTest
 /usr/bin/ld: /usr/lib64/libLLVMBPFAsmParser.a(BPFAsmParser.cpp.o): undefined reference to symbol '_ZSt21__glibcxx_assert_failPKciS0_S0_@@LLVM_14'
 /usr/bin/ld: /usr/lib64/libLLVM-14.so: error adding symbols: DSO missing from command line
 collect2: error: ld returned 1 exit status
 make[2]: *** [examples/cpp/CMakeFiles/CGroupTest.dir/build.make:163: examples/cpp/CGroupTest] Error 1
 make[1]: *** [CMakeFiles/Makefile2:1013: examples/cpp/CMakeFiles/CGroupTest.dir/all] Error 2
 make: *** [Makefile:146: all] Error 2
```
 Need '`-shared`' during compile.
