### PR TITLE
tools/scsilatency: add scsilatency tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[runqlat](tools/runqlat.py): Run queue (scheduler) latency as a histogram. [Examples](tools/runqlat_example.txt).
 - tools/[runqlen](tools/runqlen.py): Run queue length as a histogram. [Examples](tools/runqlen_example.txt).
 - tools/[runqslower](tools/runqslower.py): Trace long process scheduling delays. [Examples](tools/runqslower_example.txt).
+- tools/[scsilatency](tools/scsilatency.py): Summarize SCSI layer I/O latency as a histogram . [Examples](tools/scsilatency_example.txt).
 - tools/[shmsnoop](tools/shmsnoop.py): Trace System V shared memory syscalls. [Examples](tools/shmsnoop_example.txt).
 - tools/[sofdsnoop](tools/sofdsnoop.py): Trace FDs passed through unix sockets. [Examples](tools/sofdsnoop_example.txt).
 - tools/[slabratetop](tools/slabratetop.py): Kernel SLAB/SLUB memory cache allocation rate top. [Examples](tools/slabratetop_example.txt).

--- a/man/man8/scsilatency.8
+++ b/man/man8/scsilatency.8
@@ -1,0 +1,109 @@
+.TH scsilatency 8  "2022-10-10" "USER COMMANDS"
+.SH NAME
+scsilatency \- Summarize SCSI layer I/O latency as a histogram.
+.SH SYNOPSIS
+.B scsilatency [\-h] [\-F] [\-T] [\-m] [\-D] [\-e] [interval [count]]
+.SH DESCRIPTION
+scsilatency traces SCSI layer I/O (disk I/O), and records the distribution
+of I/O latency (time). This is printed as a histogram either on Ctrl-C, or
+after a given interval in seconds.
+
+The latency of disk I/O operations is measured from when requests are issued to the device
+up to completion. 
+
+This tool uses in-kernel eBPF maps for storing timestamps and the histogram,
+for efficiency.
+
+This works by tracing various kernel scsi_*() functions using dynamic tracing,
+and will need updating to match any changes to these functions.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+.SH OPTIONS
+\-h
+Print usage message.
+.TP
+\-T
+Include timestamps on output.
+.TP
+\-m
+Output histogram in milliseconds.
+.TP
+\-D
+Print a histogram per disk device.
+.TP
+\-F
+Print a histogram per set of I/O flags.
+.TP
+\-j
+Print a histogram dictionary
+.TP
+\-e
+Show extension summary(total, average)
+.TP
+interval
+Output interval, in seconds.
+.TP
+count
+Number of outputs.
+.SH EXAMPLES
+.TP
+Summarize SCSI layer I/O latency as a histogram:
+#
+.B scsilatency
+.TP
+Print 1 second summaries, 10 times:
+#
+.B scsilatency 1 10
+.TP
+Print 1 second summaries, using milliseconds as units for the histogram, and
+include timestamps on output:
+#
+.B scsilatency \-mT 1
+.TP
+Show a latency histogram for each disk device separately:
+#
+.B scsilatency \-D
+.TP
+Show a latency histogram in a dictionary format:
+#
+.B scsilatency \-j
+.TP
+Also show extension summary(total, average):
+#
+.B scsilatency \-e
+.SH FIELDS
+.TP
+usecs
+Microsecond range
+.TP
+msecs
+Millisecond range
+.TP
+count
+How many I/O fell into this range
+.TP
+distribution
+An ASCII bar chart to visualize the distribution (count column)
+.SH OVERHEAD
+This traces kernel functions and maintains in-kernel timestamps and a histogram,
+which are asynchronously copied to user-space. This method is very efficient,
+and the overhead for most storage I/O rates (< 10k IOPS) should be negligible.
+If you have a higher IOPS storage environment, test and quantify the overhead
+before use.
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Weibang Liu
+.SH SEE ALSO
+biosnoop(8)

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -295,6 +295,9 @@ class SmokeTests(TestCase):
     def test_runqlen(self):
         self.run_with_duration("runqlen.py 1 1")
 
+    def test_scsilatency(self):
+        self.run_with_duration("scsilatency.py 1 1")
+
     @skipUnless(kernel_version_ge(4,8), "requires kernel >= 4.8")
     def test_shmsnoop(self):
         self.run_with_int("shmsnoop.py")

