### PR TITLE
tools/nfsslower: fix on v3-only systems

### DIFF
--- a/tools/nfsslower.py
+++ b/tools/nfsslower.py
@@ -417,15 +417,17 @@ b = BPF(text=bpf_text,
     cflags=["-Wno-tautological-constant-out-of-range-compare"])
 b.attach_kprobe(event="nfs_file_read", fn_name="trace_rw_entry")
 b.attach_kprobe(event="nfs_file_write", fn_name="trace_rw_entry")
-b.attach_kprobe(event="nfs4_file_open", fn_name="trace_file_open_entry")
 b.attach_kprobe(event="nfs_file_open", fn_name="trace_file_open_entry")
 b.attach_kprobe(event="nfs_getattr", fn_name="trace_getattr_entry")
 
 b.attach_kretprobe(event="nfs_file_read", fn_name="trace_read_return")
 b.attach_kretprobe(event="nfs_file_write", fn_name="trace_write_return")
-b.attach_kretprobe(event="nfs4_file_open", fn_name="trace_file_open_return")
 b.attach_kretprobe(event="nfs_file_open", fn_name="trace_file_open_return")
 b.attach_kretprobe(event="nfs_getattr", fn_name="trace_getattr_return")
+
+if BPF.get_kprobe_functions(b'nfs4_file_open'):
+    b.attach_kprobe(event="nfs4_file_open", fn_name="trace_file_open_entry")
+    b.attach_kretprobe(event="nfs4_file_open", fn_name="trace_file_open_return")
 
 if not is_support_raw_tp:
     b.attach_kprobe(event="nfs_initiate_commit",


### PR DESCRIPTION
The nfs4_file_open tracepoints are part of nfsv4.ko, which may not be loaded on systems using NFSv3 only. Do not attempt to attach probes in this case. For nfsdist.py, a similar issue has already been addressed likewise in commit a433ef945.

Signed-off-by: Daniel Kobras <kobras@puzzle-itc.de>