### PR TITLE
libbpf-tools/softirqs: Add event counts report

### DIFF
--- a/libbpf-tools/softirqs.bpf.c
+++ b/libbpf-tools/softirqs.bpf.c
@@ -18,6 +18,7 @@ struct {
 } start SEC(".maps");
 
 __u64 counts[NR_SOFTIRQS] = {};
+__u64 time[NR_SOFTIRQS] = {};
 struct hist hists[NR_SOFTIRQS] = {};
 
 static int handle_entry(unsigned int vec_nr)
@@ -44,7 +45,8 @@ static int handle_exit(unsigned int vec_nr)
 		delta /= 1000U;
 
 	if (!targ_dist) {
-		__sync_fetch_and_add(&counts[vec_nr], delta);
+		__sync_fetch_and_add(&counts[vec_nr], 1);
+		__sync_fetch_and_add(&time[vec_nr], delta);
 	} else {
 		struct hist *hist;
 		u64 slot;

--- a/libbpf-tools/softirqs.c
+++ b/libbpf-tools/softirqs.c
@@ -19,6 +19,7 @@
 struct env {
 	bool distributed;
 	bool nanoseconds;
+	bool count;
 	time_t interval;
 	int times;
 	bool timestamp;
@@ -26,6 +27,7 @@ struct env {
 } env = {
 	.interval = 99999999,
 	.times = 99999999,
+	.count = false,
 };
 
 static volatile bool exiting;
@@ -48,6 +50,7 @@ static const struct argp_option opts[] = {
 	{ "distributed", 'd', NULL, 0, "Show distributions as histograms" },
 	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
 	{ "nanoseconds", 'N', NULL, 0, "Output in nanoseconds" },
+	{ "count", 'C', NULL, 0, "Show event counts with timing" },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
 	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
 	{},
@@ -72,6 +75,9 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		break;
 	case 'T':
 		env.timestamp = true;
+		break;
+	case 'C':
+		env.count = true;
 		break;
 	case ARGP_KEY_ARG:
 		errno = 0;
@@ -142,16 +148,24 @@ static char *vec_names[] = {
 static int print_count(struct softirqs_bpf__bss *bss)
 {
 	const char *units = env.nanoseconds ? "nsecs" : "usecs";
-	__u64 count;
+	__u64 count, time;
 	__u32 vec;
 
-	printf("%-16s %6s%5s\n", "SOFTIRQ", "TOTAL_", units);
+	printf("%-16s %-6s%-5s  %-11s\n", "SOFTIRQ", "TOTAL_", 
+			units, env.count?"TOTAL_count":"");
 
 	for (vec = 0; vec < NR_SOFTIRQS; vec++) {
+		time = __atomic_exchange_n(&bss->time[vec], 0,
+					__ATOMIC_RELAXED);
 		count = __atomic_exchange_n(&bss->counts[vec], 0,
 					__ATOMIC_RELAXED);
-		if (count > 0)
-			printf("%-16s %11llu\n", vec_names[vec], count);
+		if (count > 0) {
+			printf("%-16s %11llu", vec_names[vec], time);
+			if (env.count) {
+				printf("  %11llu", count);
+			}
+			printf("\n");
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Currently softirq only report the time but not the event counts. If we have both time and counts it will be better understand the frequency and duration of events.

Signed-off-by: Hailong Liu <liuhailong@linux.alibaba.com>