### PR TITLE
tools/syscount: add --ppid option

### DIFF
--- a/man/man8/syscount.8
+++ b/man/man8/syscount.8
@@ -2,7 +2,7 @@
 .SH NAME
 syscount \- Summarize syscall counts and latencies.
 .SH SYNOPSIS
-.B syscount [-h] [-p PID] [-t TID] [-i INTERVAL] [-d DURATION] [-T TOP] [-x] [-e ERRNO] [-L] [-m] [-P] [-l] [--syscall SYSCALL]
+.B syscount [-h] [-p PID] [-t TID] [-c PPID] [-i INTERVAL] [-d DURATION] [-T TOP] [-x] [-e ERRNO] [-L] [-m] [-P] [-l] [--syscall SYSCALL]
 .SH DESCRIPTION
 This tool traces syscall entry and exit tracepoints and summarizes either the
 number of syscalls of each type, or the number of syscalls per process. It can
@@ -22,6 +22,9 @@ Trace only this process.
 .TP
 \-t TID
 Trace only this thread.
+.TP
+\-c PPID
+Trace only child of this pid.
 .TP
 \-i INTERVAL
 Print the summary at the specified interval (in seconds).

--- a/tools/syscount_example.txt
+++ b/tools/syscount_example.txt
@@ -165,6 +165,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -p PID, --pid PID     trace only this pid
   -t TID, --tid TID     trace only this tid
+  -c PPID, --ppid PPID  trace only child of this pid
   -i INTERVAL, --interval INTERVAL
                         print summary at this interval (seconds)
   -d DURATION, --duration DURATION


### PR DESCRIPTION
we may need to run some one time command and trace its syscount.
it's not easy to get the pid.  but we can trace the ppid, usually the pid of current shell.

eg:
1. get pid of current shell(shell 1) 
```bash
grep -i ppid /proc/self/status | cut -f2
```
2. run syscount in other shell(shell 2)
```bash
syscount --ppid $pid_of_step_1
```
3. run the target command in shell 1
```bash
curl https://github.com/
```
we can trace the one time curl command with the --ppid option in this way