### PR TITLE
libbpf-tools: Avoid virtual memory area [uprobes] warning

### DIFF
--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -243,6 +243,7 @@ static bool is_file_backed(const char *mapname)
 		STARTS_WITH(mapname, "[stack") ||
 		STARTS_WITH(mapname, "/SYSV") ||
 		STARTS_WITH(mapname, "[heap]") ||
+		STARTS_WITH(mapname, "[uprobes]") ||
 		STARTS_WITH(mapname, "[vsyscall]"));
 }
 
@@ -256,6 +257,11 @@ static bool is_vdso(const char *path)
 	return !strcmp(path, "[vdso]");
 }
 
+static bool is_uprobes(const char *path)
+{
+	return !strcmp(path, "[uprobes]");
+}
+
 static int get_elf_type(const char *path)
 {
 	GElf_Ehdr hdr;
@@ -264,6 +270,8 @@ static int get_elf_type(const char *path)
 	int fd;
 
 	if (is_vdso(path))
+		return -1;
+	if (is_uprobes(path))
 		return -1;
 	e = open_elf(path, &fd);
 	if (!e)


### PR DESCRIPTION
Refer to kernel commit 704bde3cc26a ("uprobes: Use vm_special_mapping to name the XOL vma"), processes setup the [uprobes] special virtual memory area with uprobe events to excute original instruction out of line.

open_elf() would throw a warning of 'Could not open [uprobes]' when attaching uprobes, so remove '[uprobes]' from get_elf_type() to avoid it.

This warning can be reproduced with `memleak -c <command>` or `memleak -p <pid>`, for example
```
~ # memleak -p 57
using default object: libc.so.6
using page size: 4096
tracing kernel: false
Tracing outstanding memory allocs...  Hit Ctrl-C to end
[7:21:3] Top 0 stacks with outstanding allocations:
[7:21:8] Top 3 stacks with outstanding allocations:
4096 bytes in 1 allocations from stack
Could not open [uprobes]
        0 [<00ffffff980d6904>] _IO_file_doallocate+0x5a [/lib/libc.so.6]
        1 [<00fffffffffff000>] <null sym>
```