### PR TITLE
Json format output for tools

### DIFF
--- a/tests/python/test_tools_json_output.py
+++ b/tests/python/test_tools_json_output.py
@@ -48,23 +48,20 @@ class SmokeTests(TestCase):
     # Use this for commands that don't have a built-in timeout, so we have
     # to Ctrl-C out of them by sending SIGINT. If that still doesn't stop
     # them, send a kill signal 5 seconds later.
-    def run_with_int(self, command, timeout=5, kill_timeout=5,
+    def run_with_int(self, command, output={}, timeout=5, kill_timeout=5,
                      allow_early=False, kill=False):
         full_command = TOOLS_DIR + command
         signal = "KILL" if kill else "INT"
-        rc = subprocess.call("timeout -s %s -k %ds %ds %s > /dev/null" %
-                (signal, kill_timeout, timeout, full_command), shell=True)
-        # timeout returns 124 if the program did not terminate prematurely,
-        # and returns 137 if we used KILL instead of INT. So there are three
-        # sensible scenarios:
-        #   1. The script is allowed to return early, and it did, with a
-        #      success return code.
-        #   2. The script timed out and was killed by the SIGINT signal.
-        #   3. The script timed out and was killed by the SIGKILL signal, and
-        #      this was what we asked for using kill=True.
-        self.assertTrue((rc == 0 and allow_early) or rc == 124
-                        or (rc == 137 and kill), _helpful_rc_msg(rc,
-                        allow_early, kill))
+        # rc = subprocess.call("timeout -s %s -k %ds %ds %s > /dev/null" %
+        #         (signal, kill_timeout, timeout, full_command), shell=True)
+        with subprocess.Popen("timeout -s %s -k %ds %ds %s" %
+                (signal, kill_timeout, timeout, full_command), shell=True, stdout=subprocess.PIPE) as p:
+            while True:
+                line = p.stdout.readline()
+                if not line:
+                    break
+                self.assertEqual(json.loads(line.decode().replace("\'", "\"")).keys(),
+                                    output.keys(), ("Failed to get the expected json output for %s" % command))
 
     def kmod_loaded(self, mod):
         with open("/proc/modules", "r") as mods:
@@ -100,11 +97,10 @@ class SmokeTests(TestCase):
         sample = {'ts': '2023-02-06 14:02:39', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 0}, {'interval-start': 32, 'interval-end': 63, 'count': 1}, {'interval-start': 64, 'interval-end': 127, 'count': 2}, {'interval-start': 128, 'interval-end': 255, 'count': 3}, {'interval-start': 256, 'interval-end': 511, 'count': 4}]}
         self.run_with_duration("biolatency.py -j 1 1", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_biopattern(self):
-    #     sample = {"time": "15:17:50", "disk": "sda", "random": 100, "sequential": 0, "count": 22, "kbytes": 96.0}
-    #     self.run_with_int("biopattern.py -j 1 1", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_biopattern(self):
+        sample = {"time": "15:17:50", "disk": "sda", "random": 100, "sequential": 0, "count": 22, "kbytes": 96.0}
+        self.run_with_int("biopattern.py -j 1 1", sample)
 
     @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_biotop(self):
@@ -131,45 +127,40 @@ class SmokeTests(TestCase):
         sample = {'ts': '2023-02-07 09:35:15', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 11}, {'interval-start': 4, 'interval-end': 7, 'count': 50}, {'interval-start': 8, 'interval-end': 15, 'count': 123}, {'interval-start': 16, 'interval-end': 31, 'count': 160}, {'interval-start': 32, 'interval-end': 63, 'count': 207}, {'interval-start': 64, 'interval-end': 127, 'count': 356}, {'interval-start': 128, 'interval-end': 255, 'count': 406}, {'interval-start': 256, 'interval-end': 511, 'count': 115}, {'interval-start': 512, 'interval-end': 1023, 'count': 24}, {'interval-start': 1024, 'interval-end': 2047, 'count': 7}, {'interval-start': 2048, 'interval-end': 4095, 'count': 8}, {'interval-start': 4096, 'interval-end': 8191, 'count': 3}, {'interval-start': 8192, 'interval-end': 16383, 'count': 1}, {'interval-start': 16384, 'interval-end': 32767, 'count': 4}, {'interval-start': 32768, 'interval-end': 65535, 'count': 1}, {'interval-start': 65536, 'interval-end': 131071, 'count': 1}]}
         self.run_with_duration("cpudist.py -j 1 1", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_dcsnoop(self):
-    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
-    #     self.run_with_duration("dcsnoop.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_dcsnoop(self):
+        sample = {"time": 3.177727699279785, "pid": 503701, "comm": "ps", "type": "M", "filename": "auxv"}
+        self.run_with_int("dcsnoop.py -j", sample)
 
     @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_dcstat(self):
         sample = {'REFS': 7221.0, 'SLOW': 79.0, 'MISS': 48.0, 'HIT%': 99.33527212297466}
         self.run_with_duration("dcstat.py -j 1 1", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_drsnoop(self):
-    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
-    #     self.run_with_duration("drsnoop.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_drsnoop(self):
+        sample = {"timestamp": 0.0, "uid": 114, "comm": "avahi-daemon", "pid": 1019, "lat (ms)": 0.755647, "pages": 78, "free_kb": 150496}
+        self.run_with_int("drsnoop.py -j", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_execsnoop(self):
-    #     sample = {"comm": "sleep", "pid": 477788, "ppid": 477782, "retval": 0, "args": ["/usr/bin/sleep", "1"], "uid": 1000, "timestamp": 3.693091630935669}
-    #     self.run_with_duration("execsnoop.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_execsnoop(self):
+        sample = {"comm": "sleep", "pid": 477788, "ppid": 477782, "retval": 0, "args": ["/usr/bin/sleep", "1"], "uid": 1000, "timestamp": 3.693091630935669}
+        self.run_with_int("execsnoop.py -j", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_exitsnoop(self):
-    #     sample = {"timestamp": "2023-02-07T09:53:31.492", "task": "cat", "pid": 478082, "ppid": 478077, "tid": 478082, "age": 0.000976737, "exit_code": 0, "sig_info": 0}
-    #     self.run_with_duration("exitsnoop.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_exitsnoop(self):
+        sample = {"timestamp": "2023-02-07T12:56:07.050", "task": "sh", "pid": 509220, "ppid": 339993, "tid": 509220, "age": 1.026003552, "exit_code": 0, "sig_info": 0}
+        self.run_with_int("exitsnoop.py -j", sample)
 
     @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_ext4dist(self):
         sample = {'ts': '2023-02-07 10:01:02', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 52}, {'interval-start': 2, 'interval-end': 3, 'count': 1}], 'operation': 'read'}
         self.run_with_duration("ext4dist.py -j 1 1", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_ext4slower(self):
-    #     sample = {"time": "10:11:32", "task": "ib_log_flush", "pid": 1155, "type": 3, "size": 0, "offset": 0, "delta": 1.07, "filename": "ib_logfile0"}
-    #     self.run_with_duration("ext4slower.py --json 1", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_ext4slower(self):
+        sample = {"time": "13:06:09", "task": "code", "pid": 338876, "type": 3, "size": 0, "offset": 0, "delta": 1.491, "filename": "storage.json"}
+        self.run_with_int("ext4slower.py --json 1", sample)
 
     @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_filetop(self):
@@ -186,11 +177,11 @@ class SmokeTests(TestCase):
         sample = {'hardirq': 'iwlwifi', 'total_usecs': 117.603}
         self.run_with_duration("hardirqs.py -j 1 1", sample)
 
-    # TODO: enable run_with_int test
+    # TODO fix throwing KeyboardInterrupt error
     # @mayFail("This fails on github actions environment, and needs to be fixed")
     # def test_killsnoop(self):
-    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
-    #     self.run_with_duration("killsnoop.py -j", sample)
+    #     sample = {'time': '13:08:15', 'pid': 339976, 'comm': 'code', 'sig': 0, 'tpid': 339015, 'ret': 0}
+    #     self.run_with_int("killsnoop.py -j", sample)
 
     @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_llcstat(self):
@@ -212,22 +203,20 @@ class SmokeTests(TestCase):
         sample = {'ts': '2023-02-07 11:07:35', 'val_type': 'runqlen', 'data': []}
         self.run_with_duration("runqlen.py -j 1 1", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_runqslower(self):
-    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
-    #     self.run_with_duration("runqslower.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_runqslower(self):
+        sample = {'task': 'Thread<07>', 'pid': 339319, 'delta_us': 1417, 'prev_task': 'code', 'prev_pid': 339321}
+        self.run_with_int("runqslower.py -j 1000", sample)
 
     @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_slabratetop(self):
         sample = {"time": "11:14:08", "cache": "names_cache", "allocs": 2775, "bytes": 11366400}
         self.run_with_duration("slabratetop.py -j 1 1", sample)
 
-    # TODO: implement test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_sofdsnoop(self):
-    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
-    #     self.run_with_duration("sofdsnoop.py -j -d 1", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_sofdsnoop(self):
+        sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+        self.run_with_duration("sofdsnoop.py -j -d 1", sample)
 
     @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_softirqs(self):
@@ -239,23 +228,20 @@ class SmokeTests(TestCase):
         sample = {'time': '11:22:44', 'syscall': 'select', 'count': 488}
         self.run_with_duration("syscount.py -j -i 1 -d 1", sample)
 
-    # TODO: implement test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_tcpaccept(self):
-    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
-    #     self.run_with_duration("tcpaccept.py -j 1 1", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_tcpaccept(self):
+        sample = {'timestamp': 2.777171, 'pid': 2197, 'task': 'epmd', 'ip': 4, 'daddr': '127.0.0.1', 'dport': 41431, 'saddr': '127.0.1.1', 'lport': 4369}
+        self.run_with_int("tcpaccept.py -j", sample)
 
-    # TODO: implement test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_tcpcong(self):
-    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
-    #     self.run_with_duration("tcpcong.py -j 1 1", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_tcpcong(self):
+        sample = {'time': '07:59:48', 'LAddrPort': '192.168.18.11/57724', 'RAddrPort': '172.217.170.46/443', 'Open_ms': 0.004, 'Dod_ms': 0.0, 'Rcov_ms': 30.004, 'Cwr_ms': 0.0, 'Los_ms': 0.0, 'Chgs': 2}
+        self.run_with_int("tcpcong.py -j", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_tcpconnect(self):
-    #     sample = {"ts": 0, "uid": 0, "pid": 334844, "task": "Socket Thread", "ip": 4, "saddr": "192.168.18.11", "daddr": "152.199.19.160", "dport": 443, "query": ""}
-    #     self.run_with_duration("tcpconnect.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_tcpconnect(self):
+        sample = {"ts": 0, "uid": 0, "pid": 334844, "task": "Socket Thread", "ip": 4, "saddr": "192.168.18.11", "daddr": "152.199.19.160", "dport": 443, "query": ""}
+        self.run_with_int("tcpconnect.py -j", sample)
 
     @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_tcpconnlat(self):
@@ -267,47 +253,40 @@ class SmokeTests(TestCase):
         sample = {"time": "11:33:29", "timestamp": 2.660002, "pid": 334844, "task": "Socket Thread", "family": 4, "saddr": "192.168.18.11", "sport": 57506, "daddr": "172.217.170.66", "dport": 443, "tx_kb": 3.4052734375, "rx_kb": 6.3115234375, "ms": 2889.04}
         self.run_with_duration("tcplife.py -j -d 1", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_tcpretrans(self):
-    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
-    #     self.run_with_duration("tcpretrans.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_tcpretrans(self):
+        sample = {"time": "08:02:30", "pid": 557, "ip": 4, "saddr": "192.168.18.11", "lport": 57570, "daddr": "172.217.170.106", "dport": 443, "type": "R", "state": "ESTABLISHED", "seq": 2723658506}
+        self.run_with_int("tcpretrans.py -j", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_tcprtt(self):
-    #     sample = {'ts': '2023-02-07 11:37:12', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 0}, {'interval-start': 32, 'interval-end': 63, 'count': 0}, {'interval-start': 64, 'interval-end': 127, 'count': 0}, {'interval-start': 128, 'interval-end': 255, 'count': 0}, {'interval-start': 256, 'interval-end': 511, 'count': 0}, {'interval-start': 512, 'interval-end': 1023, 'count': 0}, {'interval-start': 1024, 'interval-end': 2047, 'count': 0}, {'interval-start': 2048, 'interval-end': 4095, 'count': 0}, {'interval-start': 4096, 'interval-end': 8191, 'count': 0}, {'interval-start': 8192, 'interval-end': 16383, 'count': 0}, {'interval-start': 16384, 'interval-end': 32767, 'count': 2}], 'All Addresses': '*******'}
-    #     self.run_with_duration("tcprtt.py -j 1 1", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_tcprtt(self):
+        sample = {'ts': '2023-02-07 11:37:12', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 0}, {'interval-start': 32, 'interval-end': 63, 'count': 0}, {'interval-start': 64, 'interval-end': 127, 'count': 0}, {'interval-start': 128, 'interval-end': 255, 'count': 0}, {'interval-start': 256, 'interval-end': 511, 'count': 0}, {'interval-start': 512, 'interval-end': 1023, 'count': 0}, {'interval-start': 1024, 'interval-end': 2047, 'count': 0}, {'interval-start': 2048, 'interval-end': 4095, 'count': 0}, {'interval-start': 4096, 'interval-end': 8191, 'count': 0}, {'interval-start': 8192, 'interval-end': 16383, 'count': 0}, {'interval-start': 16384, 'interval-end': 32767, 'count': 2}], 'All Addresses': '*******'}
+        self.run_with_int("tcprtt.py -j", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_tcpstates(self):
-    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
-    #     self.run_with_duration("tcpstates.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_tcpstates(self):
+        sample = {"timestamp": 0.0, "skaddr": 18446631680069333440, "pid": 334844, "task": "Socket Thread", "family": 4, "saddr": "192.168.18.11", "daddr": "172.217.170.46", "ports": 443, "oldstate": "CLOSE", "newstate": "SYN_SENT", "ms": 0.0}
+        self.run_with_int("tcpstates.py -j", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_tcpsynbl(self):
-    #     sample = {'ts': '2023-02-07 11:40:02', 'val_type': 'backlog', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 1}], 'backlog_max': 128}
-    #     self.run_with_duration("tcpsynbl.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_tcpsynbl(self):
+        sample = {'ts': '2023-02-07 11:40:02', 'val_type': 'backlog', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 1}], 'backlog_max': 128}
+        self.run_with_int("tcpsynbl.py -j", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_tcptracer(self):
-    #     sample = {"timestamp": 0.0, "type": "connect", "pid": 334844, "comm": "Socket Thread", "ip": 4, "saddr": "192.168.18.11", "daddr": "172.217.170.4", "sport": 50250, "dport": 443, "netns": 4026531840}
-    #     self.run_with_duration("tcptracer.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_tcptracer(self):
+        sample = {"timestamp": 0.000263237, "type": "close", "pid": 2197, "comm": "epmd", "ip": 4, "saddr": "127.0.1.1", "daddr": "127.0.0.1", "sport": 4369, "dport": 60007, "netns": 4026531840}
+        self.run_with_int("tcptracer.py -j", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_threadsnoop(self):
-    #     sample = {"time": 0.0, "pid": 287443, "comm": "xdg-desktop-por", "func": "[unknown]"}
-    #     self.run_with_duration("threadsnoop.py -j 1 1", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_threadsnoop(self):
+        sample = {"time": 0.0, "pid": 287443, "comm": "xdg-desktop-por", "func": "[unknown]"}
+        self.run_with_int("threadsnoop.py -j", sample)
 
-    # TODO: enable run_with_int test
-    # @mayFail("This fails on github actions environment, and needs to be fixed")
-    # def test_vfscount(self):
-    #     sample = {"addr": 18446744071599422913, "func": "vfs_rename", "count": 6}
-    #     self.run_with_duration("vfscount.py -j", sample)
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_vfscount(self):
+        sample = {"addr": 18446744071599422913, "func": "vfs_rename", "count": 6}
+        self.run_with_int("vfscount.py -j", sample)
 
     @mayFail("This fails on github actions environment, and needs to be fixed")
     def test_vfsstat(self):

--- a/tests/python/test_tools_json_output.py
+++ b/tests/python/test_tools_json_output.py
@@ -100,5 +100,219 @@ class SmokeTests(TestCase):
         sample = {'ts': '2023-02-06 14:02:39', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 0}, {'interval-start': 32, 'interval-end': 63, 'count': 1}, {'interval-start': 64, 'interval-end': 127, 'count': 2}, {'interval-start': 128, 'interval-end': 255, 'count': 3}, {'interval-start': 256, 'interval-end': 511, 'count': 4}]}
         self.run_with_duration("biolatency.py -j 1 1", sample)
 
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_biopattern(self):
+    #     sample = {"time": "15:17:50", "disk": "sda", "random": 100, "sequential": 0, "count": 22, "kbytes": 96.0}
+    #     self.run_with_int("biopattern.py -j 1 1", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_biotop(self):
+        sample = {"pid": 325, "comm": "systemd-journal", "operation": "read", "major": 8, "minor": 0, "io": 3, "kbytes": 124.0, "avg_ms": 0.598, "disk": "sda"}
+        self.run_with_duration("biotop.py -j 1 1", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_bitesize(self):
+        sample = {'ts': '2023-02-06 15:51:04', 'val_type': 'kbytes', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 1}], 'comm': 'kworker/u16:0'}
+        self.run_with_duration("bitesize.py -j -d 1", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_cachestat(self):
+        sample = {"hits": 18359, "misses": 24, "dirties": 55, "hitratio": 0.9986944459555024, "buffers_mb": 147.3828125, "cached_mb": 1511.16796875}
+        self.run_with_duration("cachestat.py -j 1 1", sample)
+    
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_cachetop(self):
+        sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+        self.run_with_duration("cachetop.py -j 1 1", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_cpudist(self):
+        sample = {'ts': '2023-02-07 09:35:15', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 11}, {'interval-start': 4, 'interval-end': 7, 'count': 50}, {'interval-start': 8, 'interval-end': 15, 'count': 123}, {'interval-start': 16, 'interval-end': 31, 'count': 160}, {'interval-start': 32, 'interval-end': 63, 'count': 207}, {'interval-start': 64, 'interval-end': 127, 'count': 356}, {'interval-start': 128, 'interval-end': 255, 'count': 406}, {'interval-start': 256, 'interval-end': 511, 'count': 115}, {'interval-start': 512, 'interval-end': 1023, 'count': 24}, {'interval-start': 1024, 'interval-end': 2047, 'count': 7}, {'interval-start': 2048, 'interval-end': 4095, 'count': 8}, {'interval-start': 4096, 'interval-end': 8191, 'count': 3}, {'interval-start': 8192, 'interval-end': 16383, 'count': 1}, {'interval-start': 16384, 'interval-end': 32767, 'count': 4}, {'interval-start': 32768, 'interval-end': 65535, 'count': 1}, {'interval-start': 65536, 'interval-end': 131071, 'count': 1}]}
+        self.run_with_duration("cpudist.py -j 1 1", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_dcsnoop(self):
+    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+    #     self.run_with_duration("dcsnoop.py -j", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_dcstat(self):
+        sample = {'REFS': 7221.0, 'SLOW': 79.0, 'MISS': 48.0, 'HIT%': 99.33527212297466}
+        self.run_with_duration("dcstat.py -j 1 1", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_drsnoop(self):
+    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+    #     self.run_with_duration("drsnoop.py -j", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_execsnoop(self):
+    #     sample = {"comm": "sleep", "pid": 477788, "ppid": 477782, "retval": 0, "args": ["/usr/bin/sleep", "1"], "uid": 1000, "timestamp": 3.693091630935669}
+    #     self.run_with_duration("execsnoop.py -j", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_exitsnoop(self):
+    #     sample = {"timestamp": "2023-02-07T09:53:31.492", "task": "cat", "pid": 478082, "ppid": 478077, "tid": 478082, "age": 0.000976737, "exit_code": 0, "sig_info": 0}
+    #     self.run_with_duration("exitsnoop.py -j", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_ext4dist(self):
+        sample = {'ts': '2023-02-07 10:01:02', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 52}, {'interval-start': 2, 'interval-end': 3, 'count': 1}], 'operation': 'read'}
+        self.run_with_duration("ext4dist.py -j 1 1", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_ext4slower(self):
+    #     sample = {"time": "10:11:32", "task": "ib_log_flush", "pid": 1155, "type": 3, "size": 0, "offset": 0, "delta": 1.07, "filename": "ib_logfile0"}
+    #     self.run_with_duration("ext4slower.py --json 1", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_filetop(self):
+        sample = {'pid': 480769, 'comm': 'sed', 'reads': 2, 'writes': 0, 'rbytes': 2.0, 'wbytes': 0.0, 'type': 'R', 'file': 'filesystems'}
+        self.run_with_duration("filetop.py -j 1 1", sample)
+
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_funccount(self):
+        # Changes output depending on the function being traces
+        # TODO: test for valid json
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_hardirqs(self):
+        sample = {'hardirq': 'iwlwifi', 'total_usecs': 117.603}
+        self.run_with_duration("hardirqs.py -j 1 1", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_killsnoop(self):
+    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+    #     self.run_with_duration("killsnoop.py -j", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_llcstat(self):
+        sample = {"pid": 6750, "name": "uwsgi", "cpu": 4, "ref": 7100, "miss": 5900, "hit": 16.90}
+        self.run_with_duration("llcstat.py -j 1", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_netqtop(self):
+        sample = {"time": "Tue Feb  7 10:46:48 2023", "direction": "rx", "queue": 0, "avg_size": 0, "size_64B": 0, "size_512B": 0, "size_2K": 0, "size_16K": 0, "size_64K": 0, "BPS": 0, "PPS": 0}
+        self.run_with_duration("netqtop.py -j -i 1 -d 1 -n lo", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_opensnoop(self):
+        sample = {'PID': 339993, 'COMM': 'code', 'FD': 51, 'ERR': 0, 'PATH': '/proc/487112/cmdline'}
+        self.run_with_duration("opensnoop.py -j -d 1", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_runqlen(self):
+        sample = {'ts': '2023-02-07 11:07:35', 'val_type': 'runqlen', 'data': []}
+        self.run_with_duration("runqlen.py -j 1 1", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_runqslower(self):
+    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+    #     self.run_with_duration("runqslower.py -j", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_slabratetop(self):
+        sample = {"time": "11:14:08", "cache": "names_cache", "allocs": 2775, "bytes": 11366400}
+        self.run_with_duration("slabratetop.py -j 1 1", sample)
+
+    # TODO: implement test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_sofdsnoop(self):
+    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+    #     self.run_with_duration("sofdsnoop.py -j -d 1", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_softirqs(self):
+        sample = {'time': '11:20:50', 'softirq': 'sched', 'total_usecs': 12808.425}
+        self.run_with_duration("softirqs.py -j 1 1", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_syscount(self):
+        sample = {'time': '11:22:44', 'syscall': 'select', 'count': 488}
+        self.run_with_duration("syscount.py -j -i 1 -d 1", sample)
+
+    # TODO: implement test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_tcpaccept(self):
+    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+    #     self.run_with_duration("tcpaccept.py -j 1 1", sample)
+
+    # TODO: implement test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_tcpcong(self):
+    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+    #     self.run_with_duration("tcpcong.py -j 1 1", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_tcpconnect(self):
+    #     sample = {"ts": 0, "uid": 0, "pid": 334844, "task": "Socket Thread", "ip": 4, "saddr": "192.168.18.11", "daddr": "152.199.19.160", "dport": 443, "query": ""}
+    #     self.run_with_duration("tcpconnect.py -j", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_tcpconnlat(self):
+        sample = {"timestamp": 12.572059, "pid": 1162, "task": "python3", "ip": 4, "saddr": "192.168.18.11", "daddr": "192.168.18.11", "lport": 33944, "dport": 5000, "lat (ms)": 0.039}
+        self.run_with_duration("tcpconnlat.py -j -d 1", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_tcplife(self):
+        sample = {"time": "11:33:29", "timestamp": 2.660002, "pid": 334844, "task": "Socket Thread", "family": 4, "saddr": "192.168.18.11", "sport": 57506, "daddr": "172.217.170.66", "dport": 443, "tx_kb": 3.4052734375, "rx_kb": 6.3115234375, "ms": 2889.04}
+        self.run_with_duration("tcplife.py -j -d 1", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_tcpretrans(self):
+    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+    #     self.run_with_duration("tcpretrans.py -j", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_tcprtt(self):
+    #     sample = {'ts': '2023-02-07 11:37:12', 'val_type': 'usecs', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 0}, {'interval-start': 2, 'interval-end': 3, 'count': 0}, {'interval-start': 4, 'interval-end': 7, 'count': 0}, {'interval-start': 8, 'interval-end': 15, 'count': 0}, {'interval-start': 16, 'interval-end': 31, 'count': 0}, {'interval-start': 32, 'interval-end': 63, 'count': 0}, {'interval-start': 64, 'interval-end': 127, 'count': 0}, {'interval-start': 128, 'interval-end': 255, 'count': 0}, {'interval-start': 256, 'interval-end': 511, 'count': 0}, {'interval-start': 512, 'interval-end': 1023, 'count': 0}, {'interval-start': 1024, 'interval-end': 2047, 'count': 0}, {'interval-start': 2048, 'interval-end': 4095, 'count': 0}, {'interval-start': 4096, 'interval-end': 8191, 'count': 0}, {'interval-start': 8192, 'interval-end': 16383, 'count': 0}, {'interval-start': 16384, 'interval-end': 32767, 'count': 2}], 'All Addresses': '*******'}
+    #     self.run_with_duration("tcprtt.py -j 1 1", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_tcpstates(self):
+    #     sample = {"time": "15:57:56", "pid": 6728, "uid": "0", "username": "root", "comm": "uwsgi", "hits": 1, "misses": 0, "dirties": 0, "read_hit_percent": 100.0, "write_hit_percent": 0}
+    #     self.run_with_duration("tcpstates.py -j", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_tcpsynbl(self):
+    #     sample = {'ts': '2023-02-07 11:40:02', 'val_type': 'backlog', 'data': [{'interval-start': 0, 'interval-end': 1, 'count': 1}], 'backlog_max': 128}
+    #     self.run_with_duration("tcpsynbl.py -j", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_tcptracer(self):
+    #     sample = {"timestamp": 0.0, "type": "connect", "pid": 334844, "comm": "Socket Thread", "ip": 4, "saddr": "192.168.18.11", "daddr": "172.217.170.4", "sport": 50250, "dport": 443, "netns": 4026531840}
+    #     self.run_with_duration("tcptracer.py -j", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_threadsnoop(self):
+    #     sample = {"time": 0.0, "pid": 287443, "comm": "xdg-desktop-por", "func": "[unknown]"}
+    #     self.run_with_duration("threadsnoop.py -j 1 1", sample)
+
+    # TODO: enable run_with_int test
+    # @mayFail("This fails on github actions environment, and needs to be fixed")
+    # def test_vfscount(self):
+    #     sample = {"addr": 18446744071599422913, "func": "vfs_rename", "count": 6}
+    #     self.run_with_duration("vfscount.py -j", sample)
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_vfsstat(self):
+        sample = {"READ": 3483.0, "WRITE": 446.0, "FSYNC": 0.0, "OPEN": 1522.0, "CREATE": 0.0}
+        self.run_with_duration("vfsstat.py -j 1 1", sample)
+
 if __name__ == "__main__":
     main()

--- a/tests/python/test_tools_json_output.py
+++ b/tests/python/test_tools_json_output.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) Sasha Goldshtein, 2017
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+import distutils.version
+import subprocess
+import os
+import re
+from unittest import main, skipUnless, TestCase
+from utils import mayFail, kernel_version_ge
+import ast
+
+TOOLS_DIR = "/home/tariro/Documents/phd/bcc/tools/"
+
+def _helpful_rc_msg(rc, allow_early, kill):
+    s = "rc was %d\n" % rc
+    if rc == 0:
+        s += "\tMeaning: command returned successfully before test timeout\n"
+    elif rc == 124:
+        s += "\tMeaning: command was killed by INT signal\n"
+    elif rc == 137:
+        s += "\tMeaning: command was killed by KILL signal\n"
+
+    s += "Command was expected to do one of:\n"
+    s += "\tBe killed by SIGINT\n"
+    if kill:
+        s += "\tBe killed by SIGKILL\n"
+    if allow_early:
+        s += "\tSuccessfully return before being killed\n"
+
+    return s
+
+@skipUnless(kernel_version_ge(4,1), "requires kernel >= 4.1")
+class SmokeTests(TestCase):
+    # Use this for commands that have a built-in timeout, so they only need
+    # to be killed in case of a hard hang.
+    def run_with_duration(self, command, output={'time': '12:12:45', 'syscall': 'sched_yield', 'count': 11407}, timeout=10):
+        full_command = TOOLS_DIR + command
+        stdout, _ = subprocess.Popen(full_command, shell=True, stdout=subprocess.PIPE).communicate()
+        
+        self.assertEqual(ast.literal_eval(stdout.decode().split("\n")[0]).keys(),
+                            output.keys(), ("Failed to get the expected json output for %s" % command))
+
+    # Use this for commands that don't have a built-in timeout, so we have
+    # to Ctrl-C out of them by sending SIGINT. If that still doesn't stop
+    # them, send a kill signal 5 seconds later.
+    def run_with_int(self, command, timeout=5, kill_timeout=5,
+                     allow_early=False, kill=False):
+        full_command = TOOLS_DIR + command
+        signal = "KILL" if kill else "INT"
+        rc = subprocess.call("timeout -s %s -k %ds %ds %s > /dev/null" %
+                (signal, kill_timeout, timeout, full_command), shell=True)
+        # timeout returns 124 if the program did not terminate prematurely,
+        # and returns 137 if we used KILL instead of INT. So there are three
+        # sensible scenarios:
+        #   1. The script is allowed to return early, and it did, with a
+        #      success return code.
+        #   2. The script timed out and was killed by the SIGINT signal.
+        #   3. The script timed out and was killed by the SIGKILL signal, and
+        #      this was what we asked for using kill=True.
+        self.assertTrue((rc == 0 and allow_early) or rc == 124
+                        or (rc == 137 and kill), _helpful_rc_msg(rc,
+                        allow_early, kill))
+
+    def kmod_loaded(self, mod):
+        with open("/proc/modules", "r") as mods:
+            reg = re.compile("^%s\s" % mod)
+            for line in mods:
+                if reg.match(line):
+                    return 1
+                return 0
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    @mayFail("This fails on github actions environment, and needs to be fixed")
+    def test_argdist(self):
+        self.run_with_duration("syscount.py -j -i 1 -d 1")
+
+if __name__ == "__main__":
+    main()

--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -239,6 +239,8 @@ u64 __time = bpf_ktime_get_ns();
                 self.filter = "" if len(parts) != 6 else parts[5]
                 self._substitute_exprs()
 
+                self.json = tool.args.json or False
+
                 # Do we need to attach an entry probe so that we can collect an
                 # argument that is required for an exit (return) probe?
                 def check(expr):
@@ -514,7 +516,10 @@ DATA_DECL
                 elif self.type == "hist":
                         label = self.label or (self._display_expr(0)
                                 if not self.is_default_expr else "retval")
-                        data.print_log2_hist(val_type=label)
+                        if self.json:
+                                data.print_json_hist(label)
+                        else:
+                                data.print_log2_hist(val_type=label)
                 if not self.cumulative:
                         data.clear()
 
@@ -648,6 +653,8 @@ argdist -I 'kernel/sched/sched.h' \\
                        "as either full path, "
                        "or relative to relative to current working directory, "
                        "or relative to default kernel header search path")
+                parser.add_argument("-j", "--json", action="store_true",
+                  help="json output")
                 self.args = parser.parse_args()
                 self.usdt_ctx = None
 

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -286,7 +286,6 @@ while (1):
     except KeyboardInterrupt:
         exiting = 1
 
-    print()
     if args.json:
         if args.timestamp:
             print("%-8s\n" % strftime("%H:%M:%S"), end="")
@@ -297,6 +296,7 @@ while (1):
             dist.print_json_hist(label, "disk", disk_print)
 
     else:
+        print()
         if args.timestamp:
             print("%-8s\n" % strftime("%H:%M:%S"), end="")
 

--- a/tools/bitesize.py
+++ b/tools/bitesize.py
@@ -15,6 +15,20 @@
 
 from bcc import BPF
 from time import sleep
+import argparse
+
+# arguments
+examples = """examples:
+    ./bitesize          # block I/O size histogram
+    ./bitesize -j       # print json output
+"""
+parser = argparse.ArgumentParser(
+    description="Block I/O size histogram",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
+args = parser.parse_args()
 
 bpf_text = """
 #include <uapi/linux/ptrace.h>
@@ -47,5 +61,9 @@ dist = b.get_table("dist")
 try:
     sleep(99999999)
 except KeyboardInterrupt:
-    dist.print_log2_hist("Kbytes", "Process Name",
+    if args.json:
+        dist.print_json_hist("Kbytes", "Process Name",
+            section_print_fn=bytes.decode)
+    else:
+        dist.print_log2_hist("Kbytes", "Process Name",
             section_print_fn=bytes.decode)

--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -177,7 +177,7 @@ while 1:
 
     if args.json:
         if tstamp:
-            print(json.dumps({"timestamp": strftime("%H:%M:%S"),
+            print(json.dumps({"time": strftime("%H:%M:%S"),
                 "hits": hits, "misses": misses, "dirties": mbd,
                 "hitratio": ratio, "buffers_mb": buff, "cached_mb": cached}))
         else:

--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -193,5 +193,6 @@ while 1:
     mpa = mbd = apcl = apd = total = misses = hits = cached = buff = 0
 
     if exiting:
-        print("Detaching...")
+        if not args.json:
+            print("Detaching...")
         exit()

--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -22,7 +22,7 @@ from bcc import BPF
 from time import sleep, strftime
 import argparse
 import signal
-import re
+import json
 from sys import argv
 
 # signal handler
@@ -62,6 +62,8 @@ parser.add_argument("count", nargs="?", default=-1,
     help="number of outputs")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 count = int(args.count)
 tstamp = args.timestamp
@@ -108,10 +110,11 @@ elif BPF.get_kprobe_functions(b'account_page_dirtied'):
 b.attach_kprobe(event="mark_buffer_dirty", fn_name="do_count")
 
 # header
-if tstamp:
-    print("%-8s " % "TIME", end="")
-print("%8s %8s %8s %8s %12s %10s" %
-     ("HITS", "MISSES", "DIRTIES", "HITRATIO", "BUFFERS_MB", "CACHED_MB"))
+if not args.json:
+    if tstamp:
+        print("%-8s " % "TIME", end="")
+    print("%8s %8s %8s %8s %12s %10s" %
+        ("HITS", "MISSES", "DIRTIES", "HITRATIO", "BUFFERS_MB", "CACHED_MB"))
 
 loop = 0
 exiting = 0
@@ -172,10 +175,20 @@ while 1:
     cached = int(mem["Cached"]) / 1024
     buff = int(mem["Buffers"]) / 1024
 
-    if tstamp:
-        print("%-8s " % strftime("%H:%M:%S"), end="")
-    print("%8d %8d %8d %7.2f%% %12.0f %10.0f" %
-        (hits, misses, mbd, 100 * ratio, buff, cached))
+    if args.json:
+        if tstamp:
+            print(json.dumps({"timestamp": strftime("%H:%M:%S"),
+                "hits": hits, "misses": misses, "dirties": mbd,
+                "hitratio": ratio, "buffers_mb": buff, "cached_mb": cached}))
+        else:
+            print(json.dumps({"hits": hits, "misses": misses,
+                "dirties": mbd, "hitratio": ratio, "buffers_mb": buff,
+                "cached_mb": cached}))
+    else:
+        if tstamp:
+            print("%-8s " % strftime("%H:%M:%S"), end="")
+        print("%8d %8d %8d %7.2f%% %12.0f %10.0f" %
+            (hits, misses, mbd, 100 * ratio, buff, cached))
 
     mpa = mbd = apcl = apd = total = misses = hits = cached = buff = 0
 

--- a/tools/cachetop.py
+++ b/tools/cachetop.py
@@ -293,6 +293,7 @@ def handle_loop(stdscr, args):
                 "time": strftime("%H:%M:%S"),
                 "pid": stat[0],
                 "uid": stat[1],
+                "username": username,
                 "comm": stat[2],
                 "hits": stat[3],
                 "misses": stat[4],

--- a/tools/cachetop.py
+++ b/tools/cachetop.py
@@ -29,6 +29,7 @@ import pwd
 import re
 import signal
 from time import sleep
+import json
 
 FIELDS = (
     "PID",
@@ -133,8 +134,9 @@ def get_processes_stats(
 
 
 def handle_loop(stdscr, args):
-    # don't wait on key press
-    stdscr.nodelay(1)
+    if stdscr:
+        # don't wait on key press
+        stdscr.nodelay(1)
     # set default sorting field
     sort_field = FIELDS.index(DEFAULT_FIELD)
     sort_reverse = True
@@ -188,8 +190,13 @@ def handle_loop(stdscr, args):
         b.attach_kprobe(event="account_page_dirtied", fn_name="do_count")
 
     exiting = 0
+    countdown = int(args.count)
 
-    while 1:
+    def print_event_stdscr():
+        nonlocal sort_reverse
+        nonlocal sort_field
+        nonlocal exiting
+        nonlocal b
         s = stdscr.getch()
         if s == ord('q'):
             exiting = 1
@@ -254,8 +261,56 @@ def handle_loop(stdscr, args):
             if i > height - 4:
                 break
         stdscr.refresh()
-        if exiting:
-            print("Detaching...")
+    
+    def print_event_json():
+        nonlocal sort_reverse
+        nonlocal sort_field
+        nonlocal exiting
+        nonlocal b
+
+        process_stats = get_processes_stats(
+            b,
+            sort_field=sort_field,
+            sort_reverse=sort_reverse)
+        
+        try:
+            sleep(args.interval)
+        except KeyboardInterrupt:
+            exiting = 1
+        for i, stat in enumerate(process_stats):
+            uid = int(stat[1])
+            try:
+                username = pwd.getpwuid(uid)[0]
+            except KeyError:
+                # `pwd` throws a KeyError if the user cannot be found. This can
+                # happen e.g. when the process is running in a cgroup that has
+                # different users from the host.
+                username = 'UNKNOWN({})'.format(uid)
+            # (int(_pid), uid, comm,
+            #  access, misses, mbd,
+            #  rhits, whits))
+            print(json.dumps({
+                "time": strftime("%H:%M:%S"),
+                "pid": stat[0],
+                "uid": stat[1],
+                "comm": stat[2],
+                "hits": stat[3],
+                "misses": stat[4],
+                "dirties": stat[5],
+                "read_hit_percent": stat[6],
+                "write_hit_percent": stat[7]
+            }))
+
+    while 1:
+        if args.json:
+            print_event_json()
+        else:
+            print_event_stdscr()
+
+        countdown -= 1
+        if exiting or countdown == 0:
+            if not args.json:
+                print("Detaching...")
             return
 
 
@@ -270,9 +325,16 @@ def parse_arguments():
         'interval', type=int, default=5, nargs='?',
         help='Interval between probes.'
     )
+    parser.add_argument("count", nargs="?", default=99999999,
+        help="number of outputs")
+    parser.add_argument("-j", "--json", action="store_true",
+        help="json output")
 
     args = parser.parse_args()
     return args
 
 args = parse_arguments()
-curses.wrapper(handle_loop, args)
+if args.json:
+    handle_loop(None, args)
+else:
+    curses.wrapper(handle_loop, args)

--- a/tools/compactsnoop.py
+++ b/tools/compactsnoop.py
@@ -44,6 +44,8 @@ parser.add_argument("-K", "--kernel-stack", action="store_true",
 parser.add_argument("-e", "--extended_fields", action="store_true",
         help="show system memory state")
 parser.add_argument("--ebpf", action="store_true", help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+        help="json output")
 args = parser.parse_args()
 debug = 0
 if args.duration:
@@ -349,14 +351,15 @@ def compact_result_to_str(status):
         return str(status)
 
 # header
-if args.timestamp:
-    print("%-14s" % ("TIME(s)"), end=" ")
-print("%-14s %-6s %-4s %-12s %-5s %-7s" %
-      ("COMM", "PID", "NODE", "ZONE", "ORDER", "MODE"), end=" ")
-if args.extended_fields:
-    print("%-8s %-8s %-8s %-8s %-8s" %
-          ("FRAGIDX", "MIN", "LOW", "HIGH", "FREE"), end=" ")
-print("%9s %16s" % ("LAT(ms)", "STATUS"))
+if not args.json:
+    if args.timestamp:
+        print("%-14s" % ("TIME(s)"), end=" ")
+    print("%-14s %-6s %-4s %-12s %-5s %-7s" %
+        ("COMM", "PID", "NODE", "ZONE", "ORDER", "MODE"), end=" ")
+    if args.extended_fields:
+        print("%-8s %-8s %-8s %-8s %-8s" %
+            ("FRAGIDX", "MIN", "LOW", "HIGH", "FREE"), end=" ")
+    print("%9s %16s" % ("LAT(ms)", "STATUS"))
 
 # process event
 def print_event(cpu, data, size):
@@ -393,8 +396,39 @@ def print_event(cpu, data, size):
 
     sys.stdout.flush()
 
+def print_event_json(cpu, data, size):
+    event = b["events"].event(data)
+
+    global initial_ts
+
+    if not initial_ts:
+        initial_ts = event.ts
+
+    json_dict = {
+        "comm": event.comm.decode("utf-8", "replace"),
+        "pid": event.pid,
+        "nid": event.nid,
+        "zone": zone_idx_to_str(event.idx),
+        "order": event.order,
+        "mode": "SYNC" if event.sync else "ASYNC",
+        "delta": float(event.delta) / 1000000,
+    }
+    if args.timestamp:
+        delta = event.ts - initial_ts
+        json_dict["timestamp"] = float(delta) / 1000000
+
+    if args.extended_fields:
+        json_dict["fragindex"] = (float(event.fragindex) / 1000)
+        json_dict["min"] = event.min
+        json_dict["low"] = event.low
+        json_dict["high"] = event.high
+        json_dict["free"] = event.free
+
 # loop with callback to print_event
-b["events"].open_perf_buffer(print_event, page_cnt=64)
+if args.json:
+    b["events"].open_perf_buffer(print_event_json, page_cnt=64)
+else:
+    b["events"].open_perf_buffer(print_event, page_cnt=64)
 start_time = datetime.now()
 while not args.duration or datetime.now() - start_time < args.duration:
     try:

--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -57,6 +57,8 @@ parser.add_argument("count", nargs="?", default=99999999,
     help="number of outputs")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 countdown = int(args.count)
 debug = 0
@@ -224,9 +226,10 @@ while (1):
     except KeyboardInterrupt:
         exiting = 1
 
-    print()
-    if args.timestamp:
-        print("%-8s\n" % strftime("%H:%M:%S"), end="")
+    if not args.json:
+        print()
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
 
     def pid_to_comm(pid):
         try:
@@ -235,7 +238,10 @@ while (1):
         except IOError:
             return str(pid)
 
-    dist.print_log2_hist(label, section, section_print_fn=pid_to_comm)
+    if not args.json:
+        dist.print_log2_hist(label, section, section_print_fn=pid_to_comm)
+    else:
+        dist.print_json_hist(label, section, section_print_fn=pid_to_comm)
 
     if args.extension:
         total = extension[0].total

--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -213,8 +213,9 @@ b = BPF(text=bpf_text, cflags=["-DMAX_PID=%d" % max_pid])
 b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
                 fn_name="sched_switch")
 
-print("Tracing %s-CPU time... Hit Ctrl-C to end." %
-      ("off" if args.offcpu else "on"))
+if not args.json:
+    print("Tracing %s-CPU time... Hit Ctrl-C to end." %
+        ("off" if args.offcpu else "on"))
 
 exiting = 0 if args.interval else 1
 dist = b.get_table("dist")

--- a/tools/exitsnoop.py
+++ b/tools/exitsnoop.py
@@ -276,7 +276,6 @@ def main():
         else:
             snoop(buffer, _print_event_json)
     except KeyboardInterrupt:
-        print()
         sys.exit()
 
     return 0

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -212,7 +212,8 @@ b.attach_kretprobe(event="ext4_file_write_iter", fn_name="trace_write_return")
 b.attach_kretprobe(event="ext4_file_open", fn_name="trace_open_return")
 b.attach_kretprobe(event="ext4_sync_file", fn_name="trace_fsync_return")
 
-print("Tracing ext4 operation latency... Hit Ctrl-C to end.")
+if not args.json:
+    print("Tracing ext4 operation latency... Hit Ctrl-C to end.")
 
 # output
 exiting = 0

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -42,6 +42,8 @@ parser.add_argument("count", nargs="?", default=99999999,
     help="number of outputs")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 pid = args.pid
 countdown = int(args.count)
@@ -224,11 +226,15 @@ while (1):
     except KeyboardInterrupt:
         exiting = 1
 
-    print()
-    if args.interval and (not args.notimestamp):
-        print(strftime("%H:%M:%S:"))
+    if not args.json:
+        print()
+        if args.interval and (not args.notimestamp):
+            print(strftime("%H:%M:%S:"))
 
-    dist.print_log2_hist(label, "operation", section_print_fn=bytes.decode)
+        dist.print_log2_hist(label, "operation", section_print_fn=bytes.decode)
+    else:
+        dist.print_json_hist(label, "operation", section_print_fn=bytes.decode)
+        
     dist.clear()
 
     countdown -= 1

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -18,7 +18,6 @@ from bcc import BPF
 from time import sleep, strftime
 import argparse
 from subprocess import call
-import json
 
 # arguments
 examples = """examples:

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -171,7 +171,8 @@ b.attach_kprobe(event="vfs_write", fn_name="trace_write_entry")
 
 DNAME_INLINE_LEN = 32  # linux/dcache.h
 
-print('Tracing... Output every %d secs. Hit Ctrl-C to end' % interval)
+if not args.json:
+    print('Tracing... Output every %d secs. Hit Ctrl-C to end' % interval)
 
 def sort_fn(counts):
     if args.sort == "all":
@@ -188,14 +189,15 @@ while 1:
         exiting = 1
 
     # header
-    if clear:
-        call("clear")
-    else:
-        print()
-    with open(loadavg) as stats:
-        print("%-8s loadavg: %s" % (strftime("%H:%M:%S"), stats.read()))
-    print("%-7s %-16s %-6s %-6s %-7s %-7s %1s %s" % ("TID", "COMM",
-        "READS", "WRITES", "R_Kb", "W_Kb", "T", "FILE"))
+    if not args.json:
+        if clear:
+            call("clear")
+        else:
+            print()
+        with open(loadavg) as stats:
+            print("%-8s loadavg: %s" % (strftime("%H:%M:%S"), stats.read()))
+        print("%-7s %-16s %-6s %-6s %-7s %-7s %1s %s" % ("TID", "COMM",
+            "READS", "WRITES", "R_Kb", "W_Kb", "T", "FILE"))
 
     # by-TID output
     counts = b.get_table("counts")
@@ -216,7 +218,7 @@ while 1:
                 "rbytes": v.rbytes / 1024,
                 "wbytes": v.wbytes / 1024,
                 "type": k.type.decode('utf-8', 'replace'),
-                "name": name,
+                "file": name,
             })
         else:
             print("%-7d %-16s %-6d %-6d %-7d %-7d %1s %s" % (k.pid,
@@ -231,5 +233,6 @@ while 1:
 
     countdown -= 1
     if exiting or countdown == 0:
-        print("Detaching...")
+        if not args.json:
+            print("Detaching...")
         exit()

--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -18,6 +18,7 @@ from bcc import BPF
 from time import sleep, strftime
 import argparse
 from subprocess import call
+import json
 
 # arguments
 examples = """examples:
@@ -48,6 +49,8 @@ parser.add_argument("count", nargs="?", default=99999999,
     help="number of outputs")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 interval = int(args.interval)
 countdown = int(args.count)
@@ -205,10 +208,22 @@ while 1:
             name = name[:-3] + "..."
 
         # print line
-        print("%-7d %-16s %-6d %-6d %-7d %-7d %1s %s" % (k.pid,
-            k.comm.decode('utf-8', 'replace'), v.reads, v.writes,
-            v.rbytes / 1024, v.wbytes / 1024,
-            k.type.decode('utf-8', 'replace'), name))
+        if args.json:
+            print("%s" % {
+                "pid": k.pid,
+                "comm": k.comm.decode('utf-8', 'replace'),
+                "reads": v.reads,
+                "writes": v.writes,
+                "rbytes": v.rbytes / 1024,
+                "wbytes": v.wbytes / 1024,
+                "type": k.type.decode('utf-8', 'replace'),
+                "name": name,
+            })
+        else:
+            print("%-7d %-16s %-6d %-6d %-7d %-7d %1s %s" % (k.pid,
+                k.comm.decode('utf-8', 'replace'), v.reads, v.writes,
+                v.rbytes / 1024, v.wbytes / 1024,
+                k.type.decode('utf-8', 'replace'), name))
 
         line += 1
         if line >= maxrows:

--- a/tools/funccount.py
+++ b/tools/funccount.py
@@ -271,8 +271,9 @@ class Tool(object):
     def run(self):
         self.probe.load()
         self.probe.attach()
-        print("Tracing %d functions for \"%s\"... Hit Ctrl-C to end." %
-              (self.probe.matched, bytes(self.args.pattern)))
+        if not self.args.json:
+            print("Tracing %d functions for \"%s\"... Hit Ctrl-C to end." %
+                (self.probe.matched, bytes(self.args.pattern)))
         exiting = 0 if self.args.interval else 1
         seconds = 0
         while True:
@@ -301,11 +302,12 @@ class Tool(object):
                         (self.probe.trace_functions[k.value].decode('utf-8', 'replace'), v.value))
             else:
                 counts = self.probe.counts()
-                print("%s", {self.probe.trace_functions[k.value].decode('utf-8', 'replace'): v.value
+                print({self.probe.trace_functions[k.value].decode('utf-8', 'replace'): v.value
                                   for k, v in counts.items() if v.value != 0})
 
             if exiting:
-                print("Detaching...")
+                if not self.args.json:
+                    print("Detaching...")
                 exit()
             else:
                 self.probe.clear()

--- a/tools/funccount.py
+++ b/tools/funccount.py
@@ -252,6 +252,8 @@ class Tool(object):
         parser.add_argument("pattern",
             type=ArgString,
             help="search expression for events")
+        parser.add_argument("-j", "--json", action="store_true",
+            help="json output")
         self.args = parser.parse_args()
         global debug
         debug = self.args.debug
@@ -284,18 +286,23 @@ class Tool(object):
             if self.args.duration and seconds >= int(self.args.duration):
                 exiting = 1
 
-            print()
-            if self.args.timestamp:
-                print("%-8s\n" % strftime("%H:%M:%S"), end="")
+            if not self.args.json:
+                print()
+                if self.args.timestamp:
+                    print("%-8s\n" % strftime("%H:%M:%S"), end="")
 
-            print("%-36s %8s" % ("FUNC", "COUNT"))
-            counts = self.probe.counts()
-            for k, v in sorted(counts.items(),
-                               key=lambda counts: counts[1].value):
-                if v.value == 0:
-                    continue
-                print("%-36s %8d" %
-                      (self.probe.trace_functions[k.value].decode('utf-8', 'replace'), v.value))
+                print("%-36s %8s" % ("FUNC", "COUNT"))
+                counts = self.probe.counts()
+                for k, v in sorted(counts.items(),
+                                key=lambda counts: counts[1].value):
+                    if v.value == 0:
+                        continue
+                    print("%-36s %8d" %
+                        (self.probe.trace_functions[k.value].decode('utf-8', 'replace'), v.value))
+            else:
+                counts = self.probe.counts()
+                print("%s", {self.probe.trace_functions[k.value].decode('utf-8', 'replace'): v.value
+                                  for k, v in counts.items() if v.value != 0})
 
             if exiting:
                 print("Detaching...")

--- a/tools/hardirqs.py
+++ b/tools/hardirqs.py
@@ -256,7 +256,7 @@ while (1):
             dist.print_json_hist(label, "hardirq", section_print_fn=bytes.decode)
         else:
             for k, v in sorted(dist.items(), key=lambda dist: dist[1].value):
-                print("%s" % { "name": k.name.decode('utf-8', 'replace'), "value": v.value / factor })
+                print("%s" % { "hardirq": k.name.decode('utf-8', 'replace'), "total_usecs": v.value / factor })
     dist.clear()
 
     sys.stdout.flush()

--- a/tools/hardirqs.py
+++ b/tools/hardirqs.py
@@ -253,7 +253,7 @@ while (1):
                 print("%-26s %11d" % (k.name.decode('utf-8', 'replace'), v.value / factor))
     else:
         if args.dist:
-            dist.print_json_hist(label, "hardirq")
+            dist.print_json_hist(label, "hardirq", section_print_fn=bytes.decode)
         else:
             for k, v in sorted(dist.items(), key=lambda dist: dist[1].value):
                 print("%s" % { "name": k.name.decode('utf-8', 'replace'), "value": v.value / factor })

--- a/tools/hardirqs.py
+++ b/tools/hardirqs.py
@@ -49,6 +49,8 @@ parser.add_argument("outputs", nargs="?", default=99999999,
     help="number of outputs")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 countdown = int(args.outputs)
 if args.count and (args.dist or args.nanoseconds):
@@ -223,10 +225,11 @@ if debug or args.ebpf:
 # load BPF program
 b = BPF(text=bpf_text)
 
-if args.count:
-    print("Tracing hard irq events... Hit Ctrl-C to end.")
-else:
-    print("Tracing hard irq event time... Hit Ctrl-C to end.")
+if not args.json:
+    if args.count:
+        print("Tracing hard irq events... Hit Ctrl-C to end.")
+    else:
+        print("Tracing hard irq event time... Hit Ctrl-C to end.")
 
 # output
 exiting = 0 if args.interval else 1
@@ -237,16 +240,23 @@ while (1):
     except KeyboardInterrupt:
         exiting = 1
 
-    print()
-    if args.timestamp:
-        print("%-8s\n" % strftime("%H:%M:%S"), end="")
+    if not args.json:
+        print()
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
 
-    if args.dist:
-        dist.print_log2_hist(label, "hardirq", section_print_fn=bytes.decode)
+        if args.dist:
+            dist.print_log2_hist(label, "hardirq", section_print_fn=bytes.decode)
+        else:
+            print("%-26s %11s" % ("HARDIRQ", "TOTAL_" + label))
+            for k, v in sorted(dist.items(), key=lambda dist: dist[1].value):
+                print("%-26s %11d" % (k.name.decode('utf-8', 'replace'), v.value / factor))
     else:
-        print("%-26s %11s" % ("HARDIRQ", "TOTAL_" + label))
-        for k, v in sorted(dist.items(), key=lambda dist: dist[1].value):
-            print("%-26s %11d" % (k.name.decode('utf-8', 'replace'), v.value / factor))
+        if args.dist:
+            dist.print_json_hist(label, "hardirq")
+        else:
+            for k, v in sorted(dist.items(), key=lambda dist: dist[1].value):
+                print("%s" % { "name": k.name.decode('utf-8', 'replace'), "value": v.value / factor })
     dist.clear()
 
     sys.stdout.flush()

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -175,7 +175,7 @@ def print_event_json(cpu, data, size):
         return
 
     print("%s" % {
-        "timestamp": strftime("%H:%M:%S"),
+        "time": strftime("%H:%M:%S"),
         "pid": event.pid,
         "comm": event.comm,
         "sig": event.sig,

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -177,7 +177,7 @@ def print_event_json(cpu, data, size):
     print("%s" % {
         "time": strftime("%H:%M:%S"),
         "pid": event.pid,
-        "comm": event.comm,
+        "comm": event.comm.decode(),
         "sig": event.sig,
         "tpid": event.tpid,
         "ret": event.ret,

--- a/tools/netqtop.py
+++ b/tools/netqtop.py
@@ -135,6 +135,65 @@ def print_table(table, qnum):
     else:
         print()
 
+def print_json_table(table, qnum, direction):
+    global print_interval
+
+    # ------- calculates --------------
+    qids=[]
+    tBPS = 0
+    tPPS = 0
+    tAVG = 0
+    tGroup = [0,0,0,0,0]
+    tpkt = 0
+    tlen = 0
+    for k, v in table.items():
+        qids += [k.value]
+        tlen += v.total_pkt_len
+        tpkt += v.num_pkt
+        tGroup[0] += v.size_64B
+        tGroup[1] += v.size_512B
+        tGroup[2] += v.size_2K
+        tGroup[3] += v.size_16K
+        tGroup[4] += v.size_64K
+    tBPS = tlen / print_interval
+    tPPS = tpkt / print_interval
+    if tpkt != 0:
+        tAVG = tlen / tpkt
+
+    # -------- print table --------------
+    for k in range(qnum):
+        if k in qids:
+            item = table[c_ushort(k)]
+            data = [
+                k,
+                item.total_pkt_len,
+                item.num_pkt,
+                item.size_64B,
+                item.size_512B,
+                item.size_2K,
+                item.size_16K,
+                item.size_64K
+            ]
+        else:
+            data = [k,0,0,0,0,0,0,0]
+        
+        # print a line per queue
+        avg = 0
+        if data[2] != 0:
+            avg = data[1] / data[2]
+        print('{"time": "%s", "direction": "%s", "queue": %d, "avg_size": %d, "size_64B": %d, "size_512B": %d, "size_2K": %d, "size_16K": %d, "size_64K": %d, "BPS": %d, "PPS": %d}' % (
+            asctime(localtime(time())),
+            direction,
+            data[0],
+            avg,
+            data[3],
+            data[4],
+            data[5],
+            data[6],
+            data[7],
+            data[1] / print_interval,
+            data[2] / print_interval
+        ))
 
 def print_result(b):
     # --------- print tx queues ---------------
@@ -155,12 +214,25 @@ def print_result(b):
     else:
         print("-"*77)
 
+def print_json(b):
+    # --------- print tx queues ---------------
+    table = b['tx_q']
+    print_json_table(table, tx_num, "tx")
+    b['tx_q'].clear()
+
+    # --------- print rx queues ---------------
+    table = b['rx_q']
+    print_json_table(table, rx_num, "rx")
+    b['rx_q'].clear()
+
 ############## specify network interface #################
 parser = argparse.ArgumentParser(description="")
 parser.add_argument("--name", "-n", type=str, default="")
 parser.add_argument("--interval", "-i", type=float, default=1)
 parser.add_argument("--throughput", "-t", action="store_true")
 parser.add_argument("--ebpf", action="store_true", help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 
 if args.ebpf:
@@ -214,6 +286,9 @@ devname_map[0] = _name
 while 1:
     try:
         sleep(print_interval)
-        print_result(b)
+        if args.json:
+            print_json(b)
+        else:
+            print_result(b)
     except KeyboardInterrupt:
         exit()

--- a/tools/netqtop.py
+++ b/tools/netqtop.py
@@ -6,6 +6,7 @@ from ctypes import *
 import argparse
 import os
 from time import sleep,time,localtime,asctime
+from datetime import datetime, timedelta
 
 # pre defines -------------------------------
 ROOT_PATH = "/sys/class/net"
@@ -233,7 +234,12 @@ parser.add_argument("--throughput", "-t", action="store_true")
 parser.add_argument("--ebpf", action="store_true", help=argparse.SUPPRESS)
 parser.add_argument("-j", "--json", action="store_true",
     help="json output")
+parser.add_argument("-d", "--duration", default=99999999,
+    help="total duration of trace in seconds")
 args = parser.parse_args()
+
+if args.duration:
+    args.duration = timedelta(seconds=int(args.duration))
 
 if args.ebpf:
     with open(EBPF_FILE) as fileobj:
@@ -283,7 +289,8 @@ _name = Devname()
 _name.name = dev_name.encode()
 devname_map[0] = _name
 
-while 1:
+start_time = datetime.now()
+while not args.duration or datetime.now() - start_time < args.duration:
     try:
         sleep(print_interval)
         if args.json:

--- a/tools/runqlat.py
+++ b/tools/runqlat.py
@@ -61,6 +61,8 @@ parser.add_argument("count", nargs="?", default=99999999,
     help="number of outputs")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 countdown = int(args.count)
 debug = 0
@@ -296,8 +298,8 @@ if not is_support_raw_tp:
     b.attach_kprobe(event="wake_up_new_task", fn_name="trace_wake_up_new_task")
     b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
                     fn_name="trace_run")
-
-print("Tracing run queue latency... Hit Ctrl-C to end.")
+if not args.json:
+    print("Tracing run queue latency... Hit Ctrl-C to end.")
 
 # output
 exiting = 0 if args.interval else 1
@@ -308,11 +310,14 @@ while (1):
     except KeyboardInterrupt:
         exiting = 1
 
-    print()
-    if args.timestamp:
-        print("%-8s\n" % strftime("%H:%M:%S"), end="")
+    if not args.json:
+        print()
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
 
-    dist.print_log2_hist(label, section, section_print_fn=int)
+        dist.print_log2_hist(label, section, section_print_fn=int)
+    else:
+        dist.print_json_hist(label, section, section_print_fn=int)
     dist.clear()
 
     countdown -= 1

--- a/tools/runqlen.py
+++ b/tools/runqlen.py
@@ -50,6 +50,8 @@ parser.add_argument("count", nargs="?", default=99999999,
     help="number of outputs")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 countdown = int(args.count)
 debug = 0
@@ -190,21 +192,10 @@ b.attach_perf_event(ev_type=PerfType.SOFTWARE,
     ev_config=PerfSWConfig.CPU_CLOCK, fn_name="do_perf_event",
     sample_period=0, sample_freq=frequency)
 
-print("Sampling run queue length... Hit Ctrl-C to end.")
+if not args.json:
+    print("Sampling run queue length... Hit Ctrl-C to end.")
 
-# output
-exiting = 0 if args.interval else 1
-dist = b.get_table("dist")
-while (1):
-    try:
-        sleep(int(args.interval))
-    except KeyboardInterrupt:
-        exiting = 1
-
-    print()
-    if args.timestamp:
-        print("%-8s\n" % strftime("%H:%M:%S"), end="")
-
+def print_event_json(dist):
     if args.runqocc:
         if args.cpus:
             # run queue occupancy, per-CPU summary
@@ -228,8 +219,8 @@ while (1):
                     runqocc = float(queued[c]) / samples
                 else:
                     runqocc = 0
-                print("runqocc, CPU %-3d %6.2f%%" % (c, 100 * runqocc))
-
+                print("{{ \"t\": {}, \"cpu\": {}, \"runqocc\": {} }}".format(
+                    strftime("%H:%M:%S"), c, 100 * runqocc))
         else:
             # run queue occupancy, system-wide summary
             idle = 0
@@ -244,11 +235,71 @@ while (1):
                 runqocc = float(queued) / samples
             else:
                 runqocc = 0
-            print("runqocc: %0.2f%%" % (100 * runqocc))
-
+            print("{{ \"t\": {}, \"runqocc\": {} }}".format(
+                strftime("%H:%M:%S"), 100 * runqocc))
     else:
-        # run queue length histograms
-        dist.print_linear_hist("runqlen", "cpu")
+        dist.print_json_hist("runqlen", "cpu")
+
+# output
+exiting = 0 if args.interval else 1
+dist = b.get_table("dist")
+while (1):
+    try:
+        sleep(int(args.interval))
+    except KeyboardInterrupt:
+        exiting = 1
+
+    if not args.json:
+        print()
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
+
+        if args.runqocc:
+            if args.cpus:
+                # run queue occupancy, per-CPU summary
+                idle = {}
+                queued = {}
+                cpumax = 0
+                for k, v in dist.items():
+                    if k.cpu > cpumax:
+                        cpumax = k.cpu
+                for c in range(0, cpumax + 1):
+                    idle[c] = 0
+                    queued[c] = 0
+                for k, v in dist.items():
+                    if k.slot == 0:
+                        idle[k.cpu] += v.value
+                    else:
+                        queued[k.cpu] += v.value
+                for c in range(0, cpumax + 1):
+                    samples = idle[c] + queued[c]
+                    if samples:
+                        runqocc = float(queued[c]) / samples
+                    else:
+                        runqocc = 0
+                    print("runqocc, CPU %-3d %6.2f%%" % (c, 100 * runqocc))
+
+            else:
+                # run queue occupancy, system-wide summary
+                idle = 0
+                queued = 0
+                for k, v in dist.items():
+                    if k.value == 0:
+                        idle += v.value
+                    else:
+                        queued += v.value
+                samples = idle + queued
+                if samples:
+                    runqocc = float(queued) / samples
+                else:
+                    runqocc = 0
+                print("runqocc: %0.2f%%" % (100 * runqocc))
+
+        else:
+            # run queue length histograms
+            dist.print_linear_hist("runqlen", "cpu")
+    else:
+        print_event_json(dist)
 
     dist.clear()
 

--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -43,6 +43,8 @@ parser.add_argument("count", nargs="?", default=99999999,
     help="number of outputs")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 interval = int(args.interval)
 countdown = int(args.count)
@@ -107,10 +109,19 @@ if debug or args.ebpf:
     if args.ebpf:
         exit()
 
+def print_json(b):
+    counts = b.get_table("counts")
+    time = strftime("%H:%M:%S")
+    for k, v in sorted(counts.items(), key=lambda counts: counts[1].size):
+       print("{{\"time\": \"{}\", \"cache\": \"{}\", \"allocs\": {}, \"bytes\": {}}}".format(
+           time, k.name, v.count, v.size))
+    counts.clear()
+
 # initialize BPF
 b = BPF(text=bpf_text)
 
-print('Tracing... Output every %d secs. Hit Ctrl-C to end' % interval)
+if not args.json:
+    print('Tracing... Output every %d secs. Hit Ctrl-C to end' % interval)
 
 # output
 exiting = 0
@@ -120,28 +131,32 @@ while 1:
     except KeyboardInterrupt:
         exiting = 1
 
-    # header
-    if clear:
-        call("clear")
+    if not args.json:
+        # header
+        if clear:
+            call("clear")
+        else:
+            print()
+        with open(loadavg) as stats:
+            print("%-8s loadavg: %s" % (strftime("%H:%M:%S"), stats.read()))
+        print("%-32s %6s %10s" % ("CACHE", "ALLOCS", "BYTES"))
+
+        # by-TID output
+        counts = b.get_table("counts")
+        line = 0
+        for k, v in reversed(sorted(counts.items(),
+                                    key=lambda counts: counts[1].size)):
+            printb(b"%-32s %6d %10d" % (k.name, v.count, v.size))
+
+            line += 1
+            if line >= maxrows:
+                break
+        counts.clear()
     else:
-        print()
-    with open(loadavg) as stats:
-        print("%-8s loadavg: %s" % (strftime("%H:%M:%S"), stats.read()))
-    print("%-32s %6s %10s" % ("CACHE", "ALLOCS", "BYTES"))
-
-    # by-TID output
-    counts = b.get_table("counts")
-    line = 0
-    for k, v in reversed(sorted(counts.items(),
-                                key=lambda counts: counts[1].size)):
-        printb(b"%-32s %6d %10d" % (k.name, v.count, v.size))
-
-        line += 1
-        if line >= maxrows:
-            break
-    counts.clear()
+        print_json(b)
 
     countdown -= 1
     if exiting or countdown == 0:
-        print("Detaching...")
+        if not args.json:
+            print("Detaching...")
         exit()

--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -114,7 +114,7 @@ def print_json(b):
     time = strftime("%H:%M:%S")
     for k, v in sorted(counts.items(), key=lambda counts: counts[1].size):
        print("{{\"time\": \"{}\", \"cache\": \"{}\", \"allocs\": {}, \"bytes\": {}}}".format(
-           time, k.name, v.count, v.size))
+           time, k.name.decode(), v.count, v.size))
     counts.clear()
 
 # initialize BPF

--- a/tools/sofdsnoop.py
+++ b/tools/sofdsnoop.py
@@ -331,6 +331,11 @@ def print_event_json(cpu, data, size):
     event = b["events"].event(data)
     tid = event.id & 0xffffffff;
 
+    global initial_ts
+
+    if not initial_ts:
+        initial_ts = event.ts
+        
     cnt = min(MAX_FD, event.fd_cnt);
 
     json_dict = {}

--- a/tools/softirqs.py
+++ b/tools/softirqs.py
@@ -219,7 +219,7 @@ while (1):
             dist.print_json_hist(label, "softirq", section_print_fn=vec_to_name)
         else:
             for k, v in sorted(dist.items(), key=lambda dist: dist[1].value):
-                print("%s" % { "time": strftime("%H:%M:%S"), "name": vec_to_name(k.vec), "value": v.value / factor })
+                print("%s" % { "time": strftime("%H:%M:%S"), "softirq": vec_to_name(k.vec), "total_usecs": v.value / factor })
     dist.clear()
 
     sys.stdout.flush()

--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -73,6 +73,8 @@ parser.add_argument("--syscall", type=str,
     help="trace this syscall only (use option -l to get all recognized syscalls)")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 if args.duration and not args.interval:
     args.interval = args.duration
@@ -233,9 +235,9 @@ bpf = BPF(text=text)
 
 def print_stats():
     if args.latency:
-        print_latency_stats()
+        print_latency_stats_json() if args.json else print_latency_stats()
     else:
-        print_count_stats()
+        print_count_stats_json() if args.json else print_count_stats()
 
 agg_colname = "PID    COMM" if args.process else "SYSCALL"
 time_colname = "TIME (ms)" if args.milliseconds else "TIME (us)"
@@ -277,12 +279,41 @@ def print_latency_stats():
     print("")
     data.clear()
 
-if args.syscall is not None:
-    print("Tracing %ssyscall '%s'... Ctrl+C to quit." %
-        ("failed " if args.failures else "", args.syscall))
-else:
-    print("Tracing %ssyscalls, printing top %d... Ctrl+C to quit." %
-        ("failed " if args.failures else "", args.top))
+def print_count_stats_json():
+    data = bpf["data"]
+    time = strftime("%H:%M:%S")
+    for k, v in sorted(data.items(), key=lambda kv: -kv[1].value)[:args.top]:
+        if k.value == 0xFFFFFFFF:
+            continue    # happens occasionally, we don't need it
+        if args.process:
+            print("%s" % {"time": time, "pid": k.value, "comm": comm_for_pid(k.value).decode(), "count": v.value})
+        else:
+            print("%s" % {"time": time, "syscall": syscall_name(k.value).decode(), "count": v.value})
+    data.clear()
+
+def print_latency_stats_json():
+    data = bpf["data"]
+    time = strftime("%H:%M:%S")
+    for k, v in sorted(data.items(),
+                       key=lambda kv: -kv[1].total_ns)[:args.top]:
+        if k.value == 0xFFFFFFFF:
+            continue    # happens occasionally, we don't need it
+        if args.process:
+            print("%s" % { "time": time, "pid": k.value, "comm": comm_for_pid(k.value).decode(),
+                          "count": v.count,
+                          "time (us)": v.total_ns / (1e6 if args.milliseconds else 1e3) })
+        else:
+            print("%s" % { "time": time, "syscall": syscall_name(k.value).decode(), "count": v.count,
+                      "time (us)": v.total_ns / (1e6 if args.milliseconds else 1e3) })
+    data.clear()
+
+if not args.json:
+    if args.syscall is not None:
+        print("Tracing %ssyscall '%s'... Ctrl+C to quit." %
+            ("failed " if args.failures else "", args.syscall))
+    else:
+        print("Tracing %ssyscalls, printing top %d... Ctrl+C to quit." %
+            ("failed " if args.failures else "", args.top))
 exiting = 0 if args.interval else 1
 seconds = 0
 while True:
@@ -298,5 +329,6 @@ while True:
     print_stats()
 
     if exiting:
-        print("Detaching...")
+        if not args.json:
+            print("Detaching...")
         exit()

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -263,14 +263,18 @@ def print_ipv6_event(cpu, data, size):
 def print_ipv4_event_json(cpu, data, size):
     event = b["ipv4_events"].event(data)
     global start_ts
-    start_ts = event.ts_us
+
+    if start_ts == 0:
+        start_ts = event.ts_us
     print("%s" % { "timestamp": (float(event.ts_us) - start_ts) / 1000000, "pid": event.pid, "task": event.task.decode('utf8'), "ip": event.ip, 
         "daddr": inet_ntop(AF_INET, pack("I", event.daddr)), "dport": event.dport, 
         "saddr": inet_ntop(AF_INET, pack("I", event.saddr)), "lport": event.lport })
 
 def print_ipv6_event_json(cpu, data, size):
+    event = b["ipv6_events"].event(data)
     global start_ts
-    start_ts = event.ts_us
+    if start_ts == 0:
+        start_ts = event.ts_us
     event = b["ipv6_events"].event(data)
     print("%s" % { "timestamp": (float(event.ts_us) - start_ts) / 1000000, "pid": event.pid, "task": event.task.decode('utf8'), "ip": event.ip, 
         "daddr": inet_ntop(AF_INET6, event.daddr), "dport": event.dport, 

--- a/tools/tcpaccept.py
+++ b/tools/tcpaccept.py
@@ -58,6 +58,8 @@ parser.add_argument("--mntnsmap",
     help="trace mount namespaces in this BPF map only")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 debug = 0
 
@@ -258,22 +260,42 @@ def print_ipv6_event(cpu, data, size):
         inet_ntop(AF_INET6, event.saddr).encode(),
         event.lport))
 
+def print_ipv4_event_json(cpu, data, size):
+    event = b["ipv4_events"].event(data)
+    global start_ts
+    start_ts = event.ts_us
+    print("%s" % { "timestamp": (float(event.ts_us) - start_ts) / 1000000, "pid": event.pid, "task": event.task.decode('utf8'), "ip": event.ip, 
+        "daddr": inet_ntop(AF_INET, pack("I", event.daddr)), "dport": event.dport, 
+        "saddr": inet_ntop(AF_INET, pack("I", event.saddr)), "lport": event.lport })
+
+def print_ipv6_event_json(cpu, data, size):
+    global start_ts
+    start_ts = event.ts_us
+    event = b["ipv6_events"].event(data)
+    print("%s" % { "timestamp": (float(event.ts_us) - start_ts) / 1000000, "pid": event.pid, "task": event.task.decode('utf8'), "ip": event.ip, 
+        "daddr": inet_ntop(AF_INET6, event.daddr), "dport": event.dport, 
+        "saddr": inet_ntop(AF_INET6, event.saddr), "lport": event.lport })
 # initialize BPF
 b = BPF(text=bpf_text)
 
 # header
-if args.time:
-    print("%-9s" % ("TIME"), end="")
-if args.timestamp:
-    print("%-9s" % ("TIME(s)"), end="")
-print("%-7s %-12s %-2s %-16s %-5s %-16s %-5s" % ("PID", "COMM", "IP", "RADDR",
-    "RPORT", "LADDR", "LPORT"))
+if not args.json:
+    if args.time:
+        print("%-9s" % ("TIME"), end="")
+    if args.timestamp:
+        print("%-9s" % ("TIME(s)"), end="")
+    print("%-7s %-12s %-2s %-16s %-5s %-16s %-5s" % ("PID", "COMM", "IP", "RADDR",
+        "RPORT", "LADDR", "LPORT"))
 
 start_ts = 0
 
 # read events
-b["ipv4_events"].open_perf_buffer(print_ipv4_event)
-b["ipv6_events"].open_perf_buffer(print_ipv6_event)
+if args.json:
+    b["ipv4_events"].open_perf_buffer(print_ipv4_event_json)
+    b["ipv6_events"].open_perf_buffer(print_ipv6_event_json)
+else:
+    b["ipv4_events"].open_perf_buffer(print_ipv4_event)
+    b["ipv6_events"].open_perf_buffer(print_ipv6_event)
 while 1:
     try:
         b.perf_buffer_poll()

--- a/tools/tcpconnlat.py
+++ b/tools/tcpconnlat.py
@@ -269,6 +269,9 @@ def print_ipv4_event_json(cpu, data, size):
     event = b["ipv4_events"].event(data)
     global start_ts
 
+    if start_ts == 0:
+        start_ts = event.ts_us
+
     print(json.dumps({
         "timestamp": (float(event.ts_us) - start_ts) / 1000000,
         "pid": event.pid,
@@ -284,7 +287,9 @@ def print_ipv4_event_json(cpu, data, size):
 def print_ipv6_event_json(cpu, data, size):
     event = b["ipv6_events"].event(data)
     global start_ts
-
+    if start_ts == 0:
+        start_ts = event.ts_us
+        
     print(json.dumps({
         "timestamp": (float(event.ts_us) - start_ts) / 1000000,
         "pid": event.pid,

--- a/tools/tcpconnlat.py
+++ b/tools/tcpconnlat.py
@@ -21,6 +21,7 @@ from socket import inet_ntop, AF_INET, AF_INET6
 from struct import pack
 import argparse
 import json
+from datetime import datetime, timedelta
 
 # arg validation
 def positive_float(val):
@@ -68,6 +69,8 @@ parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
 parser.add_argument("-j", "--json", action="store_true",
     help="json output")
+parser.add_argument("-d", "--duration", default=99999999,
+    help="total duration of trace in seconds")
 args = parser.parse_args()
 
 if args.duration_ms:
@@ -75,6 +78,9 @@ if args.duration_ms:
     duration_us = int(args.duration_ms * 1000)
 else:
     duration_us = 0   # default is show all
+
+if args.duration:
+    args.duration = timedelta(seconds=int(args.duration))
 
 debug = 0
 
@@ -329,7 +335,8 @@ else:
         b["ipv4_events"].open_perf_buffer(print_ipv4_event_json)
         b["ipv6_events"].open_perf_buffer(print_ipv6_event_json)
 
-while 1:
+start_time = datetime.now()
+while not args.duration or datetime.now() - start_time < args.duration:
     try:
         b.perf_buffer_poll()
     except KeyboardInterrupt:

--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -477,9 +477,12 @@ def print_ipv4_event_json(cpu, data, size):
     event = b["ipv4_events"].event(data)
     global start_ts
 
+    if start_ts == 0:
+        start_ts = event.ts_us
+
     print(json.dumps({
         "time": strftime("%H:%M:%S"),
-        "timestamp": float(event.ts_us) / 1000000,
+        "timestamp": (float(event.ts_us) - start_ts) / 1000000,
         "pid": event.pid,
         "task": event.task.decode('utf-8', 'replace'),
         "family": 4,
@@ -496,9 +499,12 @@ def print_ipv6_event_json(cpu, data, size):
     event = b["ipv6_events"].event(data)
     global start_ts
 
+    if start_ts == 0:
+        start_ts = event.ts_us
+
     print(json.dumps({
         "time": strftime("%H:%M:%S"),
-        "timestamp": float(event.ts_us) / 1000000,
+        "timestamp": (float(event.ts_us) - start_ts) / 1000000,
         "pid": event.pid,
         "task": event.task.decode('utf-8', 'replace'),
         "family": 6,

--- a/tools/tcplife.py
+++ b/tools/tcplife.py
@@ -28,6 +28,7 @@ import argparse
 from socket import inet_ntop, AF_INET, AF_INET6
 from struct import pack
 from time import strftime
+import json
 
 # arguments
 examples = """examples:
@@ -67,6 +68,8 @@ group.add_argument("-6", "--ipv6", action="store_true",
     help="trace IPv6 family only")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 debug = 0
 
@@ -470,29 +473,73 @@ def print_ipv6_event(cpu, data, size):
         inet_ntop(AF_INET6, event.daddr), event.ports & 0xffffffff,
         event.tx_b / 1024, event.rx_b / 1024, float(event.span_us) / 1000))
 
+def print_ipv4_event_json(cpu, data, size):
+    event = b["ipv4_events"].event(data)
+    global start_ts
+
+    print(json.dumps({
+        "time": strftime("%H:%M:%S"),
+        "timestamp": float(event.ts_us) / 1000000,
+        "pid": event.pid,
+        "task": event.task.decode('utf-8', 'replace'),
+        "family": 4,
+        "saddr": inet_ntop(AF_INET, pack("I", event.saddr)),
+        "sport": event.ports >> 32,
+        "daddr": inet_ntop(AF_INET, pack("I", event.daddr)),
+        "dport": event.ports & 0xffffffff,
+        "tx_kb": event.tx_b / 1024,
+        "rx_kb": event.rx_b / 1024,
+        "ms": float(event.span_us) / 1000
+    }))
+
+def print_ipv6_event_json(cpu, data, size):
+    event = b["ipv6_events"].event(data)
+    global start_ts
+
+    print(json.dumps({
+        "time": strftime("%H:%M:%S"),
+        "timestamp": float(event.ts_us) / 1000000,
+        "pid": event.pid,
+        "task": event.task.decode('utf-8', 'replace'),
+        "family": 6,
+        "saddr": inet_ntop(AF_INET6, event.saddr),
+        "sport": event.ports >> 32,
+        "daddr": inet_ntop(AF_INET6, event.daddr),
+        "dport": event.ports & 0xffffffff,
+        "tx_kb": event.tx_b / 1024,
+        "rx_kb": event.rx_b / 1024,
+        "ms": float(event.span_us) / 1000
+    }))
+
 # initialize BPF
 b = BPF(text=bpf_text)
 
 # header
-if args.time:
-    if args.csv:
-        print("%s," % ("TIME"), end="")
-    else:
-        print("%-8s " % ("TIME"), end="")
-if args.timestamp:
-    if args.csv:
-        print("%s," % ("TIME(s)"), end="")
-    else:
-        print("%-9s " % ("TIME(s)"), end="")
-print(header_string % ("PID", "COMM",
-    "IP" if args.wide or args.csv else "", "LADDR",
-    "LPORT", "RADDR", "RPORT", "TX_KB", "RX_KB", "MS"))
+if not args.json:
+    if args.time:
+        if args.csv:
+            print("%s," % ("TIME"), end="")
+        else:
+            print("%-8s " % ("TIME"), end="")
+    if args.timestamp:
+        if args.csv:
+            print("%s," % ("TIME(s)"), end="")
+        else:
+            print("%-9s " % ("TIME(s)"), end="")
+    print(header_string % ("PID", "COMM",
+        "IP" if args.wide or args.csv else "", "LADDR",
+        "LPORT", "RADDR", "RPORT", "TX_KB", "RX_KB", "MS"))
 
 start_ts = 0
 
 # read events
-b["ipv4_events"].open_perf_buffer(print_ipv4_event, page_cnt=64)
-b["ipv6_events"].open_perf_buffer(print_ipv6_event, page_cnt=64)
+if not args.json:
+    b["ipv4_events"].open_perf_buffer(print_ipv4_event, page_cnt=64)
+    b["ipv6_events"].open_perf_buffer(print_ipv6_event, page_cnt=64)
+else:
+    b["ipv4_events"].open_perf_buffer(print_ipv4_event_json, page_cnt=64)
+    b["ipv6_events"].open_perf_buffer(print_ipv6_event_json, page_cnt=64)
+    
 while 1:
     try:
         b.perf_buffer_poll()

--- a/tools/tcprtt.py
+++ b/tools/tcprtt.py
@@ -71,6 +71,8 @@ group.add_argument("-6", "--ipv6", action="store_true",
     help="trace IPv6 family only")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 args = parser.parse_args()
 if not args.interval:
     args.interval = args.duration
@@ -228,7 +230,8 @@ if args.debug or args.ebpf:
 b = BPF(text=bpf_text)
 b.attach_kprobe(event="tcp_rcv_established", fn_name="trace_tcp_rcv")
 
-print("Tracing TCP RTT... Hit Ctrl-C to end.")
+if not args.json:
+    print("Tracing TCP RTT... Hit Ctrl-C to end.")
 
 def print_section(addr):
     addrstr = "*******"
@@ -255,11 +258,14 @@ while (1):
     except KeyboardInterrupt:
         exiting = 1
 
-    print()
-    if args.timestamp:
-        print("%-8s\n" % strftime("%H:%M:%S"), end="")
+    if not args.json:
+        print()
+        if args.timestamp:
+            print("%-8s\n" % strftime("%H:%M:%S"), end="")
 
-    dist.print_log2_hist(label, section_header=print_header, section_print_fn=print_section)
+        dist.print_log2_hist(label, section_header=print_header, section_print_fn=print_section)
+    else:
+        dist.print_json_hist(label, section_header=print_header, section_print_fn=print_section)
     dist.clear()
     lathash.clear()
 

--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -22,6 +22,7 @@ from socket import inet_ntop, AF_INET, AF_INET6
 from struct import pack
 from time import strftime, time
 from os import getuid
+import json
 
 # arguments
 examples = """examples:
@@ -57,6 +58,8 @@ parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
 parser.add_argument("-Y", "--journal", action="store_true",
     help="log session state changes to the systemd journal")
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 group = parser.add_mutually_exclusive_group()
 group.add_argument("-4", "--ipv4", action="store_true",
     help="trace IPv4 family only")
@@ -418,30 +421,71 @@ def print_ipv6_event(cpu, data, size):
     if args.journal:
         journal.send(**journal_fields(event, AF_INET6))
 
+def print_ipv4_event_json(cpu, data, size):
+    event = b["ipv4_events"].event(data)
+    global start_ts
+
+    print(json.dumps({
+        "timestamp": (float(event.ts_us) - start_ts) / 1000000,
+        "skaddr": event.skaddr,
+        "pid": event.pid,
+        "task": event.task.decode('utf-8', 'replace'),
+        "family": 4,
+        "saddr": inet_ntop(AF_INET, pack("I", event.saddr)),
+        "daddr": inet_ntop(AF_INET, pack("I", event.daddr)),
+        "ports": event.ports,
+        "oldstate": tcpstate2str(event.oldstate),
+        "newstate": tcpstate2str(event.newstate),
+        "ms": float(event.span_us) / 1000  
+    }))
+
+def print_ipv6_event_json(cpu, data, size):
+    event = b["ipv6_events"].event(data)
+    global start_ts
+
+    print(json.dumps({
+        "timestamp": (float(event.ts_us) - start_ts) / 1000000,
+        "skaddr": event.skaddr,
+        "pid": event.pid,
+        "task": event.task.decode('utf-8', 'replace'),
+        "family": 6,
+        "saddr": inet_ntop(AF_INET6, event.saddr),
+        "daddr": inet_ntop(AF_INET6, event.daddr),
+        "ports": event.ports,
+        "oldstate": tcpstate2str(event.oldstate),
+        "newstate": tcpstate2str(event.newstate),
+        "ms": float(event.span_us) / 1000  
+    }))
+    
 # initialize BPF
 b = BPF(text=bpf_text)
 
 # header
-if args.time:
-    if args.csv:
-        print("%s," % ("TIME"), end="")
-    else:
-        print("%-8s " % ("TIME"), end="")
-if args.timestamp:
-    if args.csv:
-        print("%s," % ("TIME(s)"), end="")
-    else:
-        print("%-9s " % ("TIME(s)"), end="")
-print(header_string % ("SKADDR", "C-PID", "C-COMM",
-    "IP" if args.wide or args.csv else "",
-    "LADDR", "LPORT", "RADDR", "RPORT",
-    "OLDSTATE", "NEWSTATE", "MS"))
+if not args.json:
+    if args.time:
+        if args.csv:
+            print("%s," % ("TIME"), end="")
+        else:
+            print("%-8s " % ("TIME"), end="")
+    if args.timestamp:
+        if args.csv:
+            print("%s," % ("TIME(s)"), end="")
+        else:
+            print("%-9s " % ("TIME(s)"), end="")
+    print(header_string % ("SKADDR", "C-PID", "C-COMM",
+        "IP" if args.wide or args.csv else "",
+        "LADDR", "LPORT", "RADDR", "RPORT",
+        "OLDSTATE", "NEWSTATE", "MS"))
 
 start_ts = 0
 
 # read events
-b["ipv4_events"].open_perf_buffer(print_ipv4_event, page_cnt=64)
-b["ipv6_events"].open_perf_buffer(print_ipv6_event, page_cnt=64)
+if args.json:
+    b["ipv4_events"].open_perf_buffer(print_ipv4_event_json, page_cnt=64)
+    b["ipv6_events"].open_perf_buffer(print_ipv6_event_json, page_cnt=64)
+else:
+    b["ipv4_events"].open_perf_buffer(print_ipv4_event, page_cnt=64)
+    b["ipv6_events"].open_perf_buffer(print_ipv6_event, page_cnt=64)
 while 1:
     try:
         b.perf_buffer_poll()

--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -425,6 +425,9 @@ def print_ipv4_event_json(cpu, data, size):
     event = b["ipv4_events"].event(data)
     global start_ts
 
+    if start_ts == 0:
+        start_ts = event.ts_us
+
     print(json.dumps({
         "timestamp": (float(event.ts_us) - start_ts) / 1000000,
         "skaddr": event.skaddr,
@@ -443,6 +446,9 @@ def print_ipv6_event_json(cpu, data, size):
     event = b["ipv6_events"].event(data)
     global start_ts
 
+    if start_ts == 0:
+        start_ts = event.ts_us
+        
     print(json.dumps({
         "timestamp": (float(event.ts_us) - start_ts) / 1000000,
         "skaddr": event.skaddr,
@@ -456,7 +462,7 @@ def print_ipv6_event_json(cpu, data, size):
         "newstate": tcpstate2str(event.newstate),
         "ms": float(event.span_us) / 1000  
     }))
-    
+
 # initialize BPF
 b = BPF(text=bpf_text)
 

--- a/tools/tcpsynbl.py
+++ b/tools/tcpsynbl.py
@@ -75,7 +75,8 @@ if not args.json:
 try:
     sleep(99999999)
 except KeyboardInterrupt:
-    print()
+    if not args.json:
+        print()
 
 dist = b.get_table("dist")
 if args.json:

--- a/tools/tcpsynbl.py
+++ b/tools/tcpsynbl.py
@@ -50,6 +50,8 @@ parser = argparse.ArgumentParser(
     description="Show TCP SYN backlog.",
     formatter_class=argparse.RawDescriptionHelpFormatter,
     epilog=examples)
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
 group = parser.add_mutually_exclusive_group()
 group.add_argument("-4", "--ipv4", action="store_true",
     help="trace IPv4 family only")
@@ -67,7 +69,8 @@ else:
     b.attach_kprobe(event="tcp_v4_syn_recv_sock", fn_name="do_entry")
     b.attach_kprobe(event="tcp_v6_syn_recv_sock", fn_name="do_entry")
 
-print("Tracing SYN backlog size. Ctrl-C to end.");
+if not args.json:
+    print("Tracing SYN backlog size. Ctrl-C to end.");
 
 try:
     sleep(99999999)
@@ -75,4 +78,7 @@ except KeyboardInterrupt:
     print()
 
 dist = b.get_table("dist")
-dist.print_log2_hist("backlog", "backlog_max")
+if args.json:
+    dist.print_json_hist("backlog", "backlog_max")
+else:
+    dist.print_log2_hist("backlog", "backlog_max")

--- a/tools/vfscount.py
+++ b/tools/vfscount.py
@@ -15,18 +15,31 @@ from __future__ import print_function
 from bcc import BPF
 from time import sleep
 from sys import argv
-def usage():
-    print("USAGE: %s [time]" % argv[0])
+import json
+import argparse
+
+examples = """examples:
+    ./vfscount           # counts VFS calls  during time
+    ./vfscount -j        # print output in json format
+"""
+parser = argparse.ArgumentParser(
+    description="Counts VFS calls  during time",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument(
+    "duration", nargs="?", default=10, help="Duration, in seconds, to run")
+parser.add_argument("-j", "--json", action="store_true",
+    help="json output")
+args = parser.parse_args()
+
+if int(args.duration) == 0:
+    print ("print duration must be non-zero")
     exit()
 
 interval = 99999999
-if len(argv) > 1:
-    try:
-        interval = int(argv[1])
-        if interval == 0:
-            raise
-    except:  # also catches -h, --help
-        usage()
+if args.duration:
+    interval = int(args.duration)
+
 # load BPF program
 b = BPF(text="""
 #include <uapi/linux/ptrace.h>
@@ -47,7 +60,8 @@ int do_count(struct pt_regs *ctx) {
 b.attach_kprobe(event_re="^vfs_.*", fn_name="do_count")
 
 # header
-print("Tracing... Ctrl-C to end.")
+if not args.json:
+    print("Tracing... Ctrl-C to end.")
 
 # output
 try:
@@ -55,7 +69,9 @@ try:
 except KeyboardInterrupt:
     pass
 
-print("\n%-16s %-26s %8s" % ("ADDR", "FUNC", "COUNT"))
+if not args.json:
+    print("\n%-16s %-26s %8s" % ("ADDR", "FUNC", "COUNT"))
 counts = b.get_table("counts")
 for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
-    print("%-16x %-26s %8d" % (k.ip, b.ksym(k.ip), v.value))
+    print("%-16x %-26s %8d" % (k.ip, b.ksym(k.ip), v.value)) if not args.json else \
+        print(json.dumps({ "addr": k.ip, "func": b.ksym(k.ip).decode(), "count": v.value}))


### PR DESCRIPTION
Hi,

We used bcc tools to do performance analysis of different virtualised applications, trying to understand how they use the underlying resource. We had to provide graphs for the publication. We found it easier to graph the results when the output is in json format (especially for distribution graphs). Since we had to do this for a number of tools and applications adding a json format output option for each of the tools made it easier. In the case that someone finds this option useful this PR:

1. Adds json format output option to the tools (`-j` or `--json`)
2. Adds test cases to validate the returned json output `tests/python/test_tools_json_output.py`

In our case we used plotly to create graphs, see the sample below.

![hardirqs_count](https://user-images.githubusercontent.com/18515926/217457643-62581fb3-f8a7-4695-92c0-c377c96cb2cc.jpeg)

