### PR TITLE
libbpf-tools/gethostlatency&ksnoop: use BPF_KPROBE & BPF_KRETPROBE to define SEC function.

### DIFF
--- a/libbpf-tools/gethostlatency.bpf.c
+++ b/libbpf-tools/gethostlatency.bpf.c
@@ -61,13 +61,13 @@ static int probe_return(struct pt_regs *ctx)
 }
 
 SEC("kprobe/handle_entry")
-int handle_entry(struct pt_regs *ctx)
+int BPF_KPROBE(handle_entry)
 {
 	return probe_entry(ctx);
 }
 
 SEC("kretprobe/handle_return")
-int handle_return(struct pt_regs *ctx)
+int BPF_KRETPROBE(handle_return)
 {
 	return probe_return(ctx);
 }

--- a/libbpf-tools/ksnoop.bpf.c
+++ b/libbpf-tools/ksnoop.bpf.c
@@ -442,13 +442,13 @@ static int ksnoop(struct pt_regs *ctx, bool entry)
 }
 
 SEC("kprobe/foo")
-int kprobe_entry(struct pt_regs *ctx)
+int BPF_KPROBE(kprobe_entry)
 {
 	return ksnoop(ctx, true);
 }
 
 SEC("kretprobe/foo")
-int kprobe_return(struct pt_regs *ctx)
+int BPF_KRETPROBE(kprobe_return)
 {
 	return ksnoop(ctx, false);
 }


### PR DESCRIPTION
Some tools do not use `BPF_KPROBE` & `BPF_KRETPROBE` to define `SEC` functions. This MR is going to keep them in line.