### PR TITLE
Fix get_kprobe_functions

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -748,7 +748,7 @@ class BPF(object):
                 # Exclude all gcc 8's extra .cold functions
                 elif re.match(b'^.*\.cold(\.\d+)?$', fn):
                     continue
-                if (t.lower() in [b't', b'w']) and re.match(event_re, fn) \
+                if (t.lower() in [b't', b'w']) and re.fullmatch(event_re, fn) \
                     and fn not in blacklist:
                     fns.append(fn)
         return set(fns)     # Some functions may appear more than once


### PR DESCRIPTION
get_kprobe_functions will not only return a function that matches the regular expression, but also any function that starts with a substrings that matches it. This is obviously not the intended behavior.
The issue is easily fixed by replacing re.match by re.fullmatch.