### PR TITLE
tcpconnlat: Remove entries from map in all cases

### DIFF
--- a/libbpf-tools/tcpconnlat.bpf.c
+++ b/libbpf-tools/tcpconnlat.bpf.c
@@ -110,6 +110,15 @@ int BPF_KPROBE(tcp_rcv_state_process, struct sock *sk)
 	return handle_tcp_rcv_state_process(ctx, sk);
 }
 
+SEC("tracepoint/tcp/tcp_destroy_sock")
+int tcp_destroy_sock(struct trace_event_raw_tcp_event_sk *ctx)
+{
+	const struct sock *sk = ctx->skaddr;
+
+	bpf_map_delete_elem(&start, &sk);
+	return 0;
+}
+
 SEC("fentry/tcp_v4_connect")
 int BPF_PROG(fentry_tcp_v4_connect, struct sock *sk)
 {


### PR DESCRIPTION
If there is not any reply to the connection, the sock entry in the start map is never removed, this commit adds a new probe on tcp{4,6}_sock_destroy to remove the socket from the map in all cases.

## How to test:
### Before

```bash
$ sudo ./tcpconnlat 
```

In another terminal:

```bash
$ curl 1.1.2.2 # any IP that wont' reply back
```

```bash
$ sudo bpftool map dump name start
[{
        "key": 0xffff9a6ee67c3480,
        "value": {
            "comm": "curl",
            "ts": 19400263786185,
            "tgid": 259405,
            "pid": 259405,
            "mntns_id": 4026535510
        }
    }
]
```

If the second step is repeated, more and more entries are accumulated on the map. 

### After

Repeat the same steps, now the map doesn't have accumulated entries:

```bash
$ sudo bpftool map dump name start
[]
```

