### PR TITLE
libbpf-tools/offcputime: Add -P option to post unwind user stack backtrace using dwarf unwind via libunwind

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -369,44 +369,44 @@ To build the toolchain from source, one needs:
 * Clang, built from the same tree as LLVM
 * cmake (>=3.1), gcc (>=4.7), flex, bison
 * LuaJIT, if you want Lua support
-* Optional tools used in some examples: arping, netperf, and iperf
+* Optional tools used in some examples: arping, netperf, iperf and libunwind-dev
 
 ### Install build dependencies
 ```
 # For Focal (20.04.1 LTS)
 sudo apt install -y zip bison build-essential cmake flex git libedit-dev \
   libllvm12 llvm-12-dev libclang-12-dev python zlib1g-dev libelf-dev libfl-dev python3-setuptools \
-  liblzma-dev arping netperf iperf
+  liblzma-dev arping netperf iperf libunwind-dev
 
 # For Hirsute (21.04) or Impish (21.10)
 sudo apt install -y zip bison build-essential cmake flex git libedit-dev \
   libllvm12 llvm-12-dev libclang-12-dev python3 zlib1g-dev libelf-dev libfl-dev python3-setuptools \
-  liblzma-dev arping netperf iperf
+  liblzma-dev arping netperf iperf libunwind-dev
 
 # For Jammy (22.04)
 sudo apt install -y zip bison build-essential cmake flex git libedit-dev \
   libllvm14 llvm-14-dev libclang-14-dev python3 zlib1g-dev libelf-dev libfl-dev python3-setuptools \
-  liblzma-dev libdebuginfod-dev arping netperf iperf
+  liblzma-dev libdebuginfod-dev arping netperf iperf libunwind-dev
 
 # For Lunar Lobster (23.04)
 sudo apt install -y zip bison build-essential cmake flex git libedit-dev \
   libllvm15 llvm-15-dev libclang-15-dev python3 zlib1g-dev libelf-dev libfl-dev python3-setuptools \
-  liblzma-dev libdebuginfod-dev arping netperf iperf libpolly-15-dev
+  liblzma-dev libdebuginfod-dev arping netperf iperf libpolly-15-dev libunwind-dev
 
 # For Mantic Minotaur (23.10)
 sudo apt install -y zip bison build-essential cmake flex git libedit-dev \
   libllvm16 llvm-16-dev libclang-16-dev python3 zlib1g-dev libelf-dev libfl-dev python3-setuptools \
-  liblzma-dev libdebuginfod-dev arping netperf iperf libpolly-16-dev
+  liblzma-dev libdebuginfod-dev arping netperf iperf libpolly-16-dev libunwind-dev
 
 # For Noble Numbat (24.04)
 sudo apt install -y zip bison build-essential cmake flex git libedit-dev \
   libllvm18 llvm-18-dev libclang-18-dev python3 zlib1g-dev libelf-dev libfl-dev python3-setuptools \
-  liblzma-dev libdebuginfod-dev arping netperf iperf libpolly-18-dev
+  liblzma-dev libdebuginfod-dev arping netperf iperf libpolly-18-dev libunwind-dev
 
 # For other versions
 sudo apt-get -y install zip bison build-essential cmake flex git libedit-dev \
   libllvm3.7 llvm-3.7-dev libclang-3.7-dev python zlib1g-dev libelf-dev python3-setuptools \
-  liblzma-dev arping netperf iperf
+  liblzma-dev arping netperf iperf libunwind-dev
 
 # For Lua support
 sudo apt-get -y install luajit luajit-5.1-dev

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -31,6 +31,12 @@ USE_BLAZESYM ?= 1
 endif
 endif
 
+ifeq ($(ARCH),x86)
+USE_DWARF_UNWIND = 1
+else
+USE_DWARF_UNWIND = 0
+endif
+
 ifeq ($(wildcard $(ARCH)/),)
 $(error Architecture $(ARCH) is not supported yet. Please open an issue)
 endif
@@ -39,6 +45,9 @@ BZ_APPS = \
 	futexctn \
 	memleak \
 	opensnoop \
+	#
+
+UNW_APPS = \
 	#
 
 APPS = \
@@ -97,6 +106,7 @@ APPS = \
 	vfsstat \
 	wakeuptime \
 	$(BZ_APPS) \
+	$(UNW_APPS) \
 	#
 
 # export variables that are used in Makefile.btfgen as well.
@@ -123,6 +133,12 @@ ifeq ($(USE_BLAZESYM),1)
 COMMON_OBJ += \
 	$(LIBBLAZESYM_OBJ) \
 	$(OUTPUT)/blazesym.h \
+	#
+endif
+
+ifeq ($(USE_DWARF_UNWIND),1)
+COMMON_OBJ += \
+	$(OUTPUT)/unwind_helpers.o \
 	#
 endif
 
@@ -156,9 +172,16 @@ endif
 ifeq ($(USE_BLAZESYM),1)
 CFLAGS += -DUSE_BLAZESYM=1
 endif
+ifeq ($(USE_DWARF_UNWIND),1)
+CFLAGS += -DUSE_DWARF_UNWIND=1
+endif
 
 ifeq ($(USE_BLAZESYM),1)
 LDFLAGS += $(LIBBLAZESYM_OBJ) -lrt -lpthread -ldl
+endif
+
+ifeq ($(USE_DWARF_UNWIND),1)
+LIBUNWIND_LIBS := -lunwind-ptrace -lunwind-generic -lunwind -llzma
 endif
 
 .PHONY: clean
@@ -187,17 +210,22 @@ $(BPFTOOL): | $(BPFTOOL_OUTPUT)
 
 $(APPS): %: $(OUTPUT)/%.o $(COMMON_OBJ) $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,BINARY,$@)
-	$(Q)$(CC) $(CFLAGS) $^ $(LDFLAGS) -lelf -lz -o $@
+	$(Q)$(CC) $(CFLAGS) $^ $(LDFLAGS) -lelf -lz $(LIBUNWIND_LIBS) -o $@
 
 ifeq ($(USE_BLAZESYM),1)
 $(patsubst %,$(OUTPUT)/%.o,$(BZ_APPS)): $(OUTPUT)/blazesym.h
+endif
+
+ifeq ($(USE_DWARF_UNWIND),1)
+$(patsubst %,$(OUTPUT)/%.o,$(UNW_APPS)): unwind_helpers_types.h unwind_helpers.h
+$(patsubst %,$(OUTPUT)/%.bpf.o,$(UNW_APPS)): unwind_helpers.bpf.h
 endif
 
 $(patsubst %,$(OUTPUT)/%.o,$(APPS)): %.o: %.skel.h
 
 $(OUTPUT)/%.o: %.c $(wildcard %.h) $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,CC,$@)
-	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
+	$(Q)$(CC) $(CFLAGS) -D__TARGET_ARCH_$(ARCH) $(INCLUDES) -c $(filter %.c,$^) -o $@
 
 $(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
 	$(call msg,GEN-SKEL,$@)

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -48,6 +48,7 @@ BZ_APPS = \
 	#
 
 UNW_APPS = \
+	offcputime \
 	#
 
 APPS = \
@@ -80,7 +81,6 @@ APPS = \
 	mdflush \
 	mountsnoop \
 	numamove \
-	offcputime \
 	oomkill \
 	profile \
 	readahead \

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -48,6 +48,7 @@ BZ_APPS = \
 	#
 
 UNW_APPS = \
+	memleak \
 	offcputime \
 	#
 

--- a/libbpf-tools/memleak.c
+++ b/libbpf-tools/memleak.c
@@ -28,6 +28,10 @@
 #include <blazesym.h>
 #endif
 
+#ifdef USE_DWARF_UNWIND
+#include "unwind_helpers.h"
+#endif
+
 static struct env {
 	int interval;
 	int nr_intervals;
@@ -51,6 +55,10 @@ static struct env {
 	bool verbose;
 	char command[32];
 	char symbols_prefix[16];
+#ifdef USE_DWARF_UNWIND
+	bool dwarf_unwind;
+	int dwarf_ustack_size;
+#endif
 } env = {
 	.interval = 5, // posarg 1
 	.nr_intervals = -1, // posarg 2
@@ -73,6 +81,9 @@ static struct env {
 	.verbose = false,
 	.command = {0}, // -c --command
 	.symbols_prefix = {0},
+#ifdef USE_DWARF_UNWIND
+	.dwarf_ustack_size = 128,
+#endif
 };
 
 struct allocation_node {
@@ -90,6 +101,9 @@ struct allocation {
 
 #define OPT_PERF_MAX_STACK_DEPTH	1 /* --perf-max-stack-depth */
 #define OPT_STACK_STORAGE_SIZE		2 /* --stack-storage-size */
+#ifdef USE_DWARF_UNWIND
+#define OPT_DWARF_STACK_SIZE		3 /* --dwarf-stack-size */
+#endif
 
 #define __ATTACH_UPROBE(skel, sym_name, prog_name, is_retprobe) \
 	do { \
@@ -223,6 +237,10 @@ static const struct argp_option argp_options[] = {
 	 "the number of unique stack traces that can be stored and displayed (default 10240)", 0 },
 	{"perf-max-stack-depth", OPT_PERF_MAX_STACK_DEPTH,
 	 "PERF-MAX-STACK-DEPTH", 0, "the limit for both kernel and user stack traces (default 127)", 0 },
+#ifdef USE_DWARF_UNWIND
+	{ "dwarf-unwind", 'D', NULL, 0, "Enable DWARF mode stack traces", 0 },
+	{ "dwarf-stack-size", OPT_DWARF_STACK_SIZE, "STACK-SIZE", 0, "Set user stack size for DWARF mode (default 128)", 0 },
+#endif
 	{"verbose", 'v', NULL, 0, "verbose debug output", 0 },
 	{},
 };
@@ -397,6 +415,11 @@ int main(int argc, char *argv[])
 		bpf_map__set_max_entries(skel->maps.combined_allocs, COMBINED_ALLOCS_MAX_ENTRIES);
 		skel->rodata->combined_only = true;
 	}
+
+#ifdef USE_DWARF_UNWIND
+	if (env.dwarf_unwind)
+		UW_MAP_SET(skel, env.dwarf_ustack_size, env.stack_map_max_entries);
+#endif
 
 	// disable kernel tracepoints based on settings or availability
 	if (env.kernel_trace) {
@@ -615,6 +638,25 @@ error_t argp_parse_arg(int key, char *arg, struct argp_state *state)
 			argp_usage(state);
 		}
 		break;
+#ifdef USE_DWARF_UNWIND
+	case 'D':
+		env.dwarf_unwind = true;
+		break;
+	case OPT_DWARF_STACK_SIZE:
+		errno = 0;
+		env.dwarf_ustack_size = strtol(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "invalid stack size: %s\n", arg);
+			argp_usage(state);
+		}
+		if (env.dwarf_ustack_size > UW_STACK_MAX_SZ) {
+			fprintf(stderr, "the stack size is too big, please "
+				"increase UW_STACK_MAX_SZ's value and recompile");
+			argp_usage(state);
+		}
+
+		break;
+#endif
 	case ARGP_KEY_ARG:
 		pos_args++;
 
@@ -842,6 +884,26 @@ void print_stack_frames_by_syms_cache()
 }
 #endif
 
+static int stack_map_lookup_elem(int sfd, int *stack_id, pid_t pid, unsigned long *ip, size_t count)
+{
+#ifdef USE_DWARF_UNWIND
+	int err;
+
+	if (env.dwarf_unwind) {
+		err = uw_map_lookup_elem(stack_id, pid, ip, count);
+		if (err == -ENOBUFS) {
+			fprintf(stderr, "WARNING: The stack trace cannot be fully displayed."
+					" Consider increasing --dwarf-stack-size.\n");
+			err = 0;
+		}
+		errno = -err;
+		return err;
+	}
+#endif
+
+	return bpf_map_lookup_elem(sfd, stack_id, ip);
+}
+
 int print_stack_frames(struct allocation *allocs, size_t nr_allocs, int stack_traces_fd)
 {
 	for (size_t i = 0; i < nr_allocs; ++i) {
@@ -857,7 +919,8 @@ int print_stack_frames(struct allocation *allocs, size_t nr_allocs, int stack_tr
 			}
 		}
 
-		if (bpf_map_lookup_elem(stack_traces_fd, &alloc->stack_id, stack)) {
+		if (stack_map_lookup_elem(stack_traces_fd, (int*)&alloc->stack_id, env.pid, stack,
+					  env.perf_max_stack_depth)) {
 			if (errno == ENOENT)
 				continue;
 

--- a/libbpf-tools/unwind_helpers.bpf.h
+++ b/libbpf-tools/unwind_helpers.bpf.h
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright 2023 LG Electronics Inc.
+#ifndef __UNWIND_HELPERS_BPF_H
+#define __UNWIND_HELPERS_BPF_H
+
+#include <asm-generic/errno.h>
+#include "unwind_helpers_types.h"
+#include "maps.bpf.h"
+
+/*
+ * The usage is documented in unwind_helpers.h
+ *
+ * This file internally creates two maps to store user registers and user stack.
+ */
+
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define DEFAULT_MAX_ENTRIES 1
+#define DEFAULT_USTACK_SIZE 256
+
+const volatile bool dwarf_unwind = false;
+const volatile int targ_sample_max_entries = DEFAULT_MAX_ENTRIES;
+const volatile unsigned long targ_ustack_size = DEFAULT_USTACK_SIZE;
+
+/*
+ * Map to store sample data
+ * The length of the dumped stack and the regs dump are saved.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u32);
+	__type(value, struct sample_data);
+	__uint(max_entries, 1);
+} UW_SAMPLES_MAP SEC(".maps");
+
+/*
+ * Map to store stack dumps
+ * Separated map to allow value sizes to be adjusted at load time.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u32);
+	__type(value, u32);
+	__uint(max_entries, 1);
+} UW_STACKS_MAP SEC(".maps");
+
+/*
+ * Returns the ID of the user sample dumped for the current context.
+ */
+static int uw_get_stackid()
+{
+	struct sample_data *sample;
+	struct task_struct *task;
+	struct mm_struct *mm;
+	struct pt_regs *ctx;
+	static const struct sample_data szero = {0, };
+	static const char uzero[UW_STACK_MAX_SZ] = {0, };
+	__u64* ustack;
+	static __u32 id = 0;
+	u64 sp;
+	u32 stack_len;
+	u32 dump_len;
+
+	task = bpf_get_current_task_btf();
+	ctx = (struct pt_regs *)bpf_task_pt_regs(task);
+
+	mm = BPF_CORE_READ(task, mm);
+	if (!mm)
+		return -EINVAL;
+
+	if (id >= targ_sample_max_entries)
+		return -ENOMEM;
+
+	__sync_fetch_and_add(&id, 1);
+
+	sample = bpf_map_lookup_or_try_init(&UW_SAMPLES_MAP, &id, &szero);
+	if (!sample)
+		return -ENOENT;
+
+	ustack = bpf_map_lookup_or_try_init(&UW_STACKS_MAP, &id, &uzero);
+	if (!ustack)
+		return -ENOENT;
+
+	/* dump user regs */
+	bpf_probe_read(&sample->user_regs, sizeof(struct pt_regs), ctx);
+
+	/* dump user stack */
+	sp = PT_REGS_SP_CORE(ctx);
+	stack_len = BPF_CORE_READ(mm, start_stack) - sp;
+	dump_len = MIN(stack_len, targ_ustack_size);
+
+	if (bpf_probe_read_user(ustack, dump_len, (void*)sp) == 0)
+		sample->user_stack.size = dump_len;
+
+	return id;
+}
+
+#endif /* __UNWIND_HELPERS_BPF_H */

--- a/libbpf-tools/unwind_helpers.c
+++ b/libbpf-tools/unwind_helpers.c
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/*
+ * Post mortem Dwarf CFI based unwinding on top of regs and stack dumps.
+ * Copyright 2023 LG Electronics Inc.
+ *
+ * Lots of this code have been borrowed or heavily inspired from parts of
+ * the libunwind and perf codes.
+ * 04-Feb-2023   Eunseon Lee   Created this.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <sys/user.h>
+#include <sys/uio.h>
+#include <sys/ptrace.h>
+#include <libunwind-ptrace.h>
+#include <errno.h>
+#include <dirent.h>
+#include "unwind_helpers.h"
+#include <unistd.h>
+#include <fcntl.h>
+
+/*
+ * By default, the proc filesystem is used to read the target process memory.
+ * If the macro below is enabled, it can be switched to use ptrace.
+ */
+//#define PTRACE_READ_MEMORY_FOR_REMOTE_UNWIND
+
+/* Internal logs can be enabled by changing the LOG_LEVEL */
+#define LOG_LEVEL	WARN
+
+/* for internal logs */
+#define p_debug(fmt, ...) __p(DEBUG, "Debug", fmt, ##__VA_ARGS__)
+#define p_info(fmt, ...) __p(INFO, "Info", fmt, ##__VA_ARGS__)
+#define p_warn(fmt, ...) __p(WARN, "Warn", fmt, ##__VA_ARGS__)
+#define p_err(fmt, ...) __p(ERROR, "Error", fmt, ##__VA_ARGS__)
+
+enum log_level {
+	DEBUG,
+	INFO,
+	WARN,
+	ERROR,
+};
+
+static enum log_level log_level = LOG_LEVEL;
+static struct sample_data *g_sample;
+static size_t sample_stack_size;
+static struct bpf_object *bpf_obj;
+static int mem_fd;
+
+static void __p(enum log_level level, char *level_str, char *fmt, ...)
+{
+        va_list ap;
+
+        if (level < log_level)
+                return;
+        va_start(ap, fmt);
+        fprintf(stderr, "%s: ", level_str);
+        vfprintf(stderr, fmt, ap);
+        va_end(ap);
+        fflush(stderr);
+}
+
+/*
+ * libunwind address space for dwarf unwinding
+ */
+#ifndef PTRACE_READ_MEMORY_FOR_REMOTE_UNWIND
+static int access_dso_mem (unw_word_t addr, unw_word_t *val, pid_t pid)
+{
+	ssize_t len;
+
+	lseek(mem_fd, addr, SEEK_SET);
+
+	len = read(mem_fd, val, sizeof(*val));
+	if (len == -1)
+		return -UNW_EINVAL;
+
+	p_debug("mem[%lx] -> %lx\n", (long) addr, (long) *val);
+	return 0;
+}
+#else
+static int access_dso_mem (unw_word_t addr, unw_word_t *val, pid_t pid)
+{
+	int i, end;
+	unw_word_t tmp_val;
+
+	/*
+	 * Some 32-bit archs have to define a 64-bit unw_word_t.
+	 * Callers of this function therefore expect a 64-bit
+	 * return value, but ptrace only returns a 32-bit value
+	 * in such cases.
+	 */
+	if (sizeof(long) == 4 && sizeof(unw_word_t) == 8)
+		end = 2;
+	else
+		end = 1;
+
+	for (i = 0; i < end; i++)
+	{
+		unw_word_t tmp_addr = i == 0 ? addr : addr + 4;
+		errno = 0;
+
+		tmp_val = (unsigned long) ptrace (PTRACE_PEEKDATA, pid, tmp_addr, 0);
+		if (i == 0)
+			*val = 0;
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+		*val |= tmp_val << (i * 32);
+#else
+		*val |= i == 0 && end == 2 ? tmp_val << 32 : tmp_val;
+#endif
+
+		if (errno)
+			return -UNW_EINVAL;
+
+		p_debug("mem[%lx] -> %lx\n", (long) tmp_addr, (long) tmp_val);
+	}
+	return 0;
+}
+#endif
+
+#if defined(__TARGET_ARCH_x86) || defined(__TARGET_ARCH_arm64)
+static inline void* uc_addr (unsigned long uc[], int reg)
+{
+	return &uc[reg];
+}
+#else
+#error This Architecture is not supported yet. Please open an issue
+#endif
+
+static int access_reg(unw_addr_space_t as,
+		      unw_regnum_t regnum, unw_word_t *val,
+		      int __write, void *arg)
+{
+	unw_word_t *addr;
+	struct sample_data *sample = g_sample;
+
+	/* Don't support write, I suspect we don't need it. */
+	if (__write) {
+		p_err("unwind: access_reg w %d\n", regnum);
+		return -EINVAL;
+	}
+
+	if (!(addr = uc_addr ((unsigned long*)&sample->user_regs, regnum))) {
+		p_err("unwind: can't read reg %d\n", regnum);
+		return -EINVAL;
+	}
+
+	*val = *(unw_word_t *) addr;
+	p_debug("unwind: reg %d, val %lx\n", regnum, (unsigned long)*val);
+	return 0;
+}
+
+static int access_mem(unw_addr_space_t as,
+		      unw_word_t addr, unw_word_t *valp,
+		      int __write, void *arg)
+{
+	struct sample_data *sample = g_sample;
+	struct stack_dump *stack = &sample->user_stack;
+	unw_word_t *start;
+	unw_word_t end;
+	int offset;
+	int ret;
+	pid_t pid = *(pid_t*)arg;
+
+	/* Don't support write, probably not needed. */
+	if (__write || !stack) {
+		*valp = 0;
+		p_err("unwind: invalid args\n");
+		return -EINVAL;
+	}
+
+	if (!(start = uc_addr ((unsigned long*)&sample->user_regs, UNW_REG_SP))) {
+		p_err("unwind: can't read reg SP\n");
+		return -EINVAL;
+	}
+
+	end = *(unw_word_t *)start + (unw_word_t)(stack->size);
+
+	/* Check overflow. */
+	if (addr + sizeof(unw_word_t) < addr) {
+		p_err("unwind: overflow, addr + sizeof(unw_word_t): %lx\n", addr + sizeof(unw_word_t));
+		return -EINVAL;
+	}
+
+	if (addr < *start || addr + sizeof(unw_word_t) >= end) {
+		ret = access_dso_mem(addr, valp, pid);
+		if (ret) {
+			p_debug("unwind: access_mem %p not inside range"
+				" 0x%" PRIx64 "-0x%" PRIx64 "\n",
+				(void *) (uintptr_t) addr, start, end);
+			*valp = 0;
+			return ret;
+		}
+		return 0;
+	}
+
+	offset = addr - *(unw_word_t *)start;
+	*valp = *(unw_word_t *)&stack->data[offset];
+	p_debug("unwind: start: %lx, end: %lx, addr: %p, offset: %lx\n",
+		(unsigned long)*start, (unsigned long)end, (void*)(uintptr_t)addr, offset);
+	p_debug("unwind: access_mem addr %p val %lx, offset %d\n",
+	        (void *) (uintptr_t) addr, (unsigned long)*valp, offset);
+	return 0;
+}
+
+static unw_accessors_t accessors = {
+	.find_proc_info = _UPT_find_proc_info,
+	.put_unwind_info = _UPT_put_unwind_info,
+	.get_dyn_info_list_addr = _UPT_get_dyn_info_list_addr,
+	.access_mem = access_mem,
+	.access_reg = access_reg,
+	.access_fpreg = _UPT_access_fpreg,
+	.resume = _UPT_resume,
+	.get_proc_name = _UPT_get_proc_name,
+};
+
+
+static int get_entries(const struct sample_data *sample, pid_t pid,
+		       unsigned long *ip, int count)
+{
+	unw_cursor_t cursor;
+	void *context = NULL;
+	int err = 0;
+	int i = 0;
+#ifndef PTRACE_READ_MEMORY_FOR_REMOTE_UNWIND
+	char mem_path[256];
+#endif
+	unw_addr_space_t as = unw_create_addr_space(&accessors, 0);
+
+	if (!sample || !ip)
+		return -EINVAL;
+
+	g_sample = (struct sample_data *)sample;
+
+#ifndef PTRACE_READ_MEMORY_FOR_REMOTE_UNWIND
+	snprintf(mem_path, sizeof(mem_path), "/proc/%d/mem", pid);
+	mem_fd = open(mem_path, O_RDONLY);
+	if (mem_fd == -1) {
+		p_err("failed to open %s: %s", mem_path, strerror(errno));
+		return -EINVAL;
+	}
+	p_debug("Accessing target memory via /proc filesystem\n");
+#else
+	if (ptrace(PTRACE_ATTACH, pid, 0, 0) != 0) {
+		p_err("ERROR: cannot attach to %d\n", pid);
+		return -1;
+	}
+	p_debug("Accessing target memory via ptrace\n");
+#endif
+
+	context = _UPT_create(pid);
+	if (!context) {
+		err = -1;
+		goto cleanup;
+	}
+
+	if (unw_init_remote(&cursor, as, context) != 0) {
+		p_err("ERROR: cannot initialize cursor for remote unwinding\n");
+		return -1;
+	}
+
+	do {
+		unw_word_t pc;
+		if (unw_get_reg(&cursor, UNW_REG_IP, &pc)) {
+			p_err("ERROR: cannot read program counter\n");
+			return -1;
+		}
+
+		ip[i++] = pc;
+	} while (unw_step(&cursor) > 0 && i < count);
+#if 0
+	} while (((err = unw_step(&cursor)) > 0) && i < count);
+	if (err > 0)
+		err = -ENOBUFS;
+#endif
+
+cleanup:
+	if (context)
+		_UPT_destroy(context);
+
+#ifndef PTRACE_READ_MEMORY_FOR_REMOTE_UNWIND
+	close(mem_fd);
+#else
+	(void) ptrace(PTRACE_DETACH, pid, 0, 0);
+#endif
+
+	return err;
+}
+
+static inline unw_word_t stack_pointer(unsigned long uc[])
+{
+	return *(unw_word_t*)uc_addr(uc, UNW_REG_SP);
+}
+
+static void print_dumped_stack(stack_dump_t *user_stack)
+{
+	unw_word_t *stack = (unw_word_t *)user_stack->data;
+	int nr = user_stack->size/sizeof(unw_word_t);
+
+	p_debug("## Dumped Stack (size: %ld bytes) ##:\n", user_stack->size);
+	for (int i = 0; i < nr; i++)
+		p_debug("[%d]: %x\n", i, stack[i]);
+	p_debug("\n");
+}
+
+static void print_dumped_registers(regs_dump_t *user_regs)
+{
+	p_debug("## Dumped Regs ##: \n");
+	for (int i = 0; i <= UNW_REG_LAST; i++)
+		p_debug("Regs[%d]: 0x%lx\n", i, ((unw_word_t*)user_regs)[i]);
+}
+
+static void print_sample_dump(const int stack_id, struct sample_data *sample)
+{
+	print_dumped_registers(&sample->user_regs);
+	print_dumped_stack(&sample->user_stack);
+}
+
+int uw_map_lookup_elem(const int *stack_id, pid_t pid,
+		       unsigned long *ip, size_t count)
+{
+	int samples_map, ustacks_map;
+	struct sample_data *sample = NULL;
+	char *sample_ustack = NULL;
+	int err;
+
+	if (!stack_id || !ip)
+		return -EINVAL;
+
+	if (*stack_id == -ENOMEM)
+		return -ENOENT;
+
+	if (*stack_id < 0)
+		return -EINVAL;
+
+	memset(ip, 0, sizeof(*ip) * count);
+
+	/* Obtain dumped sample (stack and registers) from map */
+	sample = (struct sample_data*)malloc(sizeof(struct sample_data));
+	if (!sample)
+		return -ENOMEM;
+
+	sample_ustack = (char*)malloc(sample_stack_size);
+	if (!sample_ustack) {
+		err = -ENOMEM;
+		goto cleanup;
+	}
+
+	samples_map = bpf_map__fd(bpf_object__find_map_by_name(bpf_obj, NAME(UW_SAMPLES_MAP)));
+	if (samples_map < 0) {
+		err = samples_map;
+		goto cleanup;
+	}
+	ustacks_map = bpf_map__fd(bpf_object__find_map_by_name(bpf_obj, NAME(UW_STACKS_MAP)));
+	if (ustacks_map < 0) {
+		err = ustacks_map;
+		goto cleanup;
+	}
+
+	err = bpf_map_lookup_elem(samples_map, stack_id, sample);
+	if (err < 0) {
+		fprintf(stderr, "failed to lookup samples for stack %d: %d\n", *stack_id, err);
+		goto cleanup;
+	}
+
+	err = bpf_map_lookup_elem(ustacks_map, stack_id, sample_ustack);
+	if (err < 0) {
+		fprintf(stderr, "failed to lookup ustacks for stack %d: %d\n", *stack_id, err);
+		goto cleanup;
+	}
+	sample->user_stack.data = sample_ustack;
+
+	print_sample_dump(*stack_id, sample);
+
+	/* Post dwarf unwind with obtained sample (stack and registers) */
+	p_debug("Dwarf unwind for stackID %d\n", *stack_id);
+
+	err = get_entries(sample, pid, ip, count);
+	if (err)
+		p_err("get_entries failded: %d\n", err);
+
+cleanup:
+	if (sample->user_stack.data)
+		free(sample->user_stack.data);
+	if (sample)
+		free(sample);
+
+	return err;
+}
+
+int uw_map__set(const struct bpf_object *obj, size_t stack_size, size_t max_entries)
+{
+	struct bpf_map *samples_map = bpf_object__find_map_by_name(obj, NAME(UW_SAMPLES_MAP));
+	struct bpf_map *ustacks_map = bpf_object__find_map_by_name(obj, NAME(UW_STACKS_MAP));
+
+	if (samples_map < 0 || ustacks_map < 0)
+		return -EINVAL;
+
+	/* set max entries of bpf sample map */
+	bpf_map__set_max_entries(samples_map, max_entries);
+
+	/* set value size and max entries of bpf ustack map */
+	bpf_map__set_value_size(ustacks_map, stack_size);
+	bpf_map__set_max_entries(ustacks_map, max_entries);
+
+	sample_stack_size = stack_size;
+	bpf_obj = (struct bpf_object *)obj;
+
+	return 0;
+}

--- a/libbpf-tools/unwind_helpers.h
+++ b/libbpf-tools/unwind_helpers.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright 2023 LG Electronics Inc.
+#ifndef __UNWIND_HELPERS_H
+#define __UNWIND_HELPERS_H
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+#include <libunwind-ptrace.h>
+#include "unwind_helpers_types.h"
+
+/*
+ * How to Use
+ *
+ * For the helloworld tool:
+ *
+ * For helloworld.bpf.c:
+ * 1. Include unwind_helpers.bpf.h
+ * 2. Use uw_get_stackid() to obtain the stack ID
+ *
+ * For helloworld.c:
+ * 1. Include unwind_helpers.h
+ * 2. Call UW_MAP_SET before invoking *_bpf__load to init resource sizes in unwind_helper
+ * 3. Call uw_map_lookup_elem to retrieve ips for the stack ID.
+ *
+ * Additional Information
+ * Register dumps and stack dumps are stored in internal maps in unwind_helpers.
+ * The size of these maps can be configured using UW_MAP_SET().
+ */
+
+/*
+ * UW_MAP_SET(obj, stack_size, uw_max_entries)
+ *
+ * @obj: bpf_object
+ * @stack_size: max size to store each user stack
+ * @uw_max_entries: max entries to store user stacks
+ */
+#define UW_MAP_SET(o, stack_size, uw_max_entries) 		\
+({								\
+	o->rodata->dwarf_unwind = true;				\
+	o->rodata->targ_ustack_size = stack_size;		\
+	o->rodata->targ_sample_max_entries = uw_max_entries;	\
+	uw_map__set(o->obj, stack_size, uw_max_entries);	\
+})
+int uw_map__set(const struct bpf_object *obj, size_t stack_size, size_t max_entries);
+
+/*
+ * uw_map_lookup_elem
+ *
+ * allows to lookup BPF map value corresponding to stack_id.
+ *
+ * @brief **bpf_map__lookup_elem()** allows to lookup BPF map value
+ * corresponding to provided key.
+ * @stack_id: user stack id to lookup and unwind
+ * @pid: process id of @stack_id
+ * @ip: pointer to memory in which unwounded value will be stored
+ * @count: number of value data memory
+ *
+ * This function returns id of dumped user stack and registers for current context
+ * 	Perform a lookup in *map* for an entry associated to *stack_id*.
+ */
+int uw_map_lookup_elem(const int *stack_id, pid_t pid,
+		       unsigned long *ip, size_t count);
+
+#endif /* __UNWIND_HELPERS_H */

--- a/libbpf-tools/unwind_helpers_types.h
+++ b/libbpf-tools/unwind_helpers_types.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright 2023 LG Electronics Inc.
+#ifndef __UNWIND_HELPERS_TYPES_H
+#define __UNWIND_HELPERS_TYPES_H
+
+#define STRINGIFY(x)		#x
+#define NAME(x)			STRINGIFY(x)
+
+#define UW_STACK_MAX_SZ		4096
+#define UW_SAMPLES_MAP		uw_samples
+#define UW_STACKS_MAP		uw_stacks
+
+/*
+ * Defines the same structure as "struct pt_regs".
+ * Since struct pt_regs is kernel-only, this data type is defined for use in both kernel and user space.
+ */
+#if defined(__TARGET_ARCH_arm64)
+struct uw_user_regs {
+	__u64 regs[31];
+	__u64 sp;
+	__u64 pc;
+	__u64 pstate;
+};
+#elif defined(__TARGET_ARCH_x86)
+struct uw_user_regs {
+	__u64 r15;
+	__u64 r14;
+	__u64 r13;
+	__u64 r12;
+	__u64 rbp;
+	__u64 rbx;
+	__u64 r11;
+	__u64 r10;
+	__u64 r9;
+	__u64 r8;
+	__u64 rax;
+	__u64 rcx;
+	__u64 rdx;
+	__u64 rsi;
+	__u64 rdi;
+	__u64 orig_rax;
+	__u64 rip;
+	__u64 cs;
+	__u64 eflags;
+	__u64 rsp;
+	__u64 ss;
+};
+#else
+#error This Architecture is not supported yet. Please open an issue
+#endif
+
+typedef struct uw_user_regs regs_dump_t;
+
+typedef struct stack_dump {
+	__u32 size;
+	char *data;
+} stack_dump_t;
+
+struct sample_data {
+	regs_dump_t user_regs;
+	stack_dump_t user_stack;
+};
+#endif /* __UNWIND_HELPERS_TYPES_H */


### PR DESCRIPTION
This is not the finished version for review. Before I finish, I'd like to know that this feature is required by bcc.
Can you please let me know if post unwind using dwarf unwind via libunwind is needed and it helps with issues like #3515?

FYI, there are a few things left to do for this PR if needed:
- Added ARCH dependent code for x86
- Dump user stack and regs when in kernel mode
- Add libunwind for build
- etc.

1. test environment
Tested with profile in aarch64 environment.
However, the profile's review PR is not in progress, so I apply it to offcputime to share the code.

2. This is the test results.
Before: 
```
# ./profile -d -p `pidof test-strlen-abc-nofp-unwtbl`
Sampling at 49 Hertz of PID 83030 by user + kernel stack... Hit Ctrl-C to end.
^C    
    #0  0x0000007fbe74cc20 strerrordesc_np+0x1980 (/usr/lib/libc.so.6+0x9cc20)
    #1  0x0000007fbe6db30c __libc_start_main+0x9c (/usr/lib/libc.so.6+0x2b30c)
    #2  0x000000556f9c0754 _start+0x34 (/var/rootdirs/home/root/test-strlen-abc-nofp-unwtbl+0x754)
    -                test-strlen-abc (83030)
        290
