### PR TITLE
libbpf-tools: filelife: Check btf struct field for CO-RE and add vfs_open() 

### DIFF
--- a/libbpf-tools/filelife.bpf.c
+++ b/libbpf-tools/filelife.bpf.c
@@ -5,6 +5,10 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
 #include "filelife.h"
+#include "core_fixes.bpf.h"
+
+/* linux: include/linux/fs.h */
+#define FMODE_CREATED	0x100000
 
 const volatile pid_t targ_tgid = 0;
 
@@ -22,7 +26,7 @@ struct {
 } events SEC(".maps");
 
 static __always_inline int
-probe_create(struct inode *dir, struct dentry *dentry)
+probe_create(struct dentry *dentry)
 {
 	u64 id = bpf_get_current_pid_tgid();
 	u32 tgid = id >> 32;
@@ -36,36 +40,79 @@ probe_create(struct inode *dir, struct dentry *dentry)
 	return 0;
 }
 
+/**
+ * In different kernel versions, function vfs_create() has two declarations,
+ * and their parameter lists are as follows:
+ *
+ * int vfs_create(struct inode *dir, struct dentry *dentry, umode_t mode,
+ *            bool want_excl);
+ * int vfs_create(struct user_namespace *mnt_userns, struct inode *dir,
+ *            struct dentry *dentry, umode_t mode, bool want_excl);
+ */
 SEC("kprobe/vfs_create")
-int BPF_KPROBE(vfs_create, struct inode *dir, struct dentry *dentry)
+int BPF_KPROBE(vfs_create, void *arg0, void *arg1, void *arg2)
 {
-	return probe_create(dir, dentry);
+	if (renamedata_has_old_mnt_userns_field())
+		return probe_create(arg2);
+	else
+		return probe_create(arg1);
+}
+
+SEC("kprobe/vfs_open")
+int BPF_KPROBE(vfs_open, struct path *path, struct file *file)
+{
+	struct dentry *dentry = BPF_CORE_READ(path, dentry);
+	int fmode = BPF_CORE_READ(file, f_mode);
+
+	if (!(fmode & FMODE_CREATED))
+		return 0;
+
+	return probe_create(dentry);
 }
 
 SEC("kprobe/security_inode_create")
 int BPF_KPROBE(security_inode_create, struct inode *dir,
 	     struct dentry *dentry)
 {
-	return probe_create(dir, dentry);
+	return probe_create(dentry);
 }
 
+/**
+ * In different kernel versions, function vfs_unlink() has two declarations,
+ * and their parameter lists are as follows:
+ *
+ * int vfs_unlink(struct inode *dir, struct dentry *dentry,
+ *        struct inode **delegated_inode);
+ * int vfs_unlink(struct user_namespace *mnt_userns, struct inode *dir,
+ *        struct dentry *dentry, struct inode **delegated_inode);
+ */
 SEC("kprobe/vfs_unlink")
-int BPF_KPROBE(vfs_unlink, struct inode *dir, struct dentry *dentry)
+int BPF_KPROBE(vfs_unlink, void *arg0, void *arg1, void *arg2)
 {
 	u64 id = bpf_get_current_pid_tgid();
 	struct event event = {};
 	const u8 *qs_name_ptr;
 	u32 tgid = id >> 32;
 	u64 *tsp, delta_ns;
+	bool has_arg = renamedata_has_old_mnt_userns_field();
 
-	tsp = bpf_map_lookup_elem(&start, &dentry);
+	tsp = has_arg
+		? bpf_map_lookup_elem(&start, &arg2)
+		: bpf_map_lookup_elem(&start, &arg1);
 	if (!tsp)
 		return 0;   // missed entry
 
 	delta_ns = bpf_ktime_get_ns() - *tsp;
-	bpf_map_delete_elem(&start, &dentry);
 
-	qs_name_ptr = BPF_CORE_READ(dentry, d_name.name);
+	if (has_arg)
+		bpf_map_delete_elem(&start, &arg2);
+	else
+		bpf_map_delete_elem(&start, &arg1);
+
+	qs_name_ptr = has_arg
+		? BPF_CORE_READ((struct dentry *)arg2, d_name.name)
+		: BPF_CORE_READ((struct dentry *)arg1, d_name.name);
+
 	bpf_probe_read_kernel_str(&event.file, sizeof(event.file), qs_name_ptr);
 	bpf_get_current_comm(&event.task, sizeof(event.task));
 	event.delta_ns = delta_ns;

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -3,6 +3,7 @@
 //
 // Based on filelife(8) from BCC by Brendan Gregg & Allan McAleavy.
 // 20-Mar-2020   Wenbo Zhang   Created this.
+// 13-Nov-2022   Rong Tao      Check btf struct field for CO-RE and add vfs_open()
 #include <argp.h>
 #include <signal.h>
 #include <stdio.h>


### PR DESCRIPTION
I already open a PR(https://github.com/iovisor/bcc/pull/4339) for `tools/filelife.py`, i think two PR better than single one. After all, `libbpf-tools/filelife` is compiled separately, and `tools/filelife.py` is the python script.

Since kernel commit 6521f8917082("namei: prepare for idmapped mounts"), the vfs_unlink() function add argument 'struct user_namespace'. And add vfs_open() probe if 'f_mode = FMODE_CREATED'.

Link: https://github.com/iovisor/bcc/pull/4339