### PR TITLE
Edit WSL2 install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -274,19 +274,30 @@ sudo docker run --rm -it --privileged \
 ## WSL(Windows Subsystem for Linux) - Binary
 
 ### Install dependencies
-The compiling depends on the headers and lib of linux kernel module which was not found in wsl distribution packages repo. We have to compile the kernel moudle manually.
+The compiling depends on the headers and lib of linux kernel module which was not found in wsl distribution packages repo. We have to compile the kernel module manually.
 ```bash
 apt-get install flex bison libssl-dev libelf-dev dwarves
 ```
 ### Install packages
+
+First, you will need to checkout the WSL2 Linux kernel git repository:
+```
+git clone git@github.com:microsoft/WSL2-Linux-Kernel.git
+cd WSL2-Linux-Kernel
+KERNEL_VERSION=$(uname -r | cut -d '-' -f 1)
+git checkout linux-msft-wsl-$KERNEL_VERSION
+```
+
+Then compile and install:
 ```
 cp Microsoft/config-wsl .config
 make oldconfig && make prepare
 make scripts
-make modules && make modules_install
-# if your kernel version is 4.19.y
-mv /lib/modules/x.y.z-microsoft-standard+ /lib/modules/x.y.z-microsoft-standard 
+make modules
+sudo make modules_install
+sudo mv /lib/modules/$(uname -r)+ /lib/modules/$(uname -r)
 ````
+
 Then you can install bcc tools package according your distribution.
 
 If you met some problems, try to 


### PR DESCRIPTION
A few small changes to the WSL2 installation instructions based on my experience installing bcc in 5.10.102.1-microsoft-standard-WSL2 Ubuntu 22.04:

* Fix a typo "modules" in instructions.
* Add instructions for cloning the WSL2-Linux-Kernel git repo.
* Add sudo for `make modules_install` command.
* Add instructions for renaming /lib/modules/x.y.z-microsoft-standard-WSL2+ even on recent kernels (needed this on 5.10).

With these changes, I was able to compile bcc on WSL2 Ubuntu 22.04 and run `sudo /usr/share/bcc/tools/execsnoop`