### PR TITLE
Added bounded loop into the main bpf features list

### DIFF
--- a/docs/kernel-versions.md
+++ b/docs/kernel-versions.md
@@ -82,6 +82,7 @@ BPF flow dissector | 4.20 | [`d58e468b1112`](https://github.com/torvalds/linux/c
 BPF 1M insn limit | 5.2 | [`c04c0d2b968a`](https://github.com/torvalds/linux/commit/c04c0d2b968ac45d6ef020316808ef6c82325a82)
 BPF cgroup sysctl | 5.2 | [`7b146cebe30c`](https://github.com/torvalds/linux/commit/7b146cebe30cb481b0f70d85779da938da818637)
 BPF raw tracepoint writable | 5.2 | [`9df1c28bb752`](https://github.com/torvalds/linux/commit/9df1c28bb75217b244257152ab7d788bb2a386d0)
+BPF bounded loop | 5.3 | [`2589726d12a1`](https://github.com/torvalds/linux/commit/2589726d12a1b12eaaa93c7f1ea64287e383c7a5)
 BPF trampoline | 5.5 | [`fec56f5890d9`](https://github.com/torvalds/linux/commit/fec56f5890d93fc2ed74166c397dc186b1c25951)
 BPF LSM hook | 5.7 | [`fc611f47f218`](https://github.com/torvalds/linux/commit/fc611f47f2188ade2b48ff6902d5cce8baac0c58) [`641cd7b06c91`](https://github.com/torvalds/linux/commit/641cd7b06c911c5935c34f24850ea18690649917)
 BPF iterator | 5.8 | [`180139dca8b3`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=180139dca8b38c858027b8360ee10064fdb2fbf7)


### PR DESCRIPTION
Bounded loop is a main feature because it removes the major restriction of loops in BPF code have to be unrolled. Because of loop unrolling is often hard to reliably apply in practice: On the one hand because loops in code is not always easy to formalize: https://llvm.org/docs/LoopTerminology.html On the other hand, loop unrolling in clang/llvm often is not forcible because of the complexity of code generation and optimization.

Bounded loop allows more reliable verification on BPF code that uses compile-time constants as loop termination conditions. Therefore substantially simplified the writing of BPF code.