### PR TITLE
Fix: pointer 'map_ids' may be used after 'realloc'

### DIFF
--- a/introspection/bps.c
+++ b/introspection/bps.c
@@ -198,7 +198,7 @@ static int print_one_prog(uint32_t prog_id)
   const uint32_t usual_nr_map_ids = 64;
   uint32_t nr_map_ids = usual_nr_map_ids;
   struct bpf_prog_info prog_info;
-  uint32_t *map_ids =  NULL;
+  uint32_t *map_ids = NULL, *last_map_ids = NULL;
   uint32_t info_len;
   int ret = 0;
   int prog_fd;
@@ -224,11 +224,12 @@ static int print_one_prog(uint32_t prog_id)
               "Cannot allocate memory for %u map_ids for BID:%u\n",
               nr_map_ids, prog_id);
       close(prog_fd);
-      free(map_ids);
+      free(last_map_ids);
       return 1;
     }
 
     map_ids = u64_to_ptr(prog_info.map_ids);
+    last_map_ids = map_ids;
     prog_info.nr_map_ids = nr_map_ids;
     info_len = sizeof(prog_info);
     ret = bpf_obj_get_info(prog_fd, &prog_info, &info_len);


### PR DESCRIPTION
Free 'map_ids' after realloc is warning here, however, it's an error. In fact, the free() here releases the memory allocated last time, and a separate variable should be introduced to eliminate the warning here.

Environment to reproduce the problem:

```
$ cmake \
	-DCMAKE_INSTALL_PREFIX=/usr \
	-DENABLE_LLVM_SHARED=1 \
	-DCMAKE_BUILD_TYPE=Debug \
	..
$ make
...
/home/rongtao/bcc/introspection/bps.c: In function ‘print_one_prog’: /home/rongtao/bcc/introspection/bps.c:227:7:
warning: pointer ‘map_ids’ may be used after ‘realloc’ [-Wuse-after-free]
  227 |       free(map_ids);
      |       ^~~~~~~~~~~~~
/home/rongtao/bcc/introspection/bps.c:220:36: note: call to ‘realloc’ here
  220 |     prog_info.map_ids = ptr_to_u64(realloc(map_ids,
      |                                    ^~~~~~~~~~~~~~~~
  221 |                                        nr_map_ids * sizeof(*map_ids)));
      |                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

OS: Fedora37
Arch: x86_64
GCC 12.2.1
LLVM/Clang 15.0.4