--- a/tools/scsilatency.py
+++ b/tools/scsilatency.py
@@ -1,0 +1,247 @@
+#!/usr/bin/python
+# SPDX-License-Identifier: <SPDX License Expression>
+# @lint-avoid-python-3-compatibility-imports
+#
+# scsilatency    Summarize SCSI layer I/O latency as a histogram.
+#       For Linux, uses BCC, eBPF.
+#
+# USAGE: scsilatency [-h] [-T] [-Q] [-m] [-D] [-e] [interval] [count]
+#
+# Copyright (c) 10-Oct-2022, Samsung Electronics.  All rights reserved.
+# This source code is licensed under the Apache License, Version 2.0
+#
+# Written by Weibang Liu<weibang6.liu@samsung.com>.
+
+from __future__ import print_function
+from bcc import BPF
+from time import sleep, strftime
+import argparse
+import ctypes as ct
+
+# arguments
+examples = """examples:
+    ./scsilatency            # summarize SCSI layer I/O latency as a histogram
+    ./scsilatency 1 10       # print 1 second summaries, 10 times
+    ./scsilatency -mT 1      # 1s summaries, milliseconds, and timestamps
+    ./scsilatency -D         # show each disk device separately
+    ./scsilatency -F         # show I/O flags separately
+    ./scsilatency -j         # print a dictionary
+    ./scsilatency -e         # show extension summary(total, average)
+"""
+parser = argparse.ArgumentParser(
+    description="Summarize SCSI layer I/O latency as a histogram",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("-T", "--timestamp", action="store_true",
+                    help="include timestamp on output")
+parser.add_argument("-m", "--milliseconds", action="store_true",
+                    help="millisecond histogram")
+parser.add_argument("-D", "--disks", action="store_true",
+                    help="print a histogram per disk device")
+parser.add_argument("-F", "--flags", action="store_true",
+                    help="print a histogram per set of I/O flags")
+parser.add_argument("-e", "--extension", action="store_true",
+                    help="summarize average/total value")
+parser.add_argument("interval", nargs="?", default=99999999,
+                    help="output interval, in seconds")
+parser.add_argument("count", nargs="?", default=99999999,
+                    help="number of outputs")
+parser.add_argument("--ebpf", action="store_true",
+                    help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+                    help="json output")
+
+args = parser.parse_args()
+countdown = int(args.count)
+debug = 0
+
+if args.flags and args.disks:
+    print("ERROR: can only use -D or -F. Exiting.")
+    exit()
+
+# define BPF program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/blkdev.h>
+#include <scsi/scsi_cmnd.h>
+
+typedef struct disk_key {
+    char disk[DISK_NAME_LEN];
+    u64 slot;
+} disk_key_t;
+
+typedef struct flag_key {
+    u64 flags;
+    u64 slot;
+} flag_key_t;
+
+typedef struct ext_val {
+    u64 total;
+    u64 count;
+} ext_val_t;
+
+BPF_HASH(start, struct request *);
+STORAGE
+
+// start time of SCSI I/O
+int trace_req_start(struct pt_regs *ctx, struct scsi_cmnd *cmd)
+{
+    struct request *req = cmd->request;
+
+    u64 ts = bpf_ktime_get_ns();
+    start.update(&req, &ts);
+    return 0;
+}
+
+// output
+int trace_req_done(struct pt_regs *ctx, struct scsi_cmnd *cmd)
+{
+    u64 *tsp, delta;
+    struct request *req = cmd->request;
+
+    // fetch timestamp and calculate delta
+    tsp = start.lookup(&req);
+    if (tsp == 0) {
+        return 0;   // missed issue
+    }
+    delta = bpf_ktime_get_ns() - *tsp;
+
+    EXTENSION
+
+    FACTOR
+
+    // store as histogram
+    STORE
+
+    start.delete(&req);
+    return 0;
+}
+"""
+
+# code substitutions
+if args.milliseconds:
+    bpf_text = bpf_text.replace('FACTOR', 'delta /= 1000000;')
+    label = "msecs"
+else:
+    bpf_text = bpf_text.replace('FACTOR', 'delta /= 1000;')
+    label = "usecs"
+
+storage_str = ""
+store_str = ""
+if args.disks:
+    storage_str += "BPF_HISTOGRAM(dist, disk_key_t);"
+    store_str += """
+    disk_key_t key = {.slot = bpf_log2l(delta)};
+    void *__tmp = (void *)req->rq_disk->disk_name;
+    bpf_probe_read(&key.disk, sizeof(key.disk), __tmp);
+    dist.increment(key);
+    """
+elif args.flags:
+    storage_str += "BPF_HISTOGRAM(dist, flag_key_t);"
+    store_str += """
+    flag_key_t key = {.slot = bpf_log2l(delta)};
+
+    #ifdef REQ_WRITE
+        key.flags = !!(req->cmd_flags & REQ_WRITE);
+    #elif defined(REQ_OP_SHIFT)
+        key.flags = !!((req->cmd_flags >> REQ_OP_SHIFT) == REQ_OP_WRITE);
+    #else
+        key.flags = !!((req->cmd_flags & REQ_OP_MASK) == REQ_OP_WRITE);
+    #endif
+
+    dist.increment(key);
+    """
+else:
+    storage_str += "BPF_HISTOGRAM(dist);"
+    store_str += "dist.increment(bpf_log2l(delta));"
+
+if args.extension:
+    storage_str += "BPF_ARRAY(extension, ext_val_t, 1);"
+    bpf_text = bpf_text.replace('EXTENSION', """
+    u32 index = 0;
+    ext_val_t *ext_val = extension.lookup(&index);
+    if (ext_val) {
+        lock_xadd(&ext_val->total, delta);
+        lock_xadd(&ext_val->count, 1);
+    }
+    """)
+else:
+    bpf_text = bpf_text.replace('EXTENSION', '')
+bpf_text = bpf_text.replace("STORAGE", storage_str)
+bpf_text = bpf_text.replace("STORE", store_str)
+
+if debug or args.ebpf:
+    print(bpf_text)
+    if args.ebpf:
+        exit()
+
+# load BPF program
+b = BPF(text=bpf_text)
+if BPF.get_kprobe_functions(b'scsi_init_io'):
+    b.attach_kprobe(event="scsi_init_io", fn_name="trace_req_start")
+else:
+    b.attach_kprobe(event="scsi_alloc_sgtables", fn_name="trace_req_start")
+if BPF.get_kprobe_functions(b'scsi_mq_done'):
+    b.attach_kprobe(event="scsi_mq_done", fn_name="trace_req_done")
+
+if not args.json:
+    print("Tracing SCSI layer I/O... Hit Ctrl-C to end.")
+
+
+def flags_print(flags):
+    desc = ""
+    if flags == 1:
+        desc = "Write"
+    else:
+        desc = "Read"
+
+    return desc
+
+# output
+exiting = 0 if args.interval else 1
+dist = b.get_table("dist")
+if args.extension:
+    extension = b.get_table("extension")
+while (1):
+    try:
+        sleep(int(args.interval))
+    except KeyboardInterrupt:
+        exiting = 1
+
+    print()
+    if args.json:
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
+
+        if args.flags:
+            dist.print_json_hist(label, "flags", flags_print)
+
+        else:
+            dist.print_json_hist(label)
+
+    else:
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
+
+        if args.flags:
+            dist.print_log2_hist(label, "flags", flags_print)
+        else:
+            dist.print_log2_hist(label, "disk")
+        if args.extension:
+            total = extension[0].total
+            counts = extension[0].count
+            if counts > 0:
+                if label == 'msecs':
+                    total /= 1000000
+                elif label == 'usecs':
+                    total /= 1000
+                avg = total / counts
+                print("\navg = %ld %s, total: %ld %s, count: %ld\n" %
+                      (total / counts, label, total, label, counts))
+            extension.clear()
+
+    dist.clear()
+
+    countdown -= 1
+    if exiting or countdown == 0:
+        exit()

--- a/tools/scsilatency_example.txt
+++ b/tools/scsilatency_example.txt
@@ -1,0 +1,215 @@
+Demonstrations of scsilatency, the Linux eBPF/bcc version.
+
+
+scsilatency traces SCSI layer I/O (disk I/O), and records the distribution
+of I/O latency (time), printing this as a histogram when Ctrl-C is hit.
+For example:
+
+# ./scsilatency
+Tracing SCSI layer I/O... Hit Ctrl-C to end.
+^C
+     usecs           : count     distribution
+       0 -> 1        : 0        |                                      |
+       2 -> 3        : 0        |                                      |
+       4 -> 7        : 0        |                                      |
+       8 -> 15       : 0        |                                      |
+      16 -> 31       : 0        |                                      |
+      32 -> 63       : 0        |                                      |
+      64 -> 127      : 1        |                                      |
+     128 -> 255      : 12       |********                              |
+     256 -> 511      : 15       |**********                            |
+     512 -> 1023     : 43       |*******************************       |
+    1024 -> 2047     : 52       |**************************************|
+    2048 -> 4095     : 47       |**********************************    |
+    4096 -> 8191     : 52       |**************************************|
+    8192 -> 16383    : 36       |**************************            |
+   16384 -> 32767    : 15       |**********                            |
+   32768 -> 65535    : 2        |*                                     |
+   65536 -> 131071   : 2        |*                                     |
+
+The latency of the disk I/O is measured from the issue to the device to its
+completion.
+
+This example output shows a large mode of latency from about 128 microseconds
+to about 32767 microseconds (33 milliseconds). The bulk of the I/O was
+between 1 and 8 ms, which is the expected block device latency for
+rotational storage devices.
+
+The highest latency seen while tracing was between 65 and 131 milliseconds:
+the last row printed, for which there were 2 I/O.
+
+For efficiency, scsilatency uses an in-kernel eBPF map to store timestamps
+with requests, and another in-kernel map to store the histogram (the "count")
+column, which is copied to user-space only when output is printed. These
+methods lower the performance overhead when tracing is performed.
+
+
+In the following example, the -m option is used to print a histogram using
+milliseconds as the units (which eliminates the first several rows), -T to
+print timestamps with the output, and to print 1 second summaries 5 times:
+
+# ./scsilatency -mT 1 5
+Tracing SCSI layer I/O... Hit Ctrl-C to end.
+
+04:48:15
+     msecs               : count     distribution
+         0 -> 1          : 9        |****************************************|
+
+04:48:16
+
+04:48:17
+     msecs               : count     distribution
+         0 -> 1          : 1        |********************                    |
+         2 -> 3          : 2        |****************************************|
+
+04:48:18
+
+04:48:19
+     msecs               : count     distribution
+         0 -> 1          : 71       |*******                                 |
+         2 -> 3          : 13       |*                                       |
+         4 -> 7          : 32       |***                                     |
+         8 -> 15         : 380      |****************************************|
+        16 -> 31         : 7        |                                        |
+        32 -> 63         : 32       |***                                     |
+
+
+How the I/O latency distribution changes over time can be seen.
+
+
+The -D option will print a histogram per disk. Eg:
+
+# ./scsilatency -D
+Tracing SCSI layer I/O... Hit Ctrl-C to end.
+^C
+
+disk = 'sda'
+     usecs               : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 0        |                                        |
+         8 -> 15         : 0        |                                        |
+        16 -> 31         : 1991     |*                                       |
+        32 -> 63         : 14764    |********                                |
+        64 -> 127        : 67282    |****************************************|
+       128 -> 255        : 12891    |*******                                 |
+       256 -> 511        : 436      |                                        |
+       512 -> 1023       : 205      |                                        |
+      1024 -> 2047       : 383      |                                        |
+      2048 -> 4095       : 759      |                                        |
+      4096 -> 8191       : 2775     |*                                       |
+      8192 -> 16383      : 1067     |                                        |
+     16384 -> 32767      : 2309     |*                                       |
+     32768 -> 65535      : 97       |                                        |
+
+This output shows that only sda device has be accessed, usually between 0.03 ms
+and 0.2 ms.
+
+
+The -F option prints a separate histogram for each unique set of request
+flags. For example:
+
+./scsilatency.py -Fm
+Tracing SCSI layer I/O... Hit Ctrl-C to end.
+^C
+
+flags = Read
+     msecs               : count     distribution
+         0 -> 1          : 100      |****************************************|
+         2 -> 3          : 6        |**                                      |
+
+flags = Write
+     msecs               : count     distribution
+         0 -> 1          : 247      |****************************************|
+         2 -> 3          : 24       |***                                     |
+         4 -> 7          : 11       |*                                       |
+
+These can be handled differently by the storage device, and this mode lets us
+examine their performance in isolation.
+
+
+The -e option shows extension summary(total, average)
+For example:
+# ./scsilatency.py -e
+^C
+     usecs               : count     distribution
+         0 -> 1          : 0        |                                        |
+         2 -> 3          : 0        |                                        |
+         4 -> 7          : 0        |                                        |
+         8 -> 15         : 0        |                                        |
+        16 -> 31         : 0        |                                        |
+        32 -> 63         : 6        |**                                      |
+        64 -> 127        : 31       |**************                          |
+       128 -> 255        : 87       |****************************************|
+       256 -> 511        : 44       |********************                    |
+       512 -> 1023       : 11       |*****                                   |
+      1024 -> 2047       : 32       |**************                          |
+      2048 -> 4095       : 7        |***                                     |
+      4096 -> 8191       : 13       |*****                                   |
+      8192 -> 16383      : 1        |                                        |
+
+avg = 826 usecs, total: 191862 usecs, count: 232
+
+Sometimes 128 -> 255 usecs is not enough for throughput tuning.
+Especially a little difference in performance downgrade.
+By this extension, we know the value in log2 range is about 826 usecs.
+
+
+The -j option prints a dictionary of the histogram.
+For example:
+
+# ./scsilatency.py -j
+^C
+{'val_type': 'usecs', 'data': [{'count': 0, 'interval-start': 0, 'interval-end': 1}, {'count': 0, 'interval-start': 2, 'interval-end': 3}, {'count': 0, 'interval-start': 4, 'interval-end': 7}, {'count': 0, 'interval-start': 8, 'interval-end': 15}, {'count': 6, 'interval-start': 16, 'interval-end': 31}, {'count': 32, 'interval-start': 32, 'interval-end': 63}, {'count': 52, 'interval-start': 64, 'interval-end': 127}, {'count': 26, 'interval-start': 128, 'interval-end': 255}, {'count': 95, 'interval-start': 256, 'interval-end': 511}, {'count': 171, 'interval-start': 512, 'interval-end': 1023}, {'count': 356, 'interval-start': 1024, 'interval-end': 2047}, {'count': 712, 'interval-start': 2048, 'interval-end': 4095}, {'count': 2627, 'interval-start': 4096, 'interval-end': 8191}, {'count': 835, 'interval-start': 8192, 'interval-end': 16383}, {'count': 2113, 'interval-start': 16384, 'interval-end': 32767}, {'count': 62, 'interval-start': 32768, 'interval-end': 65535}, {'count': 33, 'interval-start': 65536, 'interval-end': 131071}], 'ts': '2021-01-09 04:22:46'}
+
+the key `data` is the list of the log2 histogram intervals. The `interval-start` and `interval-end` define the
+latency bucket and `count` is the number of I/O's that lie in that latency range.
+
+# ./scsilatency.py -jF
+^C
+{'val_type': 'usecs', 'flags': 'Read', 'data': [{'count': 0, 'interval-start': 0, 'interval-end': 1}, {'count': 0, 'interval-start': 2, 'interval-end': 3}, {'count': 0, 'interval-start': 4, 'interval-end': 7}, {'count': 0, 'interval-start': 8, 'interval-end': 15}, {'count': 0, 'interval-start': 16, 'interval-end': 31}, {'count': 61, 'interval-start': 32, 'interval-end': 63}, {'count': 40620, 'interval-start': 64, 'interval-end': 127}, {'count': 7493, 'interval-start': 128, 'interval-end': 255}, {'count': 368, 'interval-start': 256, 'interval-end': 511}, {'count': 96, 'interval-start': 512, 'interval-end': 1023}, {'count': 249, 'interval-start': 1024, 'interval-end': 2047}, {'count': 2767, 'interval-start': 2048, 'interval-end': 4095}, {'count': 21, 'interval-start': 4096, 'interval-end': 8191}, {'count': 4, 'interval-start': 8192, 'interval-end': 16383}, {'count': 40, 'interval-start': 16384, 'interval-end': 32767}], 'ts': '2021-01-09 04:27:11'}
+{'val_type': 'usecs', 'flags': 'Write', 'data': [{'count': 0, 'interval-start': 0, 'interval-end': 1}, {'count': 0, 'interval-start': 2, 'interval-end': 3}, {'count': 0, 'interval-start': 4, 'interval-end': 7}, {'count': 0, 'interval-start': 8, 'interval-end': 15}, {'count': 2126, 'interval-start': 16, 'interval-end': 31}, {'count': 15362, 'interval-start': 32, 'interval-end': 63}, {'count': 27248, 'interval-start': 64, 'interval-end': 127}, {'count': 3974, 'interval-start': 128, 'interval-end': 255}, {'count': 44, 'interval-start': 256, 'interval-end': 511}, {'count': 80, 'interval-start': 512, 'interval-end': 1023}, {'count': 133, 'interval-start': 1024, 'interval-end': 2047}, {'count': 265, 'interval-start': 2048, 'interval-end': 4095}, {'count': 474, 'interval-start': 4096, 'interval-end': 8191}, {'count': 2022, 'interval-start': 8192, 'interval-end': 16383}, {'count': 1402, 'interval-start': 16384, 'interval-end': 32767}, {'count': 32, 'interval-start': 32768, 'interval-end': 65535}], 'ts': '2021-01-09 04:27:11'}
+
+The -j option used with -F prints a histogram dictionary per set of I/O flags.
+
+# ./scsilatency.py -jD
+^C
+{'val_type': 'usecs', 'data': [{'count': 0, 'interval-start': 0, 'interval-end': 1}, {'count': 0, 'interval-start': 2, 'interval-end': 3}, {'count': 0, 'interval-start': 4, 'interval-end': 7}, {'count': 0, 'interval-start': 8, 'interval-end': 15}, {'count': 2052, 'interval-start': 16, 'interval-end': 31}, {'count': 15045, 'interval-start': 32, 'interval-end': 63}, {'count': 67036, 'interval-start': 64, 'interval-end': 127}, {'count': 12746, 'interval-start': 128, 'interval-end': 255}, {'count': 403, 'interval-start': 256, 'interval-end': 511}, {'count': 175, 'interval-start': 512, 'interval-end': 1023}, {'count': 345, 'interval-start': 1024, 'interval-end': 2047}, {'count': 692, 'interval-start': 2048, 'interval-end': 4095}, {'count': 2686, 'interval-start': 4096, 'interval-end': 8191}, {'count': 992, 'interval-start': 8192, 'interval-end': 16383}, {'count': 2269, 'interval-start': 16384, 'interval-end': 32767}, {'count': 61, 'interval-start': 32768, 'interval-end': 65535}, {'count': 26, 'interval-start': 65536, 'interval-end': 131071}], 'ts': '2021-01-09 04:29:16', 'Bucket ptr': 'sda'}
+
+The -j option used with -D prints a histogram dictionary per disk device.
+
+# ./scsilatency.py -jm
+^C
+{'val_type': 'msecs', 'data': [{'count': 15, 'interval-start': 0, 'interval-end': 1}, {'count': 3, 'interval-start': 2, 'interval-end': 3}], 'ts': '2021-01-09 04:30:22'}
+
+The -j with -m prints a millisecond histogram dictionary. The `value_type` key is set to msecs.
+
+USAGE message:
+
+# ./scsilatency -h
+usage: scsilatency [-h] [-T] [-m] [-D] [-F] [-e] [-j] [interval] [count]
+
+Summarize UFS layer device I/O latency as a histogram
+
+positional arguments:
+  interval            output interval, in seconds
+  count               number of outputs
+
+optional arguments:
+  -h, --help          show this help message and exit
+  -T, --timestamp     include timestamp on output
+  -m, --milliseconds  millisecond histogram
+  -D, --disks         print a histogram per disk device
+  -F, --flags         print a histogram per set of I/O flags
+  -e, --extension     summarize average/total value
+  -j, --json          json output
+
+examples:
+    ./scsilatency                    # summarize UFS driver I/O latency as a histogram
+    ./scsilatency 1 10               # print 1 second summaries, 10 times
+    ./scsilatency -mT 1              # 1s summaries, milliseconds, and timestamps
+    ./scsilatency -D                 # show each disk device separately
+    ./scsilatency -F                 # show I/O flags separately
+    ./scsilatency -j                 # print a dictionary
+    ./scsilatency -e                 # show extension summary(total, average)
+


### PR DESCRIPTION
We used BCC to monitor I/O stack performance on mobile(AArch64) platform, and found it's very efficient and use easily. Meanwhile, we found lack of some tools in multiple layers，then we devloped a tools for SCSI layer.
The mobile storage were UFS mostly, and UFS device follows SCSI protocol. This tool can be used for monitor device performance in SCSI layer.
We hope this tools can help more people.