### PR TITLE
Enable user symbol resolution on exited processes

### DIFF
--- a/src/cc/bcc_syms.cc
+++ b/src/cc/bcc_syms.cc
@@ -34,18 +34,24 @@
 
 #include "syms.h"
 
-ino_t ProcStat::getinode_() {
+bool ProcStat::getinode_(ino_t &inode) {
   struct stat s;
-  return (!stat(procfs_.c_str(), &s)) ? s.st_ino : -1;
+  if (!stat(procfs_.c_str(), &s)) {
+    inode = s.st_ino;
+    return true;
+  } else {
+    return false;
+  }
 }
 
 bool ProcStat::is_stale() {
-  ino_t cur_inode = getinode_();
-  return (cur_inode > 0) && (cur_inode != inode_);
+  ino_t cur_inode;
+  return getinode_(cur_inode) && (cur_inode != inode_);
 }
 
-ProcStat::ProcStat(int pid)
-    : procfs_(tfm::format("/proc/%d/exe", pid)), inode_(getinode_()) {}
+ProcStat::ProcStat(int pid) : procfs_(tfm::format("/proc/%d/exe", pid)) {
+  getinode_(inode_);
+}
 
 void KSyms::_add_symbol(const char *symname, const char *modname, uint64_t addr, void *p) {
   KSyms *ks = static_cast<KSyms *>(p);

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -30,12 +30,12 @@
 class ProcStat {
   std::string procfs_;
   ino_t inode_;
-  ino_t getinode_();
+  bool getinode_(ino_t &inode);
 
-public:
+ public:
   ProcStat(int pid);
   bool is_stale();
-  void reset() { inode_ = getinode_(); }
+  void reset() { getinode_(inode_); }
 };
 
 class SymbolCache {

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -29,11 +29,15 @@
 
 class ProcStat {
   std::string procfs_;
+  std::string root_symlink_;
+  std::string root_;
   ino_t inode_;
   bool getinode_(ino_t &inode);
 
  public:
   ProcStat(int pid);
+  bool refresh_root();
+  const std::string &get_root() { return root_; }
   bool is_stale();
   void reset() { getinode_(inode_); }
 };


### PR DESCRIPTION
This PR contains two commits. The first one fixes a bug in `ProcStat::is_stale` that caused it to report `true` even if the PID does not exist anymore. The second one modifies `modpath` in `ProcStat::is_stale` to resolve `/proc/.../root` symlink if possible before appending it to `mod->name`, allowing finding the ELF executable even if the process is not running at the time when `ProcSyms::resolve_addr` is called.

These together allow `bcc_symcache_resolve` to work even if the process has already exited by the time of the function call.