### PR TITLE
Adding bpf_ringbuf support to oomkill

### DIFF
--- a/libbpf-tools/compat.h
+++ b/libbpf-tools/compat.h
@@ -7,6 +7,8 @@
 #include <sys/types.h>
 #include <linux/bpf.h>
 
+#define POLL_TIMEOUT_MS 100
+
 struct bpf_buffer;
 struct bpf_map;
 

--- a/libbpf-tools/mountsnoop.c
+++ b/libbpf-tools/mountsnoop.c
@@ -24,7 +24,6 @@
 #include "btf_helpers.h"
 #include "trace_helpers.h"
 
-#define POLL_TIMEOUT_MS		100
 #define warn(...) fprintf(stderr, __VA_ARGS__)
 
 /* https://www.gnu.org/software/gnulib/manual/html_node/strerrorname_005fnp.html */

--- a/libbpf-tools/oomkill.bpf.c
+++ b/libbpf-tools/oomkill.bpf.c
@@ -1,29 +1,28 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2022 Jingxiang Zeng
+// Copyright (c) 2022 Krisztian Fekete
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
-
+#include "compat.bpf.h"
 #include "oomkill.h"
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-	__uint(key_size, sizeof(u32));
-	__uint(value_size, sizeof(u32));
-} events SEC(".maps");
 
 SEC("kprobe/oom_kill_process")
 int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 {
-	struct data_t data;
+	struct data_t *data;
 
-	data.fpid = bpf_get_current_pid_tgid() >> 32;
-	data.tpid = BPF_CORE_READ(oc, chosen, tgid);
-	data.pages = BPF_CORE_READ(oc, totalpages);
-	bpf_get_current_comm(&data.fcomm, sizeof(data.fcomm));
-	bpf_probe_read_kernel(&data.tcomm, sizeof(data.tcomm), BPF_CORE_READ(oc, chosen, comm));
-	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &data, sizeof(data));
+	data = reserve_buf(sizeof(*data));
+	if (!data)
+		return 0;
+
+	data->fpid = bpf_get_current_pid_tgid() >> 32;
+	data->tpid = BPF_CORE_READ(oc, chosen, tgid);
+	data->pages = BPF_CORE_READ(oc, totalpages);
+	bpf_get_current_comm(&data->fcomm, sizeof(data->fcomm));
+	bpf_probe_read_kernel(&data->tcomm, sizeof(data->tcomm), BPF_CORE_READ(oc, chosen, comm));
+	submit_buf(ctx, data, sizeof(*data));
 	return 0;
 }
 

--- a/libbpf-tools/oomkill.c
+++ b/libbpf-tools/oomkill.c
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 // Copyright (c) 2022 Jingxiang Zeng
+// Copyright (c) 2022 Krisztian Fekete
 //
 // Based on oomkill(8) from BCC by Brendan Gregg.
 // 13-Jan-2022   Jingxiang Zeng   Created this.
+// 17-Oct-2022   Krisztian Fekete Edited this.
 #include <argp.h>
 #include <errno.h>
 #include <signal.h>
@@ -15,11 +17,10 @@
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 #include "oomkill.skel.h"
+#include "compat.h"
 #include "oomkill.h"
 #include "btf_helpers.h"
 #include "trace_helpers.h"
-
-#define PERF_POLL_TIMEOUT_MS	100
 
 static volatile sig_atomic_t exiting = 0;
 
@@ -57,7 +58,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	return 0;
 }
 
-static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+static int handle_event(void *ctx, void *data, size_t len)
 {
 	FILE *f;
 	char buf[256];
@@ -83,6 +84,8 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	else
 		printf("%s Triggered by PID %d (\"%s\"), OOM kill of PID %d (\"%s\"), %lld pages\n",
 			ts, e->fpid, e->fcomm, e->tpid, e->tcomm, e->pages);
+
+	return 0;
 }
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
@@ -110,7 +113,7 @@ int main(int argc, char **argv)
 		.parser = parse_arg,
 		.doc = argp_program_doc,
 	};
-	struct perf_buffer *pb = NULL;
+	struct bpf_buffer *buf = NULL;
 	struct oomkill_bpf *obj;
 	int err;
 
@@ -133,6 +136,13 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	buf = bpf_buffer__new(obj->maps.events, obj->maps.heap);
+	if (!buf) {
+		err = -errno;
+		warn("failed to create ring/perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
 	err = oomkill_bpf__load(obj);
 	if (err) {
 		fprintf(stderr, "failed to load BPF object: %d\n", err);
@@ -145,11 +155,9 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), 64,
-			      handle_event, handle_lost_events, NULL, NULL);
-	if (!pb) {
-		err = -errno;
-		fprintf(stderr, "failed to open perf buffer: %d\n", err);
+	err = bpf_buffer__open(buf, handle_event, handle_lost_events, NULL);
+	if (err) {
+		fprintf(stderr, "failed to open ring/perf buffer: %d\n", err);
 		goto cleanup;
 	}
 
@@ -162,9 +170,9 @@ int main(int argc, char **argv)
 	printf("Tracing OOM kills... Ctrl-C to stop.\n");
 
 	while (!exiting) {
-		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		err = bpf_buffer__poll(buf, POLL_TIMEOUT_MS);
 		if (err < 0 && err != -EINTR) {
-			fprintf(stderr, "error polling perf buffer: %d\n", err);
+			fprintf(stderr, "error polling ring/perf buffer: %d\n", err);
 			goto cleanup;
 		}
 		/* reset err to return 0 if exiting */
@@ -172,7 +180,7 @@ int main(int argc, char **argv)
 	}
 
 cleanup:
-	perf_buffer__free(pb);
+	bpf_buffer__free(buf);
 	oomkill_bpf__destroy(obj);
 	cleanup_core_btf(&open_opts);
 


### PR DESCRIPTION
This enables using ringbuf on recent kernel versions with oomkill by leveraging the changes of https://github.com/iovisor/bcc/pull/4262.

Additionally, this moves `POLL_TIMEOUT_MS` to `compat.h` for oomkill and for the previously migrated mountsnoop example, as presumably all the examples using this header would use this renamed variable.
This was a good point suggested by @eiffel-fl.

I have performed multiple tests, and the changes are working:

```console
Tracing OOM kills... Ctrl-C to stop.
12:36:41 Triggered by PID 3731 ("bash"), OOM kill of PID 3731 ("coredns"), 7702597 pages, loadavg: 1.06 0.39 0.19 3/474 8068
12:36:41 Triggered by PID 3731 ("bash"), OOM kill of PID 3731 ("bash"), 7702597 pages, loadavg: 1.06 0.39 0.19 4/474 8068
```