### PR TITLE
wakeuptime: remove unused global var `exiting`

### DIFF
--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -38,8 +38,6 @@ static struct env {
 	.duration = 99999999,
 };
 
-static volatile bool exiting;
-
 const char *argp_program_version = "offcputime 0.1";
 const char *argp_program_bug_address =
 	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";

--- a/libbpf-tools/wakeuptime.c
+++ b/libbpf-tools/wakeuptime.c
@@ -16,8 +16,6 @@
 #include "trace_helpers.h"
 #include <unistd.h>
 
-static volatile sig_atomic_t exiting = 0;
-
 struct env {
 	pid_t pid;
 	bool user_threads_only;
@@ -153,7 +151,6 @@ static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va
 
 static void sig_int(int signo)
 {
-	exiting = 1;
 }
 
 static void print_map(struct ksyms *ksyms, struct wakeuptime_bpf *obj)


### PR DESCRIPTION
It seems that the global signal var `exiting` is of no use here, this PR is going to remove it.