### PR TITLE
libbpf-tools: Detect kernel/modules BTF using libbpf APIs

### DIFF
--- a/libbpf-tools/biotop.c
+++ b/libbpf-tools/biotop.c
@@ -23,6 +23,7 @@
 #include <bpf/bpf.h>
 #include "biotop.h"
 #include "biotop.skel.h"
+#include "compat.h"
 #include "trace_helpers.h"
 
 #define warn(...) fprintf(stderr, __VA_ARGS__)
@@ -56,7 +57,7 @@ int grow_vector(struct vector *vector) {
 		else
 			vector->capacity *= 2;
 
-		reallocated = reallocarray(vector->elems, vector->capacity, sizeof(*vector->elems));
+		reallocated = libbpf_reallocarray(vector->elems, vector->capacity, sizeof(*vector->elems));
 		if (!reallocated)
 			return -1;
 

--- a/libbpf-tools/vfsstat.c
+++ b/libbpf-tools/vfsstat.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
 	}
 
 	/* It fallbacks to kprobes when kernel does not support fentry. */
-	if (vmlinux_btf_exists() && fentry_can_attach("vfs_read", NULL)) {
+	if (fentry_can_attach("vfs_read", NULL)) {
 		bpf_program__set_autoload(skel->progs.kprobe_vfs_read, false);
 		bpf_program__set_autoload(skel->progs.kprobe_vfs_write, false);
 		bpf_program__set_autoload(skel->progs.kprobe_vfs_fsync, false);


### PR DESCRIPTION
In #4313, there are situations that ensure_core_btf is failed to detect kernel BTF existence. Let's switch to libbpf APIs to perform a best effort searching.

Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>