### PR TITLE
Truncate long uprobe names and append its hash for differentiation

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -858,17 +858,8 @@ namespace {
 constexpr size_t kEventNameSizeLimit = 224;
 
 std::string shorten_event_name(const std::string& name) {
-  constexpr size_t kHashSuffixLen = 16;
-  std::string res;
-  res.reserve(kEventNameSizeLimit);
-  res.assign(name);
-  res.resize(kEventNameSizeLimit - kHashSuffixLen);
-
-  std::stringstream stream;
-  size_t hash = std::hash<std::string>{}(name);
-  stream << std::hex << hash;
-  res.append(stream.str());
-  return res;
+  std::string hash = uint_to_hex(std::hash<std::string>{}(name));
+  return name.substr(0, kEventNameSizeLimit - hash.size()) + hash;
 }
 
 } // namespace


### PR DESCRIPTION
Sometime uprobe names can be quite long, e.g. when it contains the path to a binary in a docker container. This pull request will truncate a long uprobe name to 208 characters and append a 16 character hash of the name to the end in order to differentiate between similar names.