### PR TITLE
libbpf-tools: Add support for bpf_ringbuf

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -103,6 +103,7 @@ COMMON_OBJ = \
 	$(OUTPUT)/map_helpers.o \
 	$(OUTPUT)/uprobe_helpers.o \
 	$(OUTPUT)/btf_helpers.o \
+	$(OUTPUT)/compat.o \
 	$(if $(ENABLE_MIN_CORE_BTFS),$(OUTPUT)/min_core_btf_tar.o) \
 	#
 
@@ -172,7 +173,7 @@ $(BPFTOOL): | $(BPFTOOL_OUTPUT)
 	$(call msg,BPFTOOL,$@)
 	$(Q)$(MAKE) ARCH= CROSS_COMPILE=  OUTPUT=$(BPFTOOL_OUTPUT)/ -C $(BPFTOOL_SRC) bootstrap
 
-$(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) $(COMMON_OBJ) | $(OUTPUT)
+$(APPS): %: $(OUTPUT)/%.o $(COMMON_OBJ) $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,BINARY,$@)
 	$(Q)$(CC) $(CFLAGS) $^ $(LDFLAGS) -lelf -lz -o $@
 

--- a/libbpf-tools/compat.bpf.h
+++ b/libbpf-tools/compat.bpf.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2022 Hengqi Chen */
+
+#ifndef __COMPAT_BPF_H
+#define __COMPAT_BPF_H
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+#define MAX_EVENT_SIZE		10240
+#define RINGBUF_SIZE		(1024 * 256)
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, MAX_EVENT_SIZE);
+} heap SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, RINGBUF_SIZE);
+} events SEC(".maps");
+
+static __always_inline void *reserve_buf(__u64 size)
+{
+	static const int zero = 0;
+
+	if (bpf_core_type_exists(struct bpf_ringbuf))
+		return bpf_ringbuf_reserve(&events, size, 0);
+
+	return bpf_map_lookup_elem(&heap, &zero);
+}
+
+static __always_inline long submit_buf(void *ctx, void *buf, __u64 size)
+{
+	if (bpf_core_type_exists(struct bpf_ringbuf)) {
+		bpf_ringbuf_submit(buf, 0);
+		return 0;
+	}
+
+	return bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, buf, size);
+}
+
+#endif /* __COMPAT_BPF_H */

