### PR TITLE
Implement symbol lookup in zipped libraries.

### DIFF
--- a/docker/build/Dockerfile.ubuntu
+++ b/docker/build/Dockerfile.ubuntu
@@ -63,7 +63,8 @@ RUN apt-get update && apt-get install -y \
       libtinfo-dev \
       iperf \
       netperf \
-      xz-utils && \
+      xz-utils \
+      zip && \
       apt-get -y clean
 
 RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1

--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 
 set(bcc_table_sources table_storage.cc shared_table.cc bpffs_table.cc json_map_decl_visitor.cc)
 set(bcc_util_sources common.cc)
-set(bcc_sym_sources bcc_syms.cc bcc_elf.c bcc_perf_map.c bcc_proc.c)
+set(bcc_sym_sources bcc_syms.cc bcc_elf.c bcc_perf_map.c bcc_proc.c bcc_zip.c)
 set(bcc_common_headers libbpf.h perf_reader.h "${CMAKE_CURRENT_BINARY_DIR}/bcc_version.h")
 set(bcc_table_headers file_desc.h table_desc.h table_storage.h)
 set(bcc_api_headers bcc_common.h bpf_module.h bcc_exception.h bcc_syms.h bcc_proc.h bcc_elf.h)

--- a/src/cc/bcc_zip.c
+++ b/src/cc/bcc_zip.c
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bcc_zip.h"
+
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+// Specification of ZIP file format can be found here:
+// https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
+// For a high level overview of the structure of a ZIP file see
+// sections 4.3.1 - 4.3.6.
+
+// Data structures appearing in ZIP files do not contain any
+// padding and they might be misaligned. To allow us to safely
+// operate on pointers to such structures and their members, without
+// worrying of platform specific alignment issues, we define
+// unaligned_uint16_t and unaligned_uint32_t types with no alignment
+// requirements.
+typedef struct {
+  uint8_t raw[2];
+} unaligned_uint16_t;
+
+static uint16_t unaligned_uint16_read(unaligned_uint16_t value) {
+  uint16_t return_value;
+  memcpy(&return_value, value.raw, sizeof(return_value));
+  return return_value;
+}
+
+typedef struct {
+  uint8_t raw[4];
+} unaligned_uint32_t;
+
+static uint32_t unaligned_uint32_read(unaligned_uint32_t value) {
+  uint32_t return_value;
+  memcpy(&return_value, value.raw, sizeof(return_value));
+  return return_value;
+}
+
+#define END_OF_CD_RECORD_MAGIC 0x06054b50
+
+// See section 4.3.16 of the spec.
+struct end_of_central_directory_record {
+  // Magic value equal to END_OF_CD_RECORD_MAGIC
+  unaligned_uint32_t magic;
+
+  // Number of the file containing this structure or 0xFFFF if ZIP64 archive.
+  // Zip archive might span multiple files (disks).
+  unaligned_uint16_t this_disk;
+
+  // Number of the file containing the beginning of the central directory or
+  // 0xFFFF if ZIP64 archive.
+  unaligned_uint16_t cd_disk;
+
+  // Number of central directory records on this disk or 0xFFFF if ZIP64
+  // archive.
+  unaligned_uint16_t cd_records;
+
+  // Number of central directory records on all disks or 0xFFFF if ZIP64
+  // archive.
+  unaligned_uint16_t cd_records_total;
+
+  // Size of the central directory recrod or 0xFFFFFFFF if ZIP64 archive.
+  unaligned_uint32_t cd_size;
+
+  // Offset of the central directory from the beginning of the archive or
+  // 0xFFFFFFFF if ZIP64 archive.
+  unaligned_uint32_t cd_offset;
+
+  // Length of comment data following end of central driectory record.
+  unaligned_uint16_t comment_length;
+
+  // Up to 64k of arbitrary bytes.
+  // uint8_t comment[comment_length]
+};
+
+#define CD_FILE_HEADER_MAGIC 0x02014b50
+#define FLAG_ENCRYPTED (1 << 0)
+#define FLAG_HAS_DATA_DESCRIPTOR (1 << 3)
+
+// See section 4.3.12 of the spec.
+struct central_directory_file_header {
+  // Magic value equal to CD_FILE_HEADER_MAGIC.
+  unaligned_uint32_t magic;
+  unaligned_uint16_t version;
+  // Minimum zip version needed to extract the file.
+  unaligned_uint16_t min_version;
+  unaligned_uint16_t flags;
+  unaligned_uint16_t compression;
+  unaligned_uint16_t last_modified_time;
+  unaligned_uint16_t last_modified_date;
+  unaligned_uint32_t crc;
+  unaligned_uint32_t compressed_size;
+  unaligned_uint32_t uncompressed_size;
+  unaligned_uint16_t file_name_length;
+  unaligned_uint16_t extra_field_length;
+  unaligned_uint16_t file_comment_length;
+  // Number of the disk where the file starts or 0xFFFF if ZIP64 archive.
+  unaligned_uint16_t disk;
+  unaligned_uint16_t internal_attributes;
+  unaligned_uint32_t external_attributes;
+  // Offset from the start of the disk containing the local file header to the
+  // start of the local file header.
+  unaligned_uint32_t offset;
+};
+
+#define LOCAL_FILE_HEADER_MAGIC 0x04034b50
+
+// See section 4.3.7 of the spec.
+struct local_file_header {
+  // Magic value equal to LOCAL_FILE_HEADER_MAGIC.
+  unaligned_uint32_t magic;
+  // Minimum zip version needed to extract the file.
+  unaligned_uint16_t min_version;
+  unaligned_uint16_t flags;
+  unaligned_uint16_t compression;
+  unaligned_uint16_t last_modified_time;
+  unaligned_uint16_t last_modified_date;
+  unaligned_uint32_t crc;
+  unaligned_uint32_t compressed_size;
+  unaligned_uint32_t uncompressed_size;
+  unaligned_uint16_t file_name_length;
+  unaligned_uint16_t extra_field_length;
+};
+
+struct bcc_zip_archive {
+  void* data;
+  uint32_t size;
+  uint32_t cd_offset;
+  uint32_t cd_records;
+};
+
+static void* check_access(struct bcc_zip_archive* archive, uint32_t offset,
+                          uint32_t size) {
+  if (offset + size > archive->size || offset > offset + size) {
+    return NULL;
+  }
+  return archive->data + offset;
+}
+
+// Returns 0 on success, -1 on error and -2 if the eocd indicates
+// the archive uses features which are not supported.
+static int try_parse_end_of_central_directory(struct bcc_zip_archive* archive,
+                                              uint32_t offset) {
+  struct end_of_central_directory_record* eocd = check_access(
+      archive, offset, sizeof(struct end_of_central_directory_record));
+  if (eocd == NULL ||
+      unaligned_uint32_read(eocd->magic) != END_OF_CD_RECORD_MAGIC) {
+    return -1;
+  }
+
+  uint16_t comment_length = unaligned_uint16_read(eocd->comment_length);
+  if (offset + sizeof(struct end_of_central_directory_record) +
+          comment_length !=
+      archive->size) {
+    return -1;
+  }
+
+  uint16_t cd_records = unaligned_uint16_read(eocd->cd_records);
+  if (unaligned_uint16_read(eocd->this_disk) != 0 ||
+      unaligned_uint16_read(eocd->cd_disk) != 0 ||
+      unaligned_uint16_read(eocd->cd_records_total) != cd_records) {
+    // This is a valid eocd, but we only support single-file non-ZIP64 archives.
+    return -2;
+  }
+
+  uint32_t cd_offset = unaligned_uint32_read(eocd->cd_offset);
+  uint32_t cd_size = unaligned_uint32_read(eocd->cd_size);
+  if (check_access(archive, cd_offset, cd_size) == NULL) {
+    return -1;
+  }
+
+  archive->cd_offset = cd_offset;
+  archive->cd_records = cd_records;
+  return 0;
+}
+
+static int find_central_directory(struct bcc_zip_archive* archive) {
+  if (archive->size <= sizeof(struct end_of_central_directory_record)) {
+    return -1;
+  }
+
+  int rc = -1;
+  // Because the end of central directory ends with a variable length array of
+  // up to 0xFFFF bytes we can't know exactly where it starts and need to
+  // search for it at the end of the file, scanning the (limit, offset] range.
+  uint32_t offset =
+      archive->size - sizeof(struct end_of_central_directory_record);
+  int64_t limit = (int64_t)offset - (1 << 16);
+  for (; offset >= 0 && offset > limit && rc == -1; offset--) {
+    rc = try_parse_end_of_central_directory(archive, offset);
+  }
+
+  return rc;
+}
+
+struct bcc_zip_archive* bcc_zip_archive_open(const char* path) {
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    return NULL;
+  }
+
+  off_t size = lseek(fd, 0, SEEK_END);
+  if (size == (off_t)-1 || size > UINT32_MAX) {
+    close(fd);
+    return NULL;
+  }
+
+  void* data = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+  close(fd);
+
+  if (data == MAP_FAILED) {
+    return NULL;
+  }
+
+  struct bcc_zip_archive* archive = malloc(sizeof(struct bcc_zip_archive));
+  if (archive == NULL) {
+    munmap(data, size);
+    return NULL;
+  };
+
+  archive->data = data;
+  archive->size = size;
+  if (find_central_directory(archive)) {
+    munmap(data, size);
+    free(archive);
+    archive = NULL;
+  }
+
+  return archive;
+}
+
+void bcc_zip_archive_close(struct bcc_zip_archive* archive) {
+  munmap(archive->data, archive->size);
+  free(archive);
+}
+
+static struct local_file_header* local_file_header_at_offset(
+    struct bcc_zip_archive* archive, uint32_t offset) {
+  struct local_file_header* lfh =
+      check_access(archive, offset, sizeof(struct local_file_header));
+  if (lfh == NULL ||
+      unaligned_uint32_read(lfh->magic) != LOCAL_FILE_HEADER_MAGIC) {
+    return NULL;
+  }
+  return lfh;
+}
+
+static int get_entry_at_offset(struct bcc_zip_archive* archive, uint32_t offset,
+                               struct bcc_zip_entry* out) {
+  struct local_file_header* lfh = local_file_header_at_offset(archive, offset);
+  offset += sizeof(struct local_file_header);
+  if (lfh == NULL) {
+    return -1;
+  };
+
+  uint16_t flags = unaligned_uint16_read(lfh->flags);
+  if ((flags & FLAG_ENCRYPTED) || (flags & FLAG_HAS_DATA_DESCRIPTOR)) {
+    return -1;
+  }
+
+  uint16_t name_length = unaligned_uint16_read(lfh->file_name_length);
+  const char* name = check_access(archive, offset, name_length);
+  offset += name_length;
+  if (name == NULL) {
+    return -1;
+  }
+
+  uint16_t extra_field_length = unaligned_uint16_read(lfh->extra_field_length);
+  if (check_access(archive, offset, extra_field_length) == NULL) {
+    return -1;
+  }
+  offset += extra_field_length;
+
+  uint32_t compressed_size = unaligned_uint32_read(lfh->compressed_size);
+  void* data = check_access(archive, offset, compressed_size);
+  if (data == NULL) {
+    return -1;
+  }
+
+  out->compression = unaligned_uint16_read(lfh->compression);
+  out->name_length = name_length;
+  out->name = name;
+  out->data = data;
+  out->data_length = compressed_size;
+  out->data_offset = offset;
+
+  return 0;
+}
+
+static struct central_directory_file_header* cd_file_header_at_offset(
+    struct bcc_zip_archive* archive, uint32_t offset) {
+  struct central_directory_file_header* cdfh = check_access(
+      archive, offset, sizeof(struct central_directory_file_header));
+  if (cdfh == NULL ||
+      unaligned_uint32_read(cdfh->magic) != CD_FILE_HEADER_MAGIC) {
+    return NULL;
+  }
+  return cdfh;
+}
+
+int bcc_zip_archive_find_entry(struct bcc_zip_archive* archive,
+                               const char* file_name,
+                               struct bcc_zip_entry* out) {
+  size_t file_name_length = strlen(file_name);
+
+  uint32_t offset = archive->cd_offset;
+  for (uint32_t i = 0; i < archive->cd_records; ++i) {
+    struct central_directory_file_header* cdfh =
+        cd_file_header_at_offset(archive, offset);
+    offset += sizeof(struct central_directory_file_header);
+    if (cdfh == NULL) {
+      return -1;
+    }
+
+    uint16_t cdfh_name_length = unaligned_uint16_read(cdfh->file_name_length);
+    const char* cdfh_name = check_access(archive, offset, cdfh_name_length);
+    if (cdfh_name == NULL) {
+      return -1;
+    }
+
+    uint16_t cdfh_flags = unaligned_uint16_read(cdfh->flags);
+    if ((cdfh_flags & FLAG_ENCRYPTED) == 0 &&
+        (cdfh_flags & FLAG_HAS_DATA_DESCRIPTOR) == 0 &&
+        file_name_length == cdfh_name_length &&
+        memcmp(file_name, archive->data + offset, file_name_length) == 0) {
+      return get_entry_at_offset(archive, unaligned_uint32_read(cdfh->offset),
+                                 out);
+    }
+
+    offset += cdfh_name_length;
+    offset += unaligned_uint16_read(cdfh->extra_field_length);
+    offset += unaligned_uint16_read(cdfh->file_comment_length);
+  }
+
+  return -1;
+}
+
+int bcc_zip_archive_find_entry_at_offset(struct bcc_zip_archive* archive,
+                                         uint32_t target,
+                                         struct bcc_zip_entry* out) {
+  uint32_t offset = archive->cd_offset;
+  for (uint32_t i = 0; i < archive->cd_records; ++i) {
+    struct central_directory_file_header* cdfh =
+        cd_file_header_at_offset(archive, offset);
+    offset += sizeof(struct central_directory_file_header);
+    if (cdfh == NULL) {
+      return -1;
+    }
+
+    uint16_t cdfh_flags = unaligned_uint16_read(cdfh->flags);
+    if ((cdfh_flags & FLAG_ENCRYPTED) == 0 &&
+        (cdfh_flags & FLAG_HAS_DATA_DESCRIPTOR) == 0) {
+      if (get_entry_at_offset(archive, unaligned_uint32_read(cdfh->offset),
+                              out)) {
+        return -1;
+      }
+
+      if (out->data <= archive->data + target &&
+          archive->data + target < out->data + out->data_length) {
+        return 0;
+      }
+    }
+
+    offset += unaligned_uint16_read(cdfh->file_name_length);
+    offset += unaligned_uint16_read(cdfh->extra_field_length);
+    offset += unaligned_uint16_read(cdfh->file_comment_length);
+  }
+
+  return -1;
+}

