### PR TITLE
libbpf-tools: fsdist,fsslower: Fix redefinition of enumerator 'OPEN'

### DIFF
--- a/libbpf-tools/fsdist.bpf.c
+++ b/libbpf-tools/fsdist.bpf.c
@@ -18,7 +18,7 @@ struct {
 	__type(value, __u64);
 } starts SEC(".maps");
 
-struct hist hists[MAX_OP] = {};
+struct hist hists[F_MAX_OP] = {};
 
 static int probe_entry()
 {
@@ -46,7 +46,7 @@ static int probe_return(enum fs_file_op op)
 	if (!tsp)
 		return 0;
 
-	if (op >= MAX_OP)
+	if (op >= F_MAX_OP)
 		goto cleanup;
 
 	delta = (__s64)(ts - *tsp);
@@ -77,7 +77,7 @@ int BPF_KPROBE(file_read_entry)
 SEC("kretprobe/dummy_file_read")
 int BPF_KRETPROBE(file_read_exit)
 {
-	return probe_return(READ);
+	return probe_return(F_READ);
 }
 
 SEC("kprobe/dummy_file_write")
@@ -89,7 +89,7 @@ int BPF_KPROBE(file_write_entry)
 SEC("kretprobe/dummy_file_write")
 int BPF_KRETPROBE(file_write_exit)
 {
-	return probe_return(WRITE);
+	return probe_return(F_WRITE);
 }
 
 SEC("kprobe/dummy_file_open")
@@ -101,7 +101,7 @@ int BPF_KPROBE(file_open_entry)
 SEC("kretprobe/dummy_file_open")
 int BPF_KRETPROBE(file_open_exit)
 {
-	return probe_return(OPEN);
+	return probe_return(F_OPEN);
 }
 
 SEC("kprobe/dummy_file_sync")
@@ -113,7 +113,7 @@ int BPF_KPROBE(file_sync_entry)
 SEC("kretprobe/dummy_file_sync")
 int BPF_KRETPROBE(file_sync_exit)
 {
-	return probe_return(FSYNC);
+	return probe_return(F_FSYNC);
 }
 
 SEC("kprobe/dummy_getattr")
@@ -125,7 +125,7 @@ int BPF_KPROBE(getattr_entry)
 SEC("kretprobe/dummy_getattr")
 int BPF_KRETPROBE(getattr_exit)
 {
-	return probe_return(GETATTR);
+	return probe_return(F_GETATTR);
 }
 
 SEC("fentry/dummy_file_read")
@@ -137,7 +137,7 @@ int BPF_PROG(file_read_fentry)
 SEC("fexit/dummy_file_read")
 int BPF_PROG(file_read_fexit)
 {
-	return probe_return(READ);
+	return probe_return(F_READ);
 }
 
 SEC("fentry/dummy_file_write")
@@ -149,7 +149,7 @@ int BPF_PROG(file_write_fentry)
 SEC("fexit/dummy_file_write")
 int BPF_PROG(file_write_fexit)
 {
-	return probe_return(WRITE);
+	return probe_return(F_WRITE);
 }
 
 SEC("fentry/dummy_file_open")
@@ -161,7 +161,7 @@ int BPF_PROG(file_open_fentry)
 SEC("fexit/dummy_file_open")
 int BPF_PROG(file_open_fexit)
 {
-	return probe_return(OPEN);
+	return probe_return(F_OPEN);
 }
 
 SEC("fentry/dummy_file_sync")
@@ -173,7 +173,7 @@ int BPF_PROG(file_sync_fentry)
 SEC("fexit/dummy_file_sync")
 int BPF_PROG(file_sync_fexit)
 {
-	return probe_return(FSYNC);
+	return probe_return(F_FSYNC);
 }
 
 SEC("fentry/dummy_getattr")
@@ -185,7 +185,7 @@ int BPF_PROG(getattr_fentry)
 SEC("fexit/dummy_getattr")
 int BPF_PROG(getattr_fexit)
 {
-	return probe_return(GETATTR);
+	return probe_return(F_GETATTR);
 }
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/libbpf-tools/fsdist.c
+++ b/libbpf-tools/fsdist.c
@@ -39,44 +39,44 @@ enum fs_type {
 
 static struct fs_config {
 	const char *fs;
-	const char *op_funcs[MAX_OP];
+	const char *op_funcs[F_MAX_OP];
 } fs_configs[] = {
 	[BTRFS] = { "btrfs", {
-		[READ] = "btrfs_file_read_iter",
-		[WRITE] = "btrfs_file_write_iter",
-		[OPEN] = "btrfs_file_open",
-		[FSYNC] = "btrfs_sync_file",
-		[GETATTR] = NULL, /* not supported */
+		[F_READ] = "btrfs_file_read_iter",
+		[F_WRITE] = "btrfs_file_write_iter",
+		[F_OPEN] = "btrfs_file_open",
+		[F_FSYNC] = "btrfs_sync_file",
+		[F_GETATTR] = NULL, /* not supported */
 	}},
 	[EXT4] = { "ext4", {
-		[READ] = "ext4_file_read_iter",
-		[WRITE] = "ext4_file_write_iter",
-		[OPEN] = "ext4_file_open",
-		[FSYNC] = "ext4_sync_file",
-		[GETATTR] = "ext4_file_getattr",
+		[F_READ] = "ext4_file_read_iter",
+		[F_WRITE] = "ext4_file_write_iter",
+		[F_OPEN] = "ext4_file_open",
+		[F_FSYNC] = "ext4_sync_file",
+		[F_GETATTR] = "ext4_file_getattr",
 	}},
 	[NFS] = { "nfs", {
-		[READ] = "nfs_file_read",
-		[WRITE] = "nfs_file_write",
-		[OPEN] = "nfs_file_open",
-		[FSYNC] = "nfs_file_fsync",
-		[GETATTR] = "nfs_getattr",
+		[F_READ] = "nfs_file_read",
+		[F_WRITE] = "nfs_file_write",
+		[F_OPEN] = "nfs_file_open",
+		[F_FSYNC] = "nfs_file_fsync",
+		[F_GETATTR] = "nfs_getattr",
 	}},
 	[XFS] = { "xfs", {
-		[READ] = "xfs_file_read_iter",
-		[WRITE] = "xfs_file_write_iter",
-		[OPEN] = "xfs_file_open",
-		[FSYNC] = "xfs_file_fsync",
-		[GETATTR] = NULL, /* not supported */
+		[F_READ] = "xfs_file_read_iter",
+		[F_WRITE] = "xfs_file_write_iter",
+		[F_OPEN] = "xfs_file_open",
+		[F_FSYNC] = "xfs_file_fsync",
+		[F_GETATTR] = NULL, /* not supported */
 	}},
 };
 
 static char *file_op_names[] = {
-	[READ] = "read",
-	[WRITE] = "write",
-	[OPEN] = "open",
-	[FSYNC] = "fsync",
-	[GETATTR] = "getattr",
+	[F_READ] = "read",
+	[F_WRITE] = "write",
+	[F_OPEN] = "open",
+	[F_FSYNC] = "fsync",
+	[F_GETATTR] = "getattr",
 };
 
 static struct hist zero;
@@ -212,7 +212,7 @@ static int print_hists(struct fsdist_bpf__bss *bss)
 	const char *units = timestamp_in_ms ? "msecs" : "usecs";
 	enum fs_file_op op;
 
-	for (op = READ; op < MAX_OP; op++) {
+	for (op = F_READ; op < F_MAX_OP; op++) {
 		struct hist hist = bss->hists[op];
 
 		bss->hists[op] = zero;
@@ -231,7 +231,7 @@ static bool check_fentry()
 	const char *fn_name, *module;
 	bool support_fentry = true;
 
-	for (i = 0; i < MAX_OP; i++) {
+	for (i = 0; i < F_MAX_OP; i++) {
 		fn_name = fs_configs[fs_type].op_funcs[i];
 		module = fs_configs[fs_type].fs;
 		if (fn_name && !fentry_can_attach(fn_name, module)) {
@@ -247,17 +247,17 @@ static int fentry_set_attach_target(struct fsdist_bpf *obj)
 	struct fs_config *cfg = &fs_configs[fs_type];
 	int err = 0;
 
-	err = err ?: bpf_program__set_attach_target(obj->progs.file_read_fentry, 0, cfg->op_funcs[READ]);
-	err = err ?: bpf_program__set_attach_target(obj->progs.file_read_fexit, 0, cfg->op_funcs[READ]);
-	err = err ?: bpf_program__set_attach_target(obj->progs.file_write_fentry, 0, cfg->op_funcs[WRITE]);
-	err = err ?: bpf_program__set_attach_target(obj->progs.file_write_fexit, 0, cfg->op_funcs[WRITE]);
-	err = err ?: bpf_program__set_attach_target(obj->progs.file_open_fentry, 0, cfg->op_funcs[OPEN]);
-	err = err ?: bpf_program__set_attach_target(obj->progs.file_open_fexit, 0, cfg->op_funcs[OPEN]);
-	err = err ?: bpf_program__set_attach_target(obj->progs.file_sync_fentry, 0, cfg->op_funcs[FSYNC]);
-	err = err ?: bpf_program__set_attach_target(obj->progs.file_sync_fexit, 0, cfg->op_funcs[FSYNC]);
-	if (cfg->op_funcs[GETATTR]) {
-		err = err ?: bpf_program__set_attach_target(obj->progs.getattr_fentry, 0, cfg->op_funcs[GETATTR]);
-		err = err ?: bpf_program__set_attach_target(obj->progs.getattr_fexit, 0, cfg->op_funcs[GETATTR]);
+	err = err ?: bpf_program__set_attach_target(obj->progs.file_read_fentry, 0, cfg->op_funcs[F_READ]);
+	err = err ?: bpf_program__set_attach_target(obj->progs.file_read_fexit, 0, cfg->op_funcs[F_READ]);
+	err = err ?: bpf_program__set_attach_target(obj->progs.file_write_fentry, 0, cfg->op_funcs[F_WRITE]);
+	err = err ?: bpf_program__set_attach_target(obj->progs.file_write_fexit, 0, cfg->op_funcs[F_WRITE]);
+	err = err ?: bpf_program__set_attach_target(obj->progs.file_open_fentry, 0, cfg->op_funcs[F_OPEN]);
+	err = err ?: bpf_program__set_attach_target(obj->progs.file_open_fexit, 0, cfg->op_funcs[F_OPEN]);
+	err = err ?: bpf_program__set_attach_target(obj->progs.file_sync_fentry, 0, cfg->op_funcs[F_FSYNC]);
+	err = err ?: bpf_program__set_attach_target(obj->progs.file_sync_fexit, 0, cfg->op_funcs[F_FSYNC]);
+	if (cfg->op_funcs[F_GETATTR]) {
+		err = err ?: bpf_program__set_attach_target(obj->progs.getattr_fentry, 0, cfg->op_funcs[F_GETATTR]);
+		err = err ?: bpf_program__set_attach_target(obj->progs.getattr_fexit, 0, cfg->op_funcs[F_GETATTR]);
 	} else {
 		bpf_program__set_autoload(obj->progs.getattr_fentry, false);
 		bpf_program__set_autoload(obj->progs.getattr_fexit, false);
@@ -298,41 +298,41 @@ static int attach_kprobes(struct fsdist_bpf *obj)
 	long err = 0;
 	struct fs_config *cfg = &fs_configs[fs_type];
 
-	/* READ */
-	obj->links.file_read_entry = bpf_program__attach_kprobe(obj->progs.file_read_entry, false, cfg->op_funcs[READ]);
+	/* F_READ */
+	obj->links.file_read_entry = bpf_program__attach_kprobe(obj->progs.file_read_entry, false, cfg->op_funcs[F_READ]);
 	if (!obj->links.file_read_entry)
 		goto errout;
-	obj->links.file_read_exit = bpf_program__attach_kprobe(obj->progs.file_read_exit, true, cfg->op_funcs[READ]);
+	obj->links.file_read_exit = bpf_program__attach_kprobe(obj->progs.file_read_exit, true, cfg->op_funcs[F_READ]);
 	if (!obj->links.file_read_exit)
 		goto errout;
-	/* WRITE */
-	obj->links.file_write_entry = bpf_program__attach_kprobe(obj->progs.file_write_entry, false, cfg->op_funcs[WRITE]);
+	/* F_WRITE */
+	obj->links.file_write_entry = bpf_program__attach_kprobe(obj->progs.file_write_entry, false, cfg->op_funcs[F_WRITE]);
 	if (!obj->links.file_write_entry)
 		goto errout;
-	obj->links.file_write_exit = bpf_program__attach_kprobe(obj->progs.file_write_exit, true, cfg->op_funcs[WRITE]);
+	obj->links.file_write_exit = bpf_program__attach_kprobe(obj->progs.file_write_exit, true, cfg->op_funcs[F_WRITE]);
 	if (!obj->links.file_write_exit)
 		goto errout;
-	/* OPEN */
-	obj->links.file_open_entry = bpf_program__attach_kprobe(obj->progs.file_open_entry, false, cfg->op_funcs[OPEN]);
+	/* F_OPEN */
+	obj->links.file_open_entry = bpf_program__attach_kprobe(obj->progs.file_open_entry, false, cfg->op_funcs[F_OPEN]);
 	if (!obj->links.file_open_entry)
 		goto errout;
-	obj->links.file_open_exit = bpf_program__attach_kprobe(obj->progs.file_open_exit, true, cfg->op_funcs[OPEN]);
+	obj->links.file_open_exit = bpf_program__attach_kprobe(obj->progs.file_open_exit, true, cfg->op_funcs[F_OPEN]);
 	if (!obj->links.file_open_exit)
 		goto errout;
-	/* FSYNC */
-	obj->links.file_sync_entry = bpf_program__attach_kprobe(obj->progs.file_sync_entry, false, cfg->op_funcs[FSYNC]);
+	/* F_FSYNC */
+	obj->links.file_sync_entry = bpf_program__attach_kprobe(obj->progs.file_sync_entry, false, cfg->op_funcs[F_FSYNC]);
 	if (!obj->links.file_sync_entry)
 		goto errout;
-	obj->links.file_sync_exit = bpf_program__attach_kprobe(obj->progs.file_sync_exit, true, cfg->op_funcs[FSYNC]);
+	obj->links.file_sync_exit = bpf_program__attach_kprobe(obj->progs.file_sync_exit, true, cfg->op_funcs[F_FSYNC]);
 	if (!obj->links.file_sync_exit)
 		goto errout;
-	/* GETATTR */
-	if (!cfg->op_funcs[GETATTR])
+	/* F_GETATTR */
+	if (!cfg->op_funcs[F_GETATTR])
 		return 0;
-	obj->links.getattr_entry = bpf_program__attach_kprobe(obj->progs.getattr_entry, false, cfg->op_funcs[GETATTR]);
+	obj->links.getattr_entry = bpf_program__attach_kprobe(obj->progs.getattr_entry, false, cfg->op_funcs[F_GETATTR]);
 	if (!obj->links.getattr_entry)
 		goto errout;
-	obj->links.getattr_exit = bpf_program__attach_kprobe(obj->progs.getattr_exit, true, cfg->op_funcs[GETATTR]);
+	obj->links.getattr_exit = bpf_program__attach_kprobe(obj->progs.getattr_exit, true, cfg->op_funcs[F_GETATTR]);
 	if (!obj->links.getattr_exit)
 		goto errout;
 	return 0;

--- a/libbpf-tools/fsdist.h
+++ b/libbpf-tools/fsdist.h
@@ -3,12 +3,12 @@
 #define __FSDIST_H
 
 enum fs_file_op {
-	READ,
-	WRITE,
-	OPEN,
-	FSYNC,
-	GETATTR,
-	MAX_OP,
+	F_READ,
+	F_WRITE,
+	F_OPEN,
+	F_FSYNC,
+	F_GETATTR,
+	F_MAX_OP,
 };
 
 #define MAX_SLOTS	32

--- a/libbpf-tools/fsslower.bpf.c
+++ b/libbpf-tools/fsslower.bpf.c
@@ -82,7 +82,7 @@ static int probe_exit(void *ctx, enum fs_file_op op, ssize_t size)
 	event.delta_us = delta_ns / 1000;
 	event.end_ns = end_ns;
 	event.offset = datap->start;
-	if (op != FSYNC)
+	if (op != F_FSYNC)
 		event.size = size;
 	else
 		event.size = datap->end - datap->start;
@@ -109,7 +109,7 @@ int BPF_KPROBE(file_read_entry, struct kiocb *iocb)
 SEC("kretprobe/dummy_file_read")
 int BPF_KRETPROBE(file_read_exit, ssize_t ret)
 {
-	return probe_exit(ctx, READ, ret);
+	return probe_exit(ctx, F_READ, ret);
 }
 
 SEC("kprobe/dummy_file_write")
@@ -124,7 +124,7 @@ int BPF_KPROBE(file_write_entry, struct kiocb *iocb)
 SEC("kretprobe/dummy_file_write")
 int BPF_KRETPROBE(file_write_exit, ssize_t ret)
 {
-	return probe_exit(ctx, WRITE, ret);
+	return probe_exit(ctx, F_WRITE, ret);
 }
 
 SEC("kprobe/dummy_file_open")
@@ -136,7 +136,7 @@ int BPF_KPROBE(file_open_entry, struct inode *inode, struct file *file)
 SEC("kretprobe/dummy_file_open")
 int BPF_KRETPROBE(file_open_exit)
 {
-	return probe_exit(ctx, OPEN, 0);
+	return probe_exit(ctx, F_OPEN, 0);
 }
 
 SEC("kprobe/dummy_file_sync")
@@ -148,7 +148,7 @@ int BPF_KPROBE(file_sync_entry, struct file *file, loff_t start, loff_t end)
 SEC("kretprobe/dummy_file_sync")
 int BPF_KRETPROBE(file_sync_exit)
 {
-	return probe_exit(ctx, FSYNC, 0);
+	return probe_exit(ctx, F_FSYNC, 0);
 }
 
 SEC("fentry/dummy_file_read")
@@ -163,7 +163,7 @@ int BPF_PROG(file_read_fentry, struct kiocb *iocb)
 SEC("fexit/dummy_file_read")
 int BPF_PROG(file_read_fexit, struct kiocb *iocb, struct iov_iter *to, ssize_t ret)
 {
-	return probe_exit(ctx, READ, ret);
+	return probe_exit(ctx, F_READ, ret);
 }
 
 SEC("fentry/dummy_file_write")
@@ -178,7 +178,7 @@ int BPF_PROG(file_write_fentry, struct kiocb *iocb)
 SEC("fexit/dummy_file_write")
 int BPF_PROG(file_write_fexit, struct kiocb *iocb, struct iov_iter *from, ssize_t ret)
 {
-	return probe_exit(ctx, WRITE, ret);
+	return probe_exit(ctx, F_WRITE, ret);
 }
 
 SEC("fentry/dummy_file_open")
@@ -190,7 +190,7 @@ int BPF_PROG(file_open_fentry, struct inode *inode, struct file *file)
 SEC("fexit/dummy_file_open")
 int BPF_PROG(file_open_fexit)
 {
-	return probe_exit(ctx, OPEN, 0);
+	return probe_exit(ctx, F_OPEN, 0);
 }
 
 SEC("fentry/dummy_file_sync")
@@ -202,7 +202,7 @@ int BPF_PROG(file_sync_fentry, struct file *file, loff_t start, loff_t end)
 SEC("fexit/dummy_file_sync")
 int BPF_PROG(file_sync_fexit)
 {
-	return probe_exit(ctx, FSYNC, 0);
+	return probe_exit(ctx, F_FSYNC, 0);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/fsslower.h
+++ b/libbpf-tools/fsslower.h
@@ -6,11 +6,11 @@
 #define TASK_COMM_LEN	16
 
 enum fs_file_op {
-	READ,
-	WRITE,
-	OPEN,
-	FSYNC,
-	MAX_OP,
+	F_READ,
+	F_WRITE,
+	F_OPEN,
+	F_FSYNC,
+	F_MAX_OP,
 };
 
 struct event {


### PR DESCRIPTION
On arm64 platform, vmlinux.h already has enumerator 'OPEN', add 'F_' prefix for each 'fs_file_op' enumerator.

Reproduce the problem:
```
  $ cd libbpf-tools
  $ make
  In file included from fsdist.bpf.c:7:
  ./fsdist.h:8:2: error: redefinition of enumerator 'OPEN'
          OPEN,
          ^
  arm64/vmlinux.h:126874:2: note: previous definition is here
          OPEN = 41,
          ^
  ...
  2 warnings and 1 error generated.
```
