### PR TITLE
docs: Update build-from-source ubuntu deps to include zip and tools

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -368,6 +368,7 @@ To build the toolchain from source, one needs:
 * Clang, built from the same tree as LLVM
 * cmake (>=3.1), gcc (>=4.7), flex, bison
 * LuaJIT, if you want Lua support
+* Optional tools used in some examples: arping, netperf, and iperf
 
 ### Install build dependencies
 ```
@@ -380,24 +381,29 @@ wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
 
 # For Bionic (18.04 LTS)
-sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
-  libllvm6.0 llvm-6.0-dev libclang-6.0-dev python zlib1g-dev libelf-dev libfl-dev python3-setuptools
+sudo apt-get -y install zip bison build-essential cmake flex git libedit-dev \
+  libllvm6.0 llvm-6.0-dev libclang-6.0-dev python zlib1g-dev libelf-dev libfl-dev python3-setuptools \
+  liblzma-dev arping netperf iperf
 
 # For Focal (20.04.1 LTS)
-sudo apt install -y bison build-essential cmake flex git libedit-dev \
-  libllvm12 llvm-12-dev libclang-12-dev python zlib1g-dev libelf-dev libfl-dev python3-setuptools
+sudo apt install -y zip bison build-essential cmake flex git libedit-dev \
+  libllvm12 llvm-12-dev libclang-12-dev python zlib1g-dev libelf-dev libfl-dev python3-setuptools \
+  liblzma-dev arping netperf iperf
 
 # For Hirsute (21.04) or Impish (21.10)
-sudo apt install -y bison build-essential cmake flex git libedit-dev \
-libllvm11 llvm-11-dev libclang-11-dev python3 zlib1g-dev libelf-dev libfl-dev python3-setuptools
+sudo apt install -y zip bison build-essential cmake flex git libedit-dev \
+  libllvm11 llvm-11-dev libclang-11-dev python3 zlib1g-dev libelf-dev libfl-dev python3-setuptools \
+  liblzma-dev arping netperf iperf
 
 # For Jammy (22.04)
-sudo apt install -y bison build-essential cmake flex git libedit-dev \
-libllvm14 llvm-14-dev libclang-14-dev python3 zlib1g-dev libelf-dev libfl-dev python3-setuptools
+sudo apt install -y zip bison build-essential cmake flex git libedit-dev \
+  libllvm14 llvm-14-dev libclang-14-dev python3 zlib1g-dev libelf-dev libfl-dev python3-setuptools \
+  liblzma-dev libdebuginfod-dev arping netperf iperf
 
 # For other versions
-sudo apt-get -y install bison build-essential cmake flex git libedit-dev \
-  libllvm3.7 llvm-3.7-dev libclang-3.7-dev python zlib1g-dev libelf-dev python3-setuptools
+sudo apt-get -y install zip bison build-essential cmake flex git libedit-dev \
+  libllvm3.7 llvm-3.7-dev libclang-3.7-dev python zlib1g-dev libelf-dev python3-setuptools \
+  liblzma-dev arping netperf iperf
 
 # For Lua support
 sudo apt-get -y install luajit luajit-5.1-dev


### PR DESCRIPTION
The build-from-source instructions for ubuntu do not include `zip`, which is required for the build to complete and not automatically present on ubuntu (at least, 22.04 docker image).

As well, there are some additional libraries and tools that we should include so that users get a fully-featured build automatically.  Note that they are optional in case advanced users want to proceed without them.

Fixes #4598 