### PR TITLE
tools: killsnoop: support target PID filter

### DIFF
--- a/man/man8/killsnoop.8
+++ b/man/man8/killsnoop.8
@@ -2,7 +2,7 @@
 .SH NAME
 killsnoop \- Trace signals issued by the kill() syscall. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B killsnoop [\-h] [\-x] [-p PID]
+.B killsnoop [\-h] [\-x] [-p PID] [-T PID]
 .SH DESCRIPTION
 killsnoop traces the kill() syscall, to show signals sent via this method. This
 may be useful to troubleshoot failing applications, where an unknown mechanism
@@ -27,7 +27,10 @@ Print usage message.
 Only print failed kill() syscalls.
 .TP
 \-p PID
-Trace this process ID only (filtered in-kernel).
+Trace this process ID only which is the sender of signal (filtered in-kernel).
+.TP
+\-T PID
+Trace this target process ID only which is the receiver of signal (filtered in-kernel).
 .TP
 \-s SIGNAL
 Trace this signal only (filtered in-kernel).
@@ -44,6 +47,10 @@ Trace only kill() syscalls that failed:
 Trace PID 181 only:
 #
 .B killsnoop \-p 181
+.TP
+Trace target PID 189 only:
+#
+.B killsnoop \-T 189
 .TP
 Trace signal 9 only:
 #

--- a/tools/killsnoop_example.txt
+++ b/tools/killsnoop_example.txt
@@ -24,9 +24,11 @@ usage: killsnoop [-h] [-x] [-p PID]
 Trace signals issued by the kill() syscall
 
 optional arguments:
-  -h, --help         show this help message and exit
-  -x, --failed       only show failed kill syscalls
-  -p PID, --pid PID  trace this PID only
+  -h, --help            show this help message and exit
+  -x, --failed          only show failed kill syscalls
+  -p PID, --pid PID     trace this PID only which is the sender of signal
+  -T TPID, --tpid TPID  trace this target PID only which is the receiver of
+                        signal
   -s SIGNAL, --signal SIGNAL
                         trace this signal only
 
@@ -34,4 +36,5 @@ examples:
     ./killsnoop           # trace all kill() signals
     ./killsnoop -x        # only show failed kills
     ./killsnoop -p 181    # only trace PID 181
+    ./killsnoop -T 189    # only trace target PID 189
     ./killsnoop -s 9      # only trace signal 9


### PR DESCRIPTION
Support '-t'/'--tpid' to filter the target PID to avoid message flood, ignore other processes we don't care.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>