### PR TITLE
tools/biopattern: improve the output of biopattern

### DIFF
--- a/tools/biopattern.py
+++ b/tools/biopattern.py
@@ -123,12 +123,13 @@ while True:
             continue
 
         part_name = partitions.get(k.value, "Unknown")
+        random_percent = int(round(v.random * 100 / total))
 
         print("%-9s %-7s %5d %5d %8d %10d" % (
             strftime("%H:%M:%S"),
             part_name,
-            v.random * 100 / total,
-            v.sequential * 100 / total,
+            random_percent,
+            100 - random_percent,
             total,
             v.bytes / 1024))
 


### PR DESCRIPTION
Sometimes,  the sum of %RND and %SEQ not equal to 100 (as follows), which may be a bit of confusion. This patch try to fix it.

```
# ./biopattern -d vda 1
TIME      DISK     %RND  %SEQ    COUNT     KBYTES
16:08:16  vda       100     0       21        160
16:08:17  vda        75    25        4        248
16:08:19  vda       100     0        2          8
16:08:20  vda        85    14       63       2412
16:08:21  vda        96     3      824      20848
16:08:22  vda        96     3     3239      14496
```