### PR TITLE
Modify fentry/fexit probe function for readahead command

### DIFF
--- a/libbpf-tools/readahead.c
+++ b/libbpf-tools/readahead.c
@@ -80,7 +80,7 @@ static int readahead__set_attach_target(struct bpf_program *prog)
 {
 	int err;
 
-	err = bpf_program__set_attach_target(prog, 0, "do_page_cache_ra");
+	err = bpf_program__set_attach_target(prog, 0, "page_cache_ra_unbounded");
 	if (!err)
 		return 0;
 
@@ -119,13 +119,16 @@ int main(int argc, char **argv)
 	}
 
 	/*
-	 * Starting from v5.10-rc1 (8238287), __do_page_cache_readahead has
-	 * renamed to do_page_cache_ra. So we specify the function dynamically.
+	 * Starting from kernel commit 56a4d67c264e("mm/readahead: Switch to
+	 * page_cache_ra_order") do_page_cache_ra be replaced to page_cache_ra_order
+	 * and it's became to static.
+	 *
+	 * So we specify the function dynamically.
 	 */
-	err = readahead__set_attach_target(obj->progs.do_page_cache_ra);
+	err = readahead__set_attach_target(obj->progs.page_cache_ra_unbounded);
 	if (err)
 		goto cleanup;
-	err = readahead__set_attach_target(obj->progs.do_page_cache_ra_ret);
+	err = readahead__set_attach_target(obj->progs.page_cache_ra_unbounded_ret);
 	if (err)
 		goto cleanup;
 


### PR DESCRIPTION
Fix: readahead compile error

Error1:
 failed to set attach target for do_page_cache_ra: No such process

Error2:
 libbpf: failed to find kernel BTF type ID of '__page_cache_alloc': -3
 libbpf: prog 'page_cache_alloc_ret': failed to prepare load attributes: -3
 libbpf: prog 'page_cache_alloc_ret': failed to load: -3
 libbpf: failed to load object 'readahead_bpf'
 libbpf: failed to load BPF skeleton 'readahead_bpf': -3
 failed to load BPF object
