### PR TITLE
Make warnings consistent by switching to fprintf everywhere in oomkill example

### DIFF
--- a/libbpf-tools/oomkill.c
+++ b/libbpf-tools/oomkill.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
 	buf = bpf_buffer__new(obj->maps.events, obj->maps.heap);
 	if (!buf) {
 		err = -errno;
-		warn("failed to create ring/perf buffer: %d\n", err);
+		fprintf(stderr, "failed to create ring/perf buffer: %d\n", err);
 		goto cleanup;
 	}
 


### PR DESCRIPTION
Fixing https://github.com/iovisor/bcc/pull/4282#discussion_r1004274603.