### PR TITLE
libbpf-tools/tcplife: fix filter by ports

### DIFF
--- a/libbpf-tools/tcplife.c
+++ b/libbpf-tools/tcplife.c
@@ -184,6 +184,7 @@ int main(int argc, char **argv)
 			obj->rodata->target_sports[i++] = port_num;
 			port = strtok(NULL, ",");
 		}
+		obj->rodata->filter_sport = true;
 	}
 
 	if (target_dports) {
@@ -194,6 +195,7 @@ int main(int argc, char **argv)
 			obj->rodata->target_dports[i++] = port_num;
 			port = strtok(NULL, ",");
 		}
+		obj->rodata->filter_dport = true;
 	}
 
 	err = tcplife_bpf__load(obj);


### PR DESCRIPTION
ebpf code depends on these variables when filtered by ports:

https://github.com/iovisor/bcc/blob/dcb34dc51a9336ff88c5a57305bd04758a25808c/libbpf-tools/tcplife.bpf.c#L60-L88