### PR TITLE
libbpf-tools: match update return type in bpf_map_try_or_init()

### DIFF
--- a/libbpf-tools/maps.bpf.h
+++ b/libbpf-tools/maps.bpf.h
@@ -10,7 +10,7 @@ static __always_inline void *
 bpf_map_lookup_or_try_init(void *map, const void *key, const void *init)
 {
 	void *val;
-	long err;
+	int err;
 
 	val = bpf_map_lookup_elem(map, key);
 	if (val)


### PR DESCRIPTION
I'm finding an issue at times where the comparison: `err != -EEXIST` does not work as intended due to the type used to store `err`. There have been cases where `bpf_map_update_elem()` returns `-EEXIST` (-17), but the conditional is still entered.

Adding a log message inside the conditional like this:
```bpf_printk("update fail err %ld %d\n", err, err);```

can result in:
```... bpf_trace_printk: update fail err 4294967279, -17```

... which might show why using a `long` results in something other than the actual returned error value.

The type returned by `bpf_map_update_elem()` is `int`, so the change below keeps things consistent and avoids the unintended behavior above.