### PR TITLE
bcc: Bump CMake minimum version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
-if (${CMAKE_VERSION} VERSION_EQUAL 3.12.0 OR ${CMAKE_VERSION} VERSION_GREATER 3.12.0)
+if(${CMAKE_VERSION} VERSION_EQUAL 3.12.0 OR ${CMAKE_VERSION} VERSION_GREATER 3.12.0)
   cmake_policy(SET CMP0074 NEW)
 endif()
 
@@ -12,10 +12,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 if(CMAKE_SANITIZE_TYPE)
-    add_compile_options(-fsanitize=${CMAKE_SANITIZE_TYPE})
-    add_link_options(-fsanitize=${CMAKE_SANITIZE_TYPE})
+  add_compile_options(-fsanitize=${CMAKE_SANITIZE_TYPE})
+  add_link_options(-fsanitize=${CMAKE_SANITIZE_TYPE})
 endif()
-
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "path to install" FORCE)
@@ -32,57 +31,57 @@ endif()
 
 # populate submodule blazesym
 if(NOT NO_BLAZESYM)
-    execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR}/libbpf-tools/blazesym
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    RESULT_VARIABLE CONFIG_RESULT)
-    if(CONFIG_RESULT AND NOT CONFIG_RESULT EQUAL 0)
-      message(WARNING "Failed to add blazesym source directory to safe.directory")
-    endif()
+  execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR}/libbpf-tools/blazesym
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  RESULT_VARIABLE CONFIG_RESULT)
+  if(CONFIG_RESULT AND NOT CONFIG_RESULT EQUAL 0)
+    message(WARNING "Failed to add blazesym source directory to safe.directory")
+  endif()
 
-    execute_process(COMMAND git submodule update --init --recursive -- libbpf-tools/blazesym
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                    RESULT_VARIABLE UPDATE_RESULT)
-    if(UPDATE_RESULT AND NOT UPDATE_RESULT EQUAL 0)
-      message(WARNING "Failed to update submodule blazesym")
-    endif()
+  execute_process(COMMAND git submodule update --init --recursive -- libbpf-tools/blazesym
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  RESULT_VARIABLE UPDATE_RESULT)
+  if(UPDATE_RESULT AND NOT UPDATE_RESULT EQUAL 0)
+    message(WARNING "Failed to update submodule blazesym")
+  endif()
 endif()
 
 # populate submodules (libbpf)
 if(NOT CMAKE_USE_LIBBPF_PACKAGE)
-   execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf
-                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                   RESULT_VARIABLE CONFIG_RESULT)
-   if(CONFIG_RESULT AND NOT CONFIG_RESULT EQUAL 0)
-     message(WARNING "Failed to add libbpf source directory to safe.directory")
-   endif()
-   execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR}/libbpf-tools/bpftool
-                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                   RESULT_VARIABLE CONFIG_RESULT)
-   if(CONFIG_RESULT AND NOT CONFIG_RESULT EQUAL 0)
-     message(WARNING "Failed to add bpftool source directory to safe.directory")
-   endif()
-
-   if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/src)
-	execute_process(COMMAND git submodule update --init --recursive
+  execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  RESULT_VARIABLE UPDATE_RESULT)
-  if(UPDATE_RESULT AND NOT UPDATE_RESULT EQUAL 0)
-    message(WARNING "Failed to update submodule libbpf")
+                  RESULT_VARIABLE CONFIG_RESULT)
+  if(CONFIG_RESULT AND NOT CONFIG_RESULT EQUAL 0)
+    message(WARNING "Failed to add libbpf source directory to safe.directory")
   endif()
-   else()
-	execute_process(COMMAND git diff --shortstat ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/
-		OUTPUT_VARIABLE DIFF_STATUS)
-	if("${DIFF_STATUS}" STREQUAL "")
-		execute_process(COMMAND git submodule update --init --recursive
+  execute_process(COMMAND git config --global --add safe.directory ${CMAKE_CURRENT_SOURCE_DIR}/libbpf-tools/bpftool
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  RESULT_VARIABLE CONFIG_RESULT)
+  if(CONFIG_RESULT AND NOT CONFIG_RESULT EQUAL 0)
+    message(WARNING "Failed to add bpftool source directory to safe.directory")
+  endif()
+
+  if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/src)
+    execute_process(COMMAND git submodule update --init --recursive
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     RESULT_VARIABLE UPDATE_RESULT)
-  if(UPDATE_RESULT AND NOT UPDATE_RESULT EQUAL 0)
-    message(WARNING "Failed to update submodule libbpf")
+    if(UPDATE_RESULT AND NOT UPDATE_RESULT EQUAL 0)
+      message(WARNING "Failed to update submodule libbpf")
+    endif()
+  else()
+    execute_process(COMMAND git diff --shortstat ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/
+                    OUTPUT_VARIABLE DIFF_STATUS)
+    if("${DIFF_STATUS}" STREQUAL "")
+      execute_process(COMMAND git submodule update --init --recursive
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                      RESULT_VARIABLE UPDATE_RESULT)
+      if(UPDATE_RESULT AND NOT UPDATE_RESULT EQUAL 0)
+        message(WARNING "Failed to update submodule libbpf")
+      endif()
+    else()
+      message(WARNING "submodule libbpf dirty, so no sync")
+    endif()
   endif()
