### PR TITLE
offcputime: Allow offcputime to run on old kernels

### DIFF
--- a/libbpf-tools/offcputime.bpf.c
+++ b/libbpf-tools/offcputime.bpf.c
@@ -44,21 +44,20 @@ struct {
 
 static bool allow_record(struct task_struct *t)
 {
-	if (targ_tgid != -1 && targ_tgid != t->tgid)
+	if (targ_tgid != -1 && targ_tgid != BPF_CORE_READ(t, tgid))
 		return false;
-	if (targ_pid != -1 && targ_pid != t->pid)
+	if (targ_pid != -1 && targ_pid != BPF_CORE_READ(t, pid))
 		return false;
-	if (user_threads_only && t->flags & PF_KTHREAD)
+	if (user_threads_only && BPF_CORE_READ(t, flags) & PF_KTHREAD)
 		return false;
-	else if (kernel_threads_only && !(t->flags & PF_KTHREAD))
+	else if (kernel_threads_only && !(BPF_CORE_READ(t, flags) & PF_KTHREAD))
 		return false;
 	if (state != -1 && get_task_state(t) != state)
 		return false;
 	return true;
 }
 
-SEC("tp_btf/sched_switch")
-int BPF_PROG(sched_switch, bool preempt, struct task_struct *prev, struct task_struct *next)
+static int handle_switch(u64 *ctx, struct task_struct *prev)
 {
 	struct internal_key *i_keyp, i_key;
 	struct val_t *valp, val;
@@ -66,15 +65,15 @@ int BPF_PROG(sched_switch, bool preempt, struct task_struct *prev, struct task_s
 	u32 pid;
 
 	if (allow_record(prev)) {
-		pid = prev->pid;
+		pid = BPF_CORE_READ(prev, pid);
 		/* To distinguish idle threads of different cores */
 		if (!pid)
 			pid = bpf_get_smp_processor_id();
 		i_key.key.pid = pid;
-		i_key.key.tgid = prev->tgid;
+		i_key.key.tgid = BPF_CORE_READ(prev, tgid);
 		i_key.start_ts = bpf_ktime_get_ns();
 
-		if (prev->flags & PF_KTHREAD)
+		if (BPF_CORE_READ(prev, flags) & PF_KTHREAD)
 			i_key.key.user_stack_id = -1;
 		else
 			i_key.key.user_stack_id =
@@ -82,12 +81,12 @@ int BPF_PROG(sched_switch, bool preempt, struct task_struct *prev, struct task_s
 						BPF_F_USER_STACK);
 		i_key.key.kern_stack_id = bpf_get_stackid(ctx, &stackmap, 0);
 		bpf_map_update_elem(&start, &pid, &i_key, 0);
-		bpf_probe_read_kernel_str(&val.comm, sizeof(prev->comm), prev->comm);
+		BPF_CORE_READ_STR_INTO(&val.comm, prev, comm);
 		val.delta = 0;
 		bpf_map_update_elem(&info, &i_key.key, &val, BPF_NOEXIST);
 	}
 
-	pid = next->pid;
+	pid = bpf_get_current_pid_tgid();
 	i_keyp = bpf_map_lookup_elem(&start, &pid);
 	if (!i_keyp)
 		return 0;
@@ -105,6 +104,17 @@ int BPF_PROG(sched_switch, bool preempt, struct task_struct *prev, struct task_s
 cleanup:
 	bpf_map_delete_elem(&start, &pid);
 	return 0;
+}
+
+SEC("tp_btf/sched_switch")
+int BPF_PROG(sched_switch_btf, bool preempt, struct task_struct *prev, struct task_struct *next) {
+	return handle_switch(ctx, prev);
+}
+
+SEC("kprobe/finish_task_switch")
+int BPF_PROG(sched_switch_tp) {
+	struct task_struct *prev = (struct task_struct *)PT_REGS_PARM1_CORE((struct pt_regs *)ctx);
+	return handle_switch(ctx, prev);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -314,6 +314,12 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if (probe_tp_btf("sched_switch")) {
+		bpf_program__set_autoload(obj->progs.sched_switch_tp, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.sched_switch_btf, false);
+	}
+
 	/* initialize global data (filtering options) */
 	obj->rodata->targ_tgid = env.pid;
 	obj->rodata->targ_pid = env.tid;


### PR DESCRIPTION
Allow offcputime to run on old kernels according to https://github.com/iovisor/bcc/issues/4231.
Test OK on Ubuntu with 5.4.0 kernel.