### PR TITLE
Fix file names being empty

### DIFF
--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -273,7 +273,7 @@ bpf_text_kfunc_body = """
 
     u64 tsp = bpf_ktime_get_ns();
 
-    bpf_probe_read_user(&data.name, sizeof(data.name), (void *)filename);
+    bpf_probe_read_user_str(&data.name, sizeof(data.name), (void *)filename);
     data.id    = id;
     data.ts    = tsp / 1000;
     data.uid   = bpf_get_current_uid_gid();

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -153,7 +153,7 @@ int trace_return(struct pt_regs *ctx)
     }
 
     bpf_probe_read_kernel(&data.comm, sizeof(data.comm), valp->comm);
-    bpf_probe_read_user(&data.name, sizeof(data.name), (void *)valp->fname);
+    bpf_probe_read_user_str(&data.name, sizeof(data.name), (void *)valp->fname);
     data.id = valp->id;
     data.ts = tsp / 1000;
     data.uid = bpf_get_current_uid_gid();


### PR DESCRIPTION
I have raised the issue at https://github.com/iovisor/bcc/issues/4292 

After changing the function, opensnoop.py no longer shows empty file names. But I am not sure why the results are different for each function.

## Tests
Run in background `sudo python opensnoop.py`, then issue `strace cat foobar` in another terminal.
Tested on kernel `5.4.0-105-generic` with `python2.7` and `python3.8`

### Before changes
```
$ sudo python opensnoop.py 
PID    COMM               FD ERR PATH
141983 sh                  3   0 /dev/null
141984 sh                  3   0 /etc/ld.so.cache
141984 sh                  3   0 /lib/x86_64-linux-gnu/libc.so.6
141984 sh                  3   0 /dev/null
141985 sh                  0   0 /dev/null
141985 strace              3   0 /etc/ld.so.cache
141985 strace              3   0 /lib/x86_64-linux-gnu/librt.so.1
141985 strace              3   0 /lib/x86_64-linux-gnu/libunwind-ptrace.so.0
141985 strace              3   0 /lib/x86_64-linux-gnu/libunwind-x86_64.so.8
141985 strace              3   0 
141985 strace              3   0 /lib/x86_64-linux-gnu/libpthread.so.0
141985 strace              3   0 /lib/x86_64-linux-gnu/liblzma.so.5
141985 strace              3   0 /lib/x86_64-linux-gnu/libunwind.so.8
141985 strace              3   0 /usr/lib/locale/locale-archive
141985 strace              3   0 /usr/share/locale/locale.alias
141985 strace             -1   2 /usr/share/locale/en_US.utf8/LC_MESSAGES/libc.mo
141985 strace             -1   2 /usr/share/locale/en_US/LC_MESSAGES/libc.mo
141985 strace             -1   2 /usr/share/locale/en.utf8/LC_MESSAGES/libc.mo
141985 strace             -1   2 /usr/share/locale/en/LC_MESSAGES/libc.mo
141985 strace             -1   2 /usr/share/locale-langpack/en_US.utf8/LC_MESSAGES/libc.mo
141985 strace             -1   2 /usr/share/locale-langpack/en_US/LC_MESSAGES/libc.mo
141985 strace             -1   2 /usr/share/locale-langpack/en.utf8/LC_MESSAGES/libc.mo
141985 strace             -1   2 /usr/share/locale-langpack/en/LC_MESSAGES/libc.mo
141988 cat                 3   0 /etc/ld.so.cache
141988 cat                 3   0 /lib/x86_64-linux-gnu/libc.so.6
141988 cat                 3   0 /usr/lib/locale/locale-archive
141988 cat                -1   2 foobar
141988 cat                 3   0 /usr/share/locale/locale.alias
141988 cat                -1   2 /usr/share/locale/en_US.utf8/LC_MESSAGES/libc.mo
141988 cat                -1   2 /usr/share/locale/en_US/LC_MESSAGES/libc.mo
141988 cat                -1   2 /usr/share/locale/en.utf8/LC_MESSAGES/libc.mo
141988 cat                -1   2 /usr/share/locale/en/LC_MESSAGES/libc.mo
141988 cat                -1   2 /usr/share/locale-langpack/en_US.utf8/LC_MESSAGES/libc.mo
141988 cat                -1   2 /usr/share/locale-langpack/en_US/LC_MESSAGES/libc.mo
141988 cat                -1   2 /usr/share/locale-langpack/en.utf8/LC_MESSAGES/libc.mo
141988 cat                -1   2 /usr/share/locale-langpack/en/LC_MESSAGES/libc.mo
1      systemd            29   0 /proc/141985/comm
1      systemd            29   0 /proc/141985/comm
1      systemd            29   0 /proc/141985/cgroup
1      systemd            -1   2 /sys/fs/cgroup/memory/user.slice/user-1000.slice/session-78.scope/memory.events
```


### After changes
```
$ sudo python opensnoop.py 
PID    COMM               FD ERR PATH
141965 sh                  3   0 /dev/null
141966 sh                  3   0 /etc/ld.so.cache
141966 sh                  3   0 /lib/x86_64-linux-gnu/libc.so.6
141966 sh                  3   0 /dev/null
141967 sh                  0   0 /dev/null
141967 strace              3   0 /etc/ld.so.cache
141967 strace              3   0 /lib/x86_64-linux-gnu/librt.so.1
141967 strace              3   0 /lib/x86_64-linux-gnu/libunwind-ptrace.so.0
141967 strace              3   0 /lib/x86_64-linux-gnu/libunwind-x86_64.so.8
141967 strace              3   0 /lib/x86_64-linux-gnu/libc.so.6
141967 strace              3   0 /lib/x86_64-linux-gnu/libpthread.so.0
141967 strace              3   0 /lib/x86_64-linux-gnu/liblzma.so.5
141967 strace              3   0 /lib/x86_64-linux-gnu/libunwind.so.8
141967 strace              3   0 /usr/lib/locale/locale-archive
141967 strace              3   0 /usr/share/locale/locale.alias
141967 strace             -1   2 /usr/share/locale/en_US.utf8/LC_MESSAGES/libc.mo
141967 strace             -1   2 /usr/share/locale/en_US/LC_MESSAGES/libc.mo
141967 strace             -1   2 /usr/share/locale/en.utf8/LC_MESSAGES/libc.mo
141967 strace             -1   2 /usr/share/locale/en/LC_MESSAGES/libc.mo
141967 strace             -1   2 /usr/share/locale-langpack/en_US.utf8/LC_MESSAGES/libc.mo
141967 strace             -1   2 /usr/share/locale-langpack/en_US/LC_MESSAGES/libc.mo
141967 strace             -1   2 /usr/share/locale-langpack/en.utf8/LC_MESSAGES/libc.mo
141967 strace             -1   2 /usr/share/locale-langpack/en/LC_MESSAGES/libc.mo
141970 cat                 3   0 /etc/ld.so.cache
141970 cat                 3   0 /lib/x86_64-linux-gnu/libc.so.6
141970 cat                 3   0 /usr/lib/locale/locale-archive
141970 cat                -1   2 foobar
141970 cat                 3   0 /usr/share/locale/locale.alias
141970 cat                -1   2 /usr/share/locale/en_US.utf8/LC_MESSAGES/libc.mo
141970 cat                -1   2 /usr/share/locale/en_US/LC_MESSAGES/libc.mo
141970 cat                -1   2 /usr/share/locale/en.utf8/LC_MESSAGES/libc.mo
141970 cat                -1   2 /usr/share/locale/en/LC_MESSAGES/libc.mo
141970 cat                -1   2 /usr/share/locale-langpack/en_US.utf8/LC_MESSAGES/libc.mo
141970 cat                -1   2 /usr/share/locale-langpack/en_US/LC_MESSAGES/libc.mo
141970 cat                -1   2 /usr/share/locale-langpack/en.utf8/LC_MESSAGES/libc.mo
141970 cat                -1   2 /usr/share/locale-langpack/en/LC_MESSAGES/libc.mo
1      systemd            29   0 /proc/141967/comm
1      systemd            29   0 /proc/141967/comm
1      systemd            29   0 /proc/141967/cgroup
1      systemd            -1   2 /sys/fs/cgroup/memory/user.slice/user-1000.slice/session-78.scope/memory.events
```

