### PR TITLE
libbpf-tools: Drop libbpf_set_strict_mode() calls

### DIFF
--- a/libbpf-tools/bashreadline.c
+++ b/libbpf-tools/bashreadline.c
@@ -167,7 +167,6 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/bindsnoop.c
+++ b/libbpf-tools/bindsnoop.c
@@ -201,7 +201,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/biolatency.c
+++ b/libbpf-tools/biolatency.c
@@ -254,7 +254,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = biolatency_bpf__open();

--- a/libbpf-tools/biopattern.c
+++ b/libbpf-tools/biopattern.c
@@ -174,7 +174,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/biosnoop.c
+++ b/libbpf-tools/biosnoop.c
@@ -202,7 +202,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = biosnoop_bpf__open();

--- a/libbpf-tools/biostacks.c
+++ b/libbpf-tools/biostacks.c
@@ -145,7 +145,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = biostacks_bpf__open();

--- a/libbpf-tools/biotop.c
+++ b/libbpf-tools/biotop.c
@@ -369,7 +369,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = biotop_bpf__open();

--- a/libbpf-tools/bitesize.c
+++ b/libbpf-tools/bitesize.c
@@ -167,7 +167,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = bitesize_bpf__open();

--- a/libbpf-tools/cachestat.c
+++ b/libbpf-tools/cachestat.c
@@ -141,7 +141,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = cachestat_bpf__open();

--- a/libbpf-tools/capable.c
+++ b/libbpf-tools/capable.c
@@ -312,7 +312,6 @@ int main(int argc, char **argv)
 		}
 	}
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = capable_bpf__open();

--- a/libbpf-tools/cpudist.c
+++ b/libbpf-tools/cpudist.c
@@ -208,7 +208,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = cpudist_bpf__open();

--- a/libbpf-tools/cpufreq.c
+++ b/libbpf-tools/cpufreq.c
@@ -207,7 +207,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	nr_cpus = libbpf_num_possible_cpus();

--- a/libbpf-tools/drsnoop.c
+++ b/libbpf-tools/drsnoop.c
@@ -157,7 +157,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = drsnoop_bpf__open();

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -283,7 +283,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/exitsnoop.c
+++ b/libbpf-tools/exitsnoop.c
@@ -177,7 +177,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -121,7 +121,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/filetop.c
+++ b/libbpf-tools/filetop.c
@@ -270,7 +270,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/fsdist.c
+++ b/libbpf-tools/fsdist.c
@@ -366,7 +366,6 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/fsslower.c
+++ b/libbpf-tools/fsslower.c
@@ -371,7 +371,6 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/funclatency.c
+++ b/libbpf-tools/funclatency.c
@@ -309,7 +309,6 @@ int main(int argc, char **argv)
 
 	sigaction(SIGINT, &sigact, 0);
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/gethostlatency.c
+++ b/libbpf-tools/gethostlatency.c
@@ -234,7 +234,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/hardirqs.c
+++ b/libbpf-tools/hardirqs.c
@@ -196,7 +196,6 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = hardirqs_bpf__open();

--- a/libbpf-tools/javagc.c
+++ b/libbpf-tools/javagc.c
@@ -171,7 +171,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	skel = javagc_bpf__open();

--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -711,7 +711,6 @@ int main(int argc, char **argv)
 
 	sigaction(SIGINT, &sigact, 0);
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	ksyms = ksyms__load();

--- a/libbpf-tools/ksnoop.c
+++ b/libbpf-tools/ksnoop.c
@@ -1002,7 +1002,6 @@ int main(int argc, char *argv[])
 	if (argc < 0)
 		usage();
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	return cmd_select(argc, argv);

--- a/libbpf-tools/llcstat.c
+++ b/libbpf-tools/llcstat.c
@@ -158,7 +158,7 @@ static void print_map(struct bpf_map *map)
 			printf("%-8u ", tid);
 		}
 		printf("%-16s %-4u %12llu %12llu %6.2f%%\n",
-			info.comm, cpu, info.ref, info.miss, 
+			info.comm, cpu, info.ref, info.miss,
 			info.ref > 0 ? hit * 1.0 / info.ref * 100 : 0);
 		total_miss += info.miss;
 		total_ref += info.ref;
@@ -196,7 +196,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	nr_cpus = libbpf_num_possible_cpus();

