### PR TITLE
Hash table batch operation attribute error

### DIFF
--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -609,7 +609,13 @@ class TableBase(MutableMapping):
                 break
 
         for i in range(0, total):
-            yield (ct_keys[i], ct_values[i])
+            k = ct_keys[i]
+            v = ct_values[i]
+            if not isinstance(k, ct.Structure):
+                k = self.Key(k)
+            if not isinstance(v, ct.Structure):
+                v = self.Leaf(v)
+            yield (k, v)
 
     def zero(self):
         # Even though this is not very efficient, we grab the entire list of

--- a/tests/python/test_map_batch_ops.py
+++ b/tests/python/test_map_batch_ops.py
@@ -31,9 +31,9 @@ class TestMapBatch(TestCase):
             count = self.SUBSET_SIZE
         keys = (hmap.Key * count)()
         i = 0
-        for k, _ in sorted(hmap.items_lookup_batch()):
+        for k, _ in sorted(hmap.items_lookup_batch(), key=lambda k:k[0].value):
             if i < count:
-                keys[i] = k
+                keys[i] = k.value
                 i += 1
             else:
                 break
@@ -45,9 +45,9 @@ class TestMapBatch(TestCase):
             count = self.SUBSET_SIZE
         values = (hmap.Leaf * count)()
         i = 0
-        for _, v in sorted(hmap.items_lookup_batch()):
+        for _, v in sorted(hmap.items_lookup_batch(), key=lambda k:k[0].value):
             if i < count:
-                values[i] = v*v
+                values[i] = v.value * v.value
                 i += 1
             else:
                 break
@@ -55,9 +55,9 @@ class TestMapBatch(TestCase):
 
     def check_hashmap_values(self, it):
         i = 0
-        for k, v in sorted(it):
-            self.assertEqual(k, i)
-            self.assertEqual(v, i)
+        for k, v in sorted(it, key=lambda kv:kv[0].value):
+            self.assertEqual(k.value, i)
+            self.assertEqual(v.value, i)
             i += 1
         return i
 
@@ -129,12 +129,15 @@ class TestMapBatch(TestCase):
         # the first self.SUBSET_SIZE keys follow this rule value = keys * keys
         # the remaning keys follow this rule : value = keys
         i = 0
-        for k, v in sorted(hmap.items_lookup_batch()):
+        for k, v in sorted(hmap.items_lookup_batch(),
+                           key=lambda kv:kv[0].value):
             if i < self.SUBSET_SIZE:
-                self.assertEqual(v, k*k)  # values are the square of the keys
+                # values are the square of the keys
+                self.assertEqual(v.value, k.value * k.value)
                 i += 1
             else:
-                self.assertEqual(v, k)  # values = keys
+                # values = keys
+                self.assertEqual(v.value, k.value)
 
         self.assertEqual(i, self.SUBSET_SIZE)
 


### PR DESCRIPTION
Some tools get errors when kernel supports hash table batch operations and hash key or value is integer type.
`AttributeError: 'long' object has no attribute 'value'`

It's caused by ctypes library from python. For example, when hash tables try to do batch lookup, it will alloc arrays to stores keys and values first. If it is a ctypes integer type, after expanding to array, type of element will be changed to python 'long' or 'int'. When trying to access its value attribute, error message is generated.
```
  >>> from ctypes import *
  >>> a = c_uint(10)
  >>> type(a)
  <class 'ctypes.c_uint'>
  >>> a.value
  10
  >>> b = (c_uint * 1)(10)
  >>> type(b)
  <class '__main__.c_uint_Array_1'>
  >>> type(b[0])
  <class 'int'>
  >>> b[0].value
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
  AttributeError: 'int' object has no attribute 'value'
```
Use syscount to reproduce if kernel supports hash table batch operations:
```
--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -232,22 +232,30 @@ def agg_colval(key):
     else:
         return syscall_name(key.value)
 
+# check whether hash table batch ops is supported
+htab_batch_ops = True if BPF.kernel_struct_has_field(b'bpf_map_ops',
+        b'map_lookup_and_delete_batch') == 1 else False
+
 def print_count_stats():
     data = bpf["data"]
     print("[%s]" % strftime("%H:%M:%S"))
     print("%-22s %8s" % (agg_colname, "COUNT"))
-    for k, v in sorted(data.items(), key=lambda kv: -kv[1].value)[:args.top]:
+    for k, v in sorted(data.items_lookup_and_delete_batch()
+                       if htab_batch_ops else data.items(),
+                       key=lambda kv: -kv[1].value)[:args.top]:
         if k.value == 0xFFFFFFFF:
             continue    # happens occasionally, we don't need it
         printb(b"%-22s %8d" % (agg_colval(k), v.value))
     print("")
-    data.clear()
+    if not htab_batch_ops:
+        data.clear()
 
 def print_latency_stats():
     data = bpf["data"]
     print("[%s]" % strftime("%H:%M:%S"))
     print("%-22s %8s %16s" % (agg_colname, "COUNT", time_colname))
-    for k, v in sorted(data.items(),
+    for k, v in sorted(data.items_lookup_and_delete_batch()
+                       if htab_batch_ops else data.items(),
                        key=lambda kv: -kv[1].total_ns)[:args.top]:
         if k.value == 0xFFFFFFFF:
             continue    # happens occasionally, we don't need it
@@ -255,7 +263,8 @@ def print_latency_stats():
                (agg_colval(k), v.count,
                 v.total_ns / (1e6 if args.milliseconds else 1e3)))
     print("")
-    data.clear()
+    if not htab_batch_ops:
+        data.clear()
```
Turn back to original ctypes type in table.py can avoid this error.