### PR TITLE
libbpf-tools/wakeuptime: Fix the type of the value

### DIFF
--- a/libbpf-tools/wakeuptime.c
+++ b/libbpf-tools/wakeuptime.c
@@ -156,9 +156,10 @@ static void sig_int(int signo)
 static void print_map(struct ksyms *ksyms, struct wakeuptime_bpf *obj)
 {
 	struct key_t lookup_key = {}, next_key;
-	int err, i, counts_fd, stack_traces_fd, val;
+	int err, i, counts_fd, stack_traces_fd;
 	unsigned long *ip;
 	const struct ksym *ksym;
+	__u64 val;
 
 	ip = calloc(env.perf_max_stack_depth, sizeof(*ip));
 	if (!ip) {
@@ -190,7 +191,7 @@ static void print_map(struct ksyms *ksyms, struct wakeuptime_bpf *obj)
 		printf("	%16s %s\n","waker:", next_key.waker);
 		/*to convert val in microseconds*/
 		val /= 1000;
-		printf("	%d\n", val);
+		printf("	%lld\n", val);
 	}
 
 	free(ip);


### PR DESCRIPTION
The type of value in wakeuptime.c defined as int, it may be overflow and output as a negative numbers. Actually the type of value in map count is u64 defined at wakeuptime.bpf.c. So change the int to __u64 to fix it.

Signed-off-by: Hailong Liu <liuhailong@linux.alibaba.com>