### PR TITLE
tools/ttysnoop: add ringbuf

### DIFF
--- a/tools/ttysnoop.py
+++ b/tools/ttysnoop.py
@@ -164,15 +164,12 @@ KFUNC_PROBE(tty_write, struct kiocb *iocb, struct iov_iter *from)
 
 if BPF.kernel_struct_has_field(b'bpf_ringbuf', b'waitq') == 1:
     PERF_MODE = "USE_BPF_RING_BUF"
-else:
-    PERF_MODE = "USE_BPF_PERF_BUF"
-
-if PERF_MODE == "USE_BPF_RING_BUF":
     bpf_text = bpf_text.replace('PERF_TABLE',
                             'BPF_RINGBUF_OUTPUT(events, 64);')
     bpf_text = bpf_text.replace('PERF_OUTPUT_CTX',
                             'events.ringbuf_output(data, sizeof(*data), 0);')
 else:
+    PERF_MODE = "USE_BPF_PERF_BUF"
     bpf_text = bpf_text.replace('PERF_TABLE', 'BPF_PERF_OUTPUT(events);')
     bpf_text = bpf_text.replace('PERF_OUTPUT_CTX',
                             'events.perf_submit(ctx, data, sizeof(*data));')

--- a/tools/ttysnoop.py
+++ b/tools/ttysnoop.py
@@ -78,7 +78,7 @@ struct data_t {
 };
 
 BPF_ARRAY(data_map, struct data_t, 1);
-BPF_PERF_OUTPUT(events);
+PERF_TABLE
 
 static int do_tty_write(void *ctx, const char __user *buf, size_t count)
 {
@@ -106,7 +106,7 @@ static int do_tty_write(void *ctx, const char __user *buf, size_t count)
             data->count = BUFSIZE;
         else
             data->count = count;
-        events.perf_submit(ctx, data, sizeof(*data));
+        PERF_OUTPUT_CTX
         if (count < BUFSIZE)
             return 0;
         count -= BUFSIZE;
@@ -162,6 +162,21 @@ KFUNC_PROBE(tty_write, struct kiocb *iocb, struct iov_iter *from)
 #endif
 """
 
+if BPF.kernel_struct_has_field(b'bpf_ringbuf', b'waitq') == 1:
+    PERF_MODE = "USE_BPF_RING_BUF"
+else:
+    PERF_MODE = "USE_BPF_PERF_BUF"
+
+if PERF_MODE == "USE_BPF_RING_BUF":
+    bpf_text = bpf_text.replace('PERF_TABLE',
+                            'BPF_RINGBUF_OUTPUT(events, 64);')
+    bpf_text = bpf_text.replace('PERF_OUTPUT_CTX',
+                            'events.ringbuf_output(data, sizeof(*data), 0);')
+else:
+    bpf_text = bpf_text.replace('PERF_TABLE', 'BPF_PERF_OUTPUT(events);')
+    bpf_text = bpf_text.replace('PERF_OUTPUT_CTX',
+                            'events.perf_submit(ctx, data, sizeof(*data));')
+
 bpf_text = bpf_text.replace('PTS', str(pi.st_ino))
 if debug or args.ebpf:
     print(bpf_text)
@@ -184,9 +199,16 @@ def print_event(cpu, data, size):
     sys.stdout.flush()
 
 # loop with callback to print_event
-b["events"].open_perf_buffer(print_event)
+if PERF_MODE == "USE_BPF_RING_BUF":
+    b["events"].open_ring_buffer(print_event)
+else:
+    b["events"].open_perf_buffer(print_event, page_cnt=64)
+
 while 1:
     try:
-        b.perf_buffer_poll()
+        if PERF_MODE == "USE_BPF_RING_BUF":
+            b.ring_buffer_poll()
+        else:
+            b.perf_buffer_poll()
     except KeyboardInterrupt:
         exit()


### PR DESCRIPTION
Kernel provides BPF ringbuf from v5.8, it sloves memory efficiency and event re-ordering problems of the BPF perf buffer.

When using perfbuf it may get lots of 'Possibly lost x samples' on screen if many contents burst out to the snooping tty device. After changing to ringbuf, this issus will disappear.

Signed-off-by: mickey_zhu <mickey_zhu@realsil.com.cn>