### PR TITLE
libbpf-tools/memleak: don't kill process if attached

### DIFF
--- a/libbpf-tools/memleak.c
+++ b/libbpf-tools/memleak.c
@@ -405,7 +405,7 @@ int main(int argc, char *argv[])
 	}
 
 	// after loop ends, check for child process and cleanup accordingly
-	if (env.pid > 0) {
+	if (env.pid > 0 && strlen(env.command)) {
 		if (!child_exited) {
 			if (kill(env.pid, SIGTERM)) {
 				perror("failed to signal child process");


### PR DESCRIPTION
We should only kill traced process if it is a child process.