### PR TITLE
bcc: Fix multi-word array type handling

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -235,8 +235,8 @@ def _get_event_class(event_map):
         'void *'            : ct.c_void_p,
     }
 
-    # handle array types e.g. "int [16]" or "char[16]"
-    array_type = re.compile(r"([^ ]+) ?\[([0-9]+)\]$")
+    # handle array types e.g. "int [16]", "char[16]" or "unsigned char[16]"
+    array_type = re.compile(r"(\S+(?: \S+)*) ?\[([0-9]+)\]$")
 
     fields = []
     num_fields = lib.bpf_perf_event_fields(event_map.bpf.module, event_map._name)


### PR DESCRIPTION
A recent change caused arrays of multi-word types to not be detected properly leading to errors such as:

Type: 'unsigned char[256]' not recognized. Please define the data with ctypes manually

Fix the regular expression to allow multi-word types in arrays.

Fixes: ca1d3fd07a84 ("bcc: Fix array type handling due to llvm changes")
Cc: chenhengqi@outlook.com
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>