### PR TITLE
libbpf-tools: Add new feature doublefree

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -16,6 +16,7 @@
 /capable
 /cpudist
 /cpufreq
+/doublefree
 /drsnoop
 /execsnoop
 /exitsnoop

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -54,6 +54,7 @@ APPS = \
 	capable \
 	cpudist \
 	cpufreq \
+	doublefree \
 	drsnoop \
 	execsnoop \
 	exitsnoop \

--- a/libbpf-tools/doublefree.bpf.c
+++ b/libbpf-tools/doublefree.bpf.c
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright 2022 LG Electronics Inc. */
+#include <vmlinux.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include "doublefree.h"
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+} events SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, struct doublefree_info_t);
+	__uint(max_entries, MAX_ENTRIES);
+} allocs SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, u32);
+	__uint(max_entries, MAX_ENTRIES);
+} frees SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, u64);
+	__uint(max_entries, MAX_ENTRIES);
+} memptrs SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
+	__type(key, u32);
+	__uint(max_entries, MAX_ENTRIES);
+} stack_traces SEC(".maps");
+
+static int gen_alloc_exit(struct pt_regs *ctx, u64 address)
+{
+	struct doublefree_info_t info = {};
+
+	if (!address)
+		return 0;
+
+	info.stackid = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
+	info.alloc_count = 1;
+	bpf_map_update_elem(&allocs, &address, &info, BPF_ANY);
+
+	return 0;
+}
+
+static int gen_free_enter(struct pt_regs *ctx, void *address)
+{
+	int stackid = 0;
+	u64 addr = (u64)address;
+	struct event event = {};
+	struct doublefree_info_t *info = bpf_map_lookup_elem(&allocs, &addr);
+
+	if (!info)
+		return 0;
+
+	stackid = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
+
+	info->alloc_count--;
+	if (info->alloc_count == 0) {
+		bpf_map_update_elem(&frees, &addr, &stackid, BPF_ANY);
+	} else if (info->alloc_count < 0) {
+		event.stackid = stackid;
+		event.addr = addr;
+		bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event,
+				      sizeof(event));
+	}
+
+	return 0;
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(malloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uprobe")
+int BPF_UPROBE(free_entry, void *address)
+{
+	return gen_free_enter(ctx, address);
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(calloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uprobe")
+int BPF_UPROBE(realloc_entry, void *ptr, size_t size)
+{
+	return gen_free_enter(ctx, ptr);
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(realloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uprobe")
+int BPF_UPROBE(posix_memalign_entry, void **memptr, size_t alignment, size_t size)
+{
+	u64 memptr64 = (u64)(size_t)memptr;
+	u64 pid = bpf_get_current_pid_tgid();
+
+	bpf_map_update_elem(&memptrs, &pid, &memptr64, BPF_ANY);
+
+	return 0;
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(posix_memalign_return)
+{
+	void *addr = NULL;
+	u64 addr64 = 0;
+	u64 pid = bpf_get_current_pid_tgid();
+	u64 *memptr64 = bpf_map_lookup_elem(&memptrs, &pid);
+
+	if (!memptr64)
+		return 0;
+
+	bpf_map_delete_elem(&memptrs, &pid);
+
+	if (bpf_probe_read_user(&addr, sizeof(void *), (void *)(size_t)*memptr64))
+		return 0;
+
+	addr64 = (u64)(size_t)addr;
+
+	return gen_alloc_exit(ctx, addr64);
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(aligned_alloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(valloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(memalign_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(pvalloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uprobe")
+int BPF_UPROBE(reallocarray_entry, void *ptr, size_t nmemb, size_t size)
+{
+	return gen_free_enter(ctx, ptr);
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(reallocarray_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+char _license[] SEC("license") = "Dual BSD/GPL";

--- a/libbpf-tools/doublefree.bpf.c
+++ b/libbpf-tools/doublefree.bpf.c
@@ -1,0 +1,296 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright 2022 LG Electronics Inc. */
+#include <vmlinux.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include "doublefree.h"
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+} events SEC(".maps");
+
+/* Addresses the target currently owns, keyed by address. */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, int);
+	__uint(max_entries, MAX_ENTRIES);
+} allocs SEC(".maps");
+
+/* Addresses the target has already handed back to the allocator. */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, struct free_info);
+	__uint(max_entries, MAX_ENTRIES);
+} frees SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, u64);
+	__uint(max_entries, MAX_PENDING_CALLS);
+} memptrs SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, struct realloc_info);
+	__uint(max_entries, MAX_PENDING_CALLS);
+} realloc_args SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
+	__type(key, u32);
+	__uint(max_entries, MAX_ENTRIES);
+} stack_traces SEC(".maps");
+
+static __always_inline void report(struct pt_regs *ctx, u64 addr,
+				   int alloc_stackid, int free_stackid,
+				   int doublefree_stackid)
+{
+	struct event event = {};
+
+	event.addr = addr;
+	event.alloc_stackid = alloc_stackid;
+	event.free_stackid = free_stackid;
+	event.doublefree_stackid = doublefree_stackid;
+
+	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event,
+			      sizeof(event));
+}
+
+static int gen_alloc_exit(struct pt_regs *ctx, u64 address)
+{
+	int stackid;
+
+	if (!address)
+		return 0;
+
+	stackid = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
+	bpf_map_update_elem(&allocs, &address, &stackid, BPF_ANY);
+
+	/*
+	 * The allocator handed this address out again, so the free recorded for
+	 * it is no longer the one a later free would double up on.
+	 */
+	bpf_map_delete_elem(&frees, &address);
+
+	return 0;
+}
+
+static int gen_free_enter(struct pt_regs *ctx, void *address)
+{
+	u64 addr = (u64)address;
+	int stackid;
+	struct free_info fi = {};
+	struct free_info *prev;
+	int *alloc_stackid;
+
+	if (!addr)
+		return 0;
+
+	alloc_stackid = bpf_map_lookup_elem(&allocs, &addr);
+	if (!alloc_stackid) {
+		/*
+		 * Not a live allocation: either a free was already recorded for
+		 * it, which makes this a double free, or it was allocated before
+		 * the probes were attached and nothing can be said about it.
+		 * Only the first case needs a stack trace, and the second is the
+		 * common one when attaching to a process that is already up, so
+		 * the walk is left until there is something to report.
+		 */
+		prev = bpf_map_lookup_elem(&frees, &addr);
+		if (!prev)
+			return 0;
+
+		stackid = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
+		report(ctx, addr, prev->alloc_stackid, prev->free_stackid,
+		       stackid);
+
+		return 0;
+	}
+
+	fi.alloc_stackid = *alloc_stackid;
+	fi.free_stackid = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
+
+	/*
+	 * BPF_NOEXIST makes the insert the atomic claim on this free. When two
+	 * threads free the same address concurrently exactly one of them wins
+	 * the insert, so the loser reports instead of both concluding that they
+	 * performed the legitimate free.
+	 */
+	if (bpf_map_update_elem(&frees, &addr, &fi, BPF_NOEXIST)) {
+		prev = bpf_map_lookup_elem(&frees, &addr);
+		/* No entry means the map is full, not that this is a bug. */
+		if (prev)
+			report(ctx, addr, prev->alloc_stackid,
+			       prev->free_stackid, fi.free_stackid);
+
+		return 0;
+	}
+
+	bpf_map_delete_elem(&allocs, &addr);
+
+	return 0;
+}
+
+/*
+ * A failed realloc() leaves the original block owned by the target, so the
+ * free accounted for on entry has to be rolled back. Without this the next
+ * free() of that block is reported as a double free.
+ */
+static int undo_free(u64 addr)
+{
+	struct free_info *fi = bpf_map_lookup_elem(&frees, &addr);
+	int alloc_stackid;
+
+	if (!fi)
+		return 0;
+
+	alloc_stackid = fi->alloc_stackid;
+	bpf_map_update_elem(&allocs, &addr, &alloc_stackid, BPF_ANY);
+	bpf_map_delete_elem(&frees, &addr);
+
+	return 0;
+}
+
+static int gen_realloc_enter(struct pt_regs *ctx, void *ptr, u64 size)
+{
+	u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct realloc_info ri = {};
+
+	ri.ptr = (u64)ptr;
+	ri.size = size;
+	bpf_map_update_elem(&realloc_args, &pid_tgid, &ri, BPF_ANY);
+
+	return gen_free_enter(ctx, ptr);
+}
+
+static int gen_realloc_exit(struct pt_regs *ctx, u64 address)
+{
+	u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct realloc_info *ri = bpf_map_lookup_elem(&realloc_args, &pid_tgid);
+	bool failed;
+	u64 ptr;
+
+	if (!ri)
+		return gen_alloc_exit(ctx, address);
+
+	ptr = ri->ptr;
+	/*
+	 * realloc() only reports failure for a non-zero size. For size zero
+	 * glibc frees the block and returns NULL, which is not a failure and
+	 * has to keep the free recorded on entry.
+	 */
+	failed = !address && ptr && ri->size;
+	bpf_map_delete_elem(&realloc_args, &pid_tgid);
+
+	if (failed)
+		return undo_free(ptr);
+
+	return gen_alloc_exit(ctx, address);
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(malloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uprobe")
+int BPF_UPROBE(free_entry, void *address)
+{
+	return gen_free_enter(ctx, address);
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(calloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uprobe")
+int BPF_UPROBE(realloc_entry, void *ptr, size_t size)
+{
+	return gen_realloc_enter(ctx, ptr, size);
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(realloc_return)
+{
+	return gen_realloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uprobe")
+int BPF_UPROBE(posix_memalign_entry, void **memptr, size_t alignment, size_t size)
+{
+	u64 memptr64 = (u64)(size_t)memptr;
+	u64 pid = bpf_get_current_pid_tgid();
+
+	bpf_map_update_elem(&memptrs, &pid, &memptr64, BPF_ANY);
+
+	return 0;
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(posix_memalign_return)
+{
+	void *addr = NULL;
+	u64 addr64 = 0;
+	u64 pid = bpf_get_current_pid_tgid();
+	u64 *memptr64 = bpf_map_lookup_elem(&memptrs, &pid);
+
+	if (!memptr64)
+		return 0;
+
+	bpf_map_delete_elem(&memptrs, &pid);
+
+	if (bpf_probe_read_user(&addr, sizeof(void *), (void *)(size_t)*memptr64))
+		return 0;
+
+	addr64 = (u64)(size_t)addr;
+
+	return gen_alloc_exit(ctx, addr64);
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(aligned_alloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(valloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(memalign_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(pvalloc_return)
+{
+	return gen_alloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+SEC("uprobe")
+int BPF_UPROBE(reallocarray_entry, void *ptr, size_t nmemb, size_t size)
+{
+	return gen_realloc_enter(ctx, ptr, (u64)nmemb * size);
+}
+
+SEC("uretprobe")
+int BPF_URETPROBE(reallocarray_return)
+{
+	return gen_realloc_exit(ctx, PT_REGS_RC(ctx));
+}
+
+char _license[] SEC("license") = "Dual BSD/GPL";

--- a/libbpf-tools/doublefree.c
+++ b/libbpf-tools/doublefree.c
@@ -1,0 +1,489 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright 2022 LG Electronics Inc. */
+#include <argp.h>
+#include <stdio.h>
+#include <signal.h>
+#include <time.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "doublefree.h"
+#include "doublefree.skel.h"
+#include "trace_helpers.h"
+#include "uprobe_helpers.h"
+
+#define STACK_DEPTH 127
+#define PERF_BUFFER_PAGES 16
+#define PERF_POLL_TIMEOUT_MS 10000
+#define CHECK_FAIL true
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
+
+#define p_debug(fmt, ...) __p(stderr, DEBUG, "DEBUG", fmt, ##__VA_ARGS__)
+#define p_info(fmt, ...) __p(stderr, INFO, "INFO", fmt, ##__VA_ARGS__)
+#define p_warn(fmt, ...) __p(stderr, WARN, "WARN", fmt, ##__VA_ARGS__)
+#define p_err(fmt, ...) __p(stderr, ERROR, "ERROR", fmt, ##__VA_ARGS__)
+
+#define UPROBE_ELEM(func_name, check_fail) \
+	{ \
+		.links = obj->links.func_name##_entry, \
+		.prog = obj->progs.func_name##_entry, \
+		.pid = env.pid, \
+		.name = #func_name, \
+		.lib_path = libc_path, \
+		.is_ret = false, \
+		.check = check_fail, \
+	},
+
+#define URETPROBE_ELEM(func_name, check_fail) \
+	{ \
+		.links = obj->links.func_name##_return, \
+		.prog = obj->progs.func_name##_return, \
+		.pid = env.pid, \
+		.name = #func_name, \
+		.lib_path = libc_path, \
+		.is_ret = true, \
+		.check = check_fail, \
+	},
+
+#define UPROBE_ELEMS(func_name, check_fail) \
+		UPROBE_ELEM(func_name, check_fail) \
+		URETPROBE_ELEM(func_name, check_fail)
+
+struct probe {
+	struct bpf_link *links;
+	struct bpf_program *prog;
+	pid_t pid;
+	const char *name;
+	const char *lib_path;
+	bool is_ret;
+	bool check;
+};
+
+enum log_level {
+	DEBUG,
+	INFO,
+	WARN,
+	ERROR,
+};
+
+static volatile sig_atomic_t exiting = 0;
+
+static struct env {
+	pid_t pid;
+	int stack_storage_size;
+	int perf_max_stack_depth;
+	bool verbose;
+	char *command;
+} env = {
+	.pid = -1,
+	.stack_storage_size = MAX_ENTRIES,
+	.perf_max_stack_depth = STACK_DEPTH,
+	.verbose = false,
+	.command = NULL,
+};
+
+const char *argp_program_version = "doublefree 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] = "Detect and report doublefree error.\n"
+"\n"
+"-c or -p is a mandatory option\n"
+"EXAMPLES:\n"
+"    doublefree -p 1234             # Detect doublefree on process id 1234\n"
+"    doublefree -c a.out            # Detect doublefree on a.out\n"
+"    doublefree -c 'a.out arg'      # Detect doublefree on a.out with argument\n";
+static const struct argp_option opts[] = {
+	{ "verbose", 'v', NULL, 0, "Verbose debug output", 0 },
+	{ "help", 'h', NULL, OPTION_HIDDEN, "Show the full help", 0 },
+	{ "pid", 'p', "PID", 0, "Detect doublefree on the specified process", 0 },
+	{ "command", 'c', "COMMAND", 0, "Execute the command and detect doublefree", 0 },
+	{},
+};
+
+static struct doublefree_bpf *obj = NULL;
+static struct syms *syms = NULL;
+static enum log_level log_level = ERROR;
+
+static void __p(FILE *outstream, enum log_level level, const char *level_str,
+		const char *fmt, ...)
+{
+	va_list ap;
+	time_t t;
+	struct tm *tm;
+	char timebuf[32];
+
+	if (level < log_level)
+		return;
+
+	t = time(NULL);
+	tm = localtime(&t);
+	strftime(timebuf, sizeof(timebuf), "%Y-%b-%d %H:%M:%S", tm);
+
+	va_start(ap, fmt);
+	fprintf(outstream, "%s %s ", timebuf, level_str);
+	vfprintf(outstream, fmt, ap);
+	fprintf(outstream, "\n");
+	va_end(ap);
+	fflush(outstream);
+}
+
+static void set_log_level(enum log_level level)
+{
+	log_level = level;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level,
+			   const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'p':
+		errno = 0;
+		env.pid = strtol(arg, NULL, 10);
+		if (errno || env.pid <= 0) {
+			p_err("Invalid PID: %s", arg);
+			argp_usage(state);
+		}
+		break;
+	case 'c':
+		env.command = strdup(arg);
+		if (!env.command) {
+			p_err("Failed to set command: %s", arg);
+			argp_usage(state);
+		}
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static pid_t fork_exec(char *cmd)
+{
+	int i = 0;
+	const char *delim = " ";
+	char **argv = NULL;
+	char *ptr = NULL;
+	char *filepath = NULL;
+	pid_t pid = 0;
+
+	if (!cmd) {
+		p_err("Invalid command");
+		return -1;
+	}
+
+	pid = fork();
+	if (pid > 0) {
+		/* Child process created */
+		return pid;
+	} else if (pid == 0) {
+		/* Child process executes followings */
+
+		/*
+		 * The worst-case number of tokens is (strlen + 1) / 2
+		 * (single-char args separated by spaces). +1 for the
+		 * NULL terminator required by execve().
+		 */
+		argv = calloc(strlen(cmd) / 2 + 2, sizeof(char *));
+		if (!argv) {
+			p_err("Failed to allocate memory");
+			_exit(1);
+		}
+
+		ptr = strtok(cmd, delim);
+		if (!ptr) {
+			p_err("Invalid command");
+			free(argv);
+			_exit(1);
+		}
+
+		filepath = ptr;
+		ptr = strtok(NULL, delim);
+		argv[i++] = filepath;
+		argv[i++] = ptr;
+		do {
+			ptr = strtok(NULL, delim);
+			argv[i++] = ptr;
+		} while (ptr);
+
+		execve(filepath, argv, NULL);
+		p_err("Failed to execute %s: %s", filepath, strerror(errno));
+		free(argv);
+		_exit(1);
+	}
+
+	return -1;
+}
+
+static int attach_uprobe(struct probe *probe)
+{
+	off_t func_off = get_elf_func_offset(probe->lib_path, probe->name);
+
+	if (probe->check && func_off < 0)
+		return -1;
+
+	probe->links = bpf_program__attach_uprobe(probe->prog,
+						  probe->is_ret,
+						  probe->pid,
+						  probe->lib_path,
+						  func_off);
+	if (probe->check && !probe->links) {
+		p_err("Failed to attach u[ret]probe %s: %s", probe->name, strerror(errno));
+		return -1;
+	}
+
+	return 0;
+}
+
+static int attach_uprobes(void)
+{
+	int i = 0;
+	int err = 0;
+	char libc_path[PATH_MAX] = {};
+	struct probe probes[] = {
+		URETPROBE_ELEM(malloc, CHECK_FAIL)
+		UPROBE_ELEM(free, CHECK_FAIL)
+		URETPROBE_ELEM(calloc, CHECK_FAIL)
+		UPROBE_ELEMS(realloc, CHECK_FAIL)
+		UPROBE_ELEMS(posix_memalign, CHECK_FAIL)
+		URETPROBE_ELEM(memalign, CHECK_FAIL)
+
+		URETPROBE_ELEM(aligned_alloc, !CHECK_FAIL)
+		URETPROBE_ELEM(valloc, !CHECK_FAIL)
+		URETPROBE_ELEM(pvalloc, !CHECK_FAIL)
+		UPROBE_ELEMS(reallocarray, !CHECK_FAIL)
+	};
+
+	err = get_pid_lib_path(env.pid, "c", libc_path, PATH_MAX);
+	if (err) {
+		p_err("Failed to find libc.so, err: %d", err);
+		return err;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(probes); ++i) {
+		err = attach_uprobe(&probes[i]);
+		if (err < 0)
+			return err;
+	}
+
+	return 0;
+}
+
+static void print_backtrace(int stackid) {
+	size_t i = 0;
+	int err = 0;
+	unsigned long *ip = NULL;
+	int sfd = bpf_map__fd(obj->maps.stack_traces);
+	struct sym_info sinfo = {};
+
+	ip = calloc(env.perf_max_stack_depth, sizeof(*ip));
+	if (!ip) {
+		p_err("Failed to allocate memory");
+		return;
+	}
+
+	err = bpf_map_lookup_elem(sfd, &stackid, ip);
+	if (err < 0) {
+		p_err("Failed to lookup elem on stack map: %s", strerror(errno));
+		free(ip);
+		return;
+	}
+
+	for (i = 0; i < env.perf_max_stack_depth && ip[i]; ++i) {
+		printf("\t#%zu %#016lx", i + 1, ip[i]);
+		err = syms__map_addr_dso(syms, ip[i], &sinfo);
+		if (!err) {
+			if (sinfo.sym_name)
+				printf(" %s+0x%lx (%s+0x%lx)",
+				       sinfo.sym_name, sinfo.sym_offset,
+				       sinfo.dso_name, sinfo.dso_offset);
+			else
+				printf(" [unknown] (%s+0x%lx)",
+				       sinfo.dso_name, sinfo.dso_offset);
+		}
+		printf("\n");
+	}
+	printf("\n");
+
+	free(ip);
+}
+
+static int get_alloc_stackid(int fd, unsigned long key) {
+	struct doublefree_info_t val = {};
+	int err = 0;
+
+	err = bpf_map_lookup_elem(fd, &key, &val);
+	if (err < 0) {
+		p_err("Failed to get stacktrace info: %s", strerror(errno));
+		return err;
+	}
+
+	return val.stackid;
+}
+
+static int get_free_stackid(int fd, unsigned long key) {
+	__u32 stackid = 0;
+	int err = 0;
+
+	err = bpf_map_lookup_elem(fd, &key, &stackid);
+	if (err < 0) {
+		p_err("Failed to get stacktrace info: %s", strerror(errno));
+		return err;
+	}
+
+	return (int)stackid;
+}
+
+static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+{
+	struct event *e = data;
+	int stackid = 0;
+	int allocs_fd = bpf_map__fd(obj->maps.allocs);
+	int frees_fd = bpf_map__fd(obj->maps.frees);
+
+	if (e->err == -1) {
+		p_err("Unexpected error occurred");
+		return;
+	}
+
+	printf("\nAllocation:\n");
+	stackid = get_alloc_stackid(allocs_fd, e->addr);
+	if (stackid >= 0)
+		print_backtrace(stackid);
+
+	printf("First free:\n");
+	stackid = get_free_stackid(frees_fd, e->addr);
+	if (stackid >= 0)
+		print_backtrace(stackid);
+
+	printf("Second free:\n");
+	print_backtrace(e->stackid);
+}
+
+static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	p_err("Lost %llu events on CPU #%d!", lost_cnt, cpu);
+}
+
+int main(int argc, char **argv)
+{
+	int err = 0;
+	struct syms_cache *syms_cache = NULL;
+	struct perf_buffer *pb = NULL;
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+
+	set_log_level(INFO);
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	if (env.verbose)
+		set_log_level(DEBUG);
+
+	if (env.command != NULL) {
+		if (env.pid != -1) {
+			p_err("Use either -c or -p only");
+			return -1;
+		}
+		env.pid = fork_exec(env.command);
+		if (env.pid < 0) {
+			p_err("Failed to spawn child process");
+			return -1;
+		}
+		p_info("Execute command: %s(pid %d)", env.command, env.pid);
+	}
+
+	if (env.pid == -1) {
+		p_err("-c or -p is a mandatory option");
+		return -1;
+	}
+
+	libbpf_set_print(libbpf_print_fn);
+
+	obj = doublefree_bpf__open();
+	if (!obj) {
+		p_err("Failed to open BPF object");
+		return -1;
+	}
+
+	bpf_map__set_value_size(obj->maps.stack_traces,
+				env.perf_max_stack_depth * sizeof(__u64));
+	bpf_map__set_max_entries(obj->maps.stack_traces,
+				 env.stack_storage_size);
+
+	err = doublefree_bpf__load(obj);
+	if (err) {
+		p_err("Failed to load BPF object: %d", err);
+		return -1;
+	}
+
+	err = attach_uprobes();
+	if (err)
+		return -1;
+
+	/*
+	 * The symbols are pre-set as global variables and used in the event
+	 * handler. If a doublefree error occurs, causing the target process to
+	 * terminate, it becomes impossible to obtain symbols from the
+	 * terminated process.
+	 */
+	syms_cache = syms_cache__new(0);
+	if (!syms_cache) {
+		p_warn("Failed to load symbol");
+	} else {
+		syms = syms_cache__get_syms(syms_cache, env.pid);
+		if (!syms)
+			p_warn("Failed to get symbol");
+	}
+
+	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), PERF_BUFFER_PAGES,
+			      handle_event, handle_lost_events, NULL, NULL);
+	if (!pb) {
+		p_err("Failed to open perf buffer: %s", strerror(errno));
+		return -1;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		p_err("Failed to set signal handler: %s", strerror(errno));
+		return -1;
+	}
+
+	printf("Tracing doublefree... Hit Ctrl-C to stop\n");
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && err != -EINTR) {
+			p_err("Failed to poll perf buffer: %d", err);
+			break;
+		}
+	}
+
+	/* cleanup */
+	perf_buffer__free(pb);
+	syms_cache__free(syms_cache);
+	doublefree_bpf__destroy(obj);
+	free(env.command);
+
+	return 0;
+}

--- a/libbpf-tools/doublefree.c
+++ b/libbpf-tools/doublefree.c
@@ -1,0 +1,643 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright 2022 LG Electronics Inc. */
+#include <argp.h>
+#include <errno.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "doublefree.h"
+#include "doublefree.skel.h"
+#include "trace_helpers.h"
+#include "uprobe_helpers.h"
+
+#define STACK_DEPTH 127
+#define PERF_BUFFER_PAGES 16
+/*
+ * Short enough that the target exiting is noticed promptly, since the poll is
+ * also where the target's liveness is checked.
+ */
+#define PERF_POLL_TIMEOUT_MS 1000
+#define PERF_DRAIN_TIMEOUT_MS 100
+/* Generous bound on the syscalls the dynamic linker needs to map libc. */
+#define MAX_STARTUP_SYSCALLS 1024
+#define CHECK_FAIL true
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
+
+#define p_info(fmt, ...) __p(stderr, INFO, "INFO", fmt, ##__VA_ARGS__)
+#define p_warn(fmt, ...) __p(stderr, WARN, "WARN", fmt, ##__VA_ARGS__)
+#define p_err(fmt, ...) __p(stderr, ERROR, "ERROR", fmt, ##__VA_ARGS__)
+
+#define UPROBE_ELEM(func_name, check_fail) \
+	{ \
+		.link = &obj->links.func_name##_entry, \
+		.prog = obj->progs.func_name##_entry, \
+		.pid = env.pid, \
+		.name = #func_name, \
+		.lib_path = libc_path, \
+		.is_ret = false, \
+		.check = check_fail, \
+	},
+
+#define URETPROBE_ELEM(func_name, check_fail) \
+	{ \
+		.link = &obj->links.func_name##_return, \
+		.prog = obj->progs.func_name##_return, \
+		.pid = env.pid, \
+		.name = #func_name, \
+		.lib_path = libc_path, \
+		.is_ret = true, \
+		.check = check_fail, \
+	},
+
+#define UPROBE_ELEMS(func_name, check_fail) \
+		UPROBE_ELEM(func_name, check_fail) \
+		URETPROBE_ELEM(func_name, check_fail)
+
+struct probe {
+	/*
+	 * Points at the skeleton's link so destroying the skeleton detaches the
+	 * probe; keeping the link only in this array would leak the attachment.
+	 */
+	struct bpf_link **link;
+	struct bpf_program *prog;
+	pid_t pid;
+	const char *name;
+	const char *lib_path;
+	bool is_ret;
+	bool check;
+};
+
+enum log_level {
+	INFO,
+	WARN,
+	ERROR,
+};
+
+static volatile sig_atomic_t exiting = 0;
+
+static struct env {
+	pid_t pid;
+	int stack_storage_size;
+	int perf_max_stack_depth;
+	bool verbose;
+	char *command;
+} env = {
+	.pid = -1,
+	.stack_storage_size = MAX_ENTRIES,
+	.perf_max_stack_depth = STACK_DEPTH,
+	.verbose = false,
+	.command = NULL,
+};
+
+const char *argp_program_version = "doublefree 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] = "Detect and report double free error.\n"
+"\n"
+"-c or -p is a mandatory option\n"
+"EXAMPLES:\n"
+"    doublefree -p 1234             # Detect double free on process id 1234\n"
+"    doublefree -c a.out            # Detect double free on a.out\n"
+"    doublefree -c 'a.out arg'      # Detect double free on a.out with argument\n";
+static const struct argp_option opts[] = {
+	{ "verbose", 'v', NULL, 0, "Verbose debug output", 0 },
+	{ "help", 'h', NULL, OPTION_HIDDEN, "Show the full help", 0 },
+	{ "pid", 'p', "PID", 0, "Detect double free on the specified process", 0 },
+	{ "command", 'c', "COMMAND", 0, "Execute the command and detect double free", 0 },
+	{},
+};
+
+static struct doublefree_bpf *obj = NULL;
+static struct syms *syms = NULL;
+static enum log_level log_level = ERROR;
+/* Set once the child is running on its own and no longer ptrace-stopped. */
+static bool child_detached = false;
+static bool child_exited = false;
+
+static void __p(FILE *outstream, enum log_level level, const char *level_str,
+		const char *fmt, ...)
+{
+	va_list ap;
+	time_t t;
+	struct tm *tm;
+	char timebuf[32];
+
+	if (level < log_level)
+		return;
+
+	t = time(NULL);
+	tm = localtime(&t);
+	strftime(timebuf, sizeof(timebuf), "%Y-%b-%d %H:%M:%S", tm);
+
+	va_start(ap, fmt);
+	fprintf(outstream, "%s %s ", timebuf, level_str);
+	vfprintf(outstream, fmt, ap);
+	fprintf(outstream, "\n");
+	va_end(ap);
+	fflush(outstream);
+}
+
+static void set_log_level(enum log_level level)
+{
+	log_level = level;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level,
+			   const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'p':
+		errno = 0;
+		env.pid = strtol(arg, NULL, 10);
+		if (errno || env.pid <= 0) {
+			p_err("Invalid PID: %s", arg);
+			argp_usage(state);
+		}
+		break;
+	case 'c':
+		env.command = strdup(arg);
+		if (!env.command) {
+			p_err("Failed to set command: %s", arg);
+			argp_usage(state);
+		}
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+/*
+ * Spawn the command and leave it stopped on the execve() trap. The target has
+ * not run a single instruction yet, so the caller can resolve its mappings and
+ * attach the uprobes without racing it, and no allocation is missed. Without
+ * this the target has to be made to sleep before it allocates anything.
+ */
+static pid_t fork_exec_stopped(char *cmd)
+{
+	int i = 0;
+	int status = 0;
+	const char *delim = " ";
+	char **argv = NULL;
+	char *ptr = NULL;
+	char *filepath = NULL;
+	pid_t pid = 0;
+
+	if (!cmd) {
+		p_err("Invalid command");
+		return -1;
+	}
+
+	pid = fork();
+	if (pid < 0) {
+		p_err("Failed to fork: %s", strerror(errno));
+		return -1;
+	}
+
+	if (pid == 0) {
+		/* Child process executes followings */
+
+		/*
+		 * Ask to be stopped once execve() has replaced the image, so
+		 * the parent can attach before any target code runs.
+		 */
+		if (ptrace(PTRACE_TRACEME, 0, NULL, NULL)) {
+			p_err("Failed to trace itself: %s", strerror(errno));
+			_exit(1);
+		}
+
+		/*
+		 * The worst-case number of tokens is (strlen + 1) / 2
+		 * (single-char args separated by spaces). +1 for the
+		 * NULL terminator required by execve().
+		 */
+		argv = calloc(strlen(cmd) / 2 + 2, sizeof(char *));
+		if (!argv) {
+			p_err("Failed to allocate memory");
+			_exit(1);
+		}
+
+		ptr = strtok(cmd, delim);
+		if (!ptr) {
+			p_err("Invalid command");
+			free(argv);
+			_exit(1);
+		}
+
+		filepath = ptr;
+		ptr = strtok(NULL, delim);
+		argv[i++] = filepath;
+		argv[i++] = ptr;
+		do {
+			ptr = strtok(NULL, delim);
+			argv[i++] = ptr;
+		} while (ptr);
+
+		execve(filepath, argv, NULL);
+		p_err("Failed to execute %s: %s", filepath, strerror(errno));
+		free(argv);
+		_exit(1);
+	}
+
+	/* Parent process waits for the child to stop on the execve() trap. */
+	if (waitpid(pid, &status, 0) < 0) {
+		p_err("Failed to wait for %s: %s", cmd, strerror(errno));
+		return -1;
+	}
+
+	if (!WIFSTOPPED(status)) {
+		p_err("Failed to execute %s", cmd);
+		return -1;
+	}
+
+	return pid;
+}
+
+/* Let the target run now that the uprobes are in place. */
+static int resume_child(pid_t pid)
+{
+	if (ptrace(PTRACE_DETACH, pid, NULL, NULL)) {
+		p_err("Failed to resume %d: %s", pid, strerror(errno));
+		return -1;
+	}
+
+	child_detached = true;
+
+	return 0;
+}
+
+static bool target_alive(void)
+{
+	int status = 0;
+	pid_t ret;
+
+	if (!env.command) {
+		/* Not a child of this process, so ask the kernel about it. */
+		if (kill(env.pid, 0) && errno == ESRCH)
+			return false;
+
+		return true;
+	}
+
+	ret = waitpid(env.pid, &status, WNOHANG);
+	if (ret == 0)
+		return true;
+
+	child_exited = true;
+
+	return false;
+}
+
+/*
+ * At the execve() trap the dynamic linker has not mapped libc yet, so step the
+ * target by syscall until it shows up. That leaves the target stopped in the
+ * middle of dynamic linking, still ahead of any of the program's own code, and
+ * unlike a breakpoint on the entry point it needs no architecture-specific trap
+ * instruction.
+ */
+static int wait_lib_loaded(pid_t pid, const char *lib, char *path, size_t path_sz)
+{
+	int i = 0;
+	int sig = 0;
+	int status = 0;
+
+	for (i = 0; i < MAX_STARTUP_SYSCALLS; ++i) {
+		if (!get_pid_lib_text_path(pid, lib, path, path_sz))
+			return 0;
+
+		if (ptrace(PTRACE_SYSCALL, pid, NULL, (void *)(long)sig)) {
+			p_err("Failed to step %d: %s", pid, strerror(errno));
+			return -1;
+		}
+
+		if (waitpid(pid, &status, 0) < 0) {
+			p_err("Failed to wait for %d: %s", pid, strerror(errno));
+			return -1;
+		}
+
+		if (!WIFSTOPPED(status)) {
+			p_err("Process %d exited while loading lib%s", pid, lib);
+			return -1;
+		}
+
+		/* Forward whatever is not the syscall trap itself. */
+		sig = WSTOPSIG(status);
+		if (sig == SIGTRAP)
+			sig = 0;
+	}
+
+	p_err("lib%s was not loaded by %d", lib, pid);
+
+	return -1;
+}
+
+static int resolve_libc_path(char *path, size_t path_sz)
+{
+	if (env.command)
+		return wait_lib_loaded(env.pid, "c", path, path_sz);
+
+	if (get_pid_lib_text_path(env.pid, "c", path, path_sz)) {
+		p_err("Failed to find libc.so in process %d", env.pid);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int attach_uprobe(struct probe *probe)
+{
+	off_t func_off = get_elf_func_offset(probe->lib_path, probe->name);
+
+	if (probe->check && func_off < 0)
+		return -1;
+
+	*probe->link = bpf_program__attach_uprobe(probe->prog,
+						  probe->is_ret,
+						  probe->pid,
+						  probe->lib_path,
+						  func_off);
+	if (probe->check && !*probe->link) {
+		p_err("Failed to attach u[ret]probe %s: %s", probe->name, strerror(errno));
+		return -1;
+	}
+
+	return 0;
+}
+
+static int attach_uprobes(const char *libc_path)
+{
+	int i = 0;
+	int err = 0;
+	struct probe probes[] = {
+		URETPROBE_ELEM(malloc, CHECK_FAIL)
+		UPROBE_ELEM(free, CHECK_FAIL)
+		URETPROBE_ELEM(calloc, CHECK_FAIL)
+		UPROBE_ELEMS(realloc, CHECK_FAIL)
+		UPROBE_ELEMS(posix_memalign, CHECK_FAIL)
+		URETPROBE_ELEM(memalign, CHECK_FAIL)
+
+		URETPROBE_ELEM(aligned_alloc, !CHECK_FAIL)
+		URETPROBE_ELEM(valloc, !CHECK_FAIL)
+		URETPROBE_ELEM(pvalloc, !CHECK_FAIL)
+		UPROBE_ELEMS(reallocarray, !CHECK_FAIL)
+	};
+
+	for (i = 0; i < ARRAY_SIZE(probes); ++i) {
+		err = attach_uprobe(&probes[i]);
+		if (err < 0)
+			return err;
+	}
+
+	return 0;
+}
+
+static void print_backtrace(int stackid)
+{
+	size_t i = 0;
+	int err = 0;
+	unsigned long *ip = NULL;
+	int sfd = bpf_map__fd(obj->maps.stack_traces);
+	struct sym_info sinfo = {};
+
+	if (stackid < 0) {
+		printf("\t[stack trace unavailable]\n\n");
+		return;
+	}
+
+	ip = calloc(env.perf_max_stack_depth, sizeof(*ip));
+	if (!ip) {
+		p_err("Failed to allocate memory");
+		return;
+	}
+
+	err = bpf_map_lookup_elem(sfd, &stackid, ip);
+	if (err < 0) {
+		p_err("Failed to lookup stack id %d: %s", stackid, strerror(errno));
+		free(ip);
+		return;
+	}
+
+	for (i = 0; i < env.perf_max_stack_depth && ip[i]; ++i) {
+		printf("\t#%zu %#016lx", i + 1, ip[i]);
+		err = syms__map_addr_dso(syms, ip[i], &sinfo);
+		if (!err) {
+			if (sinfo.sym_name)
+				printf(" %s+0x%lx (%s+0x%lx)",
+				       sinfo.sym_name, sinfo.sym_offset,
+				       sinfo.dso_name, sinfo.dso_offset);
+			else
+				printf(" [unknown] (%s+0x%lx)",
+				       sinfo.dso_name, sinfo.dso_offset);
+		}
+		printf("\n");
+	}
+	printf("\n");
+
+	free(ip);
+}
+
+static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+{
+	const struct event *e = data;
+
+	printf("\nDouble free detected on %#llx\n", e->addr);
+
+	printf("\nAllocation:\n");
+	print_backtrace(e->alloc_stackid);
+
+	printf("First free:\n");
+	print_backtrace(e->free_stackid);
+
+	printf("Second free:\n");
+	print_backtrace(e->doublefree_stackid);
+}
+
+static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	p_err("Lost %llu events on CPU #%d!", lost_cnt, cpu);
+}
+
+int main(int argc, char **argv)
+{
+	int err = 0;
+	int ret = 0;
+	char libc_path[PATH_MAX] = {};
+	struct syms_cache *syms_cache = NULL;
+	struct perf_buffer *pb = NULL;
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+
+	set_log_level(INFO);
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	if (env.command && env.pid != -1) {
+		p_err("Use either -c or -p only");
+		ret = -1;
+		goto cleanup;
+	}
+
+	if (!env.command && env.pid == -1) {
+		p_err("-c or -p is a mandatory option");
+		ret = -1;
+		goto cleanup;
+	}
+
+	if (env.command) {
+		env.pid = fork_exec_stopped(env.command);
+		if (env.pid < 0) {
+			p_err("Failed to spawn child process");
+			ret = -1;
+			goto cleanup;
+		}
+		p_info("Execute command: %s(pid %d)", env.command, env.pid);
+	}
+
+	libbpf_set_print(libbpf_print_fn);
+
+	obj = doublefree_bpf__open();
+	if (!obj) {
+		p_err("Failed to open BPF object");
+		ret = -1;
+		goto cleanup;
+	}
+
+	bpf_map__set_value_size(obj->maps.stack_traces,
+				env.perf_max_stack_depth * sizeof(__u64));
+	bpf_map__set_max_entries(obj->maps.stack_traces,
+				 env.stack_storage_size);
+
+	err = doublefree_bpf__load(obj);
+	if (err) {
+		p_err("Failed to load BPF object: %d", err);
+		ret = -1;
+		goto cleanup;
+	}
+
+	/*
+	 * With -c this also walks the target up to the point where libc is
+	 * mapped, so the uprobes and the symbol cache below both see the real
+	 * target image rather than the pre-execve() one.
+	 */
+	err = resolve_libc_path(libc_path, sizeof(libc_path));
+	if (err) {
+		ret = -1;
+		goto cleanup;
+	}
+
+	err = attach_uprobes(libc_path);
+	if (err) {
+		ret = -1;
+		goto cleanup;
+	}
+
+	/*
+	 * The symbols are pre-set as global variables and used in the event
+	 * handler. If a double free error occurs, causing the target process to
+	 * terminate, it becomes impossible to obtain symbols from the
+	 * terminated process.
+	 */
+	syms_cache = syms_cache__new(0);
+	if (!syms_cache) {
+		p_warn("Failed to load symbol");
+	} else {
+		syms = syms_cache__get_syms(syms_cache, env.pid);
+		if (!syms)
+			p_warn("Failed to get symbol");
+	}
+
+	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), PERF_BUFFER_PAGES,
+			      handle_event, handle_lost_events, NULL, NULL);
+	if (!pb) {
+		p_err("Failed to open perf buffer: %s", strerror(errno));
+		ret = -1;
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		p_err("Failed to set signal handler: %s", strerror(errno));
+		ret = -1;
+		goto cleanup;
+	}
+
+	if (env.command && resume_child(env.pid)) {
+		ret = -1;
+		goto cleanup;
+	}
+
+	printf("Tracing double free... Hit Ctrl-C to stop\n");
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && err != -EINTR) {
+			p_err("Failed to poll perf buffer: %d", err);
+			ret = -1;
+			break;
+		}
+
+		if (!target_alive()) {
+			p_info("Target process %d exited", env.pid);
+			break;
+		}
+	}
+
+	/*
+	 * A double free usually kills the target, so the report is the last
+	 * thing it produces. Drain whatever is still buffered before leaving.
+	 */
+	perf_buffer__poll(pb, PERF_DRAIN_TIMEOUT_MS);
+
+cleanup:
+	perf_buffer__free(pb);
+	syms_cache__free(syms_cache);
+	doublefree_bpf__destroy(obj);
+
+	if (env.command && env.pid > 0 && !child_exited) {
+		/*
+		 * The child is ours, so do not leave it running unobserved,
+		 * and reap it rather than leaving a zombie behind.
+		 */
+		if (!child_detached)
+			ptrace(PTRACE_DETACH, env.pid, NULL, NULL);
+
+		if (kill(env.pid, SIGTERM))
+			p_warn("Failed to signal %d: %s", env.pid, strerror(errno));
+		else if (waitpid(env.pid, NULL, 0) < 0)
+			p_warn("Failed to reap %d: %s", env.pid, strerror(errno));
+	}
+
+	free(env.command);
+
+	return ret;
+}

--- a/libbpf-tools/doublefree.h
+++ b/libbpf-tools/doublefree.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright 2022 LG Electronics Inc. */
+#ifndef __DOUBLEFREE_H
+#define __DOUBLEFREE_H
+
+#define MAX_ENTRIES 65536
+
+struct event {
+	int err; /* success: 0, failure: -1 */
+	int stackid;
+	__u64 addr;
+};
+
+struct doublefree_info_t {
+	int stackid;
+	/* allocated: 1, freed: 0, doublefreed: -1 */
+	int alloc_count;
+};
+
+#endif /* __DOUBLEFREE_H */

--- a/libbpf-tools/doublefree.h
+++ b/libbpf-tools/doublefree.h
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/* Copyright 2022 LG Electronics Inc. */
+#ifndef __DOUBLEFREE_H
+#define __DOUBLEFREE_H
+
+#define MAX_ENTRIES 65536
+/*
+ * An entry in the pending-call maps is keyed by pid_tgid and lives only for
+ * the duration of one allocator call, so the bound is the number of target
+ * threads inside such a call at once, not the number of allocations.
+ */
+#define MAX_PENDING_CALLS 1024
+
+/*
+ * A report carries every stack trace it needs. Looking them up in the BPF
+ * maps from user space would race with the target reusing the address, and
+ * the stack of an unrelated allocation would be printed.
+ */
+struct event {
+	__u64 addr;
+	int alloc_stackid;
+	int free_stackid;
+	int doublefree_stackid;
+};
+
+/*
+ * An address lives in 'allocs' while the target owns it and moves to 'frees'
+ * once it is handed back, so freeing it again is simply a hit in 'frees'.
+ */
+struct free_info {
+	int alloc_stackid;
+	int free_stackid;
+};
+
+/* In-flight realloc()/reallocarray() call, keyed by pid_tgid. */
+struct realloc_info {
+	__u64 ptr;
+	__u64 size;
+};
+
+#endif /* __DOUBLEFREE_H */

--- a/libbpf-tools/uprobe_helpers.c
+++ b/libbpf-tools/uprobe_helpers.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -50,27 +51,41 @@ int get_pid_binary_path(pid_t pid, char *path, size_t path_sz)
  * path to a library matching the name `lib` that is loaded into pid's address
  * space.
  */
-int get_pid_lib_path(pid_t pid, const char *lib, char *path, size_t path_sz)
+/*
+ * Find the mapping of a library in a process. With text_only the search skips
+ * every mapping that does not carry the library's code: the dynamic linker maps
+ * the read-only header first, and a caller that needs to resolve symbols has to
+ * wait for the segment that holds them. With quiet a miss reports nothing, for
+ * callers that poll a process while the linker is still bringing the library in.
+ */
+static int find_pid_lib_path(pid_t pid, const char *lib, char *path,
+			     size_t path_sz, bool text_only, bool quiet)
 {
 	FILE *maps;
 	char *p;
 	char proc_pid_maps[32];
 	char line_buf[1024];
 	char path_buf[1024];
+	char perm[8];
 	int err = -1;
 
 	if (snprintf(proc_pid_maps, sizeof(proc_pid_maps), "/proc/%d/maps", pid)
 	    >= sizeof(proc_pid_maps)) {
-		warn("snprintf /proc/PID/maps failed");
+		if (!quiet)
+			warn("snprintf /proc/PID/maps failed");
 		return -1;
 	}
 	maps = fopen(proc_pid_maps, "r");
 	if (!maps) {
-		warn("No such pid %d\n", pid);
+		if (!quiet)
+			warn("No such pid %d\n", pid);
 		return -1;
 	}
 	while (fgets(line_buf, sizeof(line_buf), maps)) {
-		if (sscanf(line_buf, "%*x-%*x %*s %*x %*s %*u %s", path_buf) != 1)
+		if (sscanf(line_buf, "%*x-%*x %7s %*x %*s %*u %1023s",
+			   perm, path_buf) != 2)
+			continue;
+		if (text_only && !strchr(perm, 'x'))
 			continue;
 		/* e.g. /usr/lib/x86_64-linux-gnu/libc-2.31.so */
 		p = strrchr(path_buf, '/');
@@ -85,8 +100,9 @@ int get_pid_lib_path(pid_t pid, const char *lib, char *path, size_t path_sz)
 		/* libraries can have - or . after the name */
 		if (*p != '.' && *p != '-')
 			continue;
-		if (strnlen(path_buf, 1024) >= path_sz) {
-			warn("path size too small\n");
+		if (strnlen(path_buf, sizeof(path_buf)) >= path_sz) {
+			if (!quiet)
+				warn("path size too small\n");
 			goto cleanup;
 		}
 		strcpy(path, path_buf);
@@ -94,10 +110,21 @@ int get_pid_lib_path(pid_t pid, const char *lib, char *path, size_t path_sz)
 		goto cleanup;
 	}
 
-	warn("Cannot find library %s\n", lib);
+	if (!quiet)
+		warn("Cannot find library %s\n", lib);
 cleanup:
 	fclose(maps);
 	return err;
+}
+
+int get_pid_lib_path(pid_t pid, const char *lib, char *path, size_t path_sz)
+{
+	return find_pid_lib_path(pid, lib, path, path_sz, false, false);
+}
+
+int get_pid_lib_text_path(pid_t pid, const char *lib, char *path, size_t path_sz)
+{
+	return find_pid_lib_path(pid, lib, path, path_sz, true, true);
 }
 
 /*

--- a/libbpf-tools/uprobe_helpers.h
+++ b/libbpf-tools/uprobe_helpers.h
@@ -9,6 +9,7 @@
 
 int get_pid_binary_path(pid_t pid, char *path, size_t path_sz);
 int get_pid_lib_path(pid_t pid, const char *lib, char *path, size_t path_sz);
+int get_pid_lib_text_path(pid_t pid, const char *lib, char *path, size_t path_sz);
 int resolve_binary_path(const char *binary, pid_t pid, char *path, size_t path_sz);
 off_t get_elf_func_offset(const char *path, const char *func);
 Elf *open_elf(const char *path, int *fd_close);


### PR DESCRIPTION
Add doublefree tool to detect double free. It could detect user level double
free error currently and can be expanded to detect kernel level double free
error. Followings are the usage and example.

Usage:
```
Usage: doublefree [OPTION...]
Detect and report doublefree error.

-c or -p is a mandatory option
EXAMPLES:
    doublefree -p 1234             # Detect doublefree on process id 1234
    doublefree -c a.out            # Detect doublefree on a.out
    doublefree -c 'a.out arg'      # Detect doublefree on a.out with argument

  -c, --command=COMMAND      Execute the command and detect doublefree
  -p, --pid=PID              Detect doublefree on the specified process
  -v, --verbose              Verbose debug output
  -?, --help                 Give this help list
      --usage                Give a short usage message
  -V, --version              Print program version

Mandatory or optional arguments to long options are also mandatory or optional
for any corresponding short options.

Report bugs to https://github.com/iovisor/bcc/tree/master/libbpf-tools.

```
Example:
```
$ cat doublefree_generator.c
#include <unistd.h>
#include <stdlib.h>

int* foo() {
  return (int*)malloc(sizeof(int));
}

void bar(int* p) {
  free(p);
}

int main(int argc, char* argv[]) {
  sleep(10);
  int *val = foo();
  *val = 33;
  bar(val);
  *val = 84;
  bar(val);
  return 0;
}
$ gcc doublefree_generator.c
$ sudo ./doublefree -c a.out
2024-May-15 22:30:24 INFO Execute command: a.out(pid 99584)
Tracing doublefree... Hit Ctrl-C to stop
free(): double free detected in tcache 2

Allocation:
        #1 0x00564d1455819b foo+0x12 (/home/bojun/doublefree/libbpf-tools/a.out+0x119b)
        #2 0x00564d145581e3 main+0x27 (/home/bojun/doublefree/libbpf-tools/a.out+0x11e3)
        #3 0x0070c4e9429d90 [unknown] (/usr/lib/x86_64-linux-gnu/libc.so.6+0x29d90)

First deallocation:
        #1 0x0070c4e94a53e0 free+0x0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa53e0)
        #2 0x00564d145581fd main+0x41 (/home/bojun/doublefree/libbpf-tools/a.out+0x11fd)
        #3 0x0070c4e9429d90 [unknown] (/usr/lib/x86_64-linux-gnu/libc.so.6+0x29d90)

Second deallocation:
        #1 0x0070c4e94a53e0 free+0x0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa53e0)
        #2 0x00564d14558213 main+0x57 (/home/bojun/doublefree/libbpf-tools/a.out+0x1213)
        #3 0x0070c4e9429d90 [unknown] (/usr/lib/x86_64-linux-gnu/libc.so.6+0x29d90)

```