### PR TITLE
Fix padding field not initialized issue

### DIFF
--- a/examples/networking/vlan_learning/vlan_learning.c
+++ b/examples/networking/vlan_learning/vlan_learning.c
@@ -5,8 +5,8 @@
 
 struct ifindex_leaf_t {
   int out_ifindex;
-  int vlan_tci; // populated by phys2virt and used by virt2phys
-  int vlan_proto; // populated by phys2virt and used by virt2phys
+  u16 vlan_tci; // populated by phys2virt and used by virt2phys
+  u16 vlan_proto; // populated by phys2virt and used by virt2phys
   u64 tx_pkts;
   u64 tx_bytes;
 };


### PR DESCRIPTION
"u16" is enough for vlan_tci and vlan_proto fields and can avoid the padding issue.

Fixes: https://github.com/iovisor/bcc/issues/4243