### PR TITLE
killsnoop: add missing -s and -T options to the synopsis

### DIFF
--- a/man/man8/killsnoop.8
+++ b/man/man8/killsnoop.8
@@ -2,7 +2,7 @@
 .SH NAME
 killsnoop \- Trace signals issued by the kill() syscall. Uses Linux eBPF/bcc.
 .SH SYNOPSIS
-.B killsnoop [\-h] [\-x] [-p PID] [-T PID]
+.B killsnoop [\-h] [\-x] [-p PID] [-T PID] [-s SIGNAL]
 .SH DESCRIPTION
 killsnoop traces the kill() syscall, to show signals sent via this method. This
 may be useful to troubleshoot failing applications, where an unknown mechanism

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -4,7 +4,7 @@
 # killsnoop Trace signals issued by the kill() syscall.
 #           For Linux, uses BCC, eBPF. Embedded C.
 #
-# USAGE: killsnoop [-h] [-x] [-p PID] [-T PID]
+# USAGE: killsnoop [-h] [-x] [-p PID] [-T PID] [-s SIGNAL]
 #
 # Copyright (c) 2015 Brendan Gregg.
 # Licensed under the Apache License, Version 2.0 (the "License")

--- a/tools/killsnoop_example.txt
+++ b/tools/killsnoop_example.txt
@@ -19,7 +19,7 @@ The second line showed the same signal sent, this time resulting in a -3
 USAGE message:
 
 # ./killsnoop -h
-usage: killsnoop [-h] [-x] [-p PID]
+usage: killsnoop [-h] [-x] [-p PID] [-T PID] [-s SIGNAL]
 
 Trace signals issued by the kill() syscall
 


### PR DESCRIPTION
The -s option is missing from the synopsis of the killsnoop manpage, example file and the comment on top of the tool itself. Also, -T option is missing from the example file.

Signed-off-by: Jerome Marchand <jmarchan@redhat.com>