### PR TITLE
tcprtt: Consolidate kprobe and fentry implementations

### DIFF
--- a/libbpf-tools/tcprtt.bpf.c
+++ b/libbpf-tools/tcprtt.bpf.c
@@ -29,8 +29,7 @@ struct {
 
 static struct hist zero;
 
-SEC("fentry/tcp_rcv_established")
-int BPF_PROG(tcp_rcv, struct sock *sk)
+static int handle_tcp_rcv_established(struct sock *sk)
 {
 	const struct inet_sock *inet = (struct inet_sock *)(sk);
 	struct tcp_sock *ts;
@@ -40,17 +39,17 @@ int BPF_PROG(tcp_rcv, struct sock *sk)
 
 	if (targ_sport && targ_sport != BPF_CORE_READ(inet, inet_sport))
 		return 0;
-	if (targ_dport && targ_dport != sk->__sk_common.skc_dport)
+	if (targ_dport && targ_dport != BPF_CORE_READ(sk, __sk_common.skc_dport))
 		return 0;
 	if (targ_saddr && targ_saddr != BPF_CORE_READ(inet, inet_saddr))
 		return 0;
-	if (targ_daddr && targ_daddr != sk->__sk_common.skc_daddr)
+	if (targ_daddr && targ_daddr != BPF_CORE_READ(sk, __sk_common.skc_daddr))
 		return 0;
 
 	if (targ_laddr_hist)
-		key = inet->inet_saddr;
+		key = BPF_CORE_READ(inet, inet_saddr);
 	else if (targ_raddr_hist)
-		key = inet->sk.__sk_common.skc_daddr;
+		key = BPF_CORE_READ(inet, sk.__sk_common.skc_daddr);
 	else
 		key = 0;
 	histp = bpf_map_lookup_or_try_init(&hists, &key, &zero);
@@ -71,57 +70,16 @@ int BPF_PROG(tcp_rcv, struct sock *sk)
 	return 0;
 }
 
+SEC("fentry/tcp_rcv_established")
+int BPF_PROG(tcp_rcv, struct sock *sk)
+{
+	return handle_tcp_rcv_established(sk);
+}
+
 SEC("kprobe/tcp_rcv_established")
 int BPF_KPROBE(tcp_rcv_kprobe, struct sock *sk)
 {
-	const struct inet_sock *inet = (struct inet_sock *)(sk);
-	u32 srtt, saddr, daddr;
-	struct tcp_sock *ts;
-	struct hist *histp;
-	u64 key, slot;
-
-	if (targ_sport) {
-		u16 sport;
-		bpf_probe_read_kernel(&sport, sizeof(sport), &inet->inet_sport);
-		if (targ_sport != sport)
-			return 0;
-	}
-	if (targ_dport) {
-		u16 dport;
-		bpf_probe_read_kernel(&dport, sizeof(dport), &sk->__sk_common.skc_dport);
-		if (targ_dport != dport)
-			return 0;
-	}
-	bpf_probe_read_kernel(&saddr, sizeof(saddr), &inet->inet_saddr);
-	if (targ_saddr && targ_saddr != saddr)
-		return 0;
-	bpf_probe_read_kernel(&daddr, sizeof(daddr), &sk->__sk_common.skc_daddr);
-	if (targ_daddr && targ_daddr != daddr)
-		return 0;
-
-	if (targ_laddr_hist)
-		key = saddr;
-	else if (targ_raddr_hist)
-		key = daddr;
-	else
-		key = 0;
-	histp = bpf_map_lookup_or_try_init(&hists, &key, &zero);
-	if (!histp)
-		return 0;
-	ts = (struct tcp_sock *)(sk);
-	bpf_probe_read_kernel(&srtt, sizeof(srtt), &ts->srtt_us);
-	srtt >>= 3;
-	if (targ_ms)
-		srtt /= 1000U;
-	slot = log2l(srtt);
-	if (slot >= MAX_SLOTS)
-		slot = MAX_SLOTS - 1;
-	__sync_fetch_and_add(&histp->slots[slot], 1);
-	if (targ_show_ext) {
-		__sync_fetch_and_add(&histp->latency, srtt);
-		__sync_fetch_and_add(&histp->cnt, 1);
-	}
-	return 0;
+	return handle_tcp_rcv_established(sk);
 }
 
 char LICENSE[] SEC("license") = "Dual BSD/GPL";


### PR DESCRIPTION
Both implementations are identical, then they can be consolidated into a single function that is reused by both programs.