-	else()
-		message(WARNING "submodule libbpf dirty, so no sync")
-	endif()
-   endif()
 endif()
 
 # It's possible to use other kernel headers with
@@ -119,81 +118,86 @@ if(ENABLE_TESTS)
   find_package(KernelHeaders)
 endif()
 
-if (CMAKE_USE_LIBBPF_PACKAGE)
+if(CMAKE_USE_LIBBPF_PACKAGE)
   find_package(LibBpf)
 endif()
 
 if(NOT PYTHON_ONLY)
-find_package(LLVM REQUIRED CONFIG)
-message(STATUS "Found LLVM: ${LLVM_INCLUDE_DIRS} ${LLVM_PACKAGE_VERSION} (Use LLVM_ROOT envronment variable for another version of LLVM)")
+  find_package(LLVM REQUIRED CONFIG)
+  message(STATUS "Found LLVM: ${LLVM_INCLUDE_DIRS} ${LLVM_PACKAGE_VERSION} (Use LLVM_ROOT envronment variable for another version of LLVM)")
 
-if(ENABLE_CLANG_JIT)
-find_package(BISON)
-find_package(FLEX)
-find_package(LibElf REQUIRED)
-find_package(LibDebuginfod)
-if(CLANG_DIR)
-  set(CMAKE_FIND_ROOT_PATH "${CLANG_DIR}")
-  include_directories("${CLANG_DIR}/include")
-endif()
+  if(ENABLE_CLANG_JIT)
+    find_package(BISON)
+    find_package(FLEX)
+    find_package(LibElf REQUIRED)
+    find_package(LibDebuginfod)
+    if(CLANG_DIR)
+      set(CMAKE_FIND_ROOT_PATH "${CLANG_DIR}")
+      include_directories("${CLANG_DIR}/include")
+    endif()
 
-# clang is linked as a library, but the library path searching is
-# primitively supported, unlike libLLVM
-set(CLANG_SEARCH "/opt/local/llvm/lib;/usr/lib/llvm-3.7/lib;${LLVM_LIBRARY_DIRS}")
-find_library(libclangAnalysis NAMES clangAnalysis clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangAST NAMES clangAST clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangBasic NAMES clangBasic clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangCodeGen NAMES clangCodeGen clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangDriver NAMES clangDriver clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangEdit NAMES clangEdit clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangFrontend NAMES clangFrontend clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangLex NAMES clangLex clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangParse NAMES clangParse clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangRewrite NAMES clangRewrite clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangSema NAMES clangSema clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangSerialization NAMES clangSerialization clang-cpp HINTS ${CLANG_SEARCH})
-find_library(libclangASTMatchers NAMES clangASTMatchers clang-cpp HINTS ${CLANG_SEARCH})
-if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 15 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 15)
-  find_library(libclangSupport NAMES clangSupport clang-cpp HINTS ${CLANG_SEARCH})
-endif()
-find_library(libclang-shared libclang-cpp.so HINTS ${CLANG_SEARCH})
-if(libclangBasic STREQUAL "libclangBasic-NOTFOUND")
-  message(FATAL_ERROR "Unable to find clang libraries")
-endif()
-FOREACH(DIR ${LLVM_INCLUDE_DIRS})
-  include_directories("${DIR}/../tools/clang/include")
-ENDFOREACH()
-endif(ENABLE_CLANG_JIT)
+    # clang is linked as a library, but the library path searching is
+    # primitively supported, unlike libLLVM
+    set(CLANG_SEARCH "/opt/local/llvm/lib;/usr/lib/llvm-3.7/lib;${LLVM_LIBRARY_DIRS}")
+    find_library(libclangAnalysis NAMES clangAnalysis clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangAST NAMES clangAST clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangBasic NAMES clangBasic clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangCodeGen NAMES clangCodeGen clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangDriver NAMES clangDriver clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangEdit NAMES clangEdit clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangFrontend NAMES clangFrontend clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangLex NAMES clangLex clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangParse NAMES clangParse clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangRewrite NAMES clangRewrite clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangSema NAMES clangSema clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangSerialization NAMES clangSerialization clang-cpp HINTS ${CLANG_SEARCH})
+    find_library(libclangASTMatchers NAMES clangASTMatchers clang-cpp HINTS ${CLANG_SEARCH})
 
-# Set to a string path if system places kernel lib directory in
-# non-default location.
-if(NOT DEFINED BCC_KERNEL_MODULES_DIR)
-  set(BCC_KERNEL_MODULES_DIR "/lib/modules")
-endif()
+    if(${LLVM_PACKAGE_VERSION} VERSION_EQUAL 15 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 15)
+      find_library(libclangSupport NAMES clangSupport clang-cpp HINTS ${CLANG_SEARCH})
+    endif()
 
