### PR TITLE
libbpf-tools/memleak: support ksyms and syms_cache

### DIFF
--- a/libbpf-tools/memleak.bpf.c
+++ b/libbpf-tools/memleak.bpf.c
@@ -337,7 +337,7 @@ int memleak__kfree(void *ctx)
 		ptr = BPF_CORE_READ(args, ptr);
 	}
 
-	return gen_free_enter((void *)ptr);
+	return gen_free_enter(ptr);
 }
 
 SEC("tracepoint/kmem/kmem_cache_alloc")
@@ -375,7 +375,7 @@ int memleak__kmem_cache_free(void *ctx)
 		ptr = BPF_CORE_READ(args, ptr);
 	}
 
-	return gen_free_enter((void *)ptr);
+	return gen_free_enter(ptr);
 }
 
 SEC("tracepoint/kmem/mm_page_alloc")


### PR DESCRIPTION
This commit allows the use of 'ksyms' for kernel symbols and 'syms_cache' for userspace application symbols when 'blazesym' is not supported.