### PR TITLE
kvmexitaarch64: introduce a tool to show kvm exit reason and count, d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[killsnoop](tools/killsnoop.py): Trace signals issued by the kill() syscall. [Examples](tools/killsnoop_example.txt).
 - tools/[klockstat](tools/klockstat.py): Traces kernel mutex lock events and display locks statistics. [Examples](tools/klockstat_example.txt).
 - tools/[kvmexit](tools/kvmexit.py): Display the exit_reason and its statistics of each vm exit. [Examples](tools/kvmexit_example.txt).
+- tools/[kvmexitaarch64](tools/kvmexitaarch64.py): Display the kvm exit reason and count, duration of kvm exiting for all vcpus on aarch64. [Examples](tools/kvmexitaarch64_example.txt).
 - tools/[llcstat](tools/llcstat.py): Summarize CPU cache references and misses by process. [Examples](tools/llcstat_example.txt).
 - tools/[mdflush](tools/mdflush.py): Trace md flush events. [Examples](tools/mdflush_example.txt).
 - tools/[memleak](tools/memleak.py): Display outstanding memory allocations to find memory leaks. [Examples](tools/memleak_example.txt).

--- a/man/man8/kvmexitaarch64.8
+++ b/man/man8/kvmexitaarch64.8
@@ -1,0 +1,75 @@
+.TH kvmexitaarch64 8  "2023-04-14" "USER COMMANDS"
+.SH NAME
+kvmexitaarch64 \- Display the kvm exit reason and count, duration of kvm exiting for all vcpus on aarch64.
+.SH SYNOPSIS
+.B kvmexitaarch64 [\-h] [duration]
+.SH DESCRIPTION
+In the performance optimization of virtualization, the frequency of the
+KVM EXIT event often needs to be tracked. In addition, the time interval from
+the KVM EXIT event to the Guest mode(kvm entry) is more important.
+These can help us find the bottleneck of performance. So KVMexitaarch64 is here.
+
+The tool uses a BPF_HASH: to save the timestamp of KVM EXIT and ENTRY, Reason, 
+the accumulated Exit duration, maximum value, minimum value, thread TID and names.
+
+Limitation: In view of the hardware-assisted virtualization technology of
+different architectures, currently we only adapt on aarch64.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+
+This also requires Linux 4.7+ (BPF_PROG_TYPE_TRACEPOINT support).
+.SH OPTIONS
+.TP
+\-h
+Print usage message.
+.TP
+duration
+Duration of display, after sleeping several seconds.
+.SH EXAMPLES
+.TP
+Display kvm exit reasons and statistics for all threads... Hit Ctrl-C to end:
+#
+.B kvmexitaarch64
+.TP
+Display kvm exit reasons and statistics for all threads after sleeping 5 secs:
+#
+.B kvmexitaarch64 5
+.SH FIELDS 
+.TP 
+TID
+The user space's thread of each vcpu of that virtual machine.
+.TP
+TID 
+Thread group id, means qmeu's pid in user space.
+.TP 
+COMM
+The name of vcpu thread.
+.TP
+KVM_EXIT_REASON
+The reason why the vm exits on aarch64.
+.TP
+COUNT
+The counts of the @KVM_EXIT_REASONS.
+.TP
+AVG_TIME
+The average of all time interval from kvm_exit to the next kvm_entry. unit:ns
+
+.SH OVERHEAD
+This traces the "kvm_exit" and "kvm_entry" kernel function, records the exit reason 
+and time interval from the KVM EXIT event to the Guest mode(kvm entry), max value, 
+min value. In the end, given the statistics.
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+LongJun Tang <tanglongjun@kylinos.cn>

