### PR TITLE
libbpf-tools/offcputime: fix no comm&delta output if missed user stack

### DIFF
--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -241,7 +241,7 @@ print_ustack:
 
 		if (bpf_map_lookup_elem(sfd, &next_key.user_stack_id, ip) != 0) {
 			fprintf(stderr, "    [Missed User Stack]\n");
-			continue;
+			goto skip_ustack;
 		}
 
 		syms = syms_cache__get_syms(syms_cache, next_key.tgid);


### PR DESCRIPTION
The comm name, PID and delta will not be printed if hit missed user stack condition. This is going to fix it.
Before fix:
```
sudo ./offcputime -p $(pgrep -f bash)                                                                                                                                                                                                                          
^C    finish_task_switch                                                                                                                                       
    schedule_idle                                                                                                                                              
    do_idle                                                                                                                                                    
    cpu_startup_entry                                                                                                                                          
    start_secondary                                                                                                                                            
    secondary_startup_64                                                                                                                                       
    [Missed User Stack]    
```
After: 
```
sudo ./offcputime -p $(pgrep -f bash)                                                                                                                                                                            
^C    finish_task_switch
    schedule_idle
    do_idle
    cpu_startup_entry
    start_secondary
    secondary_startup_64
    [Missed User Stack]
    -                bash (2657053)
        2001973
```