### PR TITLE
libbpf-tools/ksnoop: remove always 'true' statement

### DIFF
--- a/libbpf-tools/ksnoop.c
+++ b/libbpf-tools/ksnoop.c
@@ -315,8 +315,6 @@ static int trace_to_value(struct btf *btf, struct func *func, char *argname,
 		strncpy(val->name, argname, sizeof(val->name));
 
 	for (i = 0; i < MAX_TRACES; i++) {
-		if (!func->args[i].name)
-			continue;
 		if (strcmp(argname, func->args[i].name) != 0)
 			continue;
 		p_debug("setting base arg for val %s to %d", val->name, i);


### PR DESCRIPTION
'func->args[i].name' field type 'char name[MAX_STR]' always true.

Compile warning:
```
   ksnoop.c: In function ‘trace_to_value’:
   ksnoop.c:318:21: warning: the comparison will always evaluate as ‘true’
    for the address of ‘name’ will never be NULL [-Waddress]
   318 |                 if (!func->args[i].name)
         |                     ^
   In file included from ksnoop.c:16:
   ksnoop.h:62:14: note: ‘name’ declared here
      62 |         char name[MAX_STR];
         |              ^~~~
```