### PR TITLE
How to handle exception from callback

### DIFF
--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -470,8 +470,11 @@ def print_event(cpu, data, size):
     elif event.type == EventType.EVENT_ENTRY:
         entries[event.id].append(event.name)
 
+def my_print_event(*args):
+    raise Exception("fail script")
+        
 # loop with callback to print_event
-b["events"].open_perf_buffer(print_event, page_cnt=args.buffer_pages)
+b["events"].open_perf_buffer(my_print_event, page_cnt=args.buffer_pages)
 start_time = datetime.now()
 while not args.duration or datetime.now() - start_time < args.duration:
     try:


### PR DESCRIPTION
When an exception raised from callback, the script does not fail and starts spitting huge amount of logs, e.g.
```
Exception ignored on calling ctypes callback function: <function PerfEventArray._open_perf_buffer.<locals>.raw_cb_ at 0x7f8e3a3b48b0>
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/bcc/table.py", line 767, in raw_cb_
    callback(cpu, data, size)
  File "/home/user/repos/bcc/tools/opensnoop.py", line 474, in my_print_event
    raise Exception("fail script")
Exception: fail script
``` 

From what I understand the callback function is invoked in C 
https://github.com/iovisor/bcc/blob/963e4a6489f6e858aad9d9e8fcde823bf0a649b0/src/python/bcc/table.py#L985-L993

And that the C-side code needs to raise exception with c-api https://docs.python.org/3/c-api/exceptions.html#raising-exceptions . Where would that be added? Or is global variable is the way to go?