### PR TITLE
tools/f2fsslower: add f2fsslower for F2FS

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[exitsnoop](tools/exitsnoop.py): Trace process termination (exit and fatal signals). [Examples](tools/exitsnoop_example.txt).
 - tools/[ext4dist](tools/ext4dist.py): Summarize ext4 operation latency distribution as a histogram. [Examples](tools/ext4dist_example.txt).
 - tools/[ext4slower](tools/ext4slower.py): Trace slow ext4 operations. [Examples](tools/ext4slower_example.txt).
+- tools/[f2fsslower](tools/f2fsslower.py): Trace slow F2FS operations. [Examples](tools/f2fsslower_example.txt).
 - tools/[filelife](tools/filelife.py): Trace the lifespan of short-lived files. [Examples](tools/filelife_example.txt).
 - tools/[filegone](tools/filegone.py): Trace why file gone (deleted or renamed). [Examples](tools/filegone_example.txt).
 - tools/[fileslower](tools/fileslower.py): Trace slow synchronous file reads and writes. [Examples](tools/fileslower_example.txt).

--- a/man/man8/f2fsslower.8
+++ b/man/man8/f2fsslower.8
@@ -2,7 +2,7 @@
 .SH NAME
 f2fsslower \- Trace slow f2fs file operations, with per-event details.
 .SH SYNOPSIS
-.B f2fsslower [\-h] [\-j] [\-p PID] [min_ms]
+.B f2fsslower [\-h] [\-s] [\-p PID] [min_ms]
 .SH DESCRIPTION
 This tool traces common f2fs file operations: reads, writes, opens, and
 syncs. It measures the time spent in these operations, and prints details
@@ -37,7 +37,7 @@ Trace slower than 1 ms:
 .TP
 Trace slower than 1 ms, and output just the fields in parsable format (csv):
 #
-.B f2fsslower \-j 1
+.B f2fsslower \-s 1
 .TP
 Trace all file reads and writes (warning: the output will be verbose):
 #
@@ -77,13 +77,13 @@ FILENAME
 A cached kernel file name (comes from dentry->d_name.name).
 .TP
 ENDTIME_us
-Completion timestamp, microseconds (\-j only).
+Completion timestamp, microseconds (\-s only).
 .TP
 OFFSET_b
-File offset, bytes (\-j only).
+File offset, bytes (\-s only).
 .TP
 LATENCY_us
-Latency (duration) of the I/O, in microseconds (\-j only).
+Latency (duration) of the I/O, in microseconds (\-s only).
 .SH OVERHEAD
 This adds low-overhead instrumentation to these f2fs operations,
 including reads and writes from the file system cache. Such reads and writes

--- a/man/man8/f2fsslower.8
+++ b/man/man8/f2fsslower.8
@@ -1,0 +1,113 @@
+.TH f2fsslower 8  "2022-08-15" "USER COMMANDS"
+.SH NAME
+f2fsslower \- Trace slow f2fs file operations, with per-event details.
+.SH SYNOPSIS
+.B f2fsslower [\-h] [\-j] [\-p PID] [min_ms]
+.SH DESCRIPTION
+This tool traces common f2fs file operations: reads, writes, opens, and
+syncs. It measures the time spent in these operations, and prints details
+for each that exceeded a threshold.
+
+WARNING: See the OVERHEAD section.
+
+By default, a minimum millisecond threshold of 10 is used. If a threshold of 0
+is used, all events are printed (warning: verbose).
+
+Since this works by tracing the f2fs_file_operations interface functions, it
+will need updating to match any changes to these functions.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+.SH OPTIONS
+\-p PID
+Trace this PID only.
+.TP
+min_ms
+Minimum I/O latency (duration) to trace, in milliseconds. Default is 10 ms.
+.SH EXAMPLES
+.TP
+Trace synchronous file reads and writes slower than 10 ms:
+#
+.B f2fsslower
+.TP
+Trace slower than 1 ms:
+#
+.B f2fsslower 1
+.TP
+Trace slower than 1 ms, and output just the fields in parsable format (csv):
+#
+.B f2fsslower \-j 1
+.TP
+Trace all file reads and writes (warning: the output will be verbose):
+#
+.B f2fsslower 0
+.TP
+Trace slower than 1 ms, for PID 181 only:
+#
+.B f2fsslower \-p 181 1
+.SH FIELDS
+.TP
+TIME(s)
+Time of I/O completion since the first I/O seen, in seconds.
+.TP
+COMM
+Process name.
+.TP
+PID
+Process ID.
+.TP
+T
+Type of operation. R == read, W == write, O == open, S == fsync.
+.TP
+OFF_KB
+File offset for the I/O, in Kbytes.
+.TP
+BYTES
+Size of I/O, in bytes.
+.TP
+LAT(ms)
+Latency (duration) of I/O, measured from when it was issued by VFS to the
+filesystem, to when it completed. This time is inclusive of block device I/O,
+file system CPU cycles, file system locks, run queue latency, etc. It's a more
+accurate measure of the latency suffered by applications performing file
+system I/O, than to measure this down at the block device interface.
+.TP
+FILENAME
+A cached kernel file name (comes from dentry->d_name.name).
+.TP
+ENDTIME_us
+Completion timestamp, microseconds (\-j only).
+.TP
+OFFSET_b
+File offset, bytes (\-j only).
+.TP
+LATENCY_us
+Latency (duration) of the I/O, in microseconds (\-j only).
+.SH OVERHEAD
+This adds low-overhead instrumentation to these f2fs operations,
+including reads and writes from the file system cache. Such reads and writes
+can be very frequent (depending on the workload; eg, 1M/sec), at which
+point the overhead of this tool (even if it prints no "slower" events) can
+begin to become significant. Measure and quantify before use. If this
+continues to be a problem, consider switching to a tool that prints in-kernel
+summaries only.
+.PP
+Note that the overhead of this tool should be less than fileslower(8), as
+this tool targets f2fs functions only, and not all file read/write paths
+(which can include socket I/O).
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Ting Zhang
+.SH SEE ALSO
+biosnoop(8), funccount(8), fileslower(8)

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -178,6 +178,10 @@ class SmokeTests(TestCase):
         self.run_with_int("ext4slower.py")
 
     @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