--- a/tools/kvmexitaarch64.py
+++ b/tools/kvmexitaarch64.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python3
+#
+# kvmexitaarch64.py
+#
+# Display the exit_reason and its statistics of each vm exit
+# for all vcpus of all virtual machines on aarch64. For example:
+# $./kvmexit.py 5
+# TGID     TID      COMM             KVM_EXIT_REASON  COUNT    AVG_TIME    
+# 24919    24938    b'CPU 1/KVM'     EC_WFx           143      34780751.4 
+# 24919    24938    b'CPU 1/KVM'     EC_SYS64         8        8545.0     
+# 24919    24938    b'CPU 1/KVM'     EC_DABT_LOW      2        10650.0    
+# 24919    24937    b'CPU 0/KVM'     EC_WFx           21       192253853.0
+# 24919    24937    b'CPU 0/KVM'     EC_SYS64         3        6173.3     
+#  ...
+#
+# @TID: the user space's thread of each vcpu of that virtual machine.
+# @TGID: thread group id, means qmeu's pid in user space.
+# @COMM: the name of vcpu thread.
+# @KVM_EXIT_REASON: the reason why the vm exits on aarch64.
+# @COUNT: the counts of the @KVM_EXIT_REASONS.
+# @AVG_TIME: the average of all time interval from kvm_exit to the next kvm_entry. unit:ns
+#
+# REQUIRES: Linux 4.7+ (BPF_PROG_TYPE_TRACEPOINT support)
+#
+# Copyright (c) 2023 kylinos Inc. All rights reserved.
+#
+# Author(s):
+#   Longjun Tang <tanglongjun@kylinos.cn>
+
+
+from time import sleep
+from ctypes import *
+import argparse
+import subprocess
+import os
+from bpfcc import BPF
+
+
+# arguments
+examples = """examples:
+    ./kvmexitaarch64.py                              # Display kvm_exit_reason and its statistics in real-time until Ctrl-C
+    ./kvmexitaarch64.py 5                            # Display in real-time after sleeping 5s
+"""
+
+parser = argparse.ArgumentParser(
+    description="Display kvm_exit_reason and its statistics at a timed interval on aarch64",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("duration", nargs="?", default=99999999, type=int, help="show delta for next several seconds")
+args = parser.parse_args()
+duration = int(args.duration)
+
+# Do some checks
+try:
+    # Currently, only adapte on aarch64 architecture
+    cmd = "uname -m"
+    arch_info = subprocess.check_output(cmd, shell=True).strip()
+    if b"aarch64" in arch_info:
+        pass
+    else:
+        raise Exception("Currently we only support aarch64 architecture, please do expansion if needs more.")
+
+    # Check if kvm module is loaded
+    if os.access("/dev/kvm", os.R_OK | os.W_OK):
+        pass
+    else:
+        raise Exception("Please insmod kvm module to use kvmexitaarch64 tool.")
+except Exception as e:
+    raise Exception("Failed to do precondition check, due to: %s." % e)
+
+
+# define BPF program
+prog = """
+#include <uapi/linux/ptrace.h>
+#include <linux/sched.h>
+
+// define kvm_exit structure in C
+typedef struct kvm_exit{
+    u64 exit_count;
+    u64 exit_ts;    //timestamp of kvm_exit
+    u64 entry_ts;   //timestamp of kvm_entry after kvm_exit for the same vcpu thread.
+    u64 sum_hd;
+    u64 max_hd;
+    u64 min_hd;
+}kvm_exit_t;
+
+#define MAX_ESR_EC 64
+struct kvm_exit_stat_t{
+    u64 tgid_pid;
+    char comm[TASK_COMM_LEN];
+    u32 last_exit_rs;
+    kvm_exit_t kvm_exit[MAX_ESR_EC];
+};
+
+BPF_HASH(kvm_exit_stat, u64, struct kvm_exit_stat_t);
+BPF_ARRAY(init_value, struct kvm_exit_stat_t, 1);
+
+TRACEPOINT_PROBE(kvm, kvm_entry)
+{
+    kvm_exit_t *tmp_kvm_exit = NULL;
+    u64 time_hd = 0;
+    u64 cur_tgid_pid = bpf_get_current_pid_tgid();
+    struct kvm_exit_stat_t *tmp_kvm_exit_stat = NULL;
+
+    // it will return if vcpu thread never occur kvm entry 
+    tmp_kvm_exit_stat = kvm_exit_stat.lookup(&cur_tgid_pid);
+    if (tmp_kvm_exit_stat == NULL) {
+        return 0;
+    }
+
+    if (tmp_kvm_exit_stat->last_exit_rs >= MAX_ESR_EC) {
+        return 0;
+    }
+    tmp_kvm_exit = &tmp_kvm_exit_stat->kvm_exit[tmp_kvm_exit_stat->last_exit_rs];
+
+    tmp_kvm_exit->entry_ts = bpf_ktime_get_ns();
+
+    // time_hd is time interval from kvm_exit to next kvm entry
+    time_hd = tmp_kvm_exit->entry_ts - tmp_kvm_exit->exit_ts;
+    tmp_kvm_exit->sum_hd += time_hd;
+
+    // for maximum of all time_hd
+    if (tmp_kvm_exit->max_hd == 0) {
+        tmp_kvm_exit->max_hd = time_hd;
+    } else {
+        if (time_hd > tmp_kvm_exit->max_hd) {
+            tmp_kvm_exit->max_hd = time_hd;
+        }
+    }
+
+    // for minimum of all time_hd
+    if (tmp_kvm_exit->min_hd == 0) {
+        tmp_kvm_exit->min_hd = time_hd;
+    } else {
+        if (time_hd < tmp_kvm_exit->min_hd) {
+            tmp_kvm_exit->min_hd = time_hd;
+        }
+    }
+ 
+    return 0;
+}
+
+TRACEPOINT_PROBE(kvm, kvm_exit)
+{
+    int zero = 0;
+    u32 esr_ec = args->esr_ec;
+    u64 cur_tgid_pid = bpf_get_current_pid_tgid();
+    struct kvm_exit_stat_t *tmp_kvm_exit_stat = NULL, *init = NULL;
+
+    if (esr_ec >= MAX_ESR_EC) {
+        return 0;
+    }
+
+    tmp_kvm_exit_stat = kvm_exit_stat.lookup(&cur_tgid_pid);
+    // kvm_exit_stat hash initialized when vcpu thread first time occur kvm exit
+    if (tmp_kvm_exit_stat == NULL) {
+        init = init_value.lookup(&zero);
+        if (init == NULL) {
+            return 0;
+        }
+        kvm_exit_stat.update(&cur_tgid_pid, init);
+        tmp_kvm_exit_stat = kvm_exit_stat.lookup(&cur_tgid_pid);
+        if (tmp_kvm_exit_stat == NULL) {
+            return 0;
+        }
+        tmp_kvm_exit_stat->tgid_pid = cur_tgid_pid;
+        bpf_get_current_comm(&tmp_kvm_exit_stat->comm[0], sizeof(tmp_kvm_exit_stat->comm));
+    }
+
+    // record exit reason and count
+    tmp_kvm_exit_stat->last_exit_rs = esr_ec;
+    tmp_kvm_exit_stat->kvm_exit[esr_ec].exit_count += 1;
+    tmp_kvm_exit_stat->kvm_exit[esr_ec].exit_ts = bpf_ktime_get_ns();
+
+    return 0;
+}
+"""
+
+
+"""
+From linux kernel version 4.19
+static exit_handle_fn arm_exit_handlers[] = {
+	[0 ... ESR_ELx_EC_MAX]	= kvm_handle_unknown_ec,
+	[ESR_ELx_EC_WFx]	= kvm_handle_wfx,
+	[ESR_ELx_EC_CP15_32]	= kvm_handle_cp15_32,
+	[ESR_ELx_EC_CP15_64]	= kvm_handle_cp15_64,
+	[ESR_ELx_EC_CP14_MR]	= kvm_handle_cp14_32,
+	[ESR_ELx_EC_CP14_LS]	= kvm_handle_cp14_load_store,
+	[ESR_ELx_EC_CP14_64]	= kvm_handle_cp14_64,
+	[ESR_ELx_EC_HVC32]	= handle_hvc,
+	[ESR_ELx_EC_SMC32]	= handle_smc,
+	[ESR_ELx_EC_HVC64]	= handle_hvc,
+	[ESR_ELx_EC_SMC64]	= handle_smc,
+	[ESR_ELx_EC_SYS64]	= kvm_handle_sys_reg,
+	[ESR_ELx_EC_SVE]	= handle_sve,
+	[ESR_ELx_EC_IABT_LOW]	= kvm_handle_guest_abort,
+	[ESR_ELx_EC_DABT_LOW]	= kvm_handle_guest_abort,
+	[ESR_ELx_EC_SOFTSTP_LOW]= kvm_handle_guest_debug,
+	[ESR_ELx_EC_WATCHPT_LOW]= kvm_handle_guest_debug,
+	[ESR_ELx_EC_BREAKPT_LOW]= kvm_handle_guest_debug,
+	[ESR_ELx_EC_BKPT32]	= kvm_handle_guest_debug,
+	[ESR_ELx_EC_BRK64]	= kvm_handle_guest_debug,
+	[ESR_ELx_EC_FP_ASIMD]	= handle_no_fpsimd,
+};
+"""
+aarch64_exit_reasons = (
+    "UNKNOWN_EC",
+    "EC_WFx",
+    "N/A",
+    "EC_CP15_32",
+    "EC_CP15_64",
+    "EC_CP14_MR",
+    "EC_CP14_LS",
+    "EC_FP_ASIMD",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "EC_CP14_64",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "EC_HVC32",
+    "EC_SMC32",
+    "N/A",
+    "N/A",
+    "EC_HVC64",
+    "EC_SMC64",
+    "EC_SYS64",
+    "EC_SVE",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "EC_IABT_LOW",
+    "N/A",
+    "N/A",
+    "N/A",
+    "EC_DABT_LOW",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "EC_BREAKPT_LOW",
+    "N/A",
+    "EC_SOFTSTP_LOW",
+    "N/A",
+    "EC_WATCHPT_LOW",
+    "N/A",
+    "N/A",
+    "N/A",
+    "EC_BKPT32",
+    "N/A",
+    "N/A",
+    "N/A",
+    "EC_BRK64",
+    "N/A",
+    "N/A",
+    "N/A"
+)
+
+# load BPF program
+b = BPF(text=prog)
+
+try:
+    sleep(duration)
+except KeyboardInterrupt:
+    pass
+
+# header
+print("\n%-8s %-8s %-16s %-16s %-8s %-12s" % ("TGID", "TID", "COMM", "KVM_EXIT_REASON", "COUNT", "AVG_TIME"))
+
+kvm_exit_stat = b["kvm_exit_stat"]
+for k, v in kvm_exit_stat.items():
+    tgid = k.value >> 32
+    pid = k.value & 0xffffffff
+    for i in range(0, len(aarch64_exit_reasons)):
+        if (v.kvm_exit[i].exit_count == 0):
+            continue
+        print("%-8u %-8u %-16s %-16s %-8u %-11.1f" % (tgid, pid, v.comm, aarch64_exit_reasons[i], \
+            v.kvm_exit[i].exit_count, v.kvm_exit[i].sum_hd/v.kvm_exit[i].exit_count))

--- a/tools/kvmexitaarch64_example.txt
+++ b/tools/kvmexitaarch64_example.txt
@@ -1,0 +1,62 @@
+Demonstrations of kvmexitaarch64, the Linux eBPF/bcc version.
+
+
+In the performance optimization of virtualization, the frequency of the 
+KVM EXIT event often needs to be tracked. In addition, the time interval from 
+the KVM EXIT event to the Guest mode(kvm entry) is more important. 
+These can help us find the bottleneck of performance. So KVMexitaarch64 is here.
+
+
+For example:
+
+# ./kvmexitaarch64.py
+^C
+TGID     TID      COMM             KVM_EXIT_REASON  COUNT    AVG_TIME    
+24877    24901    b'CPU 3/KVM'     EC_WFx           7        503369309.4
+24877    24900    b'CPU 2/KVM'     UNKNOWN_EC       4        1020.0     
+24877    24900    b'CPU 2/KVM'     EC_WFx           25       156462294.0
+24877    24900    b'CPU 2/KVM'     EC_DABT_LOW      2        11320.0    
+24919    24938    b'CPU 1/KVM'     EC_WFx           93       41886282.7 
+24919    24938    b'CPU 1/KVM'     EC_SYS64         11       7105.5     
+24919    24938    b'CPU 1/KVM'     EC_DABT_LOW      2        11370.0    
+24877    24899    b'CPU 1/KVM'     UNKNOWN_EC       3        1500.0   
+
+
+# ./kvmexitaarch64.py 5
+
+TGID     TID      COMM             KVM_EXIT_REASON  COUNT    AVG_TIME    
+24919    24939    b'CPU 2/KVM'     UNKNOWN_EC       1        720.0      
+24919    24939    b'CPU 2/KVM'     EC_WFx           71       70343825.8 
+24919    24939    b'CPU 2/KVM'     EC_SYS64         1        5560.0     
+24877    24901    b'CPU 3/KVM'     EC_WFx           15       320333855.1
+24877    24901    b'CPU 3/KVM'     EC_DABT_LOW      1        11640.0    
+24919    24940    b'CPU 3/KVM'     UNKNOWN_EC       1        2260.0     
+
+@TID: the user space's thread of each vcpu of that virtual machine.
+@TGID: thread group id, means qmeu's pid in user space.
+@COMM: the name of vcpu thread.
+@KVM_EXIT_REASON: the reason why the vm exits on aarch64.
+@COUNT: the counts of the @KVM_EXIT_REASONS.
+@AVG_TIME: the average of all time interval from kvm_exit to the next kvm_entry. unit:ns
+
+
+Limited:
+In view of the hardware-assisted virtualization technology of
+different architectures, currently we only adapt on aarch64.
+
+
+USAGE message:
+
+kvmexitaarch64.py [-h] [duration]
+
+Display kvm_exit_reason and its statistics at a timed interval on aarch64
+
+positional arguments:
+  duration    show delta for next several seconds
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+examples:
+    ./kvmexitaarch64.py                              # Display kvm_exit_reason and its statistics in real-time until Ctrl-C
+    ./kvmexitaarch64.py 5                            # Display in real-time after sleeping 5s


### PR DESCRIPTION
…uration of kvm exiting

In the performance optimization of virtualization, the frequency of the KVM EXIT event often needs to be tracked. In addition, the time interval from the KVM EXIT event to the guest mode(kvm entry) is more important.These can help us find the bottleneck of performance. So KVMexitaarch64 is here.

The tool uses a BPF_HASH:to save the timestamp of KVM EXIT and ENTRY, Reason, the accumulated Exit duration, maximum value, minimum value, thread TID and names.