### PR TITLE
tools/nfsslower.py: Fix uninitialized struct pad error

### DIFF
--- a/tools/nfsslower.py
+++ b/tools/nfsslower.py
@@ -195,8 +195,11 @@ static int trace_exit(struct pt_regs *ctx, int type)
 
     // populate output struct
     u32 size = PT_REGS_RC(ctx);
-    struct data_t data = {.type = type, .size = size, .delta_us = delta_us,
-        .pid = pid};
+    struct data_t data = {};
+    data.type = type;
+    data.size = size;
+    data.delta_us = delta_us;
+    data.pid = pid;
     data.ts_us = ts / 1000;
     data.offset = valp->offset;
     bpf_get_current_comm(&data.task, sizeof(data.task));
@@ -280,9 +283,14 @@ RAW_TRACEPOINT_PROBE(nfs_commit_done)
         u64 ts = bpf_ktime_get_ns();
         u64 delta_us = (ts - cp->ts) / 1000;
         u32 pid = bpf_get_current_pid_tgid() >> 32;
-        struct data_t data = {.type = TRACE_COMMIT, .offset = cp->offset,
-            .size = cp->count, .ts_us = ts/1000, .delta_us = delta_us,
-            .pid = pid};
+
+        struct data_t data = {};
+        data.type = TRACE_COMMIT;
+        data.offset = cp->offset;
+        data.size = cp->count;
+        data.ts_us = ts/1000;
+        data.delta_us = delta_us;
+        data.pid = pid;
 
         commitinfo.delete(&key);
         bpf_get_current_comm(&data.task, sizeof(data.task));
@@ -325,9 +333,14 @@ int trace_nfs_commit_done(struct pt_regs *ctx, void *task, void *calldata)
         u64 ts = bpf_ktime_get_ns();
         u64 delta_us = (ts - cp->ts) / 1000;
         u32 pid = bpf_get_current_pid_tgid() >> 32;
-        struct data_t data = {.type = TRACE_COMMIT, .offset = cp->offset,
-            .size = cp->count, .ts_us = ts/1000, .delta_us = delta_us,
-            .pid = pid};
+
+        struct data_t data = {};
+        data.type = TRACE_COMMIT;
+        data.offset = cp->offset;
+        data.size = cp->count;
+        data.ts_us = ts/1000;
+        data.delta_us = delta_us;
+        data.pid = pid;
 
         commitinfo.delete(&key);
         bpf_get_current_comm(&data.task, sizeof(data.task));


### PR DESCRIPTION
The verifier is unhappy, if data struct _pad_ is not initialized, see [0][1].

```
    $ sudo ./nfsslower.py
    ...
    ; bpf_perf_event_output(ctx, (void *)bpf_pseudo_fd(1, -2), CUR_CPU_IDENTIFIER, &data, sizeof(data));
    83: (79) r1 = *(u64 *)(r10 -144)      ; R1_w=ctx(off=0,imm=0) R10=fp0
    84: (18) r3 = 0xffffffff              ; R3_w=4294967295
    86: (b7) r5 = 96                      ; R5_w=96
    87: (85) call bpf_perf_event_output#25
    invalid indirect read from stack R4 off -136+92 size 96
    processed 84 insns (limit 1000000) max_states_per_insn 0 total_states 4 peak_states 4 mark_read 4
    ...
    raise Exception("Failed to load BPF program %s: %s" %
    Exception: Failed to load BPF program b'raw_tracepoint__nfs_commit_done': Permission denied
```

[0] https://github.com/iovisor/bcc/issues/2623
[1] https://github.com/iovisor/bcc/pull/4453
