### PR TITLE
Add missing examples files

### DIFF
--- a/examples/networking/CMakeLists.txt
+++ b/examples/networking/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(EXAMPLE_FILES simulation.py)
-set(EXAMPLE_PROGRAMS simple_tc.py tc_perf_event.py)
+set(EXAMPLE_PROGRAMS simple_tc.py tc_perf_event.py net_monitor.py simulation.py sockmap.py)
 install(FILES ${EXAMPLE_FILES} DESTINATION share/bcc/examples/networking)
 install(PROGRAMS ${EXAMPLE_PROGRAMS} DESTINATION share/bcc/examples/networking)
 

--- a/examples/networking/CMakeLists.txt
+++ b/examples/networking/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(EXAMPLE_FILES simulation.py)
-set(EXAMPLE_PROGRAMS simple_tc.py tc_perf_event.py net_monitor.py simulation.py sockmap.py)
+set(EXAMPLE_PROGRAMS simple_tc.py tc_perf_event.py net_monitor.py sockmap.py)
 install(FILES ${EXAMPLE_FILES} DESTINATION share/bcc/examples/networking)
 install(PROGRAMS ${EXAMPLE_PROGRAMS} DESTINATION share/bcc/examples/networking)
 


### PR DESCRIPTION
Add missing examples files.
```
$ ls -la /usr/share/bcc/examples/networking/
total 56
drwxr-xr-x 8 root root 4096 Nov  2 18:28 .
drwxr-xr-x 5 root root 4096 Nov  2 18:28 ..
drwxr-xr-x 2 root root 4096 Nov  2 18:28 distributed_bridge
drwxr-xr-x 2 root root 4096 Nov  2 18:28 http_filter
drwxr-xr-x 2 root root 4096 Nov  2 18:28 neighbor_sharing
-rwxr-xr-x 1 root root 3826 Nov  2 18:12 net_monitor.py
-rwxr-xr-x 1 root root  852 Nov  2 18:12 simple_tc.py
-rwxr-xr-x 1 root root 5257 Nov  2 18:12 simulation.py
-rwxr-xr-x 1 root root 3549 Nov  2 18:12 sockmap.py
-rwxr-xr-x 1 root root 2583 Nov  2 18:12 tc_perf_event.py
drwxr-xr-x 2 root root 4096 Nov  2 18:28 tunnel_monitor
drwxr-xr-x 2 root root 4096 Nov  2 18:28 vlan_learning
drwxr-xr-x 2 root root 4096 Nov  2 18:28 xdp
```
