### PR TITLE
tools/ttysnoop: Fix kfunc Unknown error

### DIFF
--- a/tools/ttysnoop.py
+++ b/tools/ttysnoop.py
@@ -13,6 +13,7 @@
 # Idea: from ttywatcher.
 #
 # 15-Oct-2016   Brendan Gregg   Created this.
+# 13-Dec-2022   Rong Tao        Detect whether kfunc is supported.
 
 from __future__ import print_function
 from bcc import BPF
@@ -130,7 +131,7 @@ int kprobe__tty_write(struct pt_regs *ctx, struct file *file,
     return do_tty_write(ctx, buf, count);
 }
 #else
-KFUNC_PROBE(tty_write, struct kiocb *iocb, struct iov_iter *from)
+PROBE_TTY_WRITE
 {
     const char __user *buf;
     const struct kvec *kvec;
@@ -161,6 +162,21 @@ KFUNC_PROBE(tty_write, struct kiocb *iocb, struct iov_iter *from)
 }
 #endif
 """
+
+probe_tty_write_kfunc = """
+KFUNC_PROBE(tty_write, struct kiocb *iocb, struct iov_iter *from)
+"""
+
+probe_tty_write_kprobe = """
+int kprobe__tty_write(struct pt_regs *ctx, struct kiocb *iocb,
+    struct iov_iter *from)
+"""
+
+is_support_kfunc = BPF.support_kfunc()
+if is_support_kfunc:
+    bpf_text = bpf_text.replace('PROBE_TTY_WRITE', probe_tty_write_kfunc)
+else:
+    bpf_text = bpf_text.replace('PROBE_TTY_WRITE', probe_tty_write_kprobe)
 
 bpf_text = bpf_text.replace('PTS', str(pi.st_ino))
 if debug or args.ebpf:


### PR DESCRIPTION
Check whether kfunc is supported, and decide whether to use kprobe or kfunc based on the test results.

How to reproduce the error:
```
$ sudo ./ttysnoop.py 7
bpf_attach_raw_tracepoint (kfunc): Unknown error 524 Traceback (most recent call last):
  File "/home/rongtao/Git/bcc/tools/./ttysnoop.py", line 175, in <module>
    b = BPF(text=bpf_text)
  File "/usr/lib/python3.9/site-packages/bcc/__init__.py", line 487, in __init__
    self._trace_autoload()
  File "/usr/lib/python3.9/site-packages/bcc/__init__.py", line 1473, in _trace_autoload
    self.attach_kfunc(fn_name=func_name)
  File "/usr/lib/python3.9/site-packages/bcc/__init__.py", line 1138, in attach_kfunc
    raise Exception("Failed to attach BPF to entry kernel func")
Exception: Failed to attach BPF to entry kernel func
```