### PR TITLE
libbpf-tools/funclatency: Clear histgram record after interval output

### DIFF
--- a/libbpf-tools/funclatency.c
+++ b/libbpf-tools/funclatency.c
@@ -371,6 +371,9 @@ int main(int argc, char **argv)
 		}
 
 		print_log2_hist(obj->bss->hist, MAX_SLOTS, unit_str());
+
+		/* Cleanup histograms for interval output */
+		memset(obj->bss->hist, 0, sizeof(obj->bss->hist));
 	}
 
 	printf("Exiting trace of %s\n", env.funcname);


### PR DESCRIPTION
Current libbpf version funclatency does't cleanup histgram record after interval output, this causes the count of each interval output include all counts from funclatency launched. This behavior doesn't match to original bcc version funclatency.

https://github.com/iovisor/bcc/blob/70e879960428f5726067db93f7c742c8b39d4886/tools/funclatency.py#L408

This commit cleanup histgram record every time while output log2 hist.

Verified on x86-64 (5.15.60) and arm64 (5.10.70)