### PR TITLE
tools: Add scsilatency, scsisnoop, f2fsdist, f2fsslower tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[exitsnoop](tools/exitsnoop.py): Trace process termination (exit and fatal signals). [Examples](tools/exitsnoop_example.txt).
 - tools/[ext4dist](tools/ext4dist.py): Summarize ext4 operation latency distribution as a histogram. [Examples](tools/ext4dist_example.txt).
 - tools/[ext4slower](tools/ext4slower.py): Trace slow ext4 operations. [Examples](tools/ext4slower_example.txt).
+- tools/[f2fsdist](tools/f2fsdist.py): Summarize F2FS operation latency distribution as a histogram. [Examples](tools/f2fsdist_example.txt)
 - tools/[filelife](tools/filelife.py): Trace the lifespan of short-lived files. [Examples](tools/filelife_example.txt).
 - tools/[filegone](tools/filegone.py): Trace why file gone (deleted or renamed). [Examples](tools/filegone_example.txt).
 - tools/[fileslower](tools/fileslower.py): Trace slow synchronous file reads and writes. [Examples](tools/fileslower_example.txt).

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[ext4dist](tools/ext4dist.py): Summarize ext4 operation latency distribution as a histogram. [Examples](tools/ext4dist_example.txt).
 - tools/[ext4slower](tools/ext4slower.py): Trace slow ext4 operations. [Examples](tools/ext4slower_example.txt).
 - tools/[f2fsdist](tools/f2fsdist.py): Summarize F2FS operation latency distribution as a histogram. [Examples](tools/f2fsdist_example.txt)
+- tools/[f2fsslower](tools/f2fsslower.py): Trace slow F2FS operations. [Examples](tools/f2fsslower_example.txt).
 - tools/[filelife](tools/filelife.py): Trace the lifespan of short-lived files. [Examples](tools/filelife_example.txt).
 - tools/[filegone](tools/filegone.py): Trace why file gone (deleted or renamed). [Examples](tools/filegone_example.txt).
 - tools/[fileslower](tools/fileslower.py): Trace slow synchronous file reads and writes. [Examples](tools/fileslower_example.txt).

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[runqlat](tools/runqlat.py): Run queue (scheduler) latency as a histogram. [Examples](tools/runqlat_example.txt).
 - tools/[runqlen](tools/runqlen.py): Run queue length as a histogram. [Examples](tools/runqlen_example.txt).
 - tools/[runqslower](tools/runqslower.py): Trace long process scheduling delays. [Examples](tools/runqslower_example.txt).
+- tools/[scsilatency](tools/scsilatency.py): Summarize SCSI layer I/O latency as a histogram . [Examples](tools/scsilatency_example.txt).
 - tools/[shmsnoop](tools/shmsnoop.py): Trace System V shared memory syscalls. [Examples](tools/shmsnoop_example.txt).
 - tools/[sofdsnoop](tools/sofdsnoop.py): Trace FDs passed through unix sockets. [Examples](tools/sofdsnoop_example.txt).
 - tools/[slabratetop](tools/slabratetop.py): Kernel SLAB/SLUB memory cache allocation rate top. [Examples](tools/slabratetop_example.txt).

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[runqlen](tools/runqlen.py): Run queue length as a histogram. [Examples](tools/runqlen_example.txt).
 - tools/[runqslower](tools/runqslower.py): Trace long process scheduling delays. [Examples](tools/runqslower_example.txt).
 - tools/[scsilatency](tools/scsilatency.py): Summarize SCSI layer I/O latency as a histogram . [Examples](tools/scsilatency_example.txt).
+- tools/[scsisnoop](tools/scsisnoop.py): Trace SCSI layer device I/O with PID and latency. [Examples](tools/scsisnoop_example.txt).
 - tools/[shmsnoop](tools/shmsnoop.py): Trace System V shared memory syscalls. [Examples](tools/shmsnoop_example.txt).
 - tools/[sofdsnoop](tools/sofdsnoop.py): Trace FDs passed through unix sockets. [Examples](tools/sofdsnoop_example.txt).
 - tools/[slabratetop](tools/slabratetop.py): Kernel SLAB/SLUB memory cache allocation rate top. [Examples](tools/slabratetop_example.txt).

--- a/man/man8/f2fsdist.8
+++ b/man/man8/f2fsdist.8
@@ -1,0 +1,80 @@
+.TH f2fsdist 8  "2022-07-28" "USER COMMANDS"
+.SH NAME
+f2fsdist \- Summarize f2fs operation latency. Uses Linux eBPF/bcc.
+.SH SYNOPSIS
+.B f2fsdist [\-h] [\-T] [\-m] [\-p PID] [interval] [count]
+.SH DESCRIPTION
+This tool summarizes time (latency) spent in common f2fs file operations: reads,
+writes, opens, and syncs, and presents it as a power-of-2 histogram. It uses an
+in-kernel eBPF map to store the histogram for efficiency.
+
+Since this works by tracing the f2fs_file_operations interface functions, it
+will need updating to match any changes to these functions.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+.SH OPTIONS
+.TP
+\-h
+Print usage message.
+.TP
+\-T
+Don't include timestamps on interval output.
+.TP
+\-m
+Output in milliseconds.
+.TP
+\-p PID
+Trace this PID only.
+.SH EXAMPLES
+.TP
+Trace f2fs operation time, and print a summary on Ctrl-C:
+#
+.B f2fsdist
+.TP
+Trace PID 181 only:
+#
+.B f2fsdist -p 181
+.TP
+Print 1 second summaries, 10 times:
+#
+.B f2fsdist 1 10
+.TP
+1 second summaries, printed in milliseconds
+#
+.B f2fsdist \-m 1
+.SH FIELDS
+.TP
+msecs
+Range of milliseconds for this bucket.
+.TP
+usecs
+Range of microseconds for this bucket.
+.TP
+count
+Number of operations in this time range.
+.TP
+distribution
+ASCII representation of the distribution (the count column).
+.SH OVERHEAD
+This adds low-overhead instrumentation to these f2fs operations,
+including reads and writes from the file system cache. Such reads and writes
+can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool may become noticeable.
+Measure and quantify before use.
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Ting Zhang
+.SH SEE ALSO
+ext4snoop(8)

--- a/man/man8/f2fsslower.8
+++ b/man/man8/f2fsslower.8
@@ -1,0 +1,113 @@
+.TH f2fsslower 8  "2022-08-15" "USER COMMANDS"
+.SH NAME
+f2fsslower \- Trace slow f2fs file operations, with per-event details.
+.SH SYNOPSIS
+.B f2fsslower [\-h] [\-j] [\-p PID] [min_ms]
+.SH DESCRIPTION
+This tool traces common f2fs file operations: reads, writes, opens, and
+syncs. It measures the time spent in these operations, and prints details
+for each that exceeded a threshold.
+
+WARNING: See the OVERHEAD section.
+
+By default, a minimum millisecond threshold of 10 is used. If a threshold of 0
+is used, all events are printed (warning: verbose).
+
+Since this works by tracing the f2fs_file_operations interface functions, it
+will need updating to match any changes to these functions.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+.SH OPTIONS
+\-p PID
+Trace this PID only.
+.TP
+min_ms
+Minimum I/O latency (duration) to trace, in milliseconds. Default is 10 ms.
+.SH EXAMPLES
+.TP
+Trace synchronous file reads and writes slower than 10 ms:
+#
+.B f2fsslower
+.TP
+Trace slower than 1 ms:
+#
+.B f2fsslower 1
+.TP
+Trace slower than 1 ms, and output just the fields in parsable format (csv):
+#
+.B f2fsslower \-j 1
+.TP
+Trace all file reads and writes (warning: the output will be verbose):
+#
+.B f2fsslower 0
+.TP
+Trace slower than 1 ms, for PID 181 only:
+#
+.B f2fsslower \-p 181 1
+.SH FIELDS
+.TP
+TIME(s)
+Time of I/O completion since the first I/O seen, in seconds.
+.TP
+COMM
+Process name.
+.TP
+PID
+Process ID.
+.TP
+T
+Type of operation. R == read, W == write, O == open, S == fsync.
+.TP
+OFF_KB
+File offset for the I/O, in Kbytes.
+.TP
+BYTES
+Size of I/O, in bytes.
+.TP
+LAT(ms)
+Latency (duration) of I/O, measured from when it was issued by VFS to the
+filesystem, to when it completed. This time is inclusive of block device I/O,
+file system CPU cycles, file system locks, run queue latency, etc. It's a more
+accurate measure of the latency suffered by applications performing file
+system I/O, than to measure this down at the block device interface.
+.TP
+FILENAME
+A cached kernel file name (comes from dentry->d_name.name).
+.TP
+ENDTIME_us
+Completion timestamp, microseconds (\-j only).
+.TP
+OFFSET_b
+File offset, bytes (\-j only).
+.TP
+LATENCY_us
+Latency (duration) of the I/O, in microseconds (\-j only).
+.SH OVERHEAD
+This adds low-overhead instrumentation to these f2fs operations,
+including reads and writes from the file system cache. Such reads and writes
+can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool (even if it prints no "slower" events) can
+begin to become significant. Measure and quantify before use. If this
+continues to be a problem, consider switching to a tool that prints in-kernel
+summaries only.
+.PP
+Note that the overhead of this tool should be less than fileslower(8), as
+this tool targets f2fs functions only, and not all file read/write paths
+(which can include socket I/O).
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Ting Zhang
+.SH SEE ALSO
+biosnoop(8), funccount(8), fileslower(8)

--- a/man/man8/scsilatency.8
+++ b/man/man8/scsilatency.8
@@ -1,0 +1,109 @@
+.TH scsilatency 8  "2022-10-10" "USER COMMANDS"
+.SH NAME
+scsilatency \- Summarize SCSI layer I/O latency as a histogram.
+.SH SYNOPSIS
+.B scsilatency [\-h] [\-F] [\-T] [\-m] [\-D] [\-e] [interval [count]]
+.SH DESCRIPTION
+scsilatency traces SCSI layer I/O (disk I/O), and records the distribution
+of I/O latency (time). This is printed as a histogram either on Ctrl-C, or
+after a given interval in seconds.
+
+The latency of disk I/O operations is measured from when requests are issued to the device
+up to completion. 
+
+This tool uses in-kernel eBPF maps for storing timestamps and the histogram,
+for efficiency.
+
+This works by tracing various kernel scsi_*() functions using dynamic tracing,
+and will need updating to match any changes to these functions.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+.SH OPTIONS
+\-h
+Print usage message.
+.TP
+\-T
+Include timestamps on output.
+.TP
+\-m
+Output histogram in milliseconds.
+.TP
+\-D
+Print a histogram per disk device.
+.TP
+\-F
+Print a histogram per set of I/O flags.
+.TP
+\-j
+Print a histogram dictionary
+.TP
+\-e
+Show extension summary(total, average)
+.TP
+interval
+Output interval, in seconds.
+.TP
+count
+Number of outputs.
+.SH EXAMPLES
+.TP
+Summarize SCSI layer I/O latency as a histogram:
+#
+.B scsilatency
+.TP
+Print 1 second summaries, 10 times:
+#
+.B scsilatency 1 10
+.TP
+Print 1 second summaries, using milliseconds as units for the histogram, and
+include timestamps on output:
+#
+.B scsilatency \-mT 1
+.TP
+Show a latency histogram for each disk device separately:
+#
+.B scsilatency \-D
+.TP
+Show a latency histogram in a dictionary format:
+#
+.B scsilatency \-j
+.TP
+Also show extension summary(total, average):
+#
+.B scsilatency \-e
+.SH FIELDS
+.TP
+usecs
+Microsecond range
+.TP
+msecs
+Millisecond range
+.TP
+count
+How many I/O fell into this range
+.TP
+distribution
+An ASCII bar chart to visualize the distribution (count column)
+.SH OVERHEAD
+This traces kernel functions and maintains in-kernel timestamps and a histogram,
+which are asynchronously copied to user-space. This method is very efficient,
+and the overhead for most storage I/O rates (< 10k IOPS) should be negligible.
+If you have a higher IOPS storage environment, test and quantify the overhead
+before use.
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Weibang Liu
+.SH SEE ALSO
+biosnoop(8)

