### PR TITLE
libbpf-tools/biosnoop: Fix out-of-bounds accessing of rq

### DIFF
--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -179,9 +179,9 @@ int BPF_PROG(block_rq_complete, struct request *rq, int error,
 			event.qdelta = stagep->issue - stagep->insert;
 	}
 	event.ts = ts;
-	event.sector = rq->__sector;
-	event.len = rq->__data_len;
-	event.cmd_flags = rq->cmd_flags;
+	event.sector = BPF_CORE_READ(rq, __sector);
+	event.len = BPF_CORE_READ(rq, __data_len);
+	event.cmd_flags = BPF_CORE_READ(rq, cmd_flags);
 	event.dev = stagep->dev;
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event,
 			sizeof(event));


### PR DESCRIPTION
I test biosnoop on riscv and arm64 with linux-6.1, and get some errors
```
  ~ # biosnoop
  libbpf: prog 'block_rq_complete': BPF program load failed: Permission denied
  libbpf: prog 'block_rq_complete': -- BEGIN PROG LOAD LOG --
  reg type unsupported for arg#0 function block_rq_complete#176
  0: R1=ctx(off=0,imm=0) R10=fp0
  ; int BPF_PROG(block_rq_complete, struct request *rq, int error,
  0: (bf) r6 = r1                       ; R1=ctx(off=0,imm=0) R6_w=ctx(off=0,imm=0)
  ; int BPF_PROG(block_rq_complete, struct request *rq, int error,
  1: (79) r1 = *(u64 *)(r6 +0)
  func 'block_rq_complete' arg0 has btf_id 5097 type STRUCT 'request'
  ...
  ; event.ts = ts;
  87: (7b) *(u64 *)(r10 -40) = r3       ; R3_w=scalar() R10=fp0 fp-40_w=mmmmmmmm
  ; event.sector = rq->__sector;
  88: (79) r1 = *(u64 *)(r10 -8)        ; R1_w=scalar() R10=fp0
  ; event.sector = rq->__sector;
  89: (79) r2 = *(u64 *)(r1 +48)
  R1 invalid mem access 'scalar'
  processed 44 insns (limit 1000000) max_states_per_insn 0 total_states 3 peak_states 3 mark_read 2
  -- END PROG LOAD LOG --
  libbpf: prog 'block_rq_complete': failed to load: -13
  libbpf: failed to load object 'biosnoop_bpf'
  libbpf: failed to load BPF skeleton 'biosnoop_bpf': -13
  failed to load BPF object: -13
```
Fixed this by using libbpf BPF_CORE_READ() macro.
