### PR TITLE
Fix libbpf-tools/cpufreq

### DIFF
--- a/libbpf-tools/cpufreq.c
+++ b/libbpf-tools/cpufreq.c
@@ -132,7 +132,7 @@ static void sig_handler(int sig)
 {
 }
 
-static int init_freqs_hmz(__u32 *freqs_mhz, int nr_cpus)
+static int init_freqs_mhz(__u32 *freqs_mhz, int nr_cpus)
 {
 	char path[64];
 	FILE *f;
@@ -233,7 +233,7 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	err = init_freqs_hmz(obj->bss->freqs_mhz, nr_cpus);
+	err = init_freqs_mhz(obj->bss->freqs_mhz, nr_cpus);
 	if (err) {
 		fprintf(stderr, "failed to init freqs\n");
 		goto cleanup;

--- a/libbpf-tools/cpufreq.c
+++ b/libbpf-tools/cpufreq.c
@@ -155,6 +155,11 @@ static int init_freqs_hmz(__u32 *freqs_mhz, int nr_cpus)
 			fclose(f);
 			return -1;
 		}
+		/*
+		 * scaling_cur_freq is in kHz. To be handled with
+		 * a small data size, it's converted in mHz.
+		 */
+		freqs_mhz[i] /= 1000;
 		fclose(f);
 	}
 

--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -973,6 +973,8 @@ void print_linear_hist(unsigned int *vals, int vals_size, unsigned int base,
 	printf("     %-13s : count     distribution\n", val_type);
 	for (i = idx_min; i <= idx_max; i++) {
 		val = vals[i];
+		if (!val)
+			continue;
 		printf("        %-10d : %-8d |", base + i * step, val);
 		print_stars(val, val_max, stars_max);
 		printf("|\n");


### PR DESCRIPTION
While trying the cpufreq tool under libbpf-tools, the improper initialization of data structure makes the result confusing, correct it, with an additional polish change for data display.