--- a/man/man8/scsisnoop.8
+++ b/man/man8/scsisnoop.8
@@ -1,0 +1,80 @@
+.TH scsisnoop 8  "2022-10-10" "USER COMMANDS"
+.SH NAME
+scsisnoop \- Trace SCSI layer I/O and print details incl. issuing PID.
+.SH SYNOPSIS
+.B scsisnoop [\-h]
+.SH DESCRIPTION
+This tools traces SCSI layer I/O (disk I/O), and prints a one-line summary
+for each I/O showing various details. These include the latency from the time of
+issue to the device to its completion, and the PID and process name from when
+the I/O was first created (which usually identifies the responsible process).
+
+This uses in-kernel eBPF maps to cache process details (PID and comm) by I/O
+request, as well as a starting timestamp for calculating I/O latency.
+
+This works by tracing various kernel scsi_*() functions using dynamic tracing,
+and will need updating to match any changes to these functions.
+
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+.SH OPTIONS
+.TP
+\-h
+Print usage message.
+.SH EXAMPLES
+.TP
+Trace all SCSI layer I/O and print a summary line per I/O:
+#
+.B scsisnoop
+.SH FIELDS
+.TP
+TIME(s)
+Time of the I/O completion, in seconds since the first I/O was seen.
+.TP
+COMM
+Cached process name, if present. This usually (but isn't guaranteed) to identify
+the responsible process for the I/O.
+.TP
+PID
+Cached process ID, if present. This usually (but isn't guaranteed) to identify
+the responsible process for the I/O.
+.TP
+DISK
+Disk device name.
+.TP
+T
+Type of I/O: R = read, W = write. This is a simplification.
+.TP
+SECTOR
+Device sector for the I/O.
+.TP
+BYTES
+Size of the I/O, in bytes.
+.TP
+LAT(ms)
+Time for the I/O (latency) from the issue to the device, to its completion,
+in milliseconds.
+.SH OVERHEAD
+Since SCSI layer I/O usually has a relatively low frequency (< 10,000/s),
+the overhead for this tool is expected to be negligible. For high IOPS storage
+systems, test and quantify before use.
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Weibang Liu
+.SH SEE ALSO
+disksnoop(8), iostat(1)

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -298,6 +298,10 @@ class SmokeTests(TestCase):
     def test_scsilatency(self):
         self.run_with_duration("scsilatency 1 1")
 
+    @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
+    def test_scsisnoop(self):
+        self.run_with_duration("scsisnoop")
+
     @skipUnless(kernel_version_ge(4,8), "requires kernel >= 4.8")
     def test_shmsnoop(self):
         self.run_with_int("shmsnoop.py")

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -295,6 +295,9 @@ class SmokeTests(TestCase):
     def test_runqlen(self):
         self.run_with_duration("runqlen.py 1 1")
 
+    def test_scsilatency(self):
+        self.run_with_duration("scsilatency 1 1")
+
     @skipUnless(kernel_version_ge(4,8), "requires kernel >= 4.8")
     def test_shmsnoop(self):
         self.run_with_int("shmsnoop.py")

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -181,6 +181,10 @@ class SmokeTests(TestCase):
         self.run_with_duration("f2fsdist.py 1 1")
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
+    def test_f2fsslower(self):
+        self.run_with_int("f2fsslower.py")
+
+    @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
     def test_filelife(self):
         self.run_with_int("filelife.py")
 

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -177,6 +177,9 @@ class SmokeTests(TestCase):
     def test_ext4slower(self):
         self.run_with_int("ext4slower.py")
 
+    def test_f2fsdist(self):
+        self.run_with_duration("f2fsdist.py 1 1")
+
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
     def test_filelife(self):
         self.run_with_int("filelife.py")

--- a/tools/f2fsdist.py
+++ b/tools/f2fsdist.py
@@ -1,0 +1,231 @@
+#!/usr/bin/python
+# SPDX-License-Identifier: <SPDX License Expression>
+# @lint-avoid-python-3-compatibility-imports
+#
+# f2fsdist  Summarize f2fs operation latency.
+#           For Linux, uses BCC, eBPF.
+#
+# USAGE: f2fsdist [-h] [-T] [-m] [-p PID] [interval] [count]
+#
+# Copyright (c) 28-JUL-2022, Samsung Electronics.  All rights reserved.
+# This source code is licensed under the Apache License, Version 2.0
+#
+# Written by Ting Zhang<ting03.zhang@samsung.com>.
+
+from __future__ import print_function
+from bcc import BPF
+from time import sleep, strftime
+import argparse
+
+# symbols
+kallsyms = "/proc/kallsyms"
+
+# arguments
+examples = """examples:
+    ./f2fsdist            # show operation latency as a histogram
+    ./f2fsdist -p 181     # trace PID 181 only
+    ./f2fsdist 1 10       # print 1 second summaries, 10 times
+    ./f2fsdist -m 5       # 5s summaries, milliseconds
+"""
+# paras description
+parser = argparse.ArgumentParser(
+    description="Summarize f2fs operation latency",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("-T", "--notimestamp", action="store_true",
+                    help="don't include timestamp on interval output")
+parser.add_argument("-m", "--milliseconds", action="store_true",
+                    help="output in milliseconds")
+parser.add_argument("-p", "--pid",
+                    help="trace this PID only")
+parser.add_argument("interval", nargs="?",
+                    help="output interval, in seconds")
+parser.add_argument("count", nargs="?", default=99999999,
+                    help="number of outputs")
+parser.add_argument("--ebpf", action="store_true",
+                    help=argparse.SUPPRESS)
+args = parser.parse_args()
+pid = args.pid
+countdown = int(args.count)
+
+if args.milliseconds:
+    factor = 1000000
+    label = "msecs"
+else:
+    factor = 1000
+    label = "usecs"
+if args.interval and int(args.interval) == 0:
+    print("ERROR: interval 0. Exiting.")
+    exit()
+debug = 0
+
+# define BPF program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/fs.h>
+#include <linux/sched.h>
+#define OP_NAME_LEN 8
+typedef struct dist_key{
+    char op[OP_NAME_LEN];
+    u64 slot;
+}dist_key_t;
+BPF_HASH(start,u32);
+BPF_HISTOGRAM(dist,dist_key_t);
+
+//time operation
+int trace_entry(struct pt_regs *ctx)
+{
+    u64 pid_tgid=bpf_get_current_pid_tgid();
+    u32 pid=pid_tgid>>32;
+    u32 tid=(u32)pid_tgid;
+    if(FILTER_PID)
+        return 0;
+    u64 ts=bpf_ktime_get_ns();
+    start.update(&tid,&ts);
+    return 0;
+}
+F2FS_TRACE_READ_CODE
+static int trace_return(struct pt_regs *ctx, const char *op)
+{
+    u64 *tsp;
+    u64 pid_tgid=bpf_get_current_pid_tgid();
+    u32 pid=pid_tgid>>32;
+    u32 tid=(u32)pid_tgid;
+    //fetch timestamp and calculate delta
+    tsp=start.lookup(&tid);
+    if(tsp==0)
+    {
+        return 0; //missed start or filtered
+    }
+    u64 delta=bpf_ktime_get_ns() - *tsp;
+    start.delete(&tid);
+
+    //Skip entries with backwards time: temp workarount for
+    if((s64) delta <0)
+        return 0;
+    delta/=FACTOR;
+
+    //store as histogram
+    dist_key_t key={.slot = bpf_log2l(delta)};
+    __builtin_memcpy(&key.op, op, sizeof(key.op));
+    dist.increment(key);
+
+    return 0;
+}
+
+int trace_read_return(struct pt_regs *ctx)
+{
+    char *op = "read";
+    return trace_return(ctx,op);
+}
+int trace_write_return(struct pt_regs *ctx)
+{
+    char *op = "write";
+    return trace_return(ctx,op);
+}
+int trace_open_return(struct pt_regs *ctx)
+{
+    char *op = "open";
+    return trace_return(ctx,op);
+}
+int trace_fsync_return(struct pt_regs *ctx)
+{
+    char *op = "fsync";
+    return trace_return(ctx,op);
+}
+"""
+# Starting from Linux 4.10 f2fs_file_operations.read_iter has been changed from
+# using generic_file_read_iter() to its own f2fs_file_read_iter().
+#
+# To detect the proper function to trace check if f2fs_file_read_iter() is
+# defined in /proc/kallsyms, if it's defined attach to that function, otherwise
+# use generic_file_read_iter() and inside the trace hook filter on f2fs read
+# events (checking if file->f_op == f2fs_file_operations).
+
+if BPF.get_kprobe_functions(b'f2fs_file_read_iter'):
+    f2fs_read_fn = 'f2fs_file_read_iter'
+    f2fs_trace_read_fn = 'trace_entry'
+    f2fs_trace_read_code = ''
+else:
+    f2fs_read_fn = 'generic_file_read_iter'
+    f2fs_trace_read_fn = 'trace_read_entry'
+    f2fs_file_ops_addr = ''
+    with open(kallsyms) as syms:
+        for line in syms:
+            (addr, size, name) = line.rstrip().split(" ", 2)
+            name = name.split("\t")[0]
+            if name == "f2fs_file_operations":
+                f2fs_file_ops_addr = "0x" + addr
+                break
+        if f2fs_file_ops_addr == '':
+            print("ERROR: no f2fs_file_operations in /proc/kallsyms. Exiting.")
+            print("HINT: the kernel should be built with CONFIG_KALLSYMS_ALL.")
+            exit()
+
+    f2fs_trace_read_code = """
+int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
+{
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
+    if (FILTER_PID)
+        return 0;
+
+    // f2fs filter on file->f_op == f2fs_file_operations
+    struct file *fp = iocb->ki_filp;
+    if ((u64)fp->f_op != %s)
+        return 0;
+
+    u64 ts = bpf_ktime_get_ns();
+    start.update(&tid, &ts);
+    return 0;
+}""" % f2fs_file_ops_addr
+
+# code replacements
+bpf_text = bpf_text.replace('F2FS_TRACE_READ_CODE', f2fs_trace_read_code)
+bpf_text = bpf_text.replace('FACTOR', str(factor))
+if args.pid:
+    bpf_text = bpf_text.replace('FILTER_PID', 'pid != %s' % pid)
+else:
+    bpf_text = bpf_text.replace('FILTER_PID', '0')
+if debug or args.ebpf:
+    print(bpf_text)
+    if args.ebpf:
+        exit()
+
+# load BPF program
+b = BPF(text=bpf_text)
+
+b.attach_kprobe(event=f2fs_read_fn, fn_name=f2fs_trace_read_fn)
+b.attach_kprobe(event="f2fs_file_write_iter", fn_name="trace_entry")
+b.attach_kprobe(event="f2fs_file_open", fn_name="trace_entry")
+b.attach_kprobe(event="f2fs_sync_file", fn_name="trace_entry")
+b.attach_kretprobe(event=f2fs_read_fn, fn_name='trace_read_return')
+b.attach_kretprobe(event="f2fs_file_write_iter", fn_name='trace_write_return')
+b.attach_kretprobe(event="f2fs_file_open", fn_name='trace_open_return')
+b.attach_kretprobe(event="f2fs_sync_file", fn_name='trace_fsync_return')
+print("Tracing f2fs operation latency... Hit Ctrl-C to end.")
+
+# output
+exiting = 0
+dist = b.get_table("dist")
+while (1):
+    try:
+        if args.interval:
+            sleep(int(args.interval))
+        else:
+            sleep(99999999)
+    except KeyboardInterrupt:
+        exiting = 1
+
+    print()
+    if args.interval and (not args.notimestamp):
+        print(strftime("%H:%M:%S:"))
+
+    dist.print_log2_hist(label, "operation", section_print_fn=bytes.decode)
+    dist.clear()
+
+    countdown -= 1
+    if exiting or countdown == 0:
+        exit()

--- a/tools/f2fsdist_example.txt
+++ b/tools/f2fsdist_example.txt
@@ -1,0 +1,162 @@
+Demonstrations of f2fsdist, the Linux eBPF/bcc version.
+
+
+f2fsdist traces f2fs reads, writes, opens, and fsyncs, and summarizes their
+latency as a power-of-2 histogram. For example:
+
+# ./f2fsdist 
+Tracing f2fs operation latency... Hit Ctrl-C to end.
+^C
+
+operation = write
+     usecs               : count     distribution
+         0 -> 1          : 8775     |******                                  |
+         2 -> 3          : 42759    |******************************          |
+         4 -> 7          : 55178    |****************************************|
+         8 -> 15         : 13147    |*********                               |
+        16 -> 31         : 239      |                                        |
+        32 -> 63         : 572      |                                        |
+        64 -> 127        : 539      |                                        |
+       128 -> 255        : 53       |                                        |
+       256 -> 511        : 489      |                                        |
+       512 -> 1023       : 15       |                                        |
+      1024 -> 2047       : 12       |                                        |
+
+operation = read
+     usecs               : count     distribution
+         0 -> 1          : 5487     |*****                                   |
+         2 -> 3          : 20530    |**********************                  |
+         4 -> 7          : 9118     |*********                               |
+         8 -> 15         : 852      |                                        |
+        16 -> 31         : 76       |                                        |
+        32 -> 63         : 38       |                                        |
+        64 -> 127        : 36862    |****************************************|
+       128 -> 255        : 10475    |***********                             |
+       256 -> 511        : 708      |                                        |
+       512 -> 1023       : 103      |                                        |
+      1024 -> 2047       : 95       |                                        |
+      2048 -> 4095       : 4        |                                        |
+      4096 -> 8191       : 9        |                                        |
+      8192 -> 16383      : 7        |                                        |
+     16384 -> 32767      : 41       |                                        |
+
+operation = open
+     usecs               : count     distribution
+         0 -> 1          : 1        |                                        |
+         2 -> 3          : 29       |*                                       |
+         4 -> 7          : 26       |*                                       |
+         8 -> 15         : 39       |**                                      |
+        16 -> 31         : 738      |****************************************|
+        32 -> 63         : 339      |******************                      |
+        64 -> 127        : 27       |*                                       |
+       128 -> 255        : 5        |                                        |
+       256 -> 511        : 1        |                                        |
+       512 -> 1023       : 0        |                                        |
+      1024 -> 2047       : 1        |                                        |
+
+operation = fsync
+     usecs               : count     distribution
+         0 -> 1          : 1185     |*                                       |
+         2 -> 3          : 44305    |****************************************|
+         4 -> 7          : 1503     |*                                       |
+         8 -> 15         : 1304     |*                                       |
+        16 -> 31         : 344      |                                        |
+        32 -> 63         : 219      |                                        |
+        64 -> 127        : 755      |                                        |
+       128 -> 255        : 14444    |*************                           |
+       256 -> 511        : 297      |                                        |
+       512 -> 1023       : 324      |                                        |
+      1024 -> 2047       : 122      |                                        |
+      2048 -> 4095       : 221      |                                        |
+      4096 -> 8191       : 17       |                                        |
+      8192 -> 16383      : 3        |                                        |
+     16384 -> 32767      : 1        |                                        |
+     32768 -> 65535      : 0        |                                        |
+     65536 -> 131071     : 6        |                                        |
+    131072 -> 262143     : 3        |                                        |
+
+
+This output shows a bi-modal distribution for read latency, with a faster
+mode of less than 7 microseconds, and a slower mode of between 256 and 1023
+microseconds. The count column shows how many events fell into that latency
+range. It's likely that the faster mode was a hit from the in-memory file
+system cache, and the slower mode is a read from a storage device (disk).
+
+This "latency" is measured from when the operation was issued from the VFS
+interface to the file system, to when it completed. This spans everything:
+block device I/O (disk I/O), file system CPU cycles, file system locks, run
+queue latency, etc. This is a better measure of the latency suffered by
+applications reading from the file system than measuring this down at the
+block device interface.
+
+Note that this only traces the common file system operations previously
+listed: other file system operations (eg, inode operations including
+getattr()) are not traced.
+
+
+An optional interval and a count can be provided, as well as -m to show the
+distributions in milliseconds. For example:
+
+# ./f2fsdist -m 1 5
+Tracing f2fs operation latency... Hit Ctrl-C to end.
+
+00:15:18:
+
+operation = read
+     msecs               : count     distribution
+         0 -> 1          : 2        |****************************************|
+
+operation = open
+     msecs               : count     distribution
+         0 -> 1          : 2        |****************************************|
+
+00:15:19:
+
+00:15:20:
+
+operation = read
+     msecs               : count     distribution
+         0 -> 1          : 12       |****************************************|
+
+operation = write
+     msecs               : count     distribution
+         0 -> 1          : 13       |****************************************|
+
+operation = open
+     msecs               : count     distribution
+         0 -> 1          : 2        |****************************************|
+
+operation = fsync
+     msecs               : count     distribution
+         0 -> 1          : 4        |****************************************|
+
+00:15:21:
+
+00:15:22:
+
+
+This shows a mixed workload.
+
+
+USAGE message:
+
+# ./f2fsdist -h
+usage: f2fsdist [-h] [-T] [-m] [-p PID] [interval] [count]
+
+Summarize f2fs operation latency
+
+positional arguments:
+  interval            output interval, in seconds
+  count               number of outputs
+
+optional arguments:
+  -h, --help          show this help message and exit
+  -T, --notimestamp   don't include timestamp on interval output
+  -m, --milliseconds  output in milliseconds
+  -p PID, --pid PID   trace this PID only
+
+examples:
+    ./f2fsdist            # show operation latency as a histogram
+    ./f2fsdist -p 181     # trace PID 181 only
+    ./f2fsdist 1 10       # print 1 second summaries, 10 times
+    ./f2fsdist -m 5       # 5s summaries, milliseconds

--- a/tools/f2fsslower.py
+++ b/tools/f2fsslower.py
@@ -1,0 +1,316 @@
+#!/usr/bin/python
+# SPDX-License-Identifier: <SPDX License Expression>
+# @lint-avoid-python-3-compatibility-imports
+#
+# f2fsslower  Trace slow f2fs operations.
+#              For Linux, uses BCC, eBPF.
+#
+# USAGE: f2fsslower [-h] [-j] [-p PID] [min_ms]
+#
+# This script traces common f2fs file operations: reads, writes, opens, and
+# syncs. It measures the time spent in these operations, and prints details
+# for each that exceeded a threshold.
+#
+# WARNING: This adds low-overhead instrumentation to these f2fs operations,
+# including reads and writes from the file system cache. Such reads and writes
+# can be very frequent (depending on the workload; eg, 1M/sec), at which
+# point the overhead of this tool (even if it prints no "slower" events) can
+# begin to become significant.
+#
+# By default, a minimum millisecond threshold of 10 is used.
+#
+# Copyright (c) 15-Aug-2022, Samsung Electronics.  All rights reserved.
+# This source code is licensed under the Apache License, Version 2.0
+#
+# Written by Ting Zhang<ting03.zhang@samsung.com>.
+
+from __future__ import print_function
+from bcc import BPF
+import argparse
+from time import strftime
+
+# symbols
+kallsyms = "/proc/kallsyms"
+
+# arguments
+examples = """examples:
+    ./f2fsslower             # trace operations slower than 10 ms (default)
+    ./f2fsslower 1           # trace operations slower than 1 ms
+    ./f2fsslower -j 1        # ... 1 ms, parsable output (csv)
+    ./f2fsslower 0           # trace all operations (warning: verbose)
+    ./f2fsslower -p 185      # trace PID 185 only
+"""
+parser = argparse.ArgumentParser(
+    description="Trace common f2fs file operations slower than a threshold",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("-j", "--csv", action="store_true",
+                    help="just print fields: comma-separated values")
+parser.add_argument("-p", "--pid",
+                    help="trace this PID only")
+parser.add_argument("min_ms", nargs="?", default='10',
+                    help="minimum I/O duration to trace, in ms (default 10)")
+parser.add_argument("--ebpf", action="store_true",
+                    help=argparse.SUPPRESS)
+args = parser.parse_args()
+min_ms = int(args.min_ms)
+pid = args.pid
+csv = args.csv
+debug = 0
+
+# define BPF program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/fs.h>
+#include <linux/sched.h>
+#include <linux/dcache.h>
+// XXX: switch these to char's when supported
+#define TRACE_READ        0
+#define TRACE_WRITE        1
+#define TRACE_OPEN        2
+#define TRACE_FSYNC        3
+struct val_t {
+    u64 ts;
+    u64 offset;
+    struct file *fp;
+};
+struct data_t {
+    // XXX: switch some to u32's when supported
+    u64 ts_us;
+    u64 type;
+    u32 size;
+    u64 offset;
+    u64 delta_us;
+    u32 pid;
+    char task[TASK_COMM_LEN];
+    char file[DNAME_INLINE_LEN];
+};
+BPF_HASH(entryinfo, u64, struct val_t);
+BPF_PERF_OUTPUT(events);
+//
+// Store timestamp and size on entry
+//
+// The current f2fs (Linux 4.5) uses generic_file_read_iter(), instead of it's
+// own function, for reads. So we need to trace that and then filter on f2fs,
+// which I do by checking file->f_op.
+// The new Linux version (since form 4.10) uses f2fs_file_read_iter(), And if
+// the 'CONFIG_FS_DAX' is not set, then f2fs_file_read_iter() will call
+// generic_file_read_iter(), else it will call f2fs_dax_read_iter(), and trace
+// generic_file_read_iter() will fail.
+int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
+{
+    u64 id =  bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+    if (FILTER_PID)
+        return 0;
+    // f2fs filter on file->f_op == f2fs_file_operations
+    struct file *fp = iocb->ki_filp;
+    if ((u64)fp->f_op != F2FS_FILE_OPERATIONS)
+        return 0;
+    // store filep and timestamp by id
+    struct val_t val = {};
+    val.ts = bpf_ktime_get_ns();
+    val.fp = fp;
+    val.offset = iocb->ki_pos;
+    if (val.fp)
+        entryinfo.update(&id, &val);
+    return 0;
+}
+// f2fs_file_write_iter():
+int trace_write_entry(struct pt_regs *ctx, struct kiocb *iocb)
+{
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+    if (FILTER_PID)
+        return 0;
+    // store filep and timestamp by id
+    struct val_t val = {};
+    val.ts = bpf_ktime_get_ns();
+    val.fp = iocb->ki_filp;
+    val.offset = iocb->ki_pos;
+    if (val.fp)
+        entryinfo.update(&id, &val);
+    return 0;
+}
+// f2fs_file_open():
+int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
+    struct file *file)
+{
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+    if (FILTER_PID)
+        return 0;
+    // store filep and timestamp by id
+    struct val_t val = {};
+    val.ts = bpf_ktime_get_ns();
+    val.fp = file;
+    val.offset = 0;
+    if (val.fp)
+        entryinfo.update(&id, &val);
+    return 0;
+}
+// f2fs_sync_file():
+int trace_fsync_entry(struct pt_regs *ctx, struct file *file)
+{
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+    if (FILTER_PID)
+        return 0;
+    // store filep and timestamp by id
+    struct val_t val = {};
+    val.ts = bpf_ktime_get_ns();
+    val.fp = file;
+    val.offset = 0;
+    if (val.fp)
+        entryinfo.update(&id, &val);
+    return 0;
+}
+//
+// Output
+//
+static int trace_return(struct pt_regs *ctx, int type)
+{
+    struct val_t *valp;
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+    valp = entryinfo.lookup(&id);
+    if (valp == 0) {
+        // missed tracing issue or filtered
+        return 0;
+    }
+    // calculate delta
+    u64 ts = bpf_ktime_get_ns();
+    u64 delta_us = (ts - valp->ts) / 1000;
+    entryinfo.delete(&id);
+    if (FILTER_US)
+        return 0;
+    // populate output struct
+    struct data_t data = {};
+    data.type = type;
+    data.size = PT_REGS_RC(ctx);
+    data.delta_us = delta_us;
+    data.pid = pid;
+    data.ts_us = ts / 1000;
+    data.offset = valp->offset;
+    bpf_get_current_comm(&data.task, sizeof(data.task));
+    // workaround (rewriter should handle file to d_name in one step):
+    struct dentry *de = NULL;
+    struct qstr qs = {};
+    de = valp->fp->f_path.dentry;
+    qs = de->d_name;
+    if (qs.len == 0)
+        return 0;
+    bpf_probe_read_kernel(&data.file, sizeof(data.file), (void *)qs.name);
+    // output
+    events.perf_submit(ctx, &data, sizeof(data));
+    return 0;
+}
+int trace_read_return(struct pt_regs *ctx)
+{
+    return trace_return(ctx, TRACE_READ);
+}
+int trace_write_return(struct pt_regs *ctx)
+{
+    return trace_return(ctx, TRACE_WRITE);
+}
+int trace_open_return(struct pt_regs *ctx)
+{
+    return trace_return(ctx, TRACE_OPEN);
+}
+int trace_fsync_return(struct pt_regs *ctx)
+{
+    return trace_return(ctx, TRACE_FSYNC);
+}
+"""
+
+# code replacements
+with open(kallsyms) as syms:
+    ops = ''
+    for line in syms:
+        (addr, size, name) = line.rstrip().split(" ", 2)
+        name = name.split("\t")[0]
+        if name == "f2fs_file_operations":
+            ops = "0x" + addr
+            break
+    if ops == '':
+        print("ERROR: no f2fs_file_operations in /proc/kallsyms. Exiting.")
+        print("HINT: the kernel should be built with CONFIG_KALLSYMS_ALL.")
+        exit()
+    bpf_text = bpf_text.replace('F2FS_FILE_OPERATIONS', ops)
+if min_ms == 0:
+    bpf_text = bpf_text.replace('FILTER_US', '0')
+else:
+    bpf_text = bpf_text.replace('FILTER_US',
+                                'delta_us <= %s' % str(min_ms * 1000))
+if args.pid:
+    bpf_text = bpf_text.replace('FILTER_PID', 'pid != %s' % pid)
+else:
+    bpf_text = bpf_text.replace('FILTER_PID', '0')
+if debug or args.ebpf:
+    print(bpf_text)
+    if args.ebpf:
+        exit()
+
+
+# process event
+def print_event(cpu, data, size):
+    event = b["events"].event(data)
+
+    type = 'R'
+    if event.type == 1:
+        type = 'W'
+    elif event.type == 2:
+        type = 'O'
+    elif event.type == 3:
+        type = 'S'
+
+    if (csv):
+        print("%d,%s,%d,%s,%d,%d,%d,%s" % (
+            event.ts_us, event.task.decode('utf-8', 'replace'), event.pid,
+            type, event.size, event.offset, event.delta_us,
+            event.file.decode('utf-8', 'replace')))
+        return
+    print("%-8s %-14.14s %-6s %1s %-7s %-8d %7.2f %s" % (strftime("%H:%M:%S"),
+          event.task.decode('utf-8', 'replace'), event.pid, type, event.size,
+          event.offset / 1024, float(event.delta_us) / 1000,
+          event.file.decode('utf-8', 'replace')))
+
+# initialize BPF
+b = BPF(text=bpf_text)
+
+# Common file functions. See earlier comment about generic_file_read_iter().
+if BPF.get_kprobe_functions(b'f2fs_file_read_iter'):
+    b.attach_kprobe(event="f2fs_file_read_iter", fn_name="trace_read_entry")
+else:
+    b.attach_kprobe(event="generic_file_read_iter", fn_name="trace_read_entry")
+b.attach_kprobe(event="f2fs_file_write_iter", fn_name="trace_write_entry")
+b.attach_kprobe(event="f2fs_file_open", fn_name="trace_open_entry")
+b.attach_kprobe(event="f2fs_sync_file", fn_name="trace_fsync_entry")
+if BPF.get_kprobe_functions(b'f2fs_file_read_iter'):
+    b.attach_kretprobe(event="f2fs_file_read_iter",
+                       fn_name="trace_read_return")
+else:
+    b.attach_kretprobe(event="generic_file_read_iter",
+                       fn_name="trace_read_return")
+b.attach_kretprobe(event="f2fs_file_write_iter", fn_name="trace_write_return")
+b.attach_kretprobe(event="f2fs_file_open", fn_name="trace_open_return")
+b.attach_kretprobe(event="f2fs_sync_file", fn_name="trace_fsync_return")
+
+# header
+if (csv):
+    print("ENDTIME_us,TASK,PID,TYPE,BYTES,OFFSET_b,LATENCY_us,FILE")
+else:
+    if min_ms == 0:
+        print("Tracing f2fs operations")
+    else:
+        print("Tracing f2fs operations slower than %d ms" % min_ms)
+    print("%-8s %-14s %-6s %1s %-7s %-8s %7s %s" % ("TIME", "COMM", "PID", "T",
+          "BYTES", "OFF_KB", "LAT(ms)", "FILENAME"))
+
+# read events
+b["events"].open_perf_buffer(print_event, page_cnt=64)
+while 1:
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/f2fsslower_example.txt
+++ b/tools/f2fsslower_example.txt
@@ -1,0 +1,260 @@
+Demonstrations of f2fsslower, the Linux eBPF/bcc version.
+
+
+f2fsslower shows f2fs reads, writes, opens, and fsyncs, slower than a threshold.
+For example:
+
+# ./f2fsslower
+Tracing f2fs operations slower than 10 ms
+TIME     COMM           PID    T BYTES   OFF_KB   LAT(ms) FILENAME
+23:27:14 Thread-11      13086  R 33554432 0         123.24 0
+23:27:14 Thread-11      13086  R 33554432 32768      16.73 0
+23:27:14 Thread-11      13086  R 33554432 0          16.39 1
+23:27:14 Thread-11      13086  R 33554432 32768      16.33 1
+23:27:14 Thread-11      13086  R 33554432 0          16.38 2
+23:27:14 Thread-11      13086  R 33554432 32768      16.29 2
+23:27:14 Thread-11      13086  R 33554432 0          16.47 3
+23:27:14 Thread-11      13086  R 33554432 32768      16.29 3
+23:27:14 Thread-11      13086  R 33554432 0          16.34 4
+23:27:14 Thread-11      13086  R 33554432 32768      16.63 4
+23:27:14 Thread-11      13086  R 33554432 0          16.27 5
+23:27:14 Thread-11      13086  R 33554432 32768      16.32 5
+23:27:14 Thread-11      13086  R 33554432 0          16.25 6
+23:27:14 Thread-11      13086  R 33554432 32768      16.56 6
+23:27:14 Thread-11      13086  R 33554432 0          17.29 7
+23:27:14 Thread-11      13086  R 33554432 32768      16.27 7
+23:27:14 Thread-11      13086  R 33554432 0          17.51 0
+23:27:14 Thread-11      13086  R 33554432 32768      16.29 0
+23:27:14 Thread-11      13086  R 33554432 0          16.41 1
+23:27:14 Thread-11      13086  R 33554432 32768      16.31 1
+23:27:14 Thread-11      13086  R 33554432 0          16.21 2
+23:27:14 Thread-11      13086  R 33554432 32768      16.44 2
+23:27:14 Thread-11      13086  R 33554432 0          16.31 3
+23:27:14 Thread-11      13086  R 33554432 32768      16.28 3
+23:27:14 Thread-11      13086  R 33554432 0          16.22 4
+23:27:14 Thread-11      13086  R 33554432 32768      16.22 4
+23:27:14 Thread-11      13086  R 33554432 0          16.25 5
+23:27:14 Thread-11      13086  R 33554432 32768      16.21 5
+23:27:14 Thread-11      13086  R 33554432 0          16.20 6
+23:27:14 Thread-11      13086  R 33554432 32768      16.35 6
+23:27:14 Thread-11      13086  R 33554432 0          16.26 7
+23:27:14 Thread-11      13086  R 33554432 32768      16.32 7
+23:27:14 Thread-11      13086  R 33554432 0          17.13 0
+23:27:14 Thread-11      13086  R 33554432 32768      16.12 0
+23:27:14 Thread-11      13086  R 33554432 0          16.65 1
+23:27:14 Thread-11      13086  R 33554432 32768      16.34 1
+23:27:14 Thread-11      13086  R 33554432 0          16.30 2
+23:27:14 Thread-11      13086  R 33554432 32768      16.30 2
+23:27:14 Thread-11      13086  R 33554432 0          16.39 3
+23:27:14 Thread-11      13086  R 33554432 32768      16.46 3
+23:27:14 Thread-11      13086  R 33554432 0          16.21 4
+23:27:14 Thread-11      13086  R 33554432 32768      16.34 4
+23:27:14 Thread-11      13086  R 33554432 0          16.43 5
+23:27:15 Thread-11      13086  R 33554432 32768      16.42 5
+23:27:15 Thread-11      13086  R 33554432 0          17.29 6
+23:27:15 Thread-11      13086  R 33554432 32768      16.64 6
+23:27:15 Thread-11      13086  R 33554432 0          16.56 7
+23:27:15 Thread-11      13086  R 33554432 32768      16.42 7
+[...]
+
+This shows various system tasks reading from f2fs. The high latency here is
+due to disk I/O, as I had just evicted the file system cache for this example.
+
+This "latency" is measured from when the operation was issued from the VFS
+interface to the file system, to when it completed. This spans everything:
+block device I/O (disk I/O), file system CPU cycles, file system locks, run
+queue latency, etc. This is a better measure of the latency suffered by
+applications reading from the file system than measuring this down at the
+block device interface.
+
+Note that this only traces the common file system operations previously
+listed: other file system operations (eg, inode operations including
+getattr()) are not traced.
+
+
+The threshold can be provided as an argument. Eg, I/O slower than 1 ms:
+
+# ./f2fsslower 1
+Tracing f2fs operations slower than 1 ms
+TIME     COMM           PID    T BYTES   OFF_KB   LAT(ms) FILENAME
+23:31:14 Thread-12      13086  R 33554432 0         124.63 0
+23:31:14 Thread-12      13086  R 33554432 32768      16.84 0
+23:31:14 Thread-12      13086  R 33554432 0          16.56 1
+23:31:14 Thread-12      13086  R 33554432 32768      16.54 1
+23:31:14 Thread-12      13086  R 33554432 0          16.56 2
+23:31:14 Thread-12      13086  R 33554432 32768      16.56 2
+23:31:14 Thread-12      13086  R 33554432 0          16.63 3
+23:31:14 Thread-12      13086  R 33554432 32768      16.47 3
+23:31:14 Thread-12      13086  R 33554432 0          16.57 4
+23:31:14 Thread-12      13086  R 33554432 32768      16.36 4
+23:31:14 Thread-12      13086  R 33554432 0          16.30 5
+23:31:14 Thread-12      13086  R 33554432 32768      16.25 5
+23:31:14 Thread-12      13086  R 33554432 0          16.28 6
+23:31:14 Thread-12      13086  R 33554432 32768      16.51 6
+23:31:14 Thread-12      13086  R 33554432 0          16.28 7
+23:31:14 Thread-12      13086  R 33554432 32768      16.36 7
+23:31:14 Thread-12      13086  R 33554432 0          16.62 0
+23:31:14 Thread-12      13086  R 33554432 32768      16.43 0
+23:31:14 Thread-12      13086  R 33554432 0          16.44 1
+23:31:14 Thread-12      13086  R 33554432 32768      16.20 1
+23:31:14 Thread-12      13086  R 33554432 0          16.19 2
+23:31:14 Thread-12      13086  R 33554432 32768      16.18 2
+23:31:14 Thread-12      13086  R 33554432 0          16.16 3
+23:31:14 Thread-12      13086  R 33554432 32768      16.20 3
+23:31:14 Thread-12      13086  R 33554432 0          16.15 4
+23:31:14 Thread-12      13086  R 33554432 32768      16.18 4
+23:31:14 Thread-12      13086  R 33554432 0          16.17 5
+23:31:14 Thread-12      13086  R 33554432 32768      16.35 5
+23:31:14 Thread-12      13086  R 33554432 0          16.44 6
+23:31:14 Thread-12      13086  R 33554432 32768      16.47 6
+23:31:14 Thread-12      13086  R 33554432 0          17.01 7
+23:31:14 Thread-12      13086  R 33554432 32768      16.19 7
+23:31:14 Thread-12      13086  R 33554432 0          17.15 0
+23:31:14 Thread-12      13086  R 33554432 32768      16.41 0
+23:31:14 Thread-12      13086  R 33554432 0          16.74 1
+23:31:14 Thread-12      13086  R 33554432 32768      16.26 1
+23:31:14 Thread-12      13086  R 33554432 0          16.51 2
+23:31:14 Thread-12      13086  R 33554432 32768      16.50 2
+23:31:14 Thread-12      13086  R 33554432 0          16.71 3
+23:31:14 Thread-12      13086  R 33554432 32768      16.51 3
+23:31:14 Thread-12      13086  R 33554432 0          16.53 4
+23:31:14 Thread-12      13086  R 33554432 32768      16.54 4
+23:31:14 Thread-12      13086  R 33554432 0          16.52 5
+23:31:14 Thread-12      13086  R 33554432 32768      16.44 5
+23:31:14 Thread-12      13086  R 33554432 0          16.67 6
+23:31:14 Thread-12      13086  R 33554432 32768      16.68 6
+23:31:15 Thread-12      13086  R 33554432 0          16.74 7
+23:31:15 Thread-12      13086  R 33554432 32768      16.65 7
+[...]
+
+This time a cksum(1) command can be seen reading various files (from /usr/bin).
+
+
+A threshold of 0 will trace all operations. Warning: the output will be
+verbose, as it will include all file system cache hits.
+
+# ./f2fsslower 0
+Tracing f2fs operations
+TIME     COMM           PID    T BYTES   OFF_KB   LAT(ms) FILENAME
+23:35:53 iop@2.0-servic 882    R 16      0           0.04 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    R 16      0           0.01 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    R 16      0           0.01 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    R 16      0           0.01 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    W 4096    0           0.08 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    W 4096    32          0.01 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    S 0       0           0.01 io-prefetcher.db
+23:35:54 perf@2.2-servi 886    O 0       0           0.04 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.09 current_fps
+23:35:54 perf@2.2-servi 886    O 0       0           0.03 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.07 current_fps
+23:35:54 perf@2.2-servi 886    O 0       0           0.03 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.10 current_fps
+23:35:54 TaskSnapshotPe 1544   O 0       0           0.15 24.proto.new
+23:35:54 perf@2.2-servi 886    O 0       0           0.03 current_fps
+23:35:54 TaskSnapshotPe 1544   W 82      0           0.05 24.proto.new
+23:35:54 perf@2.2-servi 886    W 2       0           0.08 current_fps
+23:35:54 TaskSnapshotPe 1544   S 0       0           2.43 24.proto.new
+23:35:54 perf@2.2-servi 886    O 0       0           0.07 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.07 current_fps
+23:35:54 iop@2.0-servic 882    R 16      0           0.03 io-prefetcher.db
+23:35:54 iop@2.0-servic 882    R 16      0           0.02 io-prefetcher.db
+23:35:54 perf@2.2-servi 886    O 0       0           0.02 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.07 current_fps
+23:35:54 perf@2.2-servi 886    O 0       0           0.03 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.09 current_fps
+23:35:54 perf@2.2-servi 886    O 0       0           0.03 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.08 current_fps
+23:35:54 TaskSnapshotPe 1544   O 0       0           0.01 24.jpg
+23:35:54 perf@2.2-servi 886    O 0       0           0.02 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.06 current_fps
+23:35:54 TaskSnapshotPe 1544   W 1024    0           0.04 24.jpg
+23:35:54 TaskSnapshotPe 1544   W 1024    1           0.01 24.jpg
+23:35:54 perf@2.2-servi 886    O 0       0           0.01 current_fps
+23:35:54 TaskSnapshotPe 1544   W 1024    2           0.01 24.jpg
+23:35:54 TaskSnapshotPe 1544   W 1024    3           0.00 24.jpg
+[...]
+
+The output now includes open operations ("O"), and writes ("W").
+
+
+A -j option will print just the fields (parsable output, csv):
+
+# ./f2fsslower -j 1
+ENDTIME_us,TASK,PID,TYPE,BYTES,OFFSET_b,LATENCY_us,FILE
+32897720717,Thread-14,13086,S,0,0,85033,3
+32897838343,Thread-14,13086,S,0,0,91010,4
+32898079447,Thread-14,13086,S,0,0,216140,5
+32898200395,Thread-14,13086,S,0,0,94777,6
+32898312396,Thread-14,13086,S,0,0,86556,7
+32898518082,Thread-14,13086,R,33554432,0,124118,0
+32898534981,Thread-14,13086,R,33554432,33554432,16830,0
+32898551645,Thread-14,13086,R,33554432,0,16585,1
+32898568083,Thread-14,13086,R,33554432,33554432,16388,1
+32898584740,Thread-14,13086,R,33554432,0,16604,2
+32898601152,Thread-14,13086,R,33554432,33554432,16368,2
+32898617857,Thread-14,13086,R,33554432,0,16659,3
+32898634356,Thread-14,13086,R,33554432,33554432,16456,3
+32898650861,Thread-14,13086,R,33554432,0,16457,4
+32898667344,Thread-14,13086,R,33554432,33554432,16434,4
+32898683804,Thread-14,13086,R,33554432,0,16411,5
+32898700276,Thread-14,13086,R,33554432,33554432,16421,5
+32898716713,Thread-14,13086,R,33554432,0,16372,6
+32898733204,Thread-14,13086,R,33554432,33554432,16420,6
+32898749801,Thread-14,13086,R,33554432,0,16530,7
+32898766804,Thread-14,13086,R,33554432,33554432,16937,7
+32898807153,Thread-14,13086,R,33554432,0,17290,0
+32898823493,Thread-14,13086,R,33554432,33554432,16300,0
+32898840179,Thread-14,13086,R,33554432,0,16646,1
+32898856655,Thread-14,13086,R,33554432,33554432,16442,1
+32898872967,Thread-14,13086,R,33554432,0,16268,2
+32898889270,Thread-14,13086,R,33554432,33554432,16258,2
+32898906083,Thread-14,13086,R,33554432,0,16772,3
+32898922423,Thread-14,13086,R,33554432,33554432,16298,3
+32898938893,Thread-14,13086,R,33554432,0,16430,4
+32898955217,Thread-14,13086,R,33554432,33554432,16287,4
+32898971737,Thread-14,13086,R,33554432,0,16481,5
+32898988188,Thread-14,13086,R,33554432,33554432,16415,5
+32899004665,Thread-14,13086,R,33554432,0,16439,6
+32899021297,Thread-14,13086,R,33554432,33554432,16596,6
+32899038039,Thread-14,13086,R,33554432,0,16697,7
+32899054685,Thread-14,13086,R,33554432,33554432,16604,7
+32899094190,Thread-14,13086,R,33554432,0,18062,0
+32899110914,Thread-14,13086,R,33554432,33554432,16677,0
+32899127424,Thread-14,13086,R,33554432,0,16467,1
+32899143724,Thread-14,13086,R,33554432,33554432,16259,1
+32899159998,Thread-14,13086,R,33554432,0,16235,2
+32899176506,Thread-14,13086,R,33554432,33554432,16458,2
+32899193020,Thread-14,13086,R,33554432,0,16449,3
+32899209410,Thread-14,13086,R,33554432,33554432,16326,3
+32899225756,Thread-14,13086,R,33554432,0,16281,4
+32899242571,Thread-14,13086,R,33554432,33554432,16762,4
+32899258945,Thread-14,13086,R,33554432,0,16320,5
+32899275445,Thread-14,13086,R,33554432,33554432,16453,5
+[...]
+
+This may be useful for visualizing with another tool, for example, for
+producing a scatter plot of ENDTIME vs LATENCY, to look for time-based
+patterns.
+
+
+USAGE message:
+
+# ./f2fsslower -h
+usage: f2fsslower [-h] [-j] [-p PID] [min_ms]
+
+Trace common f2fs file operations slower than a threshold
+
+positional arguments:
+  min_ms             minimum I/O duration to trace, in ms (default 10)
+
+optional arguments:
+  -h, --help         show this help message and exit
+  -j, --csv          just print fields: comma-separated values
+  -p PID, --pid PID  trace this PID only
+
+examples:
+    ./f2fsslower             # trace operations slower than 10 ms (default)
+    ./f2fsslower 1           # trace operations slower than 1 ms
+    ./f2fsslower -j 1        # ... 1 ms, parsable output (csv)
+    ./f2fsslower 0           # trace all operations (warning: verbose)
+    ./f2fsslower -p 185      # trace PID 185 only

--- a/tools/scsilatency.py
+++ b/tools/scsilatency.py
@@ -1,0 +1,247 @@
+#!/usr/bin/python
+# SPDX-License-Identifier: <SPDX License Expression>
+# @lint-avoid-python-3-compatibility-imports
+#
+# scsilatency    Summarize SCSI layer I/O latency as a histogram.
+#       For Linux, uses BCC, eBPF.
+#
+# USAGE: scsilatency [-h] [-T] [-Q] [-m] [-D] [-e] [interval] [count]
+#
+# Copyright (c) 10-Oct-2022, Samsung Electronics.  All rights reserved.
+# This source code is licensed under the Apache License, Version 2.0
+#
+# Written by Weibang Liu<weibang6.liu@samsung.com>.
+
+from __future__ import print_function
+from bcc import BPF
+from time import sleep, strftime
+import argparse
+import ctypes as ct
+
+# arguments
+examples = """examples:
+    ./scsilatency            # summarize SCSI layer I/O latency as a histogram
+    ./scsilatency 1 10       # print 1 second summaries, 10 times
+    ./scsilatency -mT 1      # 1s summaries, milliseconds, and timestamps
+    ./scsilatency -D         # show each disk device separately
+    ./scsilatency -F         # show I/O flags separately
+    ./scsilatency -j         # print a dictionary
+    ./scsilatency -e         # show extension summary(total, average)
+"""
+parser = argparse.ArgumentParser(
+    description="Summarize SCSI layer I/O latency as a histogram",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("-T", "--timestamp", action="store_true",
+                    help="include timestamp on output")
+parser.add_argument("-m", "--milliseconds", action="store_true",
+                    help="millisecond histogram")
+parser.add_argument("-D", "--disks", action="store_true",
+                    help="print a histogram per disk device")
+parser.add_argument("-F", "--flags", action="store_true",
+                    help="print a histogram per set of I/O flags")
+parser.add_argument("-e", "--extension", action="store_true",
+                    help="summarize average/total value")
+parser.add_argument("interval", nargs="?", default=99999999,
+                    help="output interval, in seconds")
+parser.add_argument("count", nargs="?", default=99999999,
+                    help="number of outputs")
+parser.add_argument("--ebpf", action="store_true",
+                    help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+                    help="json output")
+
+args = parser.parse_args()
+countdown = int(args.count)
+debug = 0
+
+if args.flags and args.disks:
+    print("ERROR: can only use -D or -F. Exiting.")
+    exit()
+
+# define BPF program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/blkdev.h>
+#include <scsi/scsi_cmnd.h>
+
+typedef struct disk_key {
+    char disk[DISK_NAME_LEN];
+    u64 slot;
+} disk_key_t;
+
+typedef struct flag_key {
+    u64 flags;
+    u64 slot;
+} flag_key_t;
+
+typedef struct ext_val {
+    u64 total;
+    u64 count;
+} ext_val_t;
+
+BPF_HASH(start, struct request *);
+STORAGE
+
+// start time of SCSI I/O
+int trace_req_start(struct pt_regs *ctx, struct scsi_cmnd *cmd)
+{
+    struct request *req = cmd->request;
+
+    u64 ts = bpf_ktime_get_ns();
+    start.update(&req, &ts);
+    return 0;
+}
+
+// output
+int trace_req_done(struct pt_regs *ctx, struct scsi_cmnd *cmd)
+{
+    u64 *tsp, delta;
+    struct request *req = cmd->request;
+
+    // fetch timestamp and calculate delta
+    tsp = start.lookup(&req);
+    if (tsp == 0) {
+        return 0;   // missed issue
+    }
+    delta = bpf_ktime_get_ns() - *tsp;
+
+    EXTENSION
+
+    FACTOR
+
+    // store as histogram
+    STORE
+
+    start.delete(&req);
+    return 0;
+}
+"""
+
+# code substitutions
+if args.milliseconds:
+    bpf_text = bpf_text.replace('FACTOR', 'delta /= 1000000;')
+    label = "msecs"
+else:
+    bpf_text = bpf_text.replace('FACTOR', 'delta /= 1000;')
+    label = "usecs"
+
+storage_str = ""
+store_str = ""
+if args.disks:
+    storage_str += "BPF_HISTOGRAM(dist, disk_key_t);"
+    store_str += """
+    disk_key_t key = {.slot = bpf_log2l(delta)};
+    void *__tmp = (void *)req->rq_disk->disk_name;
+    bpf_probe_read(&key.disk, sizeof(key.disk), __tmp);
+    dist.increment(key);
+    """
+elif args.flags:
+    storage_str += "BPF_HISTOGRAM(dist, flag_key_t);"
+    store_str += """
+    flag_key_t key = {.slot = bpf_log2l(delta)};
+
+    #ifdef REQ_WRITE
+        key.flags = !!(req->cmd_flags & REQ_WRITE);
+    #elif defined(REQ_OP_SHIFT)
+        key.flags = !!((req->cmd_flags >> REQ_OP_SHIFT) == REQ_OP_WRITE);
+    #else
+        key.flags = !!((req->cmd_flags & REQ_OP_MASK) == REQ_OP_WRITE);
+    #endif
+
+    dist.increment(key);
+    """
+else:
+    storage_str += "BPF_HISTOGRAM(dist);"
+    store_str += "dist.increment(bpf_log2l(delta));"
+
+if args.extension:
+    storage_str += "BPF_ARRAY(extension, ext_val_t, 1);"
+    bpf_text = bpf_text.replace('EXTENSION', """
+    u32 index = 0;
+    ext_val_t *ext_val = extension.lookup(&index);
+    if (ext_val) {
+        lock_xadd(&ext_val->total, delta);
+        lock_xadd(&ext_val->count, 1);
+    }
+    """)
+else:
+    bpf_text = bpf_text.replace('EXTENSION', '')
+bpf_text = bpf_text.replace("STORAGE", storage_str)
+bpf_text = bpf_text.replace("STORE", store_str)
+
+if debug or args.ebpf:
+    print(bpf_text)
+    if args.ebpf:
+        exit()
+
+# load BPF program
+b = BPF(text=bpf_text)
+if BPF.get_kprobe_functions(b'scsi_init_io'):
+    b.attach_kprobe(event="scsi_init_io", fn_name="trace_req_start")
+else:
+    b.attach_kprobe(event="scsi_alloc_sgtables", fn_name="trace_req_start")
+if BPF.get_kprobe_functions(b'scsi_mq_done'):
+    b.attach_kprobe(event="scsi_mq_done", fn_name="trace_req_done")
+
+if not args.json:
+    print("Tracing SCSI layer I/O... Hit Ctrl-C to end.")
+
+
+def flags_print(flags):
+    desc = ""
+    if flags == 1:
+        desc = "Write"
+    else:
+        desc = "Read"
+
+    return desc
+
+# output
+exiting = 0 if args.interval else 1
+dist = b.get_table("dist")
+if args.extension:
+    extension = b.get_table("extension")
+while (1):
+    try:
+        sleep(int(args.interval))
+    except KeyboardInterrupt:
+        exiting = 1
+
+    print()
+    if args.json:
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
+
+        if args.flags:
+            dist.print_json_hist(label, "flags", flags_print)
+
+        else:
+            dist.print_json_hist(label)
+
+    else:
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
+
+        if args.flags:
+            dist.print_log2_hist(label, "flags", flags_print)
+        else:
+            dist.print_log2_hist(label, "disk")
+        if args.extension:
+            total = extension[0].total
+            counts = extension[0].count
+            if counts > 0:
+                if label == 'msecs':
+                    total /= 1000000
+                elif label == 'usecs':
+                    total /= 1000
+                avg = total / counts
+                print("\navg = %ld %s, total: %ld %s, count: %ld\n" %
+                      (total / counts, label, total, label, counts))
+            extension.clear()
+
+    dist.clear()
+
+    countdown -= 1
+    if exiting or countdown == 0:
+        exit()

--- a/tools/scsilatency_example.txt
+++ b/tools/scsilatency_example.txt
@@ -1,0 +1,215 @@
+Demonstrations of scsilatency, the Linux eBPF/bcc version.
+
+
+scsilatency traces SCSI layer I/O (disk I/O), and records the distribution
+of I/O latency (time), printing this as a histogram when Ctrl-C is hit.
+For example:
+
+# ./scsilatency
+Tracing SCSI layer I/O... Hit Ctrl-C to end.
+^C
+     usecs           : count     distribution
+       0 -> 1        : 0        |                                      |
+       2 -> 3        : 0        |                                      |
+       4 -> 7        : 0        |                                      |
+       8 -> 15       : 0        |                                      |
+      16 -> 31       : 0        |                                      |
+      32 -> 63       : 0        |                                      |
+      64 -> 127      : 1        |                                      |
+     128 -> 255      : 12       |********                              |
+     256 -> 511      : 15       |**********                            |
+     512 -> 1023     : 43       |*******************************       |
+    1024 -> 2047     : 52       |**************************************|
+    2048 -> 4095     : 47       |**********************************    |
+    4096 -> 8191     : 52       |**************************************|
+    8192 -> 16383    : 36       |**************************            |
+   16384 -> 32767    : 15       |**********                            |
+   32768 -> 65535    : 2        |*                                     |
+   65536 -> 131071   : 2        |*                                     |
+
+The latency of the disk I/O is measured from the issue to the device to its
+completion.
+
+This example output shows a large mode of latency from about 128 microseconds
+to about 32767 microseconds (33 milliseconds). The bulk of the I/O was
+between 1 and 8 ms, which is the expected block device latency for
+rotational storage devices.
+
+The highest latency seen while tracing was between 65 and 131 milliseconds:
+the last row printed, for which there were 2 I/O.
+
+For efficiency, scsilatency uses an in-kernel eBPF map to store timestamps
+with requests, and another in-kernel map to store the histogram (the "count")
+column, which is copied to user-space only when output is printed. These
+methods lower the performance overhead when tracing is performed.
+
+
+In the following example, the -m option is used to print a histogram using
+milliseconds as the units (which eliminates the first several rows), -T to
+print timestamps with the output, and to print 1 second summaries 5 times:
+
+# ./scsilatency -mT 1 5
+Tracing SCSI layer I/O... Hit Ctrl-C to end.
+
+04:48:15
+     msecs               : count     distribution
+         0 -> 1          : 9        |****************************************|
+
+04:48:16
+
+04:48:17
+     msecs               : count     distribution
+         0 -> 1          : 1        |********************                    |
+         2 -> 3          : 2        |****************************************|
+
+04:48:18
+
+04:48:19
+     msecs               : count     distribution
+         0 -> 1          : 71       |*******                                 |
+         2 -> 3          : 13       |*                                       |
+         4 -> 7          : 32       |***                                     |
+         8 -> 15         : 380      |****************************************|
+        16 -> 31         : 7        |                                        |
+        32 -> 63         : 32       |***                                     |
+
+
+How the I/O latency distribution changes over time can be seen.
+
+
+The -D option will print a histogram per disk. Eg:
+
+# ./scsilatency -D
+Tracing SCSI layer I/O... Hit Ctrl-C to end.
+^C
+
+disk = 'sda'
+     usecs               : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 0        |                                        |
+         8 -> 15         : 0        |                                        |
+        16 -> 31         : 1991     |*                                       |
+        32 -> 63         : 14764    |********                                |
+        64 -> 127        : 67282    |****************************************|
+       128 -> 255        : 12891    |*******                                 |
+       256 -> 511        : 436      |                                        |
+       512 -> 1023       : 205      |                                        |
+      1024 -> 2047       : 383      |                                        |
+      2048 -> 4095       : 759      |                                        |
+      4096 -> 8191       : 2775     |*                                       |
+      8192 -> 16383      : 1067     |                                        |
+     16384 -> 32767      : 2309     |*                                       |
+     32768 -> 65535      : 97       |                                        |
+
+This output sows that only sda device has be accessed, usually between 0.03 ms
+and 0.2 ms.
+
+
+The -F option prints a separate histogram for each unique set of request
+flags. For example:
+
+./scsilatency.py -Fm
+Tracing SCSI layer I/O... Hit Ctrl-C to end.
+^C
+
+flags = Read
+     msecs               : count     distribution
+         0 -> 1          : 100      |****************************************|
+         2 -> 3          : 6        |**                                      |
+
+flags = Write
+     msecs               : count     distribution
+         0 -> 1          : 247      |****************************************|
+         2 -> 3          : 24       |***                                     |
+         4 -> 7          : 11       |*                                       |
+
+These can be handled differently by the storage device, and this mode lets us
+examine their performance in isolation.
+
+
+The -e option shows extension summary(total, average)
+For example:
+# ./scsilatency.py -e
+^C
+     usecs               : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 0        |                                        |
+         8 -> 15         : 0        |                                        |
+        16 -> 31         : 0        |                                        |
+        32 -> 63         : 6        |**                                      |
+        64 -> 127        : 31       |**************                          |
+       128 -> 255        : 87       |****************************************|
+       256 -> 511        : 44       |********************                    |
+       512 -> 1023       : 11       |*****                                   |
+      1024 -> 2047       : 32       |**************                          |
+      2048 -> 4095       : 7        |***                                     |
+      4096 -> 8191       : 13       |*****                                   |
+      8192 -> 16383      : 1        |                                        |
+
+avg = 826 usecs, total: 191862 usecs, count: 232
+
+Sometimes 128 -> 255 usecs is not enough for throughput tuning.
+Especially a little difference in performance downgrade.
+By this extension, we know the value in log2 range is about 826 usecs.
+
+
+The -j option prints a dictionary of the histogram.
+For example:
+
+# ./scsilatency.py -j
+^C
+{'val_type': 'usecs', 'data': [{'count': 0, 'interval-start': 0, 'interval-end': 1}, {'count': 0, 'interval-start': 2, 'interval-end': 3}, {'count': 0, 'interval-start': 4, 'interval-end': 7}, {'count': 0, 'interval-start': 8, 'interval-end': 15}, {'count': 6, 'interval-start': 16, 'interval-end': 31}, {'count': 32, 'interval-start': 32, 'interval-end': 63}, {'count': 52, 'interval-start': 64, 'interval-end': 127}, {'count': 26, 'interval-start': 128, 'interval-end': 255}, {'count': 95, 'interval-start': 256, 'interval-end': 511}, {'count': 171, 'interval-start': 512, 'interval-end': 1023}, {'count': 356, 'interval-start': 1024, 'interval-end': 2047}, {'count': 712, 'interval-start': 2048, 'interval-end': 4095}, {'count': 2627, 'interval-start': 4096, 'interval-end': 8191}, {'count': 835, 'interval-start': 8192, 'interval-end': 16383}, {'count': 2113, 'interval-start': 16384, 'interval-end': 32767}, {'count': 62, 'interval-start': 32768, 'interval-end': 65535}, {'count': 33, 'interval-start': 65536, 'interval-end': 131071}], 'ts': '2021-01-09 04:22:46'}
+
+the key `data` is the list of the log2 histogram intervals. The `interval-start` and `interval-end` define the
+latency bucket and `count` is the number of I/O's that lie in that latency range.
+
+# ./scsilatency.py -jF
+^C
+{'val_type': 'usecs', 'flags': 'Read', 'data': [{'count': 0, 'interval-start': 0, 'interval-end': 1}, {'count': 0, 'interval-start': 2, 'interval-end': 3}, {'count': 0, 'interval-start': 4, 'interval-end': 7}, {'count': 0, 'interval-start': 8, 'interval-end': 15}, {'count': 0, 'interval-start': 16, 'interval-end': 31}, {'count': 61, 'interval-start': 32, 'interval-end': 63}, {'count': 40620, 'interval-start': 64, 'interval-end': 127}, {'count': 7493, 'interval-start': 128, 'interval-end': 255}, {'count': 368, 'interval-start': 256, 'interval-end': 511}, {'count': 96, 'interval-start': 512, 'interval-end': 1023}, {'count': 249, 'interval-start': 1024, 'interval-end': 2047}, {'count': 2767, 'interval-start': 2048, 'interval-end': 4095}, {'count': 21, 'interval-start': 4096, 'interval-end': 8191}, {'count': 4, 'interval-start': 8192, 'interval-end': 16383}, {'count': 40, 'interval-start': 16384, 'interval-end': 32767}], 'ts': '2021-01-09 04:27:11'}
+{'val_type': 'usecs', 'flags': 'Write', 'data': [{'count': 0, 'interval-start': 0, 'interval-end': 1}, {'count': 0, 'interval-start': 2, 'interval-end': 3}, {'count': 0, 'interval-start': 4, 'interval-end': 7}, {'count': 0, 'interval-start': 8, 'interval-end': 15}, {'count': 2126, 'interval-start': 16, 'interval-end': 31}, {'count': 15362, 'interval-start': 32, 'interval-end': 63}, {'count': 27248, 'interval-start': 64, 'interval-end': 127}, {'count': 3974, 'interval-start': 128, 'interval-end': 255}, {'count': 44, 'interval-start': 256, 'interval-end': 511}, {'count': 80, 'interval-start': 512, 'interval-end': 1023}, {'count': 133, 'interval-start': 1024, 'interval-end': 2047}, {'count': 265, 'interval-start': 2048, 'interval-end': 4095}, {'count': 474, 'interval-start': 4096, 'interval-end': 8191}, {'count': 2022, 'interval-start': 8192, 'interval-end': 16383}, {'count': 1402, 'interval-start': 16384, 'interval-end': 32767}, {'count': 32, 'interval-start': 32768, 'interval-end': 65535}], 'ts': '2021-01-09 04:27:11'}
+
+The -j option used with -F prints a histogram dictionary per set of I/O flags.
+
+# ./scsilatency.py -jD
+^C
+{'val_type': 'usecs', 'data': [{'count': 0, 'interval-start': 0, 'interval-end': 1}, {'count': 0, 'interval-start': 2, 'interval-end': 3}, {'count': 0, 'interval-start': 4, 'interval-end': 7}, {'count': 0, 'interval-start': 8, 'interval-end': 15}, {'count': 2052, 'interval-start': 16, 'interval-end': 31}, {'count': 15045, 'interval-start': 32, 'interval-end': 63}, {'count': 67036, 'interval-start': 64, 'interval-end': 127}, {'count': 12746, 'interval-start': 128, 'interval-end': 255}, {'count': 403, 'interval-start': 256, 'interval-end': 511}, {'count': 175, 'interval-start': 512, 'interval-end': 1023}, {'count': 345, 'interval-start': 1024, 'interval-end': 2047}, {'count': 692, 'interval-start': 2048, 'interval-end': 4095}, {'count': 2686, 'interval-start': 4096, 'interval-end': 8191}, {'count': 992, 'interval-start': 8192, 'interval-end': 16383}, {'count': 2269, 'interval-start': 16384, 'interval-end': 32767}, {'count': 61, 'interval-start': 32768, 'interval-end': 65535}, {'count': 26, 'interval-start': 65536, 'interval-end': 131071}], 'ts': '2021-01-09 04:29:16', 'Bucket ptr': 'sda'}
+
+The -j option used with -D prints a histogram dictionary per disk device.
+
+# ./scsilatency.py -jm
+^C
+{'val_type': 'msecs', 'data': [{'count': 15, 'interval-start': 0, 'interval-end': 1}, {'count': 3, 'interval-start': 2, 'interval-end': 3}], 'ts': '2021-01-09 04:30:22'}
+
+The -j with -m prints a millisecond histogram dictionary. The `value_type` key is set to msecs.
+
+USAGE message:
+
+# ./scsilatency -h
+usage: scsilatency [-h] [-T] [-m] [-D] [-F] [-e] [-j] [interval] [count]
+
+Summarize UFS layer device I/O latency as a histogram
+
+positional arguments:
+  interval            output interval, in seconds
+  count               number of outputs
+
+optional arguments:
+  -h, --help          show this help message and exit
+  -T, --timestamp     include timestamp on output
+  -m, --milliseconds  millisecond histogram
+  -D, --disks         print a histogram per disk device
+  -F, --flags         print a histogram per set of I/O flags
+  -e, --extension     summarize average/total value
+  -j, --json          json output
+
+examples:
+    ./scsilatency                    # summarize UFS driver I/O latency as a histogram
+    ./scsilatency 1 10               # print 1 second summaries, 10 times
+    ./scsilatency -mT 1              # 1s summaries, milliseconds, and timestamps
+    ./scsilatency -D                 # show each disk device separately
+    ./scsilatency -F                 # show I/O flags separately
+    ./scsilatency -j                 # print a dictionary
+    ./scsilatency -e                 # show extension summary(total, average)
+

--- a/tools/scsisnoop.py
+++ b/tools/scsisnoop.py
@@ -1,0 +1,211 @@
+#!/usr/bin/python
+# SPDX-License-Identifier: <SPDX License Expression>
+# @lint-avoid-python-3-compatibility-imports
+#
+# scsisnoop  Trace SCSI layer I/O and print details including issuing PID.
+#           For Linux, uses BCC, eBPF.
+#
+# This uses in-kernel eBPF maps to cache process details (PID and comm) by I/O
+# request, as well as a starting timestamp for calculating I/O latency.
+#
+# Copyright (c) 10-Oct-2022, Samsung Electronics.  All rights reserved.
+# This source code is licensed under the Apache License, Version 2.0
+#
+# Written by Weibang Liu<weibang6.liu@samsung.com>.
+
+from __future__ import print_function
+from bcc import BPF
+import argparse
+
+# arguments
+examples = """examples:
+    ./scsisnoop           # trace all SCSI layer's I/O
+"""
+parser = argparse.ArgumentParser(
+    description="Trace SCSI layer I/O",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("--ebpf", action="store_true",
+                    help=argparse.SUPPRESS)
+args = parser.parse_args()
+debug = 0
+
+# define BPF program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/blkdev.h>
+#include <scsi/scsi_cmnd.h>
+
+// for saving the timestamp and __data_len of each request
+struct start_req_t {
+    u64 ts;
+    u64 data_len;
+};
+
+struct val_t {
+    u64 ts;
+    u32 pid;
+    char name[TASK_COMM_LEN];
+};
+
+struct data_t {
+    u32 pid;
+    u64 rwflag;
+    u64 delta;
+    u64 qdelta;
+    u64 sector;
+    u64 len;
+    u64 ts;
+    char disk_name[DISK_NAME_LEN];
+    char name[TASK_COMM_LEN];
+};
+
+BPF_HASH(start, struct request *, struct start_req_t);
+BPF_HASH(infobyreq, struct request *, struct val_t);
+BPF_PERF_OUTPUT(events);
+
+// cache PID and comm by-req
+int trace_pid_start(struct pt_regs *ctx, struct scsi_cmnd *cmd)
+{
+    struct val_t val = {};
+    u64 ts;
+    struct request *req = cmd->request;
+
+    if (bpf_get_current_comm(&val.name, sizeof(val.name)) == 0) {
+        val.pid = bpf_get_current_pid_tgid() >> 32;
+
+        infobyreq.update(&req, &val);
+    }
+    return 0;
+}
+
+// time SCSI I/O
+int trace_req_start(struct pt_regs *ctx, struct scsi_cmnd *cmd)
+{
+    struct request *req = cmd->request;
+    //bpf_trace_printk("[Andy]trace_start flag: %x\\n", req->cmd_flags);
+
+    struct start_req_t start_req = {
+        .ts = bpf_ktime_get_ns(),
+        .data_len = req->__data_len
+    };
+    start.update(&req, &start_req);
+    return 0;
+}
+
+// output
+int trace_req_completion(struct pt_regs *ctx, struct scsi_cmnd *cmd)
+{
+    struct start_req_t *startp;
+    struct val_t *valp;
+    struct data_t data = {};
+    u64 ts;
+    struct request *req = cmd->request;
+
+    //bpf_trace_printk("[Andy]trace_end flag: %x\\n", req->cmd_flags);
+    // fetch timestamp and calculate delta
+    startp = start.lookup(&req);
+    if (startp == 0) {
+        // missed tracing issue
+        return 0;
+    }
+    ts = bpf_ktime_get_ns();
+    data.delta = ts - startp->ts;
+    data.ts = ts / 1000;
+    data.qdelta = 0;
+
+    valp = infobyreq.lookup(&req);
+    data.len = startp->data_len;
+    if (valp == 0) {
+        data.name[0] = '?';
+        data.name[1] = 0;
+    } else {
+        data.pid = valp->pid;
+        data.sector = req->__sector;
+        bpf_probe_read_kernel(&data.name, sizeof(data.name), valp->name);
+        struct gendisk *rq_disk = req->rq_disk;
+        bpf_probe_read_kernel(&data.disk_name, sizeof(data.disk_name),
+                       rq_disk->disk_name);
+    }
+
+/*
+ * The following deals with a kernel version change (in mainline 4.7, although
+ * it may be backported to earlier kernels) with how block request write flags
+ * are tested. We handle both pre- and post-change versions here. Please avoid
+ * kernel version tests like this as much as possible: they inflate the code,
+ * test, and maintenance burden.
+ */
+#ifdef REQ_WRITE
+    data.rwflag = !!(req->cmd_flags & REQ_WRITE);
+#elif defined(REQ_OP_SHIFT)
+    data.rwflag = !!((req->cmd_flags >> REQ_OP_SHIFT) == REQ_OP_WRITE);
+#else
+    data.rwflag = !!((req->cmd_flags & REQ_OP_MASK) == REQ_OP_WRITE);
+#endif
+
+    events.perf_submit(ctx, &data, sizeof(data));
+    start.delete(&req);
+    infobyreq.delete(&req);
+
+    return 0;
+}
+"""
+
+if debug or args.ebpf:
+    print(bpf_text)
+    if args.ebpf:
+        exit()
+
+# initialize BPF
+b = BPF(text=bpf_text)
+if BPF.get_kprobe_functions(b'scsi_init_io'):
+    b.attach_kprobe(event="scsi_init_io", fn_name="trace_pid_start")
+else:
+    b.attach_kprobe(event="scsi_alloc_sgtables", fn_name="trace_pid_start")
+if BPF.get_kprobe_functions(b'scsi_init_io'):
+    b.attach_kprobe(event="scsi_init_io", fn_name="trace_req_start")
+else:
+    b.attach_kprobe(event="scsi_alloc_sgtables", fn_name="trace_req_start")
+if BPF.get_kprobe_functions(b'scsi_mq_done'):
+    b.attach_kprobe(event="scsi_mq_done", fn_name="trace_req_completion")
+
+# header
+print("%-11s %-14s %-6s %-7s %-1s %-10s %-7s" % ("TIME(s)", "COMM", "PID",
+      "DISK", "T", "SECTOR", "BYTES"), end="")
+print("%7s" % "LAT(ms)")
+
+rwflg = ""
+start_ts = 0
+prev_ts = 0
+delta = 0
+
+
+# process event
+def print_event(cpu, data, size):
+    event = b["events"].event(data)
+
+    global start_ts
+    if start_ts == 0:
+        start_ts = event.ts
+
+    if event.rwflag == 1:
+        rwflg = "W"
+    else:
+        rwflg = "R"
+
+    delta = float(event.ts) - start_ts
+
+    print("%-11.6f %-14.14s %-6s %-7s %-1s %-10s %-7s" % (
+        delta / 1000000, event.name.decode('utf-8', 'replace'), event.pid,
+        event.disk_name.decode('utf-8', 'replace'), rwflg, event.sector,
+        event.len), end="")
+
+    print("%7.2f" % (float(event.delta) / 1000000))
+
+# loop with callback to print_event
+b["events"].open_perf_buffer(print_event, page_cnt=64)
+while 1:
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/scsisnoop_example.txt
+++ b/tools/scsisnoop_example.txt
@@ -1,0 +1,63 @@
+Demonstrations of scsisnoop, the Linux eBPF/bcc version.
+
+
+scsisnoop traces SCSI layer I/O (disk I/O), and prints a line of output
+per I/O. Example:
+
+# ./scsisnoop
+TIME(s)     COMM           PID    DISK    T SECTOR     BYTES  LAT(ms)
+0.000000    kworker/u16:2  29466  sda     R 1867600    4096      0.21
+0.000330    kworker/3:1H   193    sda     R 1881480    4096      0.19
+0.001666    InputReader    1228   sda     R 1847944    155648    0.84
+0.003512    InputReader    1228   sda     R 1848256    204800    0.96
+0.003527    kworker/u16:1  31481  sda     R 1881488    4096      0.87
+0.009361    Binder:946_5   946    sda     R 1603000    122880    0.62
+0.011330    Binder:946_5   946    sda     R 1601688    147456    0.71
+5.004452    kworker/u16:5  18167  sda     R 1867568    4096      0.19
+5.004478    kworker/u16:5  18167  sda     R 1877776    4096      0.14
+5.004539    kworker/u16:2  29466  sda     R 1878816    4096      0.17
+5.004652    kworker/u16:1  31481  sda     R 1872128    4096      0.26
+5.004665    surfaceflinger 949    sda     R 1507040    32768     0.37
+5.004987    Binder:949_2   949    sda     R 1664544    12288     0.36
+5.005259    Binder:949_2   949    sda     R 1664360    65536     0.67
+
+
+This includes the PID and comm (process name) that were on-CPU at the time of
+issue (which usually means the process responsible).
+
+The latency of the disk I/O, measured from the issue to the device to its
+completion, is included as the last column.
+
+This example output is from what should be an idle system, however, the
+following is visible in iostat:
+
+$ iostat -x 1
+[...]
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           0.12    0.00    0.12    0.00    0.00   99.75
+
+Device: rrqm/s  wrqm/s    r/s    w/s  rkB/s  wkB/s  await  svctm  %util
+xvda      0.00    0.00   0.00   4.00   0.00  16.00   0.00   0.00   0.00
+xvdb      0.00    0.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00
+xvdc      0.00    0.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00
+md0       0.00    0.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00
+
+There are 4 write IOPS.
+
+The output of scsisnoop identifies the reason: multiple supervise processes are
+issuing writes to the xvda1 disk. I can now drill down on supervise using other
+tools to understand its file system workload.
+
+
+
+USAGE message:
+
+usage: scsisnoop.py [-h]
+
+Trace SCSI layer I/O
+
+optional arguments:
+  -h, --help   show this help message and exit
+
+examples:
+    ./scsisnoop           # trace all SCSI layer I/O


### PR DESCRIPTION
We used BCC to monitor I/O stack performance on mobile(AArch64) platform, and found it's very efficient and use easily. Meanwhile, we found lack of some tools in multiple layers，then we devloped 4 tools for SCSI layer and F2FS layer.
We hope these tools can help more people.