### PR TITLE
tools/biosnoop: Add support for displaying block I/O pattern

### DIFF
--- a/man/man8/biosnoop.8
+++ b/man/man8/biosnoop.8
@@ -2,7 +2,7 @@
 .SH NAME
 biosnoop \- Trace block device I/O and print details incl. issuing PID.
 .SH SYNOPSIS
-.B biosnoop [\-h] [\-Q] [\-d DISK]
+.B biosnoop [\-h] [\-Q] [\-d DISK] [\-P]
 .SH DESCRIPTION
 This tools traces block device I/O (disk I/O), and prints a one-line summary
 for each I/O showing various details. These include the latency from the time of
@@ -32,6 +32,9 @@ Include a column showing the time spent queued in the OS.
 .TP
 \-d DISK
 Trace this disk only.
+.TP
+\-P
+Display block I/O pattern (sequential or random).
 .SH EXAMPLES
 .TP
 Trace all block device I/O and print a summary line per I/O:

--- a/tools/biosnoop_example.txt
+++ b/tools/biosnoop_example.txt
@@ -64,16 +64,18 @@ TIME(s)     COMM           PID    DISK    T SECTOR     BYTES  QUE(ms) LAT(ms)
 
 USAGE message:
 
-usage: biosnoop.py [-h] [-Q] [-d DISK]
+usage: biosnoop.py [-h] [-Q] [-d DISK] [-P]
 
 Trace block I/O
 
 optional arguments:
   -h, --help            show this help message and exit
   -Q, --queue           include OS queued time
-  -d DISK, --disk DISK  Trace this disk only
+  -d DISK, --disk DISK  trace this disk only
+  -P, --pattern         display block I/O pattern (sequential or random)
 
 examples:
     ./biosnoop           # trace all block I/O
     ./biosnoop -Q        # include OS queued time
     ./biosnoop -d sdc    # trace sdc only
+    ./biosnoop -P        # display block I/O pattern


### PR DESCRIPTION
biosnoop helps me a lot when analysing disk performance problems. Sometimes, I may need to know statistics of sequential/random I/O and it looks not convenient (do some post-processings by sector + bytes columes, or joint use biopattern & biosnoop).

This patch try to add an option -P, to display block I/O pattern as need.

For example (colume 'P', 'R' means random, 'S' means sequential):

```
# ./biosnoop -P

TIME(s)     COMM           PID     DISK      T SECTOR     BYTES  P LAT(ms)
11.269319   kworker/u16:4  2784813 vda       W 113638304  8192   R    5.49
11.270254   kworker/u16:4  2784813 vda       W 114100936  425984 R    6.68
11.272153   kworker/u16:4  2784813 vda       W 114101768  212992 S    8.51
11.272626   kworker/u16:4  2784813 vda       W 114102184  516096 S    8.92
12.844246   TsysAgent      2807548 vda       W 24798464   4096   S    0.80
...
13.432908   jbd2/vda1-8    422     vda       W 4565264    331776 R    5.11
13.433622   jbd2/vda1-8    422     vda       W 4565912    4096   S    0.68
```

Please take a look, thanks. @yonghong-song 