### PR TITLE
Missing a newline('\n')

### DIFF
--- a/libbpf-tools/readahead.c
+++ b/libbpf-tools/readahead.c
@@ -31,7 +31,7 @@ const char argp_program_doc[] =
 "USAGE: readahead [--help] [-d DURATION]\n"
 "\n"
 "EXAMPLES:\n"
-"    readahead              # summarize on-CPU time as a histogram"
+"    readahead              # summarize on-CPU time as a histogram\n"
 "    readahead -d 10        # trace for 10 seconds only\n";
 
 static const struct argp_option opts[] = {


### PR DESCRIPTION
```
$ sudo ./readahead -h
Usage: readahead [OPTION...]
Show fs automatic read-ahead usage.

USAGE: readahead [--help] [-d DURATION]

EXAMPLES:
    readahead              # summarize on-CPU time as a histogram
    readahead -d 10        # trace for 10 seconds only

  -d, --duration=DURATION    Duration to trace
  -v, --verbose              Verbose debug output
  -?, --help                 Give this help list
      --usage                Give a short usage message
  -V, --version              Print program version

Mandatory or optional arguments to long options are also mandatory or optional
for any corresponding short options.

Report bugs to https://github.com/iovisor/bcc/tree/master/libbpf-tools.
```