### PR TITLE
docker: Update pip and pre-installed packages.

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -29,4 +29,6 @@ RUN \
     pip install dnslib cachetools ; \
   fi ; \
   pip3 install dnslib cachetools  && \
+  pip3 install -U pip setuptools wheel && \
+  apt-get -y remove python3-pip python3-wheel python3-setuptools && \
   dpkg -i /root/bcc/*.deb


### PR DESCRIPTION
Hi.


In Inspektor Gadget, we create a docker image and use `iovisor/bcc` as the base layer.
Sadly, we were recently [pointed](https://github.com/kubernetes/minikube/pull/15869#pullrequestreview-1351202526) there was a flawed python package in our image.

I searched the root cause and realized the flawed package was `wheel` which comes with `python3-pip`.
So, in this commit, before finishing building the image, we update all the pre-installed python packages and remove `python3-pip` to use the one installed by `pip` itself.

If you see any ways to improve this contribution, feel free to share.


Best regards.