### PR TITLE
libbpf-tools: Allow tools to run on old kernels

### DIFF
--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -75,6 +75,24 @@ int BPF_PROG(blk_account_io_start, struct request *rq)
 	return trace_pid(rq);
 }
 
+SEC("kprobe/blk_account_io_start")
+int BPF_KPROBE(kprobe_blk_account_io_start, struct request *rq)
+{
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
+	return trace_pid(rq);
+}
+
+SEC("kprobe/__blk_account_io_start")
+int BPF_KPROBE(kprobe___blk_account_io_start, struct request *rq)
+{
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return 0;
+
+	return trace_pid(rq);
+}
+
 SEC("kprobe/blk_account_io_merge_bio")
 int BPF_KPROBE(blk_account_io_merge_bio, struct request *rq)
 {

--- a/libbpf-tools/biostacks.bpf.c
+++ b/libbpf-tools/biostacks.bpf.c
@@ -67,20 +67,8 @@ int trace_start(void *ctx, struct request *rq, bool merge_bio)
 	return 0;
 }
 
-SEC("fentry/blk_account_io_start")
-int BPF_PROG(blk_account_io_start, struct request *rq)
-{
-	return trace_start(ctx, rq, false);
-}
-
-SEC("kprobe/blk_account_io_merge_bio")
-int BPF_KPROBE(blk_account_io_merge_bio, struct request *rq)
-{
-	return trace_start(ctx, rq, true);
-}
-
-SEC("fentry/blk_account_io_done")
-int BPF_PROG(blk_account_io_done, struct request *rq)
+static __always_inline
+int trace_done(void *ctx, struct request *rq)
 {
 	u64 slot, ts = bpf_ktime_get_ns();
 	struct internal_rqinfo *i_rqinfop;
@@ -108,6 +96,49 @@ int BPF_PROG(blk_account_io_done, struct request *rq)
 cleanup:
 	bpf_map_delete_elem(&rqinfos, &rq);
 	return 0;
+}
+
+
+SEC("fentry/blk_account_io_start")
+int BPF_PROG(blk_account_io_start, struct request *rq)
+{
+	return trace_start(ctx, rq, false);
+}
+
+SEC("fentry/blk_account_io_done")
+int BPF_PROG(blk_account_io_done, struct request *rq)
+{
+	return trace_done(ctx, rq);
+}
+
+SEC("kprobe/blk_account_io_start")
+int BPF_KPROBE(kprobe_blk_account_io_start, struct request *rq)
+{
+	return trace_start(ctx, rq, false);
+}
+
+SEC("kprobe/blk_account_io_done")
+int BPF_KPROBE(kprobe_blk_account_io_done, struct request *rq)
+{
+	return trace_done(ctx, rq);
+}
+
+SEC("kprobe/__blk_account_io_start")
+int BPF_KPROBE(kprobe___blk_account_io_start, struct request *rq)
+{
+	return trace_start(ctx, rq, false);
+}
+
+SEC("kprobe/__blk_account_io_done")
+int BPF_KPROBE(kprobe___blk_account_io_done, struct request *rq)
+{
+	return trace_done(ctx, rq);
+}
+
+SEC("kprobe/blk_account_io_merge_bio")
+int BPF_KPROBE(blk_account_io_merge_bio, struct request *rq)
+{
+	return trace_start(ctx, rq, true);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/readahead.c
+++ b/libbpf-tools/readahead.c
@@ -76,24 +76,6 @@ static void sig_handler(int sig)
 	exiting = true;
 }
 
-static int readahead__set_attach_target(struct bpf_program *prog)
-{
-	int err;
-
-	err = bpf_program__set_attach_target(prog, 0, "do_page_cache_ra");
-	if (!err)
-		return 0;
-
-	err = bpf_program__set_attach_target(prog, 0,
-					"__do_page_cache_readahead");
-	if (!err)
-		return 0;
-
-	fprintf(stderr, "failed to set attach target for %s: %s\n",
-		bpf_program__name(prog), strerror(-err));
-	return err;
-}
-
 int main(int argc, char **argv)
 {
 	static const struct argp argp = {
@@ -121,13 +103,45 @@ int main(int argc, char **argv)
 	 * Starting from v5.10-rc1 (8238287), __do_page_cache_readahead has
 	 * renamed to do_page_cache_ra. So we specify the function dynamically.
 	 */
-	err = readahead__set_attach_target(obj->progs.do_page_cache_ra);
-	if (err)
-		goto cleanup;
-	err = readahead__set_attach_target(obj->progs.do_page_cache_ra_ret);
-	if (err)
-		goto cleanup;
+	if (kprobe_exists("do_page_cache_ra")) {
+		if (fentry_can_attach("do_page_cache_ra", NULL)) {
+			bpf_program__set_attach_target(obj->progs.fentry_do_page_cache_ra, 0,
+						       "do_page_cache_ra");
+			bpf_program__set_attach_target(obj->progs.fexit_do_page_cache_ra, 0,
+						       "do_page_cache_ra");
+			bpf_program__set_autoload(obj->progs.kprobe_do_page_cache_ra, false);
+			bpf_program__set_autoload(obj->progs.kretprobe_do_page_cache_ra, false);
+		} else {
+			bpf_program__set_autoload(obj->progs.fentry_do_page_cache_ra, false);
+			bpf_program__set_autoload(obj->progs.fexit_do_page_cache_ra, false);
+		}
+		bpf_program__set_autoload(obj->progs.kprobe___do_page_cache_readahead, false);
+		bpf_program__set_autoload(obj->progs.kretprobe___do_page_cache_readahead, false);
+	} else {
+		if (fentry_can_attach("__do_page_cache_readahead", NULL)) {
+			bpf_program__set_attach_target(obj->progs.fentry_do_page_cache_ra, 0,
+						       "__do_page_cache_readahead");
+			bpf_program__set_attach_target(obj->progs.fexit_do_page_cache_ra, 0,
+						       "__do_page_cache_readahead");
+			bpf_program__set_autoload(obj->progs.kprobe___do_page_cache_readahead, false);
+			bpf_program__set_autoload(obj->progs.kretprobe___do_page_cache_readahead, false);
+		} else {
+			bpf_program__set_autoload(obj->progs.fentry_do_page_cache_ra, false);
+			bpf_program__set_autoload(obj->progs.fexit_do_page_cache_ra, false);
+		}
+		bpf_program__set_autoload(obj->progs.kprobe_do_page_cache_ra, false);
+		bpf_program__set_autoload(obj->progs.kretprobe_do_page_cache_ra, false);
+	}
 
+	if (fentry_can_attach("page_cache_alloc", NULL))
+		bpf_program__set_autoload(obj->progs.kretprobe_page_cache_alloc, false);
+	else
+		bpf_program__set_autoload(obj->progs.fexit_page_cache_alloc, false);
+
+	if (fentry_can_attach("mark_page_accessed", NULL))
+		bpf_program__set_autoload(obj->progs.kprobe_mark_page_accessed, false);
+	else
+		bpf_program__set_autoload(obj->progs.fentry_mark_page_accessed, false);
 	err = readahead_bpf__load(obj);
 	if (err) {
 		fprintf(stderr, "failed to load BPF object\n");


### PR DESCRIPTION
Add more tools to fallback to use kprobes if kernel lacks support for fentry/fexit,
discussion is on https://github.com/iovisor/bcc/issues/4231