### PR TITLE
tools: Fix filelife for kernels without CONFIG_SECURITY

### DIFF
--- a/tools/filelife.py
+++ b/tools/filelife.py
@@ -164,7 +164,8 @@ b.attach_kprobe(event="vfs_create", fn_name="trace_create")
 b.attach_kprobe(event="vfs_open", fn_name="trace_open")
 # newer kernels (say, 4.8) may don't fire vfs_create, so record (or overwrite)
 # the timestamp in security_inode_create():
-b.attach_kprobe(event="security_inode_create", fn_name="trace_security_inode_create")
+if BPF.get_kprobe_functions(b"security_inode_create"):
+    b.attach_kprobe(event="security_inode_create", fn_name="trace_security_inode_create")
 b.attach_kprobe(event="vfs_unlink", fn_name="trace_unlink")
 
 # header


### PR DESCRIPTION
security_inode_create presents only if CONFIG_SECURITY is on. Do not attach to it unconditionally.