### PR TITLE
Python bindings: Fix maximum allowed index for `print_linear_hist`

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -651,7 +651,7 @@ class TableBase(MutableMapping):
             raise StopIteration()
         return next_key
 
-    def decode_c_struct(self, tmp, buckets, bucket_fn, bucket_sort_fn):
+    def decode_c_struct(self, tmp, buckets, bucket_fn, bucket_sort_fn, index_max=log2_index_max):
         f1 = self.Key._fields_[0][0]
         f2 = self.Key._fields_[1][0]
         # The above code assumes that self.Key._fields_[1][0] holds the
@@ -665,7 +665,7 @@ class TableBase(MutableMapping):
             bucket = getattr(k, f1)
             if bucket_fn:
                 bucket = bucket_fn(bucket)
-            vals = tmp[bucket] = tmp.get(bucket, [0] * log2_index_max)
+            vals = tmp[bucket] = tmp.get(bucket, [0] * index_max)
             slot = getattr(k, f2)
             vals[slot] = v.value
         buckets_lst = list(tmp.keys())
@@ -775,7 +775,7 @@ class TableBase(MutableMapping):
         if isinstance(self.Key(), ct.Structure):
             tmp = {}
             buckets = []
-            self.decode_c_struct(tmp, buckets, bucket_fn, bucket_sort_fn)
+            self.decode_c_struct(tmp, buckets, bucket_fn, bucket_sort_fn, linear_index_max)
 
             for bucket in buckets:
                 vals = tmp[bucket]


### PR DESCRIPTION
This PR fixes #4613.
The maximum index allowed by `print_linear_hist` is linear_index_max (1025). It obeys this rule when the type of `Key` is not `ct.Structure`. However, when `Key` is `ct.Structure`, it decodes hashtable using `decode_c_struct`. And `decode_c_struct` only supports up to 65 indexes.
So add a param `index_max` for `decode_c_struct` will fix the issue.