### PR TITLE
offcputime: Allow offcputime to run on old kernels.

### DIFF
--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -314,6 +314,12 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if (probe_tp_btf("sched_switch")) {
+		bpf_program__set_autoload(obj->progs.sched_switch_tp, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.sched_switch_btf, false);
+	}
+
 	/* initialize global data (filtering options) */
 	obj->rodata->targ_tgid = env.pid;
 	obj->rodata->targ_pid = env.tid;


### PR DESCRIPTION
Allow offcputime to run on old kernels according to https://github.com/iovisor/bcc/issues/4231.
Test OK on Ubuntu with 5.4.0 kernel.