--- a/libbpf-tools/mdflush.c
+++ b/libbpf-tools/mdflush.c
@@ -102,7 +102,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = mdflush_bpf__open();

--- a/libbpf-tools/mountsnoop.c
+++ b/libbpf-tools/mountsnoop.c
@@ -261,7 +261,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/numamove.c
+++ b/libbpf-tools/numamove.c
@@ -81,7 +81,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = numamove_bpf__open();

--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -305,7 +305,6 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = offcputime_bpf__open();

--- a/libbpf-tools/oomkill.c
+++ b/libbpf-tools/oomkill.c
@@ -121,7 +121,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -295,7 +295,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/readahead.c
+++ b/libbpf-tools/readahead.c
@@ -109,7 +109,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = readahead_bpf__open();

--- a/libbpf-tools/runqlat.c
+++ b/libbpf-tools/runqlat.c
@@ -204,7 +204,6 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = runqlat_bpf__open();

--- a/libbpf-tools/runqlen.c
+++ b/libbpf-tools/runqlen.c
@@ -238,7 +238,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	nr_cpus = libbpf_num_possible_cpus();

--- a/libbpf-tools/runqslower.c
+++ b/libbpf-tools/runqslower.c
@@ -153,7 +153,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = runqslower_bpf__open();

--- a/libbpf-tools/sigsnoop.c
+++ b/libbpf-tools/sigsnoop.c
@@ -195,7 +195,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = sigsnoop_bpf__open();

--- a/libbpf-tools/slabratetop.c
+++ b/libbpf-tools/slabratetop.c
@@ -253,7 +253,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = slabratetop_bpf__open();

--- a/libbpf-tools/softirqs.c
+++ b/libbpf-tools/softirqs.c
@@ -151,7 +151,7 @@ static int print_count(struct softirqs_bpf__bss *bss)
 	__u64 count, time;
 	__u32 vec;
 
-	printf("%-16s %-6s%-5s  %-11s\n", "SOFTIRQ", "TOTAL_", 
+	printf("%-16s %-6s%-5s  %-11s\n", "SOFTIRQ", "TOTAL_",
 			units, env.count?"TOTAL_count":"");
 
 	for (vec = 0; vec < NR_SOFTIRQS; vec++) {
@@ -209,7 +209,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = softirqs_bpf__open();

--- a/libbpf-tools/solisten.c
+++ b/libbpf-tools/solisten.c
@@ -148,7 +148,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/statsnoop.c
+++ b/libbpf-tools/statsnoop.c
@@ -138,7 +138,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/syscount.c
+++ b/libbpf-tools/syscount.c
@@ -403,7 +403,6 @@ int main(int argc, char **argv)
 		goto free_names;
 	}
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -397,7 +397,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/tcpconnlat.c
+++ b/libbpf-tools/tcpconnlat.c
@@ -169,7 +169,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = tcpconnlat_bpf__open();

--- a/libbpf-tools/tcplife.c
+++ b/libbpf-tools/tcplife.c
@@ -158,7 +158,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/tcprtt.c
+++ b/libbpf-tools/tcprtt.c
@@ -225,7 +225,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = tcprtt_bpf__open();

--- a/libbpf-tools/tcpstates.c
+++ b/libbpf-tools/tcpstates.c
@@ -203,7 +203,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/tcpsynbl.c
+++ b/libbpf-tools/tcpsynbl.c
@@ -188,7 +188,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/tcptop.c
+++ b/libbpf-tools/tcptop.c
@@ -345,7 +345,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	family = -1;

--- a/libbpf-tools/tcptracer.c
+++ b/libbpf-tools/tcptracer.c
@@ -266,7 +266,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	err = ensure_core_btf(&open_opts);

--- a/libbpf-tools/vfsstat.c
+++ b/libbpf-tools/vfsstat.c
@@ -152,7 +152,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 

--- a/libbpf-tools/wakeuptime.c
+++ b/libbpf-tools/wakeuptime.c
@@ -221,7 +221,6 @@ int main(int argc, char **argv)
 		fprintf(stderr, "use either -u or -p");
 	}
 
-	libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
 	libbpf_set_print(libbpf_print_fn);
 
 	obj = wakeuptime_bpf__open();
@@ -272,4 +271,3 @@ cleanup:
 	ksyms__free(ksyms);
 	return err != 0;
 }
-


### PR DESCRIPTION
As of libbpf 1.0, libbpf_set_strict_mode() is a no-op, drop it.