### PR TITLE
libbpf-tools: add tcppktlat

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -53,6 +53,7 @@
 /tcpconnect
 /tcpconnlat
 /tcplife
+/tcppktlat
 /tcptracer
 /tcprtt
 /tcpstates

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -81,6 +81,7 @@ APPS = \
 	tcpconnect \
 	tcpconnlat \
 	tcplife \
+	tcppktlat \
 	tcprtt \
 	tcpstates \
 	tcpsynbl \

--- a/libbpf-tools/tcppktlat.bpf.c
+++ b/libbpf-tools/tcppktlat.bpf.c
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2023 Wenbo Zhang
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#include "compat.bpf.h"
+#include "tcppktlat.h"
+
+#define MAX_ENTRIES	10240
+#define AF_INET		2
+
+const volatile pid_t targ_pid = 0;
+const volatile pid_t targ_tid = 0;
+const volatile __u16 targ_sport = 0;
+const volatile __u16 targ_dport = 0;
+const volatile __u64 targ_min_us = 0;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, u64);
+	__type(value, u64);
+} start SEC(".maps");
+
+static int handle_tcp_probe(struct sock *sk, struct sk_buff *skb)
+{
+	const struct inet_sock *inet = (struct inet_sock *)(sk);
+	u64 sock_cookie, ts, len, doff;
+	const struct tcphdr *th;
+
+	if (targ_sport && targ_sport != BPF_CORE_READ(inet, inet_sport))
+		return 0;
+	if (targ_dport && targ_dport != BPF_CORE_READ(sk, __sk_common.skc_dport))
+		return 0;
+	th = (const struct tcphdr*)BPF_CORE_READ(skb, data);
+	doff = BPF_CORE_READ_BITFIELD_PROBED(th, doff);
+	len = BPF_CORE_READ(skb, len);
+	/* `doff * 4` means `__tcp_hdrlen` */
+	if (len <= doff * 4)
+		return 0;
+	sock_cookie = bpf_get_socket_cookie(sk);
+	ts = bpf_ktime_get_ns();
+	bpf_map_update_elem(&start, &sock_cookie, &ts, 0);
+	return 0;
+}
+
+static int handle_tcp_rcv_space_adjust(void *ctx, struct sock *sk)
+{
+	const struct inet_sock *inet = (struct inet_sock *)(sk);
+	u64 sock_cookie = bpf_get_socket_cookie(sk);
+	u64 id = bpf_get_current_pid_tgid(), *tsp;
+	u32 pid = id >> 32, tid = id;
+	struct event *eventp;
+	s64 delta_us;
+	u16 family;
+
+	tsp = bpf_map_lookup_elem(&start, &sock_cookie);
+	if (!tsp)
+		return 0;
+
+	if (targ_pid && targ_pid != pid)
+		goto cleanup;
+	if (targ_tid && targ_tid != tid)
+		goto cleanup;
+
+	delta_us = (bpf_ktime_get_ns() - *tsp) / 1000;
+	if (delta_us < 0 || delta_us <= targ_min_us)
+		goto cleanup;
+
+	eventp = reserve_buf(sizeof(*eventp));
+	if (!eventp)
+		goto cleanup;
+
+	eventp->pid = pid;
+	eventp->tid = tid;
+	eventp->delta_us = delta_us;
+	eventp->sport = BPF_CORE_READ(inet, inet_sport);
+	eventp->dport = BPF_CORE_READ(sk, __sk_common.skc_dport);
+	bpf_get_current_comm(&eventp->comm, TASK_COMM_LEN);
+	family = BPF_CORE_READ(sk, __sk_common.skc_family);
+	if (family == AF_INET) {
+		eventp->saddr[0] = BPF_CORE_READ(sk, __sk_common.skc_rcv_saddr);
+		eventp->daddr[0] = BPF_CORE_READ(sk, __sk_common.skc_daddr);
+	} else { /* family == AF_INET6 */
+		BPF_CORE_READ_INTO(eventp->saddr, sk, __sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+		BPF_CORE_READ_INTO(eventp->daddr, sk, __sk_common.skc_v6_daddr.in6_u.u6_addr32);
+	}
+	eventp->family = family;
+	submit_buf(ctx, eventp, sizeof(*eventp));
+
+cleanup:
+	bpf_map_delete_elem(&start, &sock_cookie);
+	return 0;
+}
+
+SEC("tp_btf/tcp_probe")
+int BPF_PROG(tcp_probe_btf, struct sock *sk, struct sk_buff *skb)
+{
+	return handle_tcp_probe(sk, skb);
+}
+
+SEC("tp_btf/tcp_rcv_space_adjust")
+int BPF_PROG(tcp_rcv_space_adjust_btf, struct sock *sk)
+{
+	return handle_tcp_rcv_space_adjust(ctx, sk);
+}
+
+SEC("raw_tp/tcp_probe")
+int BPF_PROG(tcp_probe, struct sock *sk, struct sk_buff *skb) {
+	return handle_tcp_probe(sk, skb);
+}
+
+SEC("raw_tp/tcp_rcv_space_adjust")
+int BPF_PROG(tcp_rcv_space_adjust, struct sock *sk)
+{
+	return handle_tcp_rcv_space_adjust(ctx, sk);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/tcppktlat.c
+++ b/libbpf-tools/tcppktlat.c
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2023 Wenbo Zhang
+#include <argp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <time.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/resource.h>
+
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+#include "tcppktlat.h"
+#include "tcppktlat.skel.h"
+#include "compat.h"
+#include "trace_helpers.h"
+
+static struct env {
+	pid_t pid;
+	pid_t tid;
+	__u64 min_us;
+	__u16 lport;
+	__u16 rport;
+	bool timestamp;
+	bool verbose;
+} env = {};
+
+static volatile sig_atomic_t exiting = 0;
+static int column_width = 15;
+
+const char *argp_program_version = "tcppktlat 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] =
+"Trace latency between TCP received pkt and picked up by userspace thread.\n"
+"\n"
+"USAGE: tcppktlat [--help] [-T] [-p PID] [-t TID] [-l LPORT] [-r RPORT] [-w] [-v]\n"
+"\n"
+"EXAMPLES:\n"
+"    tcppktlat             # Trace all TCP packet picked up latency\n"
+"    tcppktlat -T          # summarize with timestamps\n"
+"    tcppktlat -p          # filter for pid\n"
+"    tcppktlat -t          # filter for tid\n"
+"    tcppktlat -l          # filter for local port\n"
+"    tcppktlat -r          # filter for remote port\n"
+"    tcppktlat 1000        # filter for latency higher than 1000us";
+
+static const struct argp_option opts[] = {
+	{ "pid", 'p', "PID", 0, "Process PID to trace"},
+	{ "tid", 't', "TID", 0, "Thread TID to trace"},
+	{ "timestamp", 'T', NULL, 0, "include timestamp on output" },
+	{ "lport", 'l', "LPORT", 0, "filter for local port" },
+	{ "rport", 'r', "RPORT", 0, "filter for remote port" },
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ "wide", 'w', NULL, 0, "Wide column output (fits IPv6 addresses)" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	static int pos_args;
+	long long min_us;
+	int pid;
+
+	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'T':
+		env.timestamp = true;
+		break;
+	case 'p':
+		errno = 0;
+		pid = strtol(arg, NULL, 10);
+		if (errno || pid <= 0) {
+			fprintf(stderr, "Invalid PID: %s\n", arg);
+			argp_usage(state);
+		}
+		env.pid = pid;
+		break;
+	case 't':
+		errno = 0;
+		pid = strtol(arg, NULL, 10);
+		if (errno || pid <= 0) {
+			fprintf(stderr, "Invalid TID: %s\n", arg);
+			argp_usage(state);
+		}
+		env.tid = pid;
+		break;
+	case 'l':
+		errno = 0;
+		env.lport = strtoul(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "invalid lport: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 'r':
+		errno = 0;
+		env.rport = strtoul(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "invalid rport: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 'w':
+		column_width = 26;
+		break;
+	case ARGP_KEY_ARG:
+		if (pos_args++) {
+			fprintf(stderr,
+				"Unrecognized positional argument: %s\n", arg);
+			argp_usage(state);
+		}
+		errno = 0;
+		min_us = strtoll(arg, NULL, 10);
+		if (errno || min_us <= 0) {
+			fprintf(stderr, "Invalid delay (in us): %s\n", arg);
+			argp_usage(state);
+		}
+		env.min_us = min_us;
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+static int handle_event(void *ctx, void *data, size_t data_sz)
+{
+	const struct event *e = data;
+	char saddr[48], daddr[48];
+	struct tm *tm;
+	char ts[32];
+	time_t t;
+
+	if (env.timestamp) {
+		time(&t);
+		tm = localtime(&t);
+		strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+		printf("%-8s ", ts);
+	}
+	inet_ntop(e->family, &e->saddr, saddr, sizeof(saddr));
+	inet_ntop(e->family, &e->daddr, daddr, sizeof(daddr));
+
+	printf("%-7d %-7d %-16s %-*s %-5d %-*s %-5d %-.2f\n",
+		e->pid, e->tid, e->comm, column_width, saddr, e->sport, column_width, daddr,
+		e->dport, e->delta_us / 1000.0);
+
+	return 0;
+}
+
+static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct bpf_buffer *buf = NULL;
+	struct tcppktlat_bpf *obj;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	obj = tcppktlat_bpf__open();
+	if (!obj) {
+		fprintf(stderr, "failed to open BPF object\n");
+		return 1;
+	}
+
+	obj->rodata->targ_pid = env.pid;
+	obj->rodata->targ_tid = env.tid;
+	obj->rodata->targ_sport = env.lport;
+	obj->rodata->targ_dport = env.rport;
+	obj->rodata->targ_min_us = env.min_us;
+
+	buf = bpf_buffer__new(obj->maps.events, obj->maps.heap);
+	if (!buf) {
+		err = -errno;
+		fprintf(stderr, "failed to create ring/perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	if (probe_tp_btf("tcp_probe")) {
+		bpf_program__set_autoload(obj->progs.tcp_probe, false);
+		bpf_program__set_autoload(obj->progs.tcp_rcv_space_adjust, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.tcp_probe_btf, false);
+		bpf_program__set_autoload(obj->progs.tcp_rcv_space_adjust_btf, false);
+	}
+
+	err = tcppktlat_bpf__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF object: %d, maybe your kernel doesn't support `bpf_get_socket_cookie`\n", err);
+		goto cleanup;
+	}
+
+	err = tcppktlat_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF object: %d\n", err);
+		goto cleanup;
+	}
+
+	err = bpf_buffer__open(buf, handle_event, handle_lost_events, NULL);
+	if (err) {
+		fprintf(stderr, "failed to open ring/perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		fprintf(stderr, "can't set signal handler: %s\n", strerror(errno));
+		err = 1;
+		goto cleanup;
+	}
+
+	if (env.timestamp)
+		printf("%-8s ", "TIME(s)");
+	printf("%-7s %-7s %-16s %-*s %-5s %-*s %-5s %-s\n",
+		"PID", "TID", "COMM", column_width, "LADDR", "LPORT", column_width, "RADDR", "RPORT", "MS");
+
+	while (!exiting) {
+		err = bpf_buffer__poll(buf, POLL_TIMEOUT_MS);
+		if (err < 0 && err != -EINTR) {
+			fprintf(stderr, "error polling ring/perf buffer: %s\n", strerror(-err));
+			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
+	}
+cleanup:
+	bpf_buffer__free(buf);
+	tcppktlat_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/libbpf-tools/tcppktlat.h
+++ b/libbpf-tools/tcppktlat.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __TCPPKGLAT_H
+#define __TCPPKGLAT_H
+
+#define TASK_COMM_LEN	16
+
+struct event {
+	__u32 saddr[4];
+	__u32 daddr[4];
+        __u64 delta_us;
+	pid_t pid;
+	pid_t tid;
+	__u16 dport;
+	__u16 sport;
+	__u16 family;
+	char comm[TASK_COMM_LEN];
+};
+
+#endif /* __TCPPKGLAT_H_ */

--- a/libbpf-tools/tcppktlat_example.txt
+++ b/libbpf-tools/tcppktlat_example.txt
@@ -1,0 +1,70 @@
+Demonstrations of tcppktlat, the Linux BPF CO-RE version.
+
+tcppktlat traces latency between TCP received pkt and picked up by userspace thread system-wide, and prints various details.
+Example output:
+
+# tcppktlat
+PID     COMM             LADDR           LPORT RADDR           RPORT MS
+4424    etcd             127.0.0.1       2379  127.0.0.1       53202 0.06
+4405    kube-apiserver   127.0.0.1       53202 127.0.0.1       2379  0.06
+1370211 wakatime-cli     172.22.130.115  59394 143.244.210.202 443   2.75
+3894    kubelet          172.18.0.3      51584 172.18.0.4      6443  0.08
+^C
+
+In the process of tracing, when a network soft interrupt reads a TCP packet, it is placed into the corresponding socket's receive queue, and then copied from kernel space to user space by a user-level thread. The latency between receiving the packet and it being retrieved can be used to determine if there are any performance issues in the user-level path for handling received TCP packet.
+
+The -l option can be used to filter on a local port, which is filtered in-kernel.
+
+# tcppktlat -l 7000
+PID     COMM             LADDR           LPORT RADDR           RPORT MS
+1354840 server           127.0.0.1       7000  127.0.0.1       43932 0.05
+1354840 server           127.0.0.1       7000  127.0.0.1       43932 4.88
+1354840 server           127.0.0.1       7000  127.0.0.1       43932 6.02
+^C
+
+The output shows server experiences jitter and higher latency in reading data, requiring troubleshooting.
+
+
+We can use minimum latency(us) as a filtering condition.
+
+# tcppktlat 1000
+PID     COMM             LADDR           LPORT RADDR           RPORT MS
+1354840 server           127.0.0.1       7000  127.0.0.1       35924 130.21
+1370211 wakatime-cli     172.22.130.115  59394 143.244.210.202 443   2.75
+4405    kube-apiserver   ::              6443  ::              55726 1.61
+1370227 wakatime-cli     172.22.130.115  50642 143.244.210.202 443   2.80
+4405    kube-apiserver   127.0.0.1       53178 127.0.0.1       2379  1.57
+1370281 wakatime-cli     172.22.130.115  40908 143.244.210.202 443   3.31
+1370315 sshd             127.0.0.1       22    127.0.0.1       42070 6.41
+^C
+
+
+# tcppktlat --help
+Usage: tcppktlat [OPTION...]
+Trace latency between TCP received pkt and picked up by userspace thread.
+
+USAGE: tcppktlat [--help] [-T] [-p PID] [-t TID] [-l LPORT] [-r RPORT] [-v]
+
+EXAMPLES:
+    tcppktlat             # Trace all TCP packet picked up latency
+    tcppktlat -T          # summarize with timestamps
+    tcppktlat -p          # filter for pid
+    tcppktlat -t          # filter for tid
+    tcppktlat -l          # filter for local port
+    tcppktlat -r          # filter for remote port
+    tcppktlat 1000        # filter for latency higher than 1000us
+
+  -l, --lport=LPORT          filter for local port
+  -p, --pid=PID              Process PID to trace
+  -r, --rport=RPORT          filter for remote port
+  -t, --tid=TID              Thread TID to trace
+  -T, --timestamp            include timestamp on output
+  -v, --verbose              Verbose debug output
+  -?, --help                 Give this help list
+      --usage                Give a short usage message
+  -V, --version              Print program version
+
+Mandatory or optional arguments to long options are also mandatory or optional
+for any corresponding short options.
+
+Report bugs to https://github.com/iovisor/bcc/tree/master/libbpf-tools.


### PR DESCRIPTION
Add a new tool to trace latency between TCP received pkt and picked up by userspace thread. It is extremely useful in scenarios where we observe an increase in TCP end-to-end latency and cannot determine the source.

Signed-off-by: Wenbo Zhang [ethercflow@gmail.com](mailto:ethercflow@gmail.com)