+    def test_f2fsslower(self):
+        self.run_with_int("f2fsslower.py")
+
+    @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
     def test_filelife(self):
         self.run_with_int("filelife.py")
 

--- a/tools/f2fsslower.py
+++ b/tools/f2fsslower.py
@@ -38,7 +38,7 @@ kallsyms = "/proc/kallsyms"
 examples = """examples:
     ./f2fsslower             # trace operations slower than 10 ms (default)
     ./f2fsslower 1           # trace operations slower than 1 ms
-    ./f2fsslower -j 1        # ... 1 ms, parsable output (csv)
+    ./f2fsslower -s 1        # ... 1 ms, parsable output (csv)
     ./f2fsslower 0           # trace all operations (warning: verbose)
     ./f2fsslower -p 185      # trace PID 185 only
 """
@@ -46,7 +46,7 @@ parser = argparse.ArgumentParser(
     description="Trace common f2fs file operations slower than a threshold",
     formatter_class=argparse.RawDescriptionHelpFormatter,
     epilog=examples)
-parser.add_argument("-j", "--csv", action="store_true",
+parser.add_argument("-s", "--csv", action="store_true",
                     help="just print fields: comma-separated values")
 parser.add_argument("-p", "--pid",
                     help="trace this PID only")
@@ -66,7 +66,6 @@ bpf_text = """
 #include <linux/fs.h>
 #include <linux/sched.h>
 #include <linux/dcache.h>
-// XXX: switch these to char's when supported
 #define TRACE_READ        0
 #define TRACE_WRITE        1
 #define TRACE_OPEN        2
@@ -77,7 +76,6 @@ struct val_t {
     struct file *fp;
 };
 struct data_t {
-    // XXX: switch some to u32's when supported
     u64 ts_us;
     u64 type;
     u32 size;

--- a/tools/f2fsslower.py
+++ b/tools/f2fsslower.py
@@ -1,0 +1,318 @@
+#!/usr/bin/python
+# SPDX-License-Identifier: <SPDX License Expression>
+# @lint-avoid-python-3-compatibility-imports
+#
+# f2fsslower  Trace slow f2fs operations.
+#              For Linux, uses BCC, eBPF.
+#
+# USAGE: f2fsslower [-h] [-j] [-p PID] [min_ms]
+#
+# This script traces common f2fs file operations: reads, writes, opens, and
+# syncs. It measures the time spent in these operations, and prints details
+# for each that exceeded a threshold.
+#
+# WARNING: This adds low-overhead instrumentation to these f2fs operations,
+# including reads and writes from the file system cache. Such reads and writes
+# can be very frequent (depending on the workload; eg, 1M/sec), at which
+# point the overhead of this tool (even if it prints no "slower" events) can
+# begin to become significant.
+#
+# By default, a minimum millisecond threshold of 10 is used.
+#
+# Copyright (c) 2022, Samsung Electronics.  All rights reserved.
+# Licensed under the Apache License, Version 2.0 (the "License")
+# thanks for Brendan Gregg's ext4slower
+# (https://github.com/iovisor/bcc/blob/master/tools/ext4slower.py) reference.
+#
+# 15-Aug-2022   Ting Zhang   Created this.
+
+from __future__ import print_function
+from bcc import BPF
+import argparse
+from time import strftime
+
+# symbols
+kallsyms = "/proc/kallsyms"
+
+# arguments
+examples = """examples:
+    ./f2fsslower             # trace operations slower than 10 ms (default)
+    ./f2fsslower 1           # trace operations slower than 1 ms
+    ./f2fsslower -j 1        # ... 1 ms, parsable output (csv)
+    ./f2fsslower 0           # trace all operations (warning: verbose)
+    ./f2fsslower -p 185      # trace PID 185 only
+"""
+parser = argparse.ArgumentParser(
+    description="Trace common f2fs file operations slower than a threshold",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("-j", "--csv", action="store_true",
+                    help="just print fields: comma-separated values")
+parser.add_argument("-p", "--pid",
+                    help="trace this PID only")
+parser.add_argument("min_ms", nargs="?", default='10',
+                    help="minimum I/O duration to trace, in ms (default 10)")
+parser.add_argument("--ebpf", action="store_true",
+                    help=argparse.SUPPRESS)
+args = parser.parse_args()
+min_ms = int(args.min_ms)
+pid = args.pid
+csv = args.csv
+debug = 0
+
+# define BPF program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/fs.h>
+#include <linux/sched.h>
+#include <linux/dcache.h>
+// XXX: switch these to char's when supported
+#define TRACE_READ        0
+#define TRACE_WRITE        1
+#define TRACE_OPEN        2
+#define TRACE_FSYNC        3
+struct val_t {
+    u64 ts;
+    u64 offset;
+    struct file *fp;
+};
+struct data_t {
+    // XXX: switch some to u32's when supported
+    u64 ts_us;
+    u64 type;
+    u32 size;
+    u64 offset;
+    u64 delta_us;
+    u32 pid;
+    char task[TASK_COMM_LEN];
+    char file[DNAME_INLINE_LEN];
+};
+BPF_HASH(entryinfo, u64, struct val_t);
+BPF_PERF_OUTPUT(events);
+//
+// Store timestamp and size on entry
+//
+// The current f2fs (Linux 4.5) uses generic_file_read_iter(), instead of it's
+// own function, for reads. So we need to trace that and then filter on f2fs,
+// which I do by checking file->f_op.
+// The new Linux version (since form 4.10) uses f2fs_file_read_iter(), And if
+// the 'CONFIG_FS_DAX' is not set, then f2fs_file_read_iter() will call
+// generic_file_read_iter(), else it will call f2fs_dax_read_iter(), and trace
+// generic_file_read_iter() will fail.
+int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
+{
+    u64 id =  bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+    if (FILTER_PID)
+        return 0;
+    // f2fs filter on file->f_op == f2fs_file_operations
+    struct file *fp = iocb->ki_filp;
+    if ((u64)fp->f_op != F2FS_FILE_OPERATIONS)
+        return 0;
+    // store filep and timestamp by id
+    struct val_t val = {};
+    val.ts = bpf_ktime_get_ns();
+    val.fp = fp;
+    val.offset = iocb->ki_pos;
+    if (val.fp)
+        entryinfo.update(&id, &val);
+    return 0;
+}
+// f2fs_file_write_iter():
+int trace_write_entry(struct pt_regs *ctx, struct kiocb *iocb)
+{
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+    if (FILTER_PID)
+        return 0;
+    // store filep and timestamp by id
+    struct val_t val = {};
+    val.ts = bpf_ktime_get_ns();
+    val.fp = iocb->ki_filp;
+    val.offset = iocb->ki_pos;
+    if (val.fp)
+        entryinfo.update(&id, &val);
+    return 0;
+}
+// f2fs_file_open():
+int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
+    struct file *file)
+{
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+    if (FILTER_PID)
+        return 0;
+    // store filep and timestamp by id
+    struct val_t val = {};
+    val.ts = bpf_ktime_get_ns();
+    val.fp = file;
+    val.offset = 0;
+    if (val.fp)
+        entryinfo.update(&id, &val);
+    return 0;
+}
+// f2fs_sync_file():
+int trace_fsync_entry(struct pt_regs *ctx, struct file *file)
+{
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+    if (FILTER_PID)
+        return 0;
+    // store filep and timestamp by id
+    struct val_t val = {};
+    val.ts = bpf_ktime_get_ns();
+    val.fp = file;
+    val.offset = 0;
+    if (val.fp)
+        entryinfo.update(&id, &val);
+    return 0;
+}
+//
+// Output
+//
+static int trace_return(struct pt_regs *ctx, int type)
+{
+    struct val_t *valp;
+    u64 id = bpf_get_current_pid_tgid();
+    u32 pid = id >> 32; // PID is higher part
+    valp = entryinfo.lookup(&id);
+    if (valp == 0) {
+        // missed tracing issue or filtered
+        return 0;
+    }
+    // calculate delta
+    u64 ts = bpf_ktime_get_ns();
+    u64 delta_us = (ts - valp->ts) / 1000;
+    entryinfo.delete(&id);
+    if (FILTER_US)
+        return 0;
+    // populate output struct
+    struct data_t data = {};
+    data.type = type;
+    data.size = PT_REGS_RC(ctx);
+    data.delta_us = delta_us;
+    data.pid = pid;
+    data.ts_us = ts / 1000;
+    data.offset = valp->offset;
+    bpf_get_current_comm(&data.task, sizeof(data.task));
+    // workaround (rewriter should handle file to d_name in one step):
+    struct dentry *de = NULL;
+    struct qstr qs = {};
+    de = valp->fp->f_path.dentry;
+    qs = de->d_name;
+    if (qs.len == 0)
+        return 0;
+    bpf_probe_read_kernel(&data.file, sizeof(data.file), (void *)qs.name);
+    // output
+    events.perf_submit(ctx, &data, sizeof(data));
+    return 0;
+}
+int trace_read_return(struct pt_regs *ctx)
+{
+    return trace_return(ctx, TRACE_READ);
+}
+int trace_write_return(struct pt_regs *ctx)
+{
+    return trace_return(ctx, TRACE_WRITE);
+}
+int trace_open_return(struct pt_regs *ctx)
+{
+    return trace_return(ctx, TRACE_OPEN);
+}
+int trace_fsync_return(struct pt_regs *ctx)
+{
+    return trace_return(ctx, TRACE_FSYNC);
+}
+"""
+
+# code replacements
+with open(kallsyms) as syms:
+    ops = ''
+    for line in syms:
+        (addr, size, name) = line.rstrip().split(" ", 2)
+        name = name.split("\t")[0]
+        if name == "f2fs_file_operations":
+            ops = "0x" + addr
+            break
+    if ops == '':
+        print("ERROR: no f2fs_file_operations in /proc/kallsyms. Exiting.")
+        print("HINT: the kernel should be built with CONFIG_KALLSYMS_ALL.")
+        exit()
+    bpf_text = bpf_text.replace('F2FS_FILE_OPERATIONS', ops)
+if min_ms == 0:
+    bpf_text = bpf_text.replace('FILTER_US', '0')
+else:
+    bpf_text = bpf_text.replace('FILTER_US',
+                                'delta_us <= %s' % str(min_ms * 1000))
+if args.pid:
+    bpf_text = bpf_text.replace('FILTER_PID', 'pid != %s' % pid)
+else:
+    bpf_text = bpf_text.replace('FILTER_PID', '0')
+if debug or args.ebpf:
+    print(bpf_text)
+    if args.ebpf:
+        exit()
+
+
+# process event
+def print_event(cpu, data, size):
+    event = b["events"].event(data)
+
+    type = 'R'
+    if event.type == 1:
+        type = 'W'
+    elif event.type == 2:
+        type = 'O'
+    elif event.type == 3:
+        type = 'S'
+
+    if (csv):
+        print("%d,%s,%d,%s,%d,%d,%d,%s" % (
+            event.ts_us, event.task.decode('utf-8', 'replace'), event.pid,
+            type, event.size, event.offset, event.delta_us,
+            event.file.decode('utf-8', 'replace')))
+        return
+    print("%-8s %-14.14s %-6s %1s %-7s %-8d %7.2f %s" % (strftime("%H:%M:%S"),
+          event.task.decode('utf-8', 'replace'), event.pid, type, event.size,
+          event.offset / 1024, float(event.delta_us) / 1000,
+          event.file.decode('utf-8', 'replace')))
+
+# initialize BPF
+b = BPF(text=bpf_text)
+
+# Common file functions. See earlier comment about generic_file_read_iter().
+if BPF.get_kprobe_functions(b'f2fs_file_read_iter'):
+    b.attach_kprobe(event="f2fs_file_read_iter", fn_name="trace_read_entry")
+else:
+    b.attach_kprobe(event="generic_file_read_iter", fn_name="trace_read_entry")
+b.attach_kprobe(event="f2fs_file_write_iter", fn_name="trace_write_entry")
+b.attach_kprobe(event="f2fs_file_open", fn_name="trace_open_entry")
+b.attach_kprobe(event="f2fs_sync_file", fn_name="trace_fsync_entry")
+if BPF.get_kprobe_functions(b'f2fs_file_read_iter'):
+    b.attach_kretprobe(event="f2fs_file_read_iter",
+                       fn_name="trace_read_return")
+else:
+    b.attach_kretprobe(event="generic_file_read_iter",
+                       fn_name="trace_read_return")
+b.attach_kretprobe(event="f2fs_file_write_iter", fn_name="trace_write_return")
+b.attach_kretprobe(event="f2fs_file_open", fn_name="trace_open_return")
+b.attach_kretprobe(event="f2fs_sync_file", fn_name="trace_fsync_return")
+
+# header
+if (csv):
+    print("ENDTIME_us,TASK,PID,TYPE,BYTES,OFFSET_b,LATENCY_us,FILE")
+else:
+    if min_ms == 0:
+        print("Tracing f2fs operations")
+    else:
+        print("Tracing f2fs operations slower than %d ms" % min_ms)
+    print("%-8s %-14s %-6s %1s %-7s %-8s %7s %s" % ("TIME", "COMM", "PID", "T",
+          "BYTES", "OFF_KB", "LAT(ms)", "FILENAME"))
+
+# read events
+b["events"].open_perf_buffer(print_event, page_cnt=64)
+while 1:
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/tools/f2fsslower_example.txt
+++ b/tools/f2fsslower_example.txt
@@ -1,0 +1,260 @@
+Demonstrations of f2fsslower, the Linux eBPF/bcc version.
+
+
+f2fsslower shows f2fs reads, writes, opens, and fsyncs, slower than a threshold.
+For example:
+
+# ./f2fsslower
+Tracing f2fs operations slower than 10 ms
+TIME     COMM           PID    T BYTES   OFF_KB   LAT(ms) FILENAME
+23:27:14 Thread-11      13086  R 33554432 0         123.24 0
+23:27:14 Thread-11      13086  R 33554432 32768      16.73 0
+23:27:14 Thread-11      13086  R 33554432 0          16.39 1
+23:27:14 Thread-11      13086  R 33554432 32768      16.33 1
+23:27:14 Thread-11      13086  R 33554432 0          16.38 2
+23:27:14 Thread-11      13086  R 33554432 32768      16.29 2
+23:27:14 Thread-11      13086  R 33554432 0          16.47 3
+23:27:14 Thread-11      13086  R 33554432 32768      16.29 3
+23:27:14 Thread-11      13086  R 33554432 0          16.34 4
+23:27:14 Thread-11      13086  R 33554432 32768      16.63 4
+23:27:14 Thread-11      13086  R 33554432 0          16.27 5
+23:27:14 Thread-11      13086  R 33554432 32768      16.32 5
+23:27:14 Thread-11      13086  R 33554432 0          16.25 6
+23:27:14 Thread-11      13086  R 33554432 32768      16.56 6
+23:27:14 Thread-11      13086  R 33554432 0          17.29 7
+23:27:14 Thread-11      13086  R 33554432 32768      16.27 7
+23:27:14 Thread-11      13086  R 33554432 0          17.51 0
+23:27:14 Thread-11      13086  R 33554432 32768      16.29 0
+23:27:14 Thread-11      13086  R 33554432 0          16.41 1
+23:27:14 Thread-11      13086  R 33554432 32768      16.31 1
+23:27:14 Thread-11      13086  R 33554432 0          16.21 2
+23:27:14 Thread-11      13086  R 33554432 32768      16.44 2
+23:27:14 Thread-11      13086  R 33554432 0          16.31 3
+23:27:14 Thread-11      13086  R 33554432 32768      16.28 3
+23:27:14 Thread-11      13086  R 33554432 0          16.22 4
+23:27:14 Thread-11      13086  R 33554432 32768      16.22 4
+23:27:14 Thread-11      13086  R 33554432 0          16.25 5
+23:27:14 Thread-11      13086  R 33554432 32768      16.21 5
+23:27:14 Thread-11      13086  R 33554432 0          16.20 6
+23:27:14 Thread-11      13086  R 33554432 32768      16.35 6
+23:27:14 Thread-11      13086  R 33554432 0          16.26 7
+23:27:14 Thread-11      13086  R 33554432 32768      16.32 7
+23:27:14 Thread-11      13086  R 33554432 0          17.13 0
+23:27:14 Thread-11      13086  R 33554432 32768      16.12 0
+23:27:14 Thread-11      13086  R 33554432 0          16.65 1
+23:27:14 Thread-11      13086  R 33554432 32768      16.34 1
+23:27:14 Thread-11      13086  R 33554432 0          16.30 2
+23:27:14 Thread-11      13086  R 33554432 32768      16.30 2
+23:27:14 Thread-11      13086  R 33554432 0          16.39 3
+23:27:14 Thread-11      13086  R 33554432 32768      16.46 3
+23:27:14 Thread-11      13086  R 33554432 0          16.21 4
+23:27:14 Thread-11      13086  R 33554432 32768      16.34 4
+23:27:14 Thread-11      13086  R 33554432 0          16.43 5
+23:27:15 Thread-11      13086  R 33554432 32768      16.42 5
+23:27:15 Thread-11      13086  R 33554432 0          17.29 6
+23:27:15 Thread-11      13086  R 33554432 32768      16.64 6
+23:27:15 Thread-11      13086  R 33554432 0          16.56 7
+23:27:15 Thread-11      13086  R 33554432 32768      16.42 7
+[...]
+
+This shows various system tasks reading from f2fs. The high latency here is
+due to disk I/O, as I had just evicted the file system cache for this example.
+
+This "latency" is measured from when the operation was issued from the VFS
+interface to the file system, to when it completed. This spans everything:
+block device I/O (disk I/O), file system CPU cycles, file system locks, run
+queue latency, etc. This is a better measure of the latency suffered by
+applications reading from the file system than measuring this down at the
+block device interface.
+
+Note that this only traces the common file system operations previously
+listed: other file system operations (eg, inode operations including
+getattr()) are not traced.
+
+
+The threshold can be provided as an argument. Eg, I/O slower than 1 ms:
+
+# ./f2fsslower 1
+Tracing f2fs operations slower than 1 ms
+TIME     COMM           PID    T BYTES   OFF_KB   LAT(ms) FILENAME
+23:31:14 Thread-12      13086  R 33554432 0         124.63 0
+23:31:14 Thread-12      13086  R 33554432 32768      16.84 0
+23:31:14 Thread-12      13086  R 33554432 0          16.56 1
+23:31:14 Thread-12      13086  R 33554432 32768      16.54 1
+23:31:14 Thread-12      13086  R 33554432 0          16.56 2
+23:31:14 Thread-12      13086  R 33554432 32768      16.56 2
+23:31:14 Thread-12      13086  R 33554432 0          16.63 3
+23:31:14 Thread-12      13086  R 33554432 32768      16.47 3
+23:31:14 Thread-12      13086  R 33554432 0          16.57 4
+23:31:14 Thread-12      13086  R 33554432 32768      16.36 4
+23:31:14 Thread-12      13086  R 33554432 0          16.30 5
+23:31:14 Thread-12      13086  R 33554432 32768      16.25 5
+23:31:14 Thread-12      13086  R 33554432 0          16.28 6
+23:31:14 Thread-12      13086  R 33554432 32768      16.51 6
+23:31:14 Thread-12      13086  R 33554432 0          16.28 7
+23:31:14 Thread-12      13086  R 33554432 32768      16.36 7
+23:31:14 Thread-12      13086  R 33554432 0          16.62 0
+23:31:14 Thread-12      13086  R 33554432 32768      16.43 0
+23:31:14 Thread-12      13086  R 33554432 0          16.44 1
+23:31:14 Thread-12      13086  R 33554432 32768      16.20 1
+23:31:14 Thread-12      13086  R 33554432 0          16.19 2
+23:31:14 Thread-12      13086  R 33554432 32768      16.18 2
+23:31:14 Thread-12      13086  R 33554432 0          16.16 3
+23:31:14 Thread-12      13086  R 33554432 32768      16.20 3
+23:31:14 Thread-12      13086  R 33554432 0          16.15 4
+23:31:14 Thread-12      13086  R 33554432 32768      16.18 4
+23:31:14 Thread-12      13086  R 33554432 0          16.17 5
+23:31:14 Thread-12      13086  R 33554432 32768      16.35 5
+23:31:14 Thread-12      13086  R 33554432 0          16.44 6
+23:31:14 Thread-12      13086  R 33554432 32768      16.47 6
+23:31:14 Thread-12      13086  R 33554432 0          17.01 7
+23:31:14 Thread-12      13086  R 33554432 32768      16.19 7
+23:31:14 Thread-12      13086  R 33554432 0          17.15 0
+23:31:14 Thread-12      13086  R 33554432 32768      16.41 0
+23:31:14 Thread-12      13086  R 33554432 0          16.74 1
+23:31:14 Thread-12      13086  R 33554432 32768      16.26 1
+23:31:14 Thread-12      13086  R 33554432 0          16.51 2
+23:31:14 Thread-12      13086  R 33554432 32768      16.50 2
+23:31:14 Thread-12      13086  R 33554432 0          16.71 3
+23:31:14 Thread-12      13086  R 33554432 32768      16.51 3
+23:31:14 Thread-12      13086  R 33554432 0          16.53 4
+23:31:14 Thread-12      13086  R 33554432 32768      16.54 4
+23:31:14 Thread-12      13086  R 33554432 0          16.52 5
+23:31:14 Thread-12      13086  R 33554432 32768      16.44 5
+23:31:14 Thread-12      13086  R 33554432 0          16.67 6
+23:31:14 Thread-12      13086  R 33554432 32768      16.68 6
+23:31:15 Thread-12      13086  R 33554432 0          16.74 7
+23:31:15 Thread-12      13086  R 33554432 32768      16.65 7
+[...]
+
+This time a cksum(1) command can be seen reading various files (from /usr/bin).
+
+
+A threshold of 0 will trace all operations. Warning: the output will be
+verbose, as it will include all file system cache hits.
+
+# ./f2fsslower 0
+Tracing f2fs operations
+TIME     COMM           PID    T BYTES   OFF_KB   LAT(ms) FILENAME
+23:35:53 iop@2.0-servic 882    R 16      0           0.04 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    R 16      0           0.01 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    R 16      0           0.01 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    R 16      0           0.01 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    W 4096    0           0.08 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    W 4096    32          0.01 io-prefetcher.db
+23:35:53 iop@2.0-servic 882    S 0       0           0.01 io-prefetcher.db
+23:35:54 perf@2.2-servi 886    O 0       0           0.04 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.09 current_fps
+23:35:54 perf@2.2-servi 886    O 0       0           0.03 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.07 current_fps
+23:35:54 perf@2.2-servi 886    O 0       0           0.03 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.10 current_fps
+23:35:54 TaskSnapshotPe 1544   O 0       0           0.15 24.proto.new
+23:35:54 perf@2.2-servi 886    O 0       0           0.03 current_fps
+23:35:54 TaskSnapshotPe 1544   W 82      0           0.05 24.proto.new
+23:35:54 perf@2.2-servi 886    W 2       0           0.08 current_fps
+23:35:54 TaskSnapshotPe 1544   S 0       0           2.43 24.proto.new
+23:35:54 perf@2.2-servi 886    O 0       0           0.07 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.07 current_fps
+23:35:54 iop@2.0-servic 882    R 16      0           0.03 io-prefetcher.db
+23:35:54 iop@2.0-servic 882    R 16      0           0.02 io-prefetcher.db
+23:35:54 perf@2.2-servi 886    O 0       0           0.02 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.07 current_fps
+23:35:54 perf@2.2-servi 886    O 0       0           0.03 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.09 current_fps
+23:35:54 perf@2.2-servi 886    O 0       0           0.03 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.08 current_fps
+23:35:54 TaskSnapshotPe 1544   O 0       0           0.01 24.jpg
+23:35:54 perf@2.2-servi 886    O 0       0           0.02 current_fps
+23:35:54 perf@2.2-servi 886    W 2       0           0.06 current_fps
+23:35:54 TaskSnapshotPe 1544   W 1024    0           0.04 24.jpg
+23:35:54 TaskSnapshotPe 1544   W 1024    1           0.01 24.jpg
+23:35:54 perf@2.2-servi 886    O 0       0           0.01 current_fps
+23:35:54 TaskSnapshotPe 1544   W 1024    2           0.01 24.jpg
+23:35:54 TaskSnapshotPe 1544   W 1024    3           0.00 24.jpg
+[...]
+
+The output now includes open operations ("O"), and writes ("W").
+
+
+A -j option will print just the fields (parsable output, csv):
+
+# ./f2fsslower -j 1
+ENDTIME_us,TASK,PID,TYPE,BYTES,OFFSET_b,LATENCY_us,FILE
+32897720717,Thread-14,13086,S,0,0,85033,3
+32897838343,Thread-14,13086,S,0,0,91010,4
+32898079447,Thread-14,13086,S,0,0,216140,5
+32898200395,Thread-14,13086,S,0,0,94777,6
+32898312396,Thread-14,13086,S,0,0,86556,7
+32898518082,Thread-14,13086,R,33554432,0,124118,0
+32898534981,Thread-14,13086,R,33554432,33554432,16830,0
+32898551645,Thread-14,13086,R,33554432,0,16585,1
+32898568083,Thread-14,13086,R,33554432,33554432,16388,1
+32898584740,Thread-14,13086,R,33554432,0,16604,2
+32898601152,Thread-14,13086,R,33554432,33554432,16368,2
+32898617857,Thread-14,13086,R,33554432,0,16659,3
+32898634356,Thread-14,13086,R,33554432,33554432,16456,3
+32898650861,Thread-14,13086,R,33554432,0,16457,4
+32898667344,Thread-14,13086,R,33554432,33554432,16434,4
+32898683804,Thread-14,13086,R,33554432,0,16411,5
+32898700276,Thread-14,13086,R,33554432,33554432,16421,5
+32898716713,Thread-14,13086,R,33554432,0,16372,6
+32898733204,Thread-14,13086,R,33554432,33554432,16420,6
+32898749801,Thread-14,13086,R,33554432,0,16530,7
+32898766804,Thread-14,13086,R,33554432,33554432,16937,7
+32898807153,Thread-14,13086,R,33554432,0,17290,0
+32898823493,Thread-14,13086,R,33554432,33554432,16300,0
+32898840179,Thread-14,13086,R,33554432,0,16646,1
+32898856655,Thread-14,13086,R,33554432,33554432,16442,1
+32898872967,Thread-14,13086,R,33554432,0,16268,2
+32898889270,Thread-14,13086,R,33554432,33554432,16258,2
+32898906083,Thread-14,13086,R,33554432,0,16772,3
+32898922423,Thread-14,13086,R,33554432,33554432,16298,3
+32898938893,Thread-14,13086,R,33554432,0,16430,4
+32898955217,Thread-14,13086,R,33554432,33554432,16287,4
+32898971737,Thread-14,13086,R,33554432,0,16481,5
+32898988188,Thread-14,13086,R,33554432,33554432,16415,5
+32899004665,Thread-14,13086,R,33554432,0,16439,6
+32899021297,Thread-14,13086,R,33554432,33554432,16596,6
+32899038039,Thread-14,13086,R,33554432,0,16697,7
+32899054685,Thread-14,13086,R,33554432,33554432,16604,7
+32899094190,Thread-14,13086,R,33554432,0,18062,0
+32899110914,Thread-14,13086,R,33554432,33554432,16677,0
+32899127424,Thread-14,13086,R,33554432,0,16467,1
+32899143724,Thread-14,13086,R,33554432,33554432,16259,1
+32899159998,Thread-14,13086,R,33554432,0,16235,2
+32899176506,Thread-14,13086,R,33554432,33554432,16458,2
+32899193020,Thread-14,13086,R,33554432,0,16449,3
+32899209410,Thread-14,13086,R,33554432,33554432,16326,3
+32899225756,Thread-14,13086,R,33554432,0,16281,4
+32899242571,Thread-14,13086,R,33554432,33554432,16762,4
+32899258945,Thread-14,13086,R,33554432,0,16320,5
+32899275445,Thread-14,13086,R,33554432,33554432,16453,5
+[...]
+
+This may be useful for visualizing with another tool, for example, for
+producing a scatter plot of ENDTIME vs LATENCY, to look for time-based
+patterns.
+
+
+USAGE message:
+
+# ./f2fsslower -h
+usage: f2fsslower [-h] [-j] [-p PID] [min_ms]
+
+Trace common f2fs file operations slower than a threshold
+
+positional arguments:
+  min_ms             minimum I/O duration to trace, in ms (default 10)
+
+optional arguments:
+  -h, --help         show this help message and exit
+  -j, --csv          just print fields: comma-separated values
+  -p PID, --pid PID  trace this PID only
+
+examples:
+    ./f2fsslower             # trace operations slower than 10 ms (default)
+    ./f2fsslower 1           # trace operations slower than 1 ms
+    ./f2fsslower -j 1        # ... 1 ms, parsable output (csv)
+    ./f2fsslower 0           # trace all operations (warning: verbose)
+    ./f2fsslower -p 185      # trace PID 185 only

--- a/tools/f2fsslower_example.txt
+++ b/tools/f2fsslower_example.txt
@@ -177,9 +177,9 @@ TIME     COMM           PID    T BYTES   OFF_KB   LAT(ms) FILENAME
 The output now includes open operations ("O"), and writes ("W").
 
 
-A -j option will print just the fields (parsable output, csv):
+A -s option will print just the fields (parsable output, csv):
 
-# ./f2fsslower -j 1
+# ./f2fsslower -s 1
 ENDTIME_us,TASK,PID,TYPE,BYTES,OFFSET_b,LATENCY_us,FILE
 32897720717,Thread-14,13086,S,0,0,85033,3
 32897838343,Thread-14,13086,S,0,0,91010,4
@@ -249,12 +249,12 @@ positional arguments:
 
 optional arguments:
   -h, --help         show this help message and exit
-  -j, --csv          just print fields: comma-separated values
+  -s, --csv          just print fields: comma-separated values
   -p PID, --pid PID  trace this PID only
 
 examples:
     ./f2fsslower             # trace operations slower than 10 ms (default)
     ./f2fsslower 1           # trace operations slower than 1 ms
-    ./f2fsslower -j 1        # ... 1 ms, parsable output (csv)
+    ./f2fsslower -s 1        # ... 1 ms, parsable output (csv)
     ./f2fsslower 0           # trace all operations (warning: verbose)
     ./f2fsslower -p 185      # trace PID 185 only


### PR DESCRIPTION
Add f2fsslower tool, which can be used for tracing mobile platform IO operations in F2FS layer.
F2FS (Flash Friendly File System) is an open source flash file system 
designed specifically for NAND-based storage devices, which currently mainly used on mobile platforms.