### PR TITLE
libbpf-tools/cachestat: Introduce tracepoint writeback_dirty_{page,folio}

### DIFF
--- a/libbpf-tools/cachestat.bpf.c
+++ b/libbpf-tools/cachestat.bpf.c
@@ -73,4 +73,18 @@ int BPF_KPROBE(kprobe_mark_buffer_dirty)
 	return 0;
 }
 
+SEC("tracepoint/writeback/writeback_dirty_folio")
+int tracepoint__writeback_dirty_folio(struct trace_event_raw_sys_enter* ctx)
+{
+	__sync_fetch_and_add(&misses, -1);
+	return 0;
+}
+
+SEC("tracepoint/writeback/writeback_dirty_page")
+int tracepoint__writeback_dirty_page(struct trace_event_raw_sys_enter* ctx)
+{
+	__sync_fetch_and_add(&misses, -1);
+	return 0;
+}
+
 char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
Add tracepoint:writeback:writeback_dirty_{page,folio} support.

kernel commit 9fb0a7da0c52("writeback: add more tracepoints") add writeback_dirty_page tracepoint, kernel commit b9b0ff61eef5("mm/writeback: Convert tracing writeback_page_template to folios") replace writeback_dirty_page to writeback_dirty_folio.

Both folio_account_dirtied() and account_page_dirtied() are static functions and they may be gone during compilation.