--- a/libbpf-tools/compat.c
+++ b/libbpf-tools/compat.c
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2022 Hengqi Chen */
+
+#include "compat.h"
+#include "trace_helpers.h"
+#include <stdlib.h>
+#include <errno.h>
+#include <bpf/libbpf.h>
+
+#define PERF_BUFFER_PAGES	64
+
+struct bpf_buffer {
+	struct bpf_map *events;
+	void *inner;
+	bpf_buffer_sample_fn fn;
+	void *ctx;
+	int type;
+};
+
+static void perfbuf_sample_fn(void *ctx, int cpu, void *data, __u32 size)
+{
+	struct bpf_buffer *buffer = ctx;
+	bpf_buffer_sample_fn fn;
+
+	fn = buffer->fn;
+	if (!fn)
+		return;
+
+	(void)fn(buffer->ctx, data, size);
+}
+
+struct bpf_buffer *bpf_buffer__new(struct bpf_map *events, struct bpf_map *heap)
+{
+	struct bpf_buffer *buffer;
+	bool use_ringbuf;
+	int type;
+
+	use_ringbuf = probe_ringbuf();
+	if (use_ringbuf) {
+		bpf_map__set_autocreate(heap, false);
+		type = BPF_MAP_TYPE_RINGBUF;
+	} else {
+		bpf_map__set_type(events, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+		bpf_map__set_key_size(events, sizeof(int));
+		bpf_map__set_value_size(events, sizeof(int));
+		type = BPF_MAP_TYPE_PERF_EVENT_ARRAY;
+	}
+
+	buffer = calloc(1, sizeof(*buffer));
+	if (!buffer) {
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	buffer->events = events;
+	buffer->type = type;
+	return buffer;
+}
+
+int bpf_buffer__open(struct bpf_buffer *buffer, bpf_buffer_sample_fn sample_cb,
+		     bpf_buffer_lost_fn lost_cb, void *ctx)
+{
+	int fd, type;
+	void *inner;
+
+	fd = bpf_map__fd(buffer->events);
+	type = buffer->type;
+
+	switch (type) {
+	case BPF_MAP_TYPE_PERF_EVENT_ARRAY:
+		buffer->fn = sample_cb;
+		buffer->ctx = ctx;
+		inner = perf_buffer__new(fd, PERF_BUFFER_PAGES, perfbuf_sample_fn, lost_cb, buffer, NULL);
+		break;
+	case BPF_MAP_TYPE_RINGBUF:
+		inner = ring_buffer__new(fd, sample_cb, ctx, NULL);
+		break;
+	default:
+		return 0;
+	}
+
+	if (!inner)
+		return -errno;
+
+	buffer->inner = inner;
+	return 0;
+}
+
+int bpf_buffer__poll(struct bpf_buffer *buffer, int timeout_ms)
+{
+	switch (buffer->type) {
+	case BPF_MAP_TYPE_PERF_EVENT_ARRAY:
+		return perf_buffer__poll(buffer->inner, timeout_ms);
+	case BPF_MAP_TYPE_RINGBUF:
+		return ring_buffer__poll(buffer->inner, timeout_ms);
+	default:
+		return -EINVAL;
+	}
+}
+
+void bpf_buffer__free(struct bpf_buffer *buffer)
+{
+	if (!buffer)
+		return;
+
+	switch (buffer->type) {
+	case BPF_MAP_TYPE_PERF_EVENT_ARRAY:
+		perf_buffer__free(buffer->inner);
+		break;
+	case BPF_MAP_TYPE_RINGBUF:
+		ring_buffer__free(buffer->inner);
+		break;
+	}
+	free(buffer);
+}

--- a/libbpf-tools/compat.h
+++ b/libbpf-tools/compat.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2022 Hengqi Chen */
+
+#ifndef __COMPAT_H
+#define __COMPAT_H
+
+#include <sys/types.h>
+#include <linux/bpf.h>
+
+struct bpf_buffer;
+struct bpf_map;
+
+typedef int (*bpf_buffer_sample_fn)(void *ctx, void *data, size_t size);
+typedef void (*bpf_buffer_lost_fn)(void *ctx, int cpu, __u64 cnt);
+
+struct bpf_buffer *bpf_buffer__new(struct bpf_map *events, struct bpf_map *heap);
+int bpf_buffer__open(struct bpf_buffer *buffer, bpf_buffer_sample_fn sample_cb,
+		     bpf_buffer_lost_fn lost_cb, void *ctx);
+int bpf_buffer__poll(struct bpf_buffer *, int timeout_ms);
+void bpf_buffer__free(struct bpf_buffer *);
+
+#endif /* __COMPAT_H */

--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -1140,3 +1140,15 @@ bool probe_tp_btf(const char *name)
 		close(fd);
 	return fd >= 0;
 }
+
+bool probe_ringbuf()
+{
+	int map_fd;
+
+	map_fd = bpf_map_create(BPF_MAP_TYPE_RINGBUF, NULL, 0, 0, getpagesize(), NULL);
+	if (map_fd < 0)
+		return false;
+
+	close(map_fd);
+	return true;
+}

--- a/libbpf-tools/trace_helpers.h
+++ b/libbpf-tools/trace_helpers.h
@@ -95,5 +95,6 @@ bool vmlinux_btf_exists(void);
 bool module_btf_exists(const char *mod);
 
 bool probe_tp_btf(const char *name);
+bool probe_ringbuf();
 
 #endif /* __TRACE_HELPERS_H */


### PR DESCRIPTION
This patch introduces bpf_ringbuf to the existing libbpf-tools. Currently, most tools use PERF_EVENT_ARRAY for event-based tracing. For newer kernels, we could use bpf_ringbuf instead, for better performance. In this commit, we introduce two new header files: compat.bpf.h and compat.h, for BPF programs and userspace program respectively, providing uniform APIs for perfbuf/ringbuf handling in a CO-RE way.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>