### PR TITLE
argdist: print process name COMM

### DIFF
--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -128,12 +128,9 @@ u64 __time = bpf_ktime_get_ns();
         
         def _generate_comm_prefix(self):
                 text = """
-enum {
-        TASK_COMM_LEN = 16,
-};
 struct val_t {
         u32 pid;
-        char name[TASK_COMM_LEN];
+        char name[sizeof(struct __string_t)];
 };
 struct val_t val = {.pid = (bpf_get_current_pid_tgid() >> 32) };
 bpf_get_current_comm(&val.name, sizeof(val.name));

--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -583,6 +583,9 @@ argdist -p 1005 -H 'r:c:read()'
 argdist -C 'r::__vfs_read():u32:$PID:$latency > 100000'
         Print frequency of reads by process where the latency was >0.1ms
 
+argdist -C 'r::__vfs_read():u32:$COMM:$latency > 100000'
+        Print frequency of reads by process name where the latency was >0.1ms
+
 argdist -H 'r::__vfs_read(void *file, void *buf, size_t count):size_t:
             $entry(count):$latency > 1000000'
         Print a histogram of read sizes that were longer than 1ms

--- a/tools/argdist_example.txt
+++ b/tools/argdist_example.txt
@@ -203,6 +203,24 @@ r::__vfs_read():u32:$PID:$latency > 100000
 
 It looks like process 2780 performed 21 slow reads.
 
+You can print the name of the process. This is helpful for short lived processes
+and for easier identification of processes response. For example, we can identify
+the process using the epoll I/O multiplexing system call
+
+# ./argdist -C 't:syscalls:sys_exit_epoll_wait():char*:$COMM'
+[19:57:56]
+t:syscalls:sys_exit_epoll_wait():char*:$COMM
+	COUNT      EVENT
+	4          $COMM = b'node'
+[19:57:57]
+t:syscalls:sys_exit_epoll_wait():char*:$COMM
+	COUNT      EVENT
+	2          $COMM = b'open5gs-sgwud'
+	3          $COMM = b'open5gs-sgwcd'
+	3          $COMM = b'open5gs-nrfd'
+	3          $COMM = b'open5gs-udmd'
+	4          $COMM = b'open5gs-scpd'
+
 Occasionally, entry parameter values are also interesting. For example, you
 might be curious how long it takes malloc() to allocate memory -- nanoseconds
 per byte allocated. Let's go:
@@ -412,6 +430,9 @@ argdist -p 1005 -H 'r:c:read()'
 
 argdist -C 'r::__vfs_read():u32:$PID:$latency > 100000'
         Print frequency of reads by process where the latency was >0.1ms
+
+argdist -C 'r::__vfs_read():u32:$COMM:$latency > 100000'
+        Print frequency of reads by process name where the latency was >0.1ms
 
 argdist -H 'r::__vfs_read(void *file, void *buf, size_t count):size_t:$entry(count):$latency > 1000000' 
         Print a histogram of read sizes that were longer than 1ms


### PR DESCRIPTION
Hi,

Thank you for this project.

I would want to use `argdist` but instead of getting the PID I need the process name. The reason being I have short lived processes, and I want to inspect the sockets created by the processes if they are non-blocking. To make it easier to identify the process I want the tool to print the process name, supporting something like `argdist -c -C 't:syscalls:sys_enter_accept4():int,char*,int:args->fd,$COMM,args->flags&00004000'`. I managed to make some code changes in this PR but I am facing an issue with the output, see below

```
t:syscalls:sys_enter_accept4():int,char*,int:args->fd,$COMM,args->flags&00004000
	COUNT      EVENT
	2          args->fd = 9, $COMM = b'nrf', args->flags&00004000 = 2048
	4          args->fd = 9, $COMM = b'nrf', args->flags&00004000 = 2048
	4          args->fd = 9, $COMM = b'nrf', args->flags&00004000 = 2048
	4          args->fd = 9, $COMM = b'nrf', args->flags&00004000 = 2048
```

Although the COMM is successfully extracted, it results in what should be the same count being separate. I am assuming this is due to the pointer to the COMM being saved in the BPF_HASH map. I would appreciate pointers to resolving this.

Thanks,