### PR TITLE
Filter with available_filter_functions in BPF.get_kprobe_functions()

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -698,6 +698,15 @@ class BPF(object):
                 raise e
             blacklist = set([])
 
+        avail_filter_file = "%s/tracing/available_filter_functions" % DEBUGFS
+        try:
+            with open(avail_filter_file, "rb") as avail_filter_f:
+                avail_filter = set([line.rstrip().split()[0] for line in avail_filter_f])
+        except IOError as e:
+            if e.errno != errno.EPERM:
+                raise e
+            avail_filter = set([])
+
         fns = []
 
         in_init_section = 0
@@ -749,7 +758,8 @@ class BPF(object):
                 elif re.match(b'^.*\.cold(\.\d+)?$', fn):
                     continue
                 if (t.lower() in [b't', b'w']) and re.fullmatch(event_re, fn) \
-                    and fn not in blacklist:
+                    and fn not in blacklist \
+                    and fn in avail_filter:
                     fns.append(fn)
         return set(fns)     # Some functions may appear more than once
 


### PR DESCRIPTION
To fix tools/funccount 'Failed to attach BPF program' error.

bcc commit e16b628bed37("Add more hints for error kprobe") added hint for failed probes, but did not resolve the issue. If the function is untraceable, use /sys/kernel/debug/tracing/available_filter_functions filter it out.

For example:

In the 6.2.9 kernel, vfsuid_gt_kuid() is the inline function, at which point funccount attach vfsuid_gt_kuid() fails, causing the program to fail.

````
    $ sudo ./funccount.py -r 'vfs.*'
    cannot attach kprobe, Invalid argument
    Failed to attach BPF program b'trace_count_1' to kprobe b'vfsuid_eq_kuid'
````

These functions all have the same situation:

````
    vfsuid_gt_kuid, vfsgid_eq_kgid, vfsgid_gt_kgid
    vfsuid_lt_kuid, vfsuid_eq_kuid, vfsgid_lt_kgid
````

Use available_filter_functions to filter out untraceable probes:

````
    $ sudo ./funccount.py -r '^vfs.*'
    Tracing 74 functions for "b'^vfs.*'"... Hit Ctrl-C to end.
    ^C
    FUNC                                    COUNT
    vfs_fsync_range                             2
    vfs_writev                                  3
    vfs_statfs.part.0.isra.0                    3
    vfs_readv                                   3
    vfs_getxattr                                6
    vfs_write                                 101
    vfs_open                                  144
    vfs_statx                                 166
    vfs_fstatat                               166
    vfs_getattr_nosec                         166
    vfs_read                                  406
````

At first, I wanted to artificially skip untraceable probes by using --skip, @chenghengqi suggested using available_filter_functions filtering [0].

[0] https://github.com/iovisor/bcc/pull/4564