```

After:
```
# ./profile -P -d -p `pidof test-strlen-abc-nofp-unwtbl`
Sampling at 49 Hertz of PID 83030 by user + kernel stack... Hit Ctrl-C to end.
^C    
    #0  0x0000007fbe74cc20 strerrordesc_np+0x1980 (/usr/lib/libc.so.6+0x9cc20)
    #1  0x000000556f9c087c c+0x30 (/var/rootdirs/home/root/test-strlen-abc-nofp-unwtbl+0x87c)
    #2  0x000000556f9c0840 b+0x8 (/var/rootdirs/home/root/test-strlen-abc-nofp-unwtbl+0x840)
    #3  0x000000556f9c082c a+0x8 (/var/rootdirs/home/root/test-strlen-abc-nofp-unwtbl+0x82c)
    #4  0x000000556f9c08c4 main+0x10 (/var/rootdirs/home/root/test-strlen-abc-nofp-unwtbl+0x8c4)
    #6  0x0000007fbe6db230 __libc_init_first+0x70 (/usr/lib/libc.so.6+0x2b230)
    -                test-strlen-abc (83030)
        1
```
3. test executable information
Test executable has no frame pointer, but has an unwind table (.eh_frame).
3.1 compile option : -fomit-frame-pointer -funwind-tables 
3.2 code 
```
#include <assert.h>
#include <stdlib.h>
#include <string.h>

char buf[8*1024*1024];

int a(void);
int b(void);
int c(void);

typedef size_t (*strlen_t)(const char *); 
strlen_t getlen = strlen;

int a(void)
{
        return b() - 1;
}

int b(void)
{
        return c() + 1;
}

int c() 
{
        memset(buf, '+', sizeof(buf)-1);

        while (1) {
                size_t len = getlen(buf);
                assert(len == sizeof(buf) - 1); 
        }

        // not reached
        return 1;
}

int main(int argc, char **argv)
{
        a();
}
```

Thank you.