### PR TITLE
tools/profile: Allow to increment hash storage size to aviod missing keys

### DIFF
--- a/tools/profile_example.txt
+++ b/tools/profile_example.txt
@@ -744,7 +744,7 @@ USAGE message:
 
 # ./profile -h
 usage: profile.py [-h] [-p PID | -L TID] [-U | -K] [-F FREQUENCY | -c COUNT]
-                  [-d] [-a] [-I] [-f]
+                  [-d] [-a] [-I] [-f] [--hash-storage-size HASH_STORAGE_SIZE]
                   [--stack-storage-size STACK_STORAGE_SIZE] [-C CPU]
                   [--cgroupmap CGROUPMAP] [--mntnsmap MNTNSMAP]
                   [duration]
@@ -756,8 +756,10 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -p PID, --pid PID     profile process with this PID only
-  -L TID, --tid TID     profile thread with this TID only
+  -p PID, --pid PID     profile process with one or more comma separated PIDs
+                        only
+  -L TID, --tid TID     profile thread with one or more comma separated TIDs
+                        only
   -U, --user-stacks-only
                         show stacks from user space only (no kernel space
                         stacks)
@@ -773,6 +775,9 @@ optional arguments:
   -I, --include-idle    include CPU idle stacks
   -f, --folded          output folded format, one line per stack (for flame
                         graphs)
+  --hash-storage-size HASH_STORAGE_SIZE
+                        the number of hash keys that can be stored and
+                        (default 40960)
   --stack-storage-size STACK_STORAGE_SIZE
                         the number of unique stack traces that can be stored
                         and displayed (default 16384)


### PR DESCRIPTION
`BPF_HASH(counts, struct key_t);` uses default hash storage size 10240, usually not enough to cover heavy workloads in a production environment (many cores and many running threads) for 5 seconds only, hash table becomes full and misses some keys. 

This patch try to improve the situation:
1. Add an warn if hash table is full and remind users to increase hash storage size
2. Add option `--hash-storage-size` to increase hash storage size
3. Use default value 40960 instread of 10240 (10240 often not enough, 40960 covers more cases) 

@yonghong-song @chenhengqi Please take a look, thanks.