### PR TITLE
libbpf-tools/numamove: Fix failed to attach: ERROR: strerror_r(-524)=22

### DIFF
--- a/libbpf-tools/numamove.bpf.c
+++ b/libbpf-tools/numamove.bpf.c
@@ -14,8 +14,7 @@ struct {
 __u64 latency = 0;
 __u64 num = 0;
 
-SEC("fentry/migrate_misplaced_page")
-int BPF_PROG(migrate_misplaced_page)
+static int __migrate_misplaced_page(void)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	u64 ts = bpf_ktime_get_ns();
@@ -24,8 +23,19 @@ int BPF_PROG(migrate_misplaced_page)
 	return 0;
 }
 
-SEC("fexit/migrate_misplaced_page")
-int BPF_PROG(migrate_misplaced_page_exit)
+SEC("fentry/migrate_misplaced_page")
+int BPF_PROG(fentry_migrate_misplaced_page)
+{
+	return __migrate_misplaced_page();
+}
+
+SEC("kprobe/migrate_misplaced_page")
+int BPF_PROG(kprobe_migrate_misplaced_page)
+{
+	return __migrate_misplaced_page();
+}
+
+static int __migrate_misplaced_page_exit(void)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	u64 *tsp, ts = bpf_ktime_get_ns();
@@ -43,6 +53,18 @@ int BPF_PROG(migrate_misplaced_page_exit)
 cleanup:
 	bpf_map_delete_elem(&start, &pid);
 	return 0;
+}
+
+SEC("fexit/migrate_misplaced_page")
+int BPF_PROG(fexit_migrate_misplaced_page_exit)
+{
+	return __migrate_misplaced_page_exit();
+}
+
+SEC("kretprobe/migrate_misplaced_page")
+int BPF_PROG(kretprobe_migrate_misplaced_page_exit)
+{
+	return __migrate_misplaced_page_exit();
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/numamove.c
+++ b/libbpf-tools/numamove.c
@@ -2,7 +2,8 @@
 // Copyright (c) 2020 Wenbo Zhang
 //
 // Based on numamove(8) from BPF-Perf-Tools-Book by Brendan Gregg.
-// 8-Jun-2020   Wenbo Zhang   Created this.
+//  8-Jun-2020   Wenbo Zhang   Created this.
+// 30-Jan-2023   Rong Tao      Use fentry_can_attach() to decide use fentry/kprobe.
 #include <argp.h>
 #include <signal.h>
 #include <stdio.h>
@@ -83,7 +84,7 @@ int main(int argc, char **argv)
 	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
-	obj = numamove_bpf__open_and_load();
+	obj = numamove_bpf__open();
 	if (!obj) {
 		fprintf(stderr, "failed to open and/or load BPF object\n");
 		return 1;
@@ -91,6 +92,21 @@ int main(int argc, char **argv)
 
 	if (!obj->bss) {
 		fprintf(stderr, "Memory-mapping BPF maps is supported starting from Linux 5.7, please upgrade.\n");
+		goto cleanup;
+	}
+
+	/* It fallbacks to kprobes when kernel does not support fentry. */
+	if (fentry_can_attach("migrate_misplaced_page", NULL)) {
+		bpf_program__set_autoload(obj->progs.kprobe_migrate_misplaced_page, false);
+		bpf_program__set_autoload(obj->progs.kretprobe_migrate_misplaced_page_exit, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.fentry_migrate_misplaced_page, false);
+		bpf_program__set_autoload(obj->progs.fexit_migrate_misplaced_page_exit, false);
+	}
+
+	err = numamove_bpf__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF skelect: %d\n", err);
 		goto cleanup;
 	}
 


### PR DESCRIPTION
Add kprobe and use fentry_can_attach() to decide whether to use fentry or kprobe.

logs:
```
$ sudo ./numamove
libbpf: prog 'fentry_migrate_misplaced_page': failed to attach: ERROR: strerror_r(-524)=22
libbpf: prog 'fentry_migrate_misplaced_page': failed to auto-attach: -524
failed to attach BPF programs
```