### PR TITLE
libbpf-tools/runqlen: Use rq instead of cfs_rq when getting nr_running

### DIFF
--- a/libbpf-tools/runqlen.bpf.c
+++ b/libbpf-tools/runqlen.bpf.c
@@ -18,7 +18,7 @@ int do_sample(struct bpf_perf_event_data *ctx)
 	u64 slot, cpu = 0;
 
 	task = (void*)bpf_get_current_task();
-	slot = BPF_CORE_READ(task, se.cfs_rq, nr_running);
+	slot = BPF_CORE_READ(task, se.cfs_rq, rq, nr_running);
 	/*
 	 * Calculate run queue length by subtracting the currently running task,
 	 * if present. len 0 == idle, len 1 == one running task.


### PR DESCRIPTION
The rq->nr_running can more accurately reflect the queuing congestion of tasks on the current cpu, while cfs_rq->nr_running can only reflect a part of the group in the container environment.

Signed-off-by: Hailong Liu <liuhailong@linux.alibaba.com>