### PR TITLE
bcc: support building with external libbpf package and older uapi lin…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ examples/cgroupid/cgroupid
 # Output from docker builds
 scripts/docker/output/
 /output/
+
+# UAPI header generated for libbpf package-based builds
+src/cc/compat/linux/bpf.h

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -4,7 +4,11 @@
 include_directories(${PROJECT_BINARY_DIR}/src/cc)
 include_directories(${PROJECT_SOURCE_DIR}/src/cc)
 include_directories(${PROJECT_SOURCE_DIR}/src/cc/api)
+if (CMAKE_USE_LIBBPF_PACKAGE AND LIBBPF_FOUND)
+include_directories(${PROJECT_SOURCE_DIR}/src/cc/compat)
+else()
 include_directories(${PROJECT_SOURCE_DIR}/src/cc/libbpf/include/uapi)
+endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")

--- a/introspection/CMakeLists.txt
+++ b/introspection/CMakeLists.txt
@@ -3,7 +3,11 @@
 
 include_directories(${PROJECT_SOURCE_DIR}/src/cc)
 include_directories(${PROJECT_SOURCE_DIR}/src/cc/api)
+if (CMAKE_USE_LIBBPF_PACKAGE AND LIBBPF_FOUND)
+include_directories(${PROJECT_SOURCE_DIR}/src/cc/compat)
+else()
 include_directories(${PROJECT_SOURCE_DIR}/src/cc/libbpf/include/uapi)
+endif()
 
 option(INSTALL_INTROSPECTION "Install BPF introspection tools" ON)
 option(BPS_LINK_RT "Pass -lrt to linker when linking bps tool" ON)

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -15,6 +15,12 @@ endif (LIBDEBUGINFOD_FOUND)
 # todo: if check for kernel version
 if (CMAKE_USE_LIBBPF_PACKAGE AND LIBBPF_FOUND)
   include_directories(${LIBBPF_INCLUDE_DIRS})
+  # create up-to-date linux/bpf.h from virtual_bpf.h (remove string wrapper);
+  # when libbpf is built as a submodule we use its version of linux/bpf.h
+  # so this does similar for the libbpf package, removing reliance on the
+  # system uapi header which can be out of date.
+  execute_process(COMMAND sh -c "cd ${CMAKE_CURRENT_SOURCE_DIR}/compat/linux && grep -ve '\\*\\*\\*\\*' virtual_bpf.h > bpf.h")
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/compat)
 else()
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libbpf/include)
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/libbpf/include/uapi)

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -3,7 +3,11 @@
 
 include_directories(${PROJECT_SOURCE_DIR}/src/cc)
 include_directories(${PROJECT_SOURCE_DIR}/src/cc/api)
+if (CMAKE_USE_LIBBPF_PACKAGE AND LIBBPF_FOUND)
+include_directories(${PROJECT_SOURCE_DIR}/src/cc/compat)
+else()
 include_directories(${PROJECT_SOURCE_DIR}/src/cc/libbpf/include/uapi)
+endif()
 include_directories(${PROJECT_SOURCE_DIR}/tests/python/include)
 
 add_executable(test_static test_static.c)


### PR DESCRIPTION
…ux/bpf.h

When building bcc with a relatively new packaged libbpf (0.8.1) and -DCMAKE_USE_LIBBPF_PACKAGE:BOOL=TRUE, multiple compilation failures are encountered due the fact the system uapi header in /usr/include/linux/bpf.h is not very recent (this is often the case for distros, which sync it via a kernel headers package quite conservatively due to use by glibc).

With libbpf built via git submodule, the uapi header included in the libbpf package is used, so here a similar approach is proposed for the external package build.  Instead of having to sync another file the already present compat/linux/virtual_bpf.h is used; we copy it to compat/linux/bpf.h (eliminating the string prefix/suffix on first/last lines).

From there, we ensure that places that assume the presence of the libbpf git submodule point at compat/ as a location to find the uapi header.

Signed-off-by: Alan Maguire <alan.maguire@oracle.com>