### PR TITLE
bcc_zip_archive_open should not loop indefinitely for bad archives

### DIFF
--- a/src/cc/bcc_zip.c
+++ b/src/cc/bcc_zip.c
@@ -202,9 +202,9 @@ static int find_central_directory(struct bcc_zip_archive* archive) {
   // Because the end of central directory ends with a variable length array of
   // up to 0xFFFF bytes we can't know exactly where it starts and need to
   // search for it at the end of the file, scanning the (limit, offset] range.
-  uint32_t offset =
-      archive->size - sizeof(struct end_of_central_directory_record);
-  int64_t limit = (int64_t)offset - (1 << 16);
+  int64_t offset =
+      (int64_t)archive->size - sizeof(struct end_of_central_directory_record);
+  int64_t limit = offset - (1 << 16);
   for (; offset >= 0 && offset > limit && rc == -1; offset--) {
     rc = try_parse_end_of_central_directory(archive, offset);
   }

--- a/tests/cc/test_zip.cc
+++ b/tests/cc/test_zip.cc
@@ -21,6 +21,7 @@
 
 #define LIB_ENTRY_NAME "libdebuginfo_test_lib.so"
 #define ENTRY_IN_SUBDIR_NAME "zip_subdir/file.txt"
+#define NOT_AN_ARCHIVE_PATH CMAKE_CURRENT_BINARY_DIR "/dummy_proc_map.txt"
 #define TEST_ARCHIVE_PATH CMAKE_CURRENT_BINARY_DIR "/archive.zip"
 
 namespace {
@@ -46,6 +47,11 @@ const void* get_uncompressed_data(const bcc_zip_entry& entry) {
 }
 
 }  // namespace
+
+TEST_CASE("returns error for non-zip files", "[zip]") {
+  bcc_zip_archive* archive = bcc_zip_archive_open(NOT_AN_ARCHIVE_PATH);
+  REQUIRE(archive == nullptr);
+}
 
 TEST_CASE("finds entries in a zip archive by name", "[zip]") {
   bcc_zip_archive* archive = bcc_zip_archive_open(TEST_ARCHIVE_PATH);


### PR DESCRIPTION
This pull request fixes infinite loop when trying to parse a short non-zip file as a zip archive.
If `limit` is negative then the loop never breaks as `offset` is unsigned.