### PR TITLE
libbpf-tools: fix biosnoop exit code

### DIFF
--- a/libbpf-tools/biosnoop.c
+++ b/libbpf-tools/biosnoop.c
@@ -334,10 +334,10 @@ int main(int argc, char **argv)
 			fprintf(stderr, "error polling perf buffer: %s\n", strerror(-err));
 			goto cleanup;
 		}
-		if (env.duration && get_ktime_ns() > time_end)
-			goto cleanup;
 		/* reset err to return 0 if exiting */
 		err = 0;
+		if (env.duration && get_ktime_ns() > time_end)
+			break;
 	}
 
 cleanup:


### PR DESCRIPTION
perf_buffer__poll returns a count or a negative error value. If the loop is broken because of timeout err needs to be zero or else an error is flagged. As the count may be non-zero, and this isn't an error, move the setting of err to zero earlier. This also allows switching a goto to a break.