### PR TITLE
Fix for incomplete static libraries.

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -160,7 +160,7 @@ endif()
 
 if(ENABLE_CPP_API)
   add_subdirectory(api)
-  list(APPEND bcc_common_libs_for_a api-static)
+  target_sources(bcc-static PRIVATE $<TARGET_OBJECTS:api-objects>)
   # Keep all API functions
   list(APPEND bcc_common_libs_for_s -Wl,--whole-archive api-static -Wl,--no-whole-archive)
 endif()
@@ -174,6 +174,8 @@ if(ENABLE_USDT)
 endif()
 
 add_subdirectory(frontends)
+
+target_sources(bcc-static PRIVATE $<TARGET_OBJECTS:clang_frontend-objects>)
 
 # Link against LLVM libraries
 target_link_libraries(bcc-shared ${bcc_common_libs_for_s})

--- a/src/cc/api/CMakeLists.txt
+++ b/src/cc/api/CMakeLists.txt
@@ -1,3 +1,4 @@
 set(bcc_api_sources BPF.cc BPFTable.cc)
 add_library(api-static STATIC ${bcc_api_sources})
+add_library(api-objects OBJECT ${bcc_api_sources})
 install(FILES BPF.h BPFTable.h COMPONENT libbcc DESTINATION include/bcc)

--- a/src/cc/frontends/clang/CMakeLists.txt
+++ b/src/cc/frontends/clang/CMakeLists.txt
@@ -9,4 +9,5 @@ if(DEFINED BCC_BACKUP_COMPILE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBCC_BACKUP_COMPILE='${BCC_BACKUP_COMPILE}'")
 endif()
 
-add_library(clang_frontend STATIC loader.cc b_frontend_action.cc tp_frontend_action.cc kbuild_helper.cc ../../common.cc)
+add_library(clang_frontend-objects OBJECT loader.cc b_frontend_action.cc tp_frontend_action.cc kbuild_helper.cc)
+add_library(clang_frontend STATIC $<TARGET_OBJECTS:clang_frontend-objects>)


### PR DESCRIPTION
Installed static libraries, namely libbcc.a, libbcc_bpf.a and libbcc-loader-static.a, do not contain all the symbols that are needed for linking BCC statically into one's project.

The reason for this issue is that in CMake, when linking static library against another library (by using the target_link_libraries statement), the effect is not a combined static library. CMake will only record a dependency from the target library to the source library.

This is why when bcc-static is linked against api-static, the bcc-static library (libbcc.a) does not contain symbols from api-static, making it necessary to install api-static to <prefix>/lib along other library files. Ditto for clang_frontend.

This is not the case when building shared libraries.

This changeset fixes the issue by using a CMake feature named "object libraries" (https://cmake.org/cmake/help/v3.25/command/add_library.html#object-libraries). Intermediate targets, such as api-static and clang_frontend, are built as object libraries.

A feature that is only available since CMake 3.12 is linking such libraries using the target_link_library statement. Until the project transitions to requiring CMake version 3.12 or higher, we have to "link" object libraries using the target_sources statement instead.