### PR TITLE
tools/cpudist: Bugfix incorrect cpu key when pid not equal to 0

### DIFF
--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -96,7 +96,7 @@ static inline void store_start(u32 tgid, u32 pid, u32 cpu, u64 ts)
     if (IDLE_FILTER)
         return;
 
-    entry_key_t entry_key = { .pid = pid, .cpu = cpu };
+    entry_key_t entry_key = { .pid = pid, .cpu = (pid == 0 ? cpu : 0xFFFFFFFF) };
     start.update(&entry_key, &ts);
 }
 
@@ -108,7 +108,7 @@ static inline void update_hist(u32 tgid, u32 pid, u32 cpu, u64 ts)
     if (IDLE_FILTER)
         return;
 
-    entry_key_t entry_key = { .pid = pid, .cpu = cpu };
+    entry_key_t entry_key = { .pid = pid, .cpu = (pid == 0 ? cpu : 0xFFFFFFFF) };
     u64 *tsp = start.lookup(&entry_key);
     if (tsp == 0)
         return;


### PR DESCRIPTION
When pid != 0, current cpu should not be used as a part of key, it may run on different CPUs, which causes start.lookup(key) returns NULL. Just pid can be unique key, here we use an invalid value (0xFFFFFFFF) to fill cpu field of struct entry_key_t.

When pid == 0, still use current cpu as key to distinguish different swappers.

@yonghong-song Please take a look, thanks.