### PR TITLE
libbpf-tools/memleak: remove unused arg "PERCPU"

### DIFF
--- a/libbpf-tools/memleak.c
+++ b/libbpf-tools/memleak.c
@@ -187,7 +187,7 @@ static const struct argp_option argp_options[] = {
 	{"min-size", 'z', "MIN_SIZE", 0, "capture only allocations larger than this size"},
 	{"max-size", 'Z', "MAX_SIZE", 0, "capture only allocations smaller than this size"},
 	{"obj", 'O', "OBJECT", 0, "attach to allocator functions in the specified object"},
-	{"percpu", 'P', "PERCPU", 0, "trace percpu allocations"},
+	{"percpu", 'P', NULL, 0, "trace percpu allocations"},
 	{},
 };
 

--- a/libbpf-tools/memleak.c
+++ b/libbpf-tools/memleak.c
@@ -150,7 +150,7 @@ const char *argp_program_bug_address =
 const char argp_args_doc[] =
 "Trace outstanding memory allocations\n"
 "\n"
-"USAGE: memleak [-h] [-c COMMAND] [-p PID] [-t] [-n] [-a] [-o AGE_MS] [-C] [-F] [-s SAMPLE_RATE] [-T TOP_STACKS] [-z MIN_SIZE] [-Z MAX_SIZE] [-O OBJECT] [-P PERCPU] [INTERVAL] [INTERVALS]\n"
+"USAGE: memleak [-h] [-c COMMAND] [-p PID] [-t] [-n] [-a] [-o AGE_MS] [-C] [-F] [-s SAMPLE_RATE] [-T TOP_STACKS] [-z MIN_SIZE] [-Z MAX_SIZE] [-O OBJECT] [-P] [INTERVAL] [INTERVALS]\n"
 "\n"
 "EXAMPLES:\n"
 "./memleak -p $(pidof allocs)\n"


### PR DESCRIPTION
'memleak -P' is used to trace percpu allocations, no argument is needed