### PR TITLE
libbpf-tools/opensnoop: Display mode.

### DIFF
--- a/libbpf-tools/opensnoop.h
+++ b/libbpf-tools/opensnoop.h
@@ -9,6 +9,7 @@
 struct args_t {
 	const char *fname;
 	int flags;
+	__u16 mode;
 };
 
 struct event {
@@ -21,6 +22,7 @@ struct event {
 	__u64 callers[2];
 	char comm[TASK_COMM_LEN];
 	char fname[NAME_MAX];
+	__u16 mode;
 };
 
 #endif /* __OPENSNOOP_H */


### PR DESCRIPTION
Hi.


In this contribution, I added the displyaing of file permission mode to `opensnoop` when extended information are requested:

```
$ sudo ./opensnoop -e
PID    COMM              FD ERR FLAGS    MODE PATH
125035 touch              3   0 02000000 000 /etc/ld.so.cache
125035 touch              3   0 02000000 000 /lib/x86_64-linux-gnu/libc.so.6
125035 touch              3   0 02000000 000 /usr/lib/locale/locale-archive
125035 touch              3   0 00004501 666 /tmp/quux
4274   zsh                3   0 00001501 666 /tmp/corge
125072 zsh                3   0 00001501 666 /dev/null
125106 cat                3   0 02000000 000 /etc/ld.so.cache
125106 cat                3   0 02000000 000 /lib/x86_64-linux-gnu/libc.so.6
125106 cat                3   0 02000000 000 /usr/lib/locale/locale-archive
125106 cat                3   0 00000000 000 /tmp/corge
```

Note that, this information is meaningful only when `open*()` is used to create a file, otherwise its value is 0.

Best regards and thank you in advance.