### PR TITLE
tools/funccount: Fix abort error when counting tracepoints

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1005,7 +1005,7 @@ class BPF(object):
                 if os.path.isdir(evt_dir):
                     tp = ("%s:%s" % (category, event))
                     if re.match(tp_re.decode(), tp):
-                        results.append(tp)
+                        results.append(tp.encode())
         return results
 
     @staticmethod


### PR DESCRIPTION
When counting tracepoints, funccount raises such an exception:
```
./funccount.py t:block:*
Tracing 18 functions for "b't:block:*'"... Hit Ctrl-C to end.
^C
FUNC                                    COUNT
'str' object has no attribute 'decode'
```

The main reason is BPF.get_tracepoints() returns a list of str, while other functions  (BPF.get_user_functions_and_addresses) returns a list of bytes, this patch try to fix this.