### PR TITLE
[DRAFT] Add golang to ubuntu dockerfiles

### DIFF
--- a/docker/build/Dockerfile.ubuntu
+++ b/docker/build/Dockerfile.ubuntu
@@ -63,7 +63,8 @@ RUN apt-get update && apt-get install -y \
       libtinfo-dev \
       iperf \
       netperf \
-      xz-utils && \
+      xz-utils \
+      golang-go && \
       apt-get -y clean
 
 RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1


### PR DESCRIPTION
In order to support properly testing ongoing work to incorporate `iovisor/gobpf` code into this repo (https://github.com/iovisor/bcc/pull/4449), we need to be able to test the bindings in this repository. So try adding `golang-go` to the ubuntu container.

Note that we can't use `actions/setup-go@v2` GH action used by `gobpf`'s CI as we're running tests within containers on the CI, not directly on the CI.

Marking [DRAFT] for now as I haven't touched the dockerfiles in a while and probably forgot / am misunderstanding something.