### PR TITLE
libbpf-tools/cpudist: Allow cpudist to run on old kernels

### DIFF
--- a/libbpf-tools/cpudist.c
+++ b/libbpf-tools/cpudist.c
@@ -217,6 +217,11 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if (probe_tp_btf("sched_switch"))
+		bpf_program__set_autoload(obj->progs.sched_switch_tp, false);
+	else
+		bpf_program__set_autoload(obj->progs.sched_switch_btf, false);
+
 	/* initialize global data (filtering options) */
 	obj->rodata->filter_cg = env.cg;
 	obj->rodata->targ_per_process = env.per_process;


### PR DESCRIPTION
According to https://github.com/iovisor/bcc/issues/4231

Test OK on Ubuntu 20.04 with 5.4.0-97-generic kernel like this:

```
$ sudo ./cpudist  
libbpf: sched_switch is not found in vmlinux BTF
Tracing on-CPU time... Hit Ctrl-C to end.
^C
     usecs               : count    distribution
         0 -> 1          : 5        |**                                      |
         2 -> 3          : 6        |**                                      |
         4 -> 7          : 14       |*****                                   |
         8 -> 15         : 22       |*********                               |
        16 -> 31         : 29       |************                            |
        32 -> 63         : 28       |***********                             |
        64 -> 127        : 51       |*********************                   |
       128 -> 255        : 15       |******                                  |
       256 -> 511        : 17       |*******                                 |
       512 -> 1023       : 29       |************                            |
      1024 -> 2047       : 67       |****************************            |
      2048 -> 4095       : 89       |*************************************   |
      4096 -> 8191       : 90       |*************************************   |
      8192 -> 16383      : 95       |****************************************|

```