### PR TITLE
libbpf-tool/solisten: Modify port type

### DIFF
--- a/libbpf-tools/solisten.h
+++ b/libbpf-tools/solisten.h
@@ -10,7 +10,7 @@ struct event {
 	__u32 proto;
 	int backlog;
 	int ret;
-	short port;
+	__u16 port;
 	char task[TASK_COMM_LEN];
 };
 


### PR DESCRIPTION
Negative number occurs when short is used as the port type

Current situation:
![image](https://user-images.githubusercontent.com/58356743/206478109-750fe36f-e59e-4d26-8794-967312cf8be7.png)

Correct situation:
![image](https://user-images.githubusercontent.com/58356743/206478421-508924b1-7045-47a0-ae8e-4d8227478af4.png)