-if(NOT DEFINED BCC_PROG_TAG_DIR)
-  set(BCC_PROG_TAG_DIR "/var/tmp/bcc")
-endif()
+    find_library(libclang-shared libclang-cpp.so HINTS ${CLANG_SEARCH})
 
-# As reported in issue #735, GCC 6 has some behavioral problems when
-# dealing with -isystem. Hence, skip the warning optimization
-# altogether on that compiler.
-option(USINGISYSTEM "using -isystem" ON)
-execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-if (USINGISYSTEM AND GCC_VERSION VERSION_LESS 6.0)
-  # iterate over all available directories in LLVM_INCLUDE_DIRS to
-  # generate a correctly tokenized list of parameters
-  foreach(ONE_LLVM_INCLUDE_DIR ${LLVM_INCLUDE_DIRS})
-    set(CXX_ISYSTEM_DIRS "${CXX_ISYSTEM_DIRS} -isystem ${ONE_LLVM_INCLUDE_DIR}")
-  endforeach()
-endif()
+    if(libclangBasic STREQUAL "libclangBasic-NOTFOUND")
+      message(FATAL_ERROR "Unable to find clang libraries")
+    endif()
 
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 16 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 16)
-  set(CMAKE_CXX_STANDARD 17)
-else()
-  set(CMAKE_CXX_STANDARD 14)
-endif()
+    FOREACH(DIR ${LLVM_INCLUDE_DIRS})
+      include_directories("${DIR}/../tools/clang/include")
+    ENDFOREACH()
+
+  endif(ENABLE_CLANG_JIT)
+
+  # Set to a string path if system places kernel lib directory in
+  # non-default location.
+  if(NOT DEFINED BCC_KERNEL_MODULES_DIR)
+    set(BCC_KERNEL_MODULES_DIR "/lib/modules")
+  endif()
+
+  if(NOT DEFINED BCC_PROG_TAG_DIR)
+    set(BCC_PROG_TAG_DIR "/var/tmp/bcc")
+  endif()
+
+  # As reported in issue #735, GCC 6 has some behavioral problems when
+  # dealing with -isystem. Hence, skip the warning optimization
+  # altogether on that compiler.
+  option(USINGISYSTEM "using -isystem" ON)
+  execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+  if(USINGISYSTEM AND GCC_VERSION VERSION_LESS 6.0)
+    # iterate over all available directories in LLVM_INCLUDE_DIRS to
+    # generate a correctly tokenized list of parameters
+    foreach(ONE_LLVM_INCLUDE_DIR ${LLVM_INCLUDE_DIRS})
+      set(CXX_ISYSTEM_DIRS "${CXX_ISYSTEM_DIRS} -isystem ${ONE_LLVM_INCLUDE_DIR}")
+    endforeach()
+  endif()
+
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  if(${LLVM_PACKAGE_VERSION} VERSION_EQUAL 16 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 16)
+    set(CMAKE_CXX_STANDARD 17)
+  else()
+    set(CMAKE_CXX_STANDARD 14)
+  endif()
 
 endif(NOT PYTHON_ONLY)
 
@@ -202,25 +206,29 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ${CXX_ISYSTEM_DIRS}")
 
 add_subdirectory(src)
 add_subdirectory(introspection)
+
 if(ENABLE_CLANG_JIT)
-if(ENABLE_EXAMPLES)
-add_subdirectory(examples)
-endif(ENABLE_EXAMPLES)
-if(ENABLE_MAN)
-add_subdirectory(man)
-endif(ENABLE_MAN)
-if(ENABLE_TESTS)
-add_subdirectory(tests)
-endif(ENABLE_TESTS)
-add_subdirectory(tools)
+  if(ENABLE_EXAMPLES)
+    add_subdirectory(examples)
+  endif(ENABLE_EXAMPLES)
+
+  if(ENABLE_MAN)
+    add_subdirectory(man)
+  endif(ENABLE_MAN)
+
+  if(ENABLE_TESTS)
+    add_subdirectory(tests)
+  endif(ENABLE_TESTS)
+
+  add_subdirectory(tools)
 endif(ENABLE_CLANG_JIT)
 
 if(NOT TARGET uninstall)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CmakeUninstall.cmake.in"
-	"${CMAKE_CURRENT_BINARY_DIR}/CmakeUninstall.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/CmakeUninstall.cmake"
     IMMEDIATE @ONLY)
 
   add_custom_target(uninstall
-	  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/CmakeUninstall.cmake)
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/CmakeUninstall.cmake)
 endif()


### PR DESCRIPTION
Bump CMake minimum version to 2.8.12 to avoid the following warning:
    CMake Deprecation Warning at CMakeLists.txt:3 (cmake_minimum_required):
      Compatibility with CMake < 2.8.12 will be removed from a future version of
      CMake.

      Update the VERSION argument <min> value or use a ...<max> suffix to tell
      CMake that the project does not need compatibility with older versions.

While at it, also use 2-space for indentions for the whole file.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>