### PR TITLE
runqlen/cpuunclaimed: Fix runnable_weight issue after Linux 5.7

### DIFF
--- a/tools/runqlen.py
+++ b/tools/runqlen.py
@@ -90,7 +90,7 @@ unsigned long dummy(struct sched_entity *entity)
 
     # Get a temporary file name
     tmp_file = NamedTemporaryFile(delete=False)
-    tmp_file.close();
+    tmp_file.close()
 
     # Duplicate and close stderr (fd = 2)
     old_stderr = dup(2)
@@ -122,9 +122,12 @@ bpf_text = """
 
 // Declare enough of cfs_rq to find nr_running, since we can't #import the
 // header. This will need maintenance. It is from kernel/sched/sched.h:
+// The runnable_weight field is removed from Linux 5.7.0
 struct cfs_rq_partial {
     struct load_weight load;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 7, 0)
     RUNNABLE_WEIGHT_FIELD
+#endif
     unsigned int nr_running, h_nr_running;
 };
 
@@ -172,7 +175,10 @@ else:
         'BPF_HISTOGRAM(dist, unsigned int);')
     bpf_text = bpf_text.replace('STORE', 'dist.atomic_increment(len);')
 
-if check_runnable_weight_field():
+# If target has BTF enabled, use BTF to check runnable_weight field exists in
+# cfs_rq first, otherwise fallback to use check_runnable_weight_field().
+if BPF.kernel_struct_has_field(b'cfs_rq', b'runnable_weight') == 1 \
+        or check_runnable_weight_field():
     bpf_text = bpf_text.replace('RUNNABLE_WEIGHT_FIELD', 'unsigned long runnable_weight;')
 else:
     bpf_text = bpf_text.replace('RUNNABLE_WEIGHT_FIELD', '')


### PR DESCRIPTION
runqlen / cpuunclaimed add check_runnable_weight_field() as workaround to check runnable_weight presents in struct cfs_rq in kernel/sched/sched.h by trying to access runnable_weight field of struct
sched_entity in include/linux/sched.h. Please check more details in PR #1510 and #2164.

Unfortunately, the runnable_weight field of struct cfs_rq is removed, but the runnable_weight field of struct sched_entity is remained by following patchset series from Linux version 5.7.0.

- https://yhbt.net/lore/all/20200214152729.6059-4-vincent.guittot@linaro.org/
- https://yhbt.net/lore/all/20200214152729.6059-5-vincent.guittot@linaro.org/

Please also check the source of Linux below.

- include/linux/sched.h - https://elixir.bootlin.com/linux/v5.7/source/include/linux/sched.h#L475
- kernel/sched/sched.h - https://elixir.bootlin.com/linux/v5.7/source/kernel/sched/sched.h#L502

This PR checks runnable_weight field exists by using kernel_struct_has_field() if target system with BTF enabled, otherwise fallback to legacy on-the-fly compiling check. In the meantime, add Linux version 5.7.0 check in structure definition cfs_rq_partial to prevent issue if target system w/o BTF enabled and Linux version > 5.7.

Please check more details in https://github.com/iovisor/bcc/issues/4602.

Verified with following target:
- 5.15.60, w/ BTF, x86-64, Arch Linux
- 5.10.145, w/o BTF, arm64, Android
- 5.4.70, w/o BTF, arm64, WebOS
- 4.14.209, w/o BTF, arm32, Android