### PR TITLE
libbpf-tools/cachestat: Fix failed to attach: ERROR: strerror_r(-524)=22

### DIFF
--- a/libbpf-tools/cachestat.bpf.c
+++ b/libbpf-tools/cachestat.bpf.c
@@ -9,28 +9,64 @@ __s64 misses = 0;	/* total of add to lru because of read misses */
 __u64 mbd = 0;  	/* total of mark_buffer_dirty events */
 
 SEC("fentry/add_to_page_cache_lru")
-int BPF_PROG(add_to_page_cache_lru)
+int BPF_PROG(fentry_add_to_page_cache_lru)
 {
 	__sync_fetch_and_add(&misses, 1);
 	return 0;
 }
 
 SEC("fentry/mark_page_accessed")
-int BPF_PROG(mark_page_accessed)
+int BPF_PROG(fentry_mark_page_accessed)
 {
 	__sync_fetch_and_add(&total, 1);
 	return 0;
 }
 
 SEC("fentry/account_page_dirtied")
-int BPF_PROG(account_page_dirtied)
+int BPF_PROG(fentry_account_page_dirtied)
 {
 	__sync_fetch_and_add(&misses, -1);
 	return 0;
 }
 
 SEC("fentry/mark_buffer_dirty")
-int BPF_PROG(mark_buffer_dirty)
+int BPF_PROG(fentry_mark_buffer_dirty)
+{
+	__sync_fetch_and_add(&total, -1);
+	__sync_fetch_and_add(&mbd, 1);
+	return 0;
+}
+
+SEC("kprobe/add_to_page_cache_lru")
+int BPF_KPROBE(kprobe_add_to_page_cache_lru)
+{
+	__sync_fetch_and_add(&misses, 1);
+	return 0;
+}
+
+SEC("kprobe/mark_page_accessed")
+int BPF_KPROBE(kprobe_mark_page_accessed)
+{
+	__sync_fetch_and_add(&total, 1);
+	return 0;
+}
+
+SEC("kprobe/account_page_dirtied")
+int BPF_KPROBE(kprobe_account_page_dirtied)
+{
+	__sync_fetch_and_add(&misses, -1);
+	return 0;
+}
+
+SEC("kprobe/folio_account_dirtied")
+int BPF_KPROBE(kprobe_folio_account_dirtied)
+{
+	__sync_fetch_and_add(&misses, -1);
+	return 0;
+}
+
+SEC("kprobe/mark_buffer_dirty")
+int BPF_KPROBE(kprobe_mark_buffer_dirty)
 {
 	__sync_fetch_and_add(&total, -1);
 	__sync_fetch_and_add(&mbd, 1);

--- a/libbpf-tools/cachestat.c
+++ b/libbpf-tools/cachestat.c
@@ -2,7 +2,9 @@
 // Copyright (c) 2021 Wenbo Zhang
 //
 // Based on cachestat(8) from BCC by Brendan Gregg and Allan McAleavy.
-// 8-Mar-2021   Wenbo Zhang   Created this.
+//  8-Mar-2021   Wenbo Zhang   Created this.
+// 30-Jan-2023   Rong Tao      Add kprobe and use fentry_can_attach() decide
+//                             use fentry/kprobe
 #include <argp.h>
 #include <signal.h>
 #include <stdio.h>
@@ -153,12 +155,43 @@ int main(int argc, char **argv)
 	 * in kernel commit 203a31516616 ("mm/writeback: Add __folio_mark_dirty()")
 	 */
 	if (fentry_can_attach("folio_account_dirtied", NULL)) {
-		err = bpf_program__set_attach_target(obj->progs.account_page_dirtied, 0,
+		err = bpf_program__set_attach_target(obj->progs.fentry_account_page_dirtied, 0,
 						     "folio_account_dirtied");
 		if (err) {
 			fprintf(stderr, "failed to set attach target\n");
 			goto cleanup;
 		}
+	}
+	if (kprobe_exists("folio_account_dirtied")) {
+		bpf_program__set_autoload(obj->progs.kprobe_account_page_dirtied, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.kprobe_folio_account_dirtied, false);
+	}
+
+	/* It fallbacks to kprobes when kernel does not support fentry. */
+	if (fentry_can_attach("folio_account_dirtied", NULL)
+		|| fentry_can_attach("account_page_dirtied", NULL)) {
+		bpf_program__set_autoload(obj->progs.kprobe_account_page_dirtied, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.fentry_account_page_dirtied, false);
+	}
+
+	if (fentry_can_attach("add_to_page_cache_lru", NULL)) {
+		bpf_program__set_autoload(obj->progs.kprobe_add_to_page_cache_lru, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.fentry_add_to_page_cache_lru, false);
+	}
+
+	if (fentry_can_attach("mark_page_accessed", NULL)) {
+		bpf_program__set_autoload(obj->progs.kprobe_mark_page_accessed, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.fentry_mark_page_accessed, false);
+	}
+
+	if (fentry_can_attach("mark_buffer_dirty", NULL)) {
+		bpf_program__set_autoload(obj->progs.kprobe_mark_buffer_dirty, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.fentry_mark_buffer_dirty, false);
 	}
 
 	err = cachestat_bpf__load(obj);


### PR DESCRIPTION
Add kprobes and use fentry_can_attach() to decide whether to use fentry or kprobe.
