### PR TITLE
Fix compilation error when built with llvm17

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -17,7 +17,9 @@
 
 #include <fcntl.h>
 #include <linux/bpf.h>
+#if LLVM_MAJOR_VERSION <= 16
 #include <llvm-c/Transforms/IPO.h>
+#endif
 #include <llvm/ExecutionEngine/MCJIT.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #if LLVM_MAJOR_VERSION >= 16
@@ -43,7 +45,9 @@
 #include <llvm/Object/SymbolSize.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Transforms/IPO.h>
+#if LLVM_MAJOR_VERSION <= 16
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#endif
 #include <net/if.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
With llvm17, building bcc hits the following compilation errors:
  ...
  /home/yhs/work/bcc/src/cc/bpf_module.cc:21:10: fatal error: llvm-c/Transforms/IPO.h: No such file or directory
   21 | #include <llvm-c/Transforms/IPO.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
  /home/yhs/work/bcc/src/cc/bpf_module.cc:48:10: fatal error: llvm/Transforms/IPO/PassManagerBuilder.h: No such file or directory
   48 | #include <llvm/Transforms/IPO/PassManagerBuilder.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

The above two files are removed by https://reviews.llvm.org/D144970 and https://reviews.llvm.org/D145835