### PR TITLE
Fix a llvm compilation error

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -20,7 +20,11 @@
 #include <llvm-c/Transforms/IPO.h>
 #include <llvm/ExecutionEngine/MCJIT.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#if LLVM_MAJOR_VERSION >= 16
+#include <llvm/IRPrinter/IRPrintingPasses.h>
+#else
 #include <llvm/IR/IRPrintingPasses.h>
+#endif
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 


### PR DESCRIPTION
With latest llvm16, I got the following compilation error:
  /.../src/cc/bpf_module.cc: In member function ‘void ebpf::BPFModule::dump_ir(llvm::Module&)’:
  /.../src/cc/bpf_module.cc:259:15: error: ‘PrintModulePass’ was not declared in this scope
     MPM.addPass(PrintModulePass(errs()));
                 ^~~~~~~~~~~~~~~
  ...

The error is due to the llvm patch https://reviews.llvm.org/D138081. Fix the issue by adjust corresponding header file locaiton as in the above llvm patch.

Signed-off-by: Yonghong Song <yhs@fb.com>