### PR TITLE
don't quit due to ensure_core_btf failure

### DIFF
--- a/libbpf-tools/bashreadline.c
+++ b/libbpf-tools/bashreadline.c
@@ -173,7 +173,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		warn("failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		goto cleanup;
 	}
 
 	obj = bashreadline_bpf__open_opts(&open_opts);

--- a/libbpf-tools/bindsnoop.c
+++ b/libbpf-tools/bindsnoop.c
@@ -207,7 +207,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = bindsnoop_bpf__open_opts(&open_opts);

--- a/libbpf-tools/biopattern.c
+++ b/libbpf-tools/biopattern.c
@@ -180,7 +180,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = biopattern_bpf__open_opts(&open_opts);

--- a/libbpf-tools/biotop.c
+++ b/libbpf-tools/biotop.c
@@ -47,6 +47,15 @@ struct vector {
 	void **elems;
 };
 
+static inline void *reallocarray_handwrite(void *ptr, size_t nmemb, size_t size)
+{
+        size_t total;
+        if (size == 0 || nmemb > ULONG_MAX / size)
+                return NULL;
+        total = nmemb * size;
+        return realloc(ptr, total);
+}
+
 int grow_vector(struct vector *vector) {
 	if (vector->nr >= vector->capacity) {
 		void **reallocated;
@@ -56,7 +65,7 @@ int grow_vector(struct vector *vector) {
 		else
 			vector->capacity *= 2;
 
-		reallocated = reallocarray(vector->elems, vector->capacity, sizeof(*vector->elems));
+		reallocated = reallocarray_handwrite(vector->elems, vector->capacity, sizeof(*vector->elems));
 		if (!reallocated)
 			return -1;
 

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -289,7 +289,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = execsnoop_bpf__open_opts(&open_opts);

--- a/libbpf-tools/exitsnoop.c
+++ b/libbpf-tools/exitsnoop.c
@@ -183,7 +183,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = exitsnoop_bpf__open_opts(&open_opts);

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -126,7 +126,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = filelife_bpf__open_opts(&open_opts);

--- a/libbpf-tools/filetop.c
+++ b/libbpf-tools/filetop.c
@@ -276,7 +276,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = filetop_bpf__open_opts(&open_opts);

--- a/libbpf-tools/fsdist.c
+++ b/libbpf-tools/fsdist.c
@@ -372,7 +372,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	skel = fsdist_bpf__open_opts(&open_opts);

--- a/libbpf-tools/fsslower.c
+++ b/libbpf-tools/fsslower.c
@@ -377,7 +377,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	skel = fsslower_bpf__open_opts(&open_opts);

--- a/libbpf-tools/funclatency.c
+++ b/libbpf-tools/funclatency.c
@@ -315,7 +315,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = funclatency_bpf__open_opts(&open_opts);

--- a/libbpf-tools/gethostlatency.c
+++ b/libbpf-tools/gethostlatency.c
@@ -240,7 +240,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = gethostlatency_bpf__open_opts(&open_opts);

--- a/libbpf-tools/llcstat.c
+++ b/libbpf-tools/llcstat.c
@@ -215,7 +215,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = llcstat_bpf__open_opts(&open_opts);

--- a/libbpf-tools/mountsnoop.c
+++ b/libbpf-tools/mountsnoop.c
@@ -267,7 +267,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = mountsnoop_bpf__open_opts(&open_opts);

--- a/libbpf-tools/oomkill.c
+++ b/libbpf-tools/oomkill.c
@@ -127,7 +127,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = oomkill_bpf__open_opts(&open_opts);

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -301,7 +301,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = opensnoop_bpf__open_opts(&open_opts);

--- a/libbpf-tools/runqlen.c
+++ b/libbpf-tools/runqlen.c
@@ -250,7 +250,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = runqlen_bpf__open_opts(&open_opts);

--- a/libbpf-tools/solisten.c
+++ b/libbpf-tools/solisten.c
@@ -154,7 +154,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = solisten_bpf__open_opts(&open_opts);

--- a/libbpf-tools/statsnoop.c
+++ b/libbpf-tools/statsnoop.c
@@ -144,7 +144,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = statsnoop_bpf__open_opts(&open_opts);

--- a/libbpf-tools/syscount.c
+++ b/libbpf-tools/syscount.c
@@ -409,7 +409,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = syscount_bpf__open_opts(&open_opts);

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -403,7 +403,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = tcpconnect_bpf__open_opts(&open_opts);

--- a/libbpf-tools/tcplife.c
+++ b/libbpf-tools/tcplife.c
@@ -164,7 +164,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = tcplife_bpf__open_opts(&open_opts);

--- a/libbpf-tools/tcpstates.c
+++ b/libbpf-tools/tcpstates.c
@@ -209,7 +209,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		warn("failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = tcpstates_bpf__open_opts(&open_opts);

--- a/libbpf-tools/tcpsynbl.c
+++ b/libbpf-tools/tcpsynbl.c
@@ -194,7 +194,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = tcpsynbl_bpf__open_opts(&open_opts);

--- a/libbpf-tools/tcptracer.c
+++ b/libbpf-tools/tcptracer.c
@@ -272,7 +272,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	obj = tcptracer_bpf__open_opts(&open_opts);

--- a/libbpf-tools/vfsstat.c
+++ b/libbpf-tools/vfsstat.c
@@ -159,7 +159,6 @@ int main(int argc, char **argv)
 	err = ensure_core_btf(&open_opts);
 	if (err) {
 		fprintf(stderr, "failed to fetch necessary BTF for CO-RE: %s\n", strerror(-err));
-		return 1;
 	}
 
 	skel = vfsstat_bpf__open();


### PR DESCRIPTION
Sometimes `ensure_core_btf()` failure is not fatal.
I upgraded CentOS 7 kernel to `5.4.221-1.el7.elrepo.x86_64`, extracted `vmlinux.h` via `bpftool` and built libbpf-tools.
Several tools fail to start:
```
$ sudo ./execsnoop
failed to fetch necessary BTF for CO-RE: Operation not supported
```
With this patch, these tool work as expected.
