### PR TITLE
tools/scsisnoop: add scsisnoop tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[runqlat](tools/runqlat.py): Run queue (scheduler) latency as a histogram. [Examples](tools/runqlat_example.txt).
 - tools/[runqlen](tools/runqlen.py): Run queue length as a histogram. [Examples](tools/runqlen_example.txt).
 - tools/[runqslower](tools/runqslower.py): Trace long process scheduling delays. [Examples](tools/runqslower_example.txt).
+- tools/[scsisnoop](tools/scsisnoop.py): Trace SCSI layer device I/O with PID and latency. [Examples](tools/scsisnoop_example.txt).
 - tools/[shmsnoop](tools/shmsnoop.py): Trace System V shared memory syscalls. [Examples](tools/shmsnoop_example.txt).
 - tools/[sofdsnoop](tools/sofdsnoop.py): Trace FDs passed through unix sockets. [Examples](tools/sofdsnoop_example.txt).
 - tools/[slabratetop](tools/slabratetop.py): Kernel SLAB/SLUB memory cache allocation rate top. [Examples](tools/slabratetop_example.txt).

--- a/man/man8/scsisnoop.8
+++ b/man/man8/scsisnoop.8
@@ -1,0 +1,80 @@
+.TH scsisnoop 8  "2022-10-10" "USER COMMANDS"
+.SH NAME
+scsisnoop \- Trace SCSI layer I/O and print details incl. issuing PID.
+.SH SYNOPSIS
+.B scsisnoop [\-h]
+.SH DESCRIPTION
+This tools traces SCSI layer I/O (disk I/O), and prints a one-line summary
+for each I/O showing various details. These include the latency from the time of
+issue to the device to its completion, and the PID and process name from when
+the I/O was first created (which usually identifies the responsible process).
+
+This uses in-kernel eBPF maps to cache process details (PID and comm) by I/O
+request, as well as a starting timestamp for calculating I/O latency.
+
+This works by tracing various kernel scsi_*() functions using dynamic tracing,
+and will need updating to match any changes to these functions.
+
+This makes use of a Linux 4.4 feature (bpf_perf_event_output());
+for kernels older than 4.4, see the version under tools/old,
+which uses an older mechanism
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+.SH OPTIONS
+.TP
+\-h
+Print usage message.
+.SH EXAMPLES
+.TP
+Trace all SCSI layer I/O and print a summary line per I/O:
+#
+.B scsisnoop
+.SH FIELDS
+.TP
+TIME(s)
+Time of the I/O completion, in seconds since the first I/O was seen.
+.TP
+COMM
+Cached process name, if present. This usually (but isn't guaranteed) to identify
+the responsible process for the I/O.
+.TP
+PID
+Cached process ID, if present. This usually (but isn't guaranteed) to identify
+the responsible process for the I/O.
+.TP
+DISK
+Disk device name.
+.TP
+T
+Type of I/O: R = read, W = write. This is a simplification.
+.TP
+SECTOR
+Device sector for the I/O.
+.TP
+BYTES
+Size of the I/O, in bytes.
+.TP
+LAT(ms)
+Time for the I/O (latency) from the issue to the device, to its completion,
+in milliseconds.
+.SH OVERHEAD
+Since SCSI layer I/O usually has a relatively low frequency (< 10,000/s),
+the overhead for this tool is expected to be negligible. For high IOPS storage
+systems, test and quantify before use.
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Weibang Liu
+.SH SEE ALSO
+disksnoop(8), iostat(1)

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -295,6 +295,10 @@ class SmokeTests(TestCase):
     def test_runqlen(self):
         self.run_with_duration("runqlen.py 1 1")
 
+    @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
+    def test_scsisnoop(self):
+        self.run_with_int("scsisnoop.py")
+
     @skipUnless(kernel_version_ge(4,8), "requires kernel >= 4.8")
     def test_shmsnoop(self):
         self.run_with_int("shmsnoop.py")

--- a/tools/scsisnoop.py
+++ b/tools/scsisnoop.py
@@ -1,0 +1,212 @@
+#!/usr/bin/python
+# SPDX-License-Identifier: <SPDX License Expression>
+# @lint-avoid-python-3-compatibility-imports
+#
+# scsisnoop  Trace SCSI layer I/O and print details including issuing PID.
+#           For Linux, uses BCC, eBPF.
+#
+# This uses in-kernel eBPF maps to cache process details (PID and comm) by I/O
+# request, as well as a starting timestamp for calculating I/O latency.
+# thanks for Brendan Gregg's biosnoop
+# (https://github.com/iovisor/bcc/blob/master/tools/biosnoop.py) guidance.
+#
+# Copyright (c) 2022, Samsung Electronics.  All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License")
+#
+# 10-Oct-2022 Weibang Liu<weibang6.liu@samsung.com>    Created this.
+
+from __future__ import print_function
+from bcc import BPF
+import argparse
+
+# arguments
+examples = """examples:
+    ./scsisnoop           # trace all SCSI layer's I/O
+"""
+parser = argparse.ArgumentParser(
+    description="Trace SCSI layer I/O",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("--ebpf", action="store_true",
+                    help=argparse.SUPPRESS)
+args = parser.parse_args()
+debug = 0
+
+# define BPF program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/blkdev.h>
+#include <scsi/scsi_cmnd.h>
+
+// for saving the timestamp and __data_len of each request
+struct start_req_t {
+    u64 ts;
+    u64 data_len;
+};
+
+struct val_t {
+    u64 ts;
+    u32 pid;
+    char name[TASK_COMM_LEN];
+};
+
+struct data_t {
+    u32 pid;
+    u64 rwflag;
+    u64 delta;
+    u64 qdelta;
+    u64 sector;
+    u64 len;
+    u64 ts;
+    char disk_name[DISK_NAME_LEN];
+    char name[TASK_COMM_LEN];
+};
+
+BPF_HASH(start, struct request *, struct start_req_t);
+BPF_HASH(infobyreq, struct request *, struct val_t);
+BPF_PERF_OUTPUT(events);
+
+// cache PID and comm by-req
+int trace_pid_start(struct pt_regs *ctx, struct scsi_cmnd *cmd)
+{
+    struct val_t val = {};
+    u64 ts;
+    struct request *req = cmd->request;
+
+    if (bpf_get_current_comm(&val.name, sizeof(val.name)) == 0) {
+        val.pid = bpf_get_current_pid_tgid() >> 32;
+
+        infobyreq.update(&req, &val);
+    }
+    return 0;
+}
+
+// time SCSI I/O
+int trace_req_start(struct pt_regs *ctx, struct scsi_cmnd *cmd)
+{
+    struct request *req = cmd->request;
+
+    struct start_req_t start_req = {
+        .ts = bpf_ktime_get_ns(),
+        .data_len = req->__data_len
+    };
+    start.update(&req, &start_req);
+    return 0;
+}
+
+// output
+int trace_req_completion(struct pt_regs *ctx, struct scsi_cmnd *cmd)
+{
+    struct start_req_t *startp;
+    struct val_t *valp;
+    struct data_t data = {};
+    u64 ts;
+    struct request *req = cmd->request;
+
+    // fetch timestamp and calculate delta
+    startp = start.lookup(&req);
+    if (startp == 0) {
+        // missed tracing issue
+        return 0;
+    }
+    ts = bpf_ktime_get_ns();
+    data.delta = ts - startp->ts;
+    data.ts = ts / 1000;
+    data.qdelta = 0;
+
+    valp = infobyreq.lookup(&req);
+    data.len = startp->data_len;
+    if (valp == 0) {
+        data.name[0] = '?';
+        data.name[1] = 0;
+    } else {
+        data.pid = valp->pid;
+        data.sector = req->__sector;
+        bpf_probe_read_kernel(&data.name, sizeof(data.name), valp->name);
+        struct gendisk *rq_disk = req->rq_disk;
+        bpf_probe_read_kernel(&data.disk_name, sizeof(data.disk_name),
+                       rq_disk->disk_name);
+    }
+
+/*
+ * The following deals with a kernel version change (in mainline 4.7, although
+ * it may be backported to earlier kernels) with how block request write flags
+ * are tested. We handle both pre- and post-change versions here. Please avoid
+ * kernel version tests like this as much as possible: they inflate the code,
+ * test, and maintenance burden.
+ * This paragraph is quoted from biosnoop.py
+ */
+#ifdef REQ_WRITE
+    data.rwflag = !!(req->cmd_flags & REQ_WRITE);
+#elif defined(REQ_OP_SHIFT)
+    data.rwflag = !!((req->cmd_flags >> REQ_OP_SHIFT) == REQ_OP_WRITE);
+#else
+    data.rwflag = !!((req->cmd_flags & REQ_OP_MASK) == REQ_OP_WRITE);
+#endif
+
+    events.perf_submit(ctx, &data, sizeof(data));
+    start.delete(&req);
+    infobyreq.delete(&req);
+
+    return 0;
+}
+"""
+
+if debug or args.ebpf:
+    print(bpf_text)
+    if args.ebpf:
+        exit()
+
+# initialize BPF
+b = BPF(text=bpf_text)
+if BPF.get_kprobe_functions(b'scsi_init_io'):
+    b.attach_kprobe(event="scsi_init_io", fn_name="trace_pid_start")
+else:
+    b.attach_kprobe(event="scsi_alloc_sgtables", fn_name="trace_pid_start")
+if BPF.get_kprobe_functions(b'scsi_init_io'):
+    b.attach_kprobe(event="scsi_init_io", fn_name="trace_req_start")
+else:
+    b.attach_kprobe(event="scsi_alloc_sgtables", fn_name="trace_req_start")
+if BPF.get_kprobe_functions(b'scsi_mq_done'):
+    b.attach_kprobe(event="scsi_mq_done", fn_name="trace_req_completion")
+
+# header
+print("%-11s %-14s %-6s %-7s %-1s %-10s %-7s" % ("TIME(s)", "COMM", "PID",
+      "DISK", "T", "SECTOR", "BYTES"), end="")
+print("%7s" % "LAT(ms)")
+
+rwflg = ""
+start_ts = 0
+prev_ts = 0
+delta = 0
+
+
+# process event
+def print_event(cpu, data, size):
+    event = b["events"].event(data)
+
+    global start_ts
+    if start_ts == 0:
+        start_ts = event.ts
+
+    if event.rwflag == 1:
+        rwflg = "W"
+    else:
+        rwflg = "R"
+
+    delta = float(event.ts) - start_ts
+
+    print("%-11.6f %-14.14s %-6s %-7s %-1s %-10s %-7s" % (
+        delta / 1000000, event.name.decode('utf-8', 'replace'), event.pid,
+        event.disk_name.decode('utf-8', 'replace'), rwflg, event.sector,
+        event.len), end="")
+
+    print("%7.2f" % (float(event.delta) / 1000000))
+
+# loop with callback to print_event
+b["events"].open_perf_buffer(print_event, page_cnt=64)
+while 1:
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/scsisnoop_example.txt
+++ b/tools/scsisnoop_example.txt
@@ -1,0 +1,63 @@
+Demonstrations of scsisnoop, the Linux eBPF/bcc version.
+
+
+scsisnoop traces SCSI layer I/O (disk I/O), and prints a line of output
+per I/O. Example:
+
+# ./scsisnoop
+TIME(s)     COMM           PID    DISK    T SECTOR     BYTES  LAT(ms)
+0.000000    kworker/u16:2  29466  sda     R 1867600    4096      0.21
+0.000330    kworker/3:1H   193    sda     R 1881480    4096      0.19
+0.001666    InputReader    1228   sda     R 1847944    155648    0.84
+0.003512    InputReader    1228   sda     R 1848256    204800    0.96
+0.003527    kworker/u16:1  31481  sda     R 1881488    4096      0.87
+0.009361    Binder:946_5   946    sda     R 1603000    122880    0.62
+0.011330    Binder:946_5   946    sda     R 1601688    147456    0.71
+5.004452    kworker/u16:5  18167  sda     R 1867568    4096      0.19
+5.004478    kworker/u16:5  18167  sda     R 1877776    4096      0.14
+5.004539    kworker/u16:2  29466  sda     R 1878816    4096      0.17
+5.004652    kworker/u16:1  31481  sda     R 1872128    4096      0.26
+5.004665    surfaceflinger 949    sda     R 1507040    32768     0.37
+5.004987    Binder:949_2   949    sda     R 1664544    12288     0.36
+5.005259    Binder:949_2   949    sda     R 1664360    65536     0.67
+
+
+This includes the PID and comm (process name) that were on-CPU at the time of
+issue (which usually means the process responsible).
+
+The latency of the disk I/O, measured from the issue to the device to its
+completion, is included as the last column.
+
+This example output is from what should be an idle system, however, the
+following is visible in iostat:
+
+$ iostat -x 1
+[...]
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           0.12    0.00    0.12    0.00    0.00   99.75
+
+Device: rrqm/s  wrqm/s    r/s    w/s  rkB/s  wkB/s  await  svctm  %util
+xvda      0.00    0.00   0.00   4.00   0.00  16.00   0.00   0.00   0.00
+xvdb      0.00    0.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00
+xvdc      0.00    0.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00
+md0       0.00    0.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00
+
+There are 4 write IOPS.
+
+The output of scsisnoop identifies the reason: multiple supervise processes are
+issuing writes to the xvda1 disk. I can now drill down on supervise using other
+tools to understand its file system workload.
+
+
+
+USAGE message:
+
+usage: scsisnoop.py [-h]
+
+Trace SCSI layer I/O
+
+optional arguments:
+  -h, --help   show this help message and exit
+
+examples:
+    ./scsisnoop           # trace all SCSI layer I/O


### PR DESCRIPTION
We used BCC to monitor I/O stack performance on mobile(AArch64) platform, and found it's very efficient and use easily. Meanwhile, we found lack of some tools in multiple layers，then we devloped a tools for SCSI layer.
The mobile storage were UFS mostly, and UFS device follows SCSI protocol. This tool can be used for monitor device performance in SCSI layer.
We hope this tool can help more people.