### PR TITLE
fix the Makefile of libbpf-tools,make it support cross compile

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -90,7 +90,7 @@ APPS = \
 	#
 
 # export variables that are used in Makefile.btfgen as well.
-export OUTPUT BPFTOOL BTFHUB_ARCHIVE APPS
+export OUTPUT BPFTOOL ARCH BTFHUB_ARCHIVE APPS
 
 FSDIST_ALIASES = btrfsdist ext4dist nfsdist xfsdist
 FSSLOWER_ALIASES = btrfsslower ext4slower nfsslower xfsslower

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -13,7 +13,7 @@ CFLAGS := -g -O2 -Wall
 BPFCFLAGS := -g -O2 -Wall
 INSTALL ?= install
 prefix ?= /usr/local
-ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' \
+ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' \
 			 | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' \
 			 | sed 's/riscv64/riscv/' | sed 's/loongarch.*/loongarch/')
 BTFHUB_ARCHIVE ?= $(abspath btfhub-archive)
@@ -90,7 +90,7 @@ APPS = \
 	#
 
 # export variables that are used in Makefile.btfgen as well.
-export OUTPUT BPFTOOL ARCH BTFHUB_ARCHIVE APPS
+export OUTPUT BPFTOOL BTFHUB_ARCHIVE APPS
 
 FSDIST_ALIASES = btrfsdist ext4dist nfsdist xfsdist
 FSSLOWER_ALIASES = btrfsslower ext4slower nfsslower xfsslower


### PR DESCRIPTION
Hi,bro!
When i buited these tools in libbpf-tools with yocto 4.x,I got these errors:https://github.com/iovisor/bcc/issues/4417#issue-1518224690.    Finally,I found a bug of libbpf-toos Makefile,the Makefile used 'uname -m' to confirm the ARCH,I think this way is reasonable.such as i buit them with yocto on X86-ubuntu system,the process is a classic cross compile,the ARCH's  value should take the target system  architecture.So i commite my bugfix, i hope you can pass it:)
