### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -12,6 +12,10 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+  pull-requests: read # to read pull requests (dorny/paths-filter)
+
 jobs:
   test_bcc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-build-containers.yml
+++ b/.github/workflows/publish-build-containers.yml
@@ -11,9 +11,14 @@ on:
     paths:
       - 'docker/build/**'
 
+permissions: {}
+
 jobs:
 
   publish_ghcr:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+      packages: write # to push container
     name: Publish To GitHub Container Registry
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   # Optionally publish container images to custom docker repository,
   # guarded by presence of all required github secrets.


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.