### PR TITLE
bcc/python: Add ring_buffer_epoll_fd() API to get fd of ring buffer.

### DIFF
--- a/src/cc/libbpf.c
+++ b/src/cc/libbpf.c
@@ -1696,6 +1696,12 @@ int bpf_consume_ringbuf(struct ring_buffer *rb) {
     return ring_buffer__consume(rb);
 }
 
+/* Get an fd that can be used to sleep until data is available in the
+ * ring(s). */
+int bpf_epoll_fd_ringbuf(struct ring_buffer *rb) {
+    return ring_buffer__epoll_fd(rb);
+}
+
 int bcc_iter_attach(int prog_fd, union bpf_iter_link_info *link_info,
                     uint32_t link_info_len)
 {

--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -162,6 +162,7 @@ int bpf_add_ringbuf(struct ring_buffer *rb, int map_fd,
                     ring_buffer_sample_fn sample_cb, void *ctx);
 int bpf_poll_ringbuf(struct ring_buffer *rb, int timeout_ms);
 int bpf_consume_ringbuf(struct ring_buffer *rb);
+int bpf_epoll_fd_ringbuf(struct ring_buffer *rb);
 
 int bpf_obj_pin(int fd, const char *pathname);
 int bpf_obj_get(const char *pathname);

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1727,6 +1727,16 @@ class BPF(object):
             raise Exception("No ring buffers to poll")
         lib.bpf_consume_ringbuf(self._ringbuf_manager)
 
+    def ring_buffer_epoll_fd(self):
+        """ring_buffer_epoll_fd(self)
+
+        Get an fd that can be used to sleep until data is available
+        in the ring(s).
+        """
+        if not self._ringbuf_manager:
+            raise Exception("No ring buffers to poll")
+        return lib.bpf_epoll_fd_ringbuf(self._ringbuf_manager)
+
     def free_bcc_memory(self):
         return lib.bcc_free_memory()
 

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -180,6 +180,8 @@ lib.bpf_poll_ringbuf.restype = ct.c_int
 lib.bpf_poll_ringbuf.argtypes = [ct.c_void_p, ct.c_int]
 lib.bpf_consume_ringbuf.restype = ct.c_int
 lib.bpf_consume_ringbuf.argtypes = [ct.c_void_p]
+lib.bpf_epoll_fd_ringbuf.restype = ct.c_int
+lib.bpf_epoll_fd_ringbuf.argtypes = [ct.c_void_p]
 
 # bcc symbol helpers
 class bcc_symbol(ct.Structure):


### PR DESCRIPTION
Add an API for Python programs to get the file descriptor of the ring buffer. This API is named ring_buffer_epoll_fd() and can be used to add async event handling to python programs.

For example the common loop in the examples:

  try:
      while 1:
          b.ring_buffer_poll()
  except KeyboardInterrupt:
      sys.exit()

Can be re-written as:

  ring_fd = b.ring_buffer_epoll_fd()
  epoll = select.epoll()
  epoll.register(ring_fd, select.EPOLLIN)

  try:
      while 1:
          events = epoll.poll()
          for fd, event in events:
              if fd == ring_fd:
                  b.ring_buffer_consume()
  except KeyboardInterrupt:
      sys.exit()