--- a/src/cc/bcc_zip.h
+++ b/src/cc/bcc_zip.h
@@ -65,6 +65,13 @@ int bcc_zip_archive_find_entry_at_offset(struct bcc_zip_archive* archive,
                                          uint32_t offset,
                                          struct bcc_zip_entry* out);
 
+// Opens a zip archives and looks up entry within the archive.
+// Provided path is interpreted as archive path followed by "!/"
+// characters and name of the zip entry. This convention is used
+// by Android tools.
+struct bcc_zip_archive* bcc_zip_archive_open_and_find(
+    const char* path, struct bcc_zip_entry* out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cc/bcc_zip.h
+++ b/src/cc/bcc_zip.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIBBCC_ZIP_H
+#define LIBBCC_ZIP_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Represents an opened zip archive.
+// Only basic ZIP files are supported, in particular the following are not
+// supported:
+// - encryption
+// - streaming
+// - multi-part ZIP files
+// - ZIP64
+struct bcc_zip_archive;
+
+// Carries information on name, compression method and data corresponding to
+// a file in a zip archive.
+struct bcc_zip_entry {
+  // Compression method as defined in pkzip spec. 0 means data is uncompressed.
+  uint16_t compression;
+
+  // Non-null terminated name of the file.
+  const char* name;
+  // Length of the file name.
+  uint16_t name_length;
+
+  // Pointer to the file data.
+  const void* data;
+  // Length of the file data.
+  uint32_t data_length;
+  // Offset of the file data within the archive.
+  uint32_t data_offset;
+};
+
+// Opens a zip archive. Returns NULL in case of an error.
+struct bcc_zip_archive* bcc_zip_archive_open(const char* path);
+
+// Closes a zip archive and releases resources.
+void bcc_zip_archive_close(struct bcc_zip_archive* archive);
+
+// Looks up data corresponding to a file in given zip archive.
+int bcc_zip_archive_find_entry(struct bcc_zip_archive* archive,
+                               const char* name, struct bcc_zip_entry* out);
+
+int bcc_zip_archive_find_entry_at_offset(struct bcc_zip_archive* archive,
+                                         uint32_t offset,
+                                         struct bcc_zip_entry* out);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/tests/cc/CMakeLists.txt
+++ b/tests/cc/CMakeLists.txt
@@ -42,7 +42,8 @@ set(TEST_LIBBCC_SOURCES
 	test_usdt_args.cc
 	test_usdt_probes.cc
 	utils.cc
-	test_parse_tracepoint.cc)
+	test_parse_tracepoint.cc
+	test_zip.cc)
 
 file(COPY dummy_proc_map.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 add_library(usdt_test_lib SHARED usdt_test_lib.cc)
@@ -82,9 +83,17 @@ if(LIBLZMA_FOUND)
   list(APPEND DEBUGINFO_TARGETS with_gnu_debugdata)
 endif(LIBLZMA_FOUND)
 
+add_custom_command(OUTPUT archive.zip
+                   COMMAND mkdir -p zip_subdir
+                   COMMAND echo "This is a text file" > zip_subdir/file.txt
+                   COMMAND zip -0 archive.zip libdebuginfo_test_lib.so zip_subdir/file.txt
+                   DEPENDS debuginfo_test_lib
+                   BYPRODUCTS zip_subdir/file.txt)
+add_custom_target(zip_archive DEPENDS archive.zip)
+
 if(NOT CMAKE_USE_LIBBPF_PACKAGE)
   add_executable(test_libbcc ${TEST_LIBBCC_SOURCES})
-  add_dependencies(test_libbcc bcc-shared ${DEBUGINFO_TARGETS})
+  add_dependencies(test_libbcc bcc-shared zip_archive ${DEBUGINFO_TARGETS})
 
   target_link_libraries(test_libbcc ${PROJECT_BINARY_DIR}/src/cc/libbcc.so dl usdt_test_lib)
   set_target_properties(test_libbcc PROPERTIES INSTALL_RPATH ${PROJECT_BINARY_DIR}/src/cc)
@@ -95,7 +104,7 @@ endif()
 
 if(LIBBPF_FOUND)
   add_executable(test_libbcc_no_libbpf ${TEST_LIBBCC_SOURCES})
-  add_dependencies(test_libbcc_no_libbpf bcc-shared ${DEBUGINFO_TARGETS})
+  add_dependencies(test_libbcc_no_libbpf bcc-shared zip_archive ${DEBUGINFO_TARGETS})
 
   target_link_libraries(test_libbcc_no_libbpf ${PROJECT_BINARY_DIR}/src/cc/libbcc.so dl usdt_test_lib ${LIBBPF_LIBRARIES})
   set_target_properties(test_libbcc_no_libbpf PROPERTIES INSTALL_RPATH ${PROJECT_BINARY_DIR}/src/cc)

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -112,6 +112,18 @@ TEST_CASE("resolve symbol name in external library using loaded libraries", "[c_
   bcc_procutils_free(sym.module);
 }
 
+TEST_CASE("resolve symbol name in external zipped library", "[c_api]") {
+  struct bcc_symbol sym;
+  std::string lib_path =
+      CMAKE_CURRENT_BINARY_DIR "/archive.zip!/libdebuginfo_test_lib.so";
+
+  REQUIRE(bcc_resolve_symname(lib_path.c_str(), "symbol", 0x0, 0, nullptr,
+                              &sym) == 0);
+  REQUIRE(sym.module == lib_path);
+  REQUIRE(sym.offset != 0);
+  bcc_procutils_free(sym.module);
+}
+
 namespace {
 
 void system(const std::string &command) {

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -112,14 +112,19 @@ TEST_CASE("resolve symbol name in external library using loaded libraries", "[c_
   bcc_procutils_free(sym.module);
 }
 
+namespace {
+
+static std::string zipped_lib_path() {
+  return CMAKE_CURRENT_BINARY_DIR "/archive.zip!/libdebuginfo_test_lib.so";
+}
+
+}  // namespace
+
 TEST_CASE("resolve symbol name in external zipped library", "[c_api]") {
   struct bcc_symbol sym;
-  std::string lib_path =
-      CMAKE_CURRENT_BINARY_DIR "/archive.zip!/libdebuginfo_test_lib.so";
-
-  REQUIRE(bcc_resolve_symname(lib_path.c_str(), "symbol", 0x0, 0, nullptr,
-                              &sym) == 0);
-  REQUIRE(sym.module == lib_path);
+  REQUIRE(bcc_resolve_symname(zipped_lib_path().c_str(), "symbol", 0x0, 0,
+                              nullptr, &sym) == 0);
+  REQUIRE(sym.module == zipped_lib_path());
   REQUIRE(sym.offset != 0);
   bcc_procutils_free(sym.module);
 }
@@ -781,6 +786,27 @@ TEST_CASE("searching for modules in /proc/[pid]/maps", "[c_api][!mayfail]") {
   }
 
   fclose(dummy_maps);
+
+  SECTION("seach for lib in zip") {
+    std::string line =
+        "7f151476e000-7f1514779000 r-xp 00001000 00:1b "
+        "72809479 " CMAKE_CURRENT_BINARY_DIR "/archive.zip\n";
+    dummy_maps = fmemopen(nullptr, line.size(), "w+");
+    REQUIRE(fwrite(line.c_str(), line.size(), 1, dummy_maps) == 1);
+    fseek(dummy_maps, 0, SEEK_SET);
+
+    struct mod_search search;
+    memset(&search, 0, sizeof(struct mod_search));
+    std::string zip_entry_path = zipped_lib_path();
+    search.name = zip_entry_path.c_str();
+    int res = _procfs_maps_each_module(dummy_maps, getpid(),
+                                       _bcc_syms_find_module, &search);
+    REQUIRE(res == 0);
+    REQUIRE(search.start == 0x7f151476e000);
+    REQUIRE(search.file_offset < 0x1000);
+
+    fclose(dummy_maps);
+  }
 }
 
 TEST_CASE("resolve global addr in libc in this process", "[c_api][!mayfail]") {

--- a/tests/cc/test_zip.cc
+++ b/tests/cc/test_zip.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+
+#include "bcc_zip.h"
+#include "catch.hpp"
+
+#define LIB_ENTRY_NAME "libdebuginfo_test_lib.so"
+#define ENTRY_IN_SUBDIR_NAME "zip_subdir/file.txt"
+#define TEST_ARCHIVE_PATH CMAKE_CURRENT_BINARY_DIR "/archive.zip"
+
+namespace {
+
+bcc_zip_entry get_uncompressed_entry(bcc_zip_archive* archive,
+                                     const char* asset_name) {
+  bcc_zip_entry out;
+  REQUIRE(bcc_zip_archive_find_entry(archive, asset_name, &out) == 0);
+
+  REQUIRE(out.compression == 0);
+  REQUIRE(out.name_length == strlen(asset_name));
+  REQUIRE(memcmp(out.name, asset_name, strlen(asset_name)) == 0);
+  REQUIRE(out.data_offset > 0);
+
+  return out;
+}
+
+}  // namespace
+
+TEST_CASE("finds entries in a zip archive by name", "[zip]") {
+  bcc_zip_archive* archive = bcc_zip_archive_open(TEST_ARCHIVE_PATH);
+  REQUIRE(archive != nullptr);
+
+  bcc_zip_entry entry = get_uncompressed_entry(archive, LIB_ENTRY_NAME);
+  REQUIRE(memcmp(entry.data,
+                 "\x7f"
+                 "ELF",
+                 4) == 0);
+
+  entry = get_uncompressed_entry(archive, ENTRY_IN_SUBDIR_NAME);
+  REQUIRE(memcmp(entry.data, "This is a text file\n", 20) == 0);
+
+  REQUIRE(bcc_zip_archive_find_entry(archive, "missing", &entry) == -1);
+
+  bcc_zip_archive_close(archive);
+}
+
+TEST_CASE("finds entries in a zip archive by offset", "[zip]") {
+  bcc_zip_archive* archive = bcc_zip_archive_open(TEST_ARCHIVE_PATH);
+  REQUIRE(archive != nullptr);
+
+  bcc_zip_entry entry;
+  REQUIRE(bcc_zip_archive_find_entry_at_offset(archive, 100, &entry) == 0);
+  REQUIRE(entry.compression == 0);
+  REQUIRE(entry.name_length == strlen(LIB_ENTRY_NAME));
+  REQUIRE(memcmp(entry.name, LIB_ENTRY_NAME, strlen(LIB_ENTRY_NAME)) == 0);
+  REQUIRE(entry.data_offset > 0);
+  REQUIRE(memcmp(entry.data,
+                 "\x7f"
+                 "ELF",
+                 4) == 0);
+
+  REQUIRE(bcc_zip_archive_find_entry_at_offset(archive, 100000, &entry) == -1);
+
+  bcc_zip_archive_close(archive);
+}


### PR DESCRIPTION
Implement symbol lookup in zipped libraries.

On Android dynamic linker is capable of loading libraries directly from zip archives, provided that they are uncompressed and 4kb aligned. This pull request implements ability to set probes and lookup symbols in such libraries. In particular:
- minimal ZIP parser is added (`bcc_zip.c`)
- `bcc_elf_file` is extended to represent zipped libraries as well
- zip and apk files are checked for libs when parsing process' maps
- `bpf_attach_uprobe` adjusts file offsets and paths accordingly when probing libs inside a zip file
- libraries inside zip files can be referred to using the same notation as implemented in simpleperf: "/path/to/a/zip!/path/within/a/zip". For example: `trace '/data/app/com.example/base.apk!/lib/arm64-v8a/libtest.so:some_function'` traces `some_function` defined in `lib/arm64-v8a/libtest.so` embedded in `/data/app/com.example/base.apk` archive.

Test plan:
- use trace to trace and symbolicate functions defined in a zipped library
- use bpftrace to trace and symbolicate functions defined in a zipped library