### PR TITLE
tools: Update default stack storage size to reduce frequent warnings

### DIFF
--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -13,6 +13,7 @@
 #
 # 13-Jan-2016	Brendan Gregg	Created this.
 # 27-Mar-2023	Rocky Xing      Added option to show symbol offsets.
+# 04-Apr-2023   Rocky Xing      Updated default stack storage size.
 
 from __future__ import print_function
 from bcc import BPF
@@ -85,10 +86,10 @@ parser.add_argument("-f", "--folded", action="store_true",
     help="output folded format")
 parser.add_argument("-s", "--offset", action="store_true",
     help="show address offsets")
-parser.add_argument("--stack-storage-size", default=1024,
+parser.add_argument("--stack-storage-size", default=16384,
     type=positive_nonzero_int,
     help="the number of unique stack traces that can be stored and "
-         "displayed (default 1024)")
+         "displayed (default 16384)")
 parser.add_argument("duration", nargs="?", default=99999999,
     type=positive_nonzero_int,
     help="duration of trace, in seconds")

--- a/tools/offcputime_example.txt
+++ b/tools/offcputime_example.txt
@@ -748,7 +748,7 @@ optional arguments:
   -s, --offset          show address offsets
   --stack-storage-size STACK_STORAGE_SIZE
                         the number of unique stack traces that can be stored
-                        and displayed (default 1024)
+                        and displayed (default 16384)
   -m MIN_BLOCK_TIME, --min-block-time MIN_BLOCK_TIME
                         the amount of time in microseconds over which we store
                         traces (default 1)

--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -9,6 +9,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
 # 20-Jan-2016   Brendan Gregg   Created this.
+# 04-Apr-2023   Rocky Xing      Updated default stack storage size.
 
 from __future__ import print_function
 from bcc import BPF
@@ -100,10 +101,10 @@ parser.add_argument("-d", "--delimited", action="store_true",
     help="insert delimiter between kernel/user stacks")
 parser.add_argument("-f", "--folded", action="store_true",
     help="output folded format")
-parser.add_argument("--stack-storage-size", default=1024,
+parser.add_argument("--stack-storage-size", default=16384,
     type=positive_nonzero_int,
     help="the number of unique stack traces that can be stored and "
-         "displayed (default 1024)")
+         "displayed (default 16384)")
 parser.add_argument("duration", nargs="?", default=99999999,
     type=positive_nonzero_int,
     help="duration of trace, in seconds")

--- a/tools/offwaketime_example.txt
+++ b/tools/offwaketime_example.txt
@@ -335,7 +335,7 @@ optional arguments:
   -f, --folded          output folded format
   --stack-storage-size STACK_STORAGE_SIZE
                         the number of unique stack traces that can be stored
-                        and displayed (default 1024)
+                        and displayed (default 16384)
   -m MIN_BLOCK_TIME, --min-block-time MIN_BLOCK_TIME
                         the amount of time in microseconds over which we store
                         traces (default 1)

--- a/tools/wakeuptime.py
+++ b/tools/wakeuptime.py
@@ -10,6 +10,7 @@
 #
 # 14-Jan-2016	Brendan Gregg	Created this.
 # 03-Apr-2023	Rocky Xing   	Modified the order of stack output.
+# 04-Apr-2023   Rocky Xing      Updated default stack storage size.
 
 from __future__ import print_function
 from bcc import BPF
@@ -58,10 +59,10 @@ parser.add_argument("-v", "--verbose", action="store_true",
     help="show raw addresses")
 parser.add_argument("-f", "--folded", action="store_true",
     help="output folded format")
-parser.add_argument("--stack-storage-size", default=1024,
+parser.add_argument("--stack-storage-size", default=16384,
     type=positive_nonzero_int,
     help="the number of unique stack traces that can be stored and "
-         "displayed (default 1024)")
+         "displayed (default 16384)")
 parser.add_argument("duration", nargs="?", default=99999999,
     type=positive_nonzero_int,
     help="duration of trace, in seconds")

--- a/tools/wakeuptime_example.txt
+++ b/tools/wakeuptime_example.txt
@@ -466,7 +466,7 @@ optional arguments:
   -f, --folded          output folded format
   --stack-storage-size STACK_STORAGE_SIZE
                         the number of unique stack traces that can be stored
-                        and displayed (default 1024)
+                        and displayed (default 16384)
   -m MIN_BLOCK_TIME, --min-block-time MIN_BLOCK_TIME
                         the amount of time in microseconds over which we store
                         traces (default 1)


### PR DESCRIPTION
Nowadays, default stack storage size (1024) often not enough for tools `offwaketime/offcputime/wakeuptime`, even on a not busy production machine, `Consider increasing --stack-storage-size` is a bit annoying. As tools `klockstat/profile`,  this patch try to increment default stack storage size to 16384. 