### PR TITLE
tools/offcputime: Add option to show symbol offsets

### DIFF
--- a/tools/offcputime_example.txt
+++ b/tools/offcputime_example.txt
@@ -719,7 +719,7 @@ creating your "off-CPU time flame graphs".
 USAGE message:
 
 # ./offcputime.py -h
-usage: offcputime.py [-h] [-p PID | -t TID | -u | -k] [-U | -K] [-d] [-f]
+usage: offcputime.py [-h] [-p PID | -t TID | -u | -k] [-U | -K] [-d] [-f] [-s]
                      [--stack-storage-size STACK_STORAGE_SIZE]
                      [-m MIN_BLOCK_TIME] [-M MAX_BLOCK_TIME] [--state STATE]
                      [duration]
@@ -745,6 +745,7 @@ optional arguments:
                         stacks)
   -d, --delimited       insert delimiter between kernel/user stacks
   -f, --folded          output folded format
+  -s, --offset          show address offsets
   --stack-storage-size STACK_STORAGE_SIZE
                         the number of unique stack traces that can be stored
                         and displayed (default 1024)
@@ -761,6 +762,7 @@ examples:
     ./offcputime             # trace off-CPU stack time until Ctrl-C
     ./offcputime 5           # trace for 5 seconds only
     ./offcputime -f 5        # 5 seconds, and output in folded format
+    ./offcputime -s 5        # 5 seconds, and show symbol offsets
     ./offcputime -m 1000     # trace only events that last more than 1000 usec
     ./offcputime -M 10000    # trace only events that last less than 10000 usec
     ./offcputime -p 185      # only trace threads for PID 185


### PR DESCRIPTION
Usually, I want to view symbol & offset (now only symbol printed), for example:

```
  tcp_sendmsg+0x1
  sock_sendmsg+0x38
  sock_write_iter+0x85
  __vfs_write+0xe3
  vfs_write+0xb8
  SyS_write+0x55
  entry_SYSCALL_64_fastpath+0x1e
```

Like stackcount, add option -s to show symbol offset: https://github.com/iovisor/bcc/blob/master/tools/stackcount.py#L211 