### PR TITLE
libbpf-tools: Allow tcppktlat to run on old kernels

### DIFF
--- a/libbpf-tools/tcppktlat.c
+++ b/libbpf-tools/tcppktlat.c
@@ -212,9 +212,11 @@ int main(int argc, char **argv)
 	if (probe_tp_btf("tcp_probe")) {
 		bpf_program__set_autoload(obj->progs.tcp_probe, false);
 		bpf_program__set_autoload(obj->progs.tcp_rcv_space_adjust, false);
+		bpf_program__set_autoload(obj->progs.tcp_destroy_sock, false);
 	} else {
 		bpf_program__set_autoload(obj->progs.tcp_probe_btf, false);
 		bpf_program__set_autoload(obj->progs.tcp_rcv_space_adjust_btf, false);
+		bpf_program__set_autoload(obj->progs.tcp_destroy_sock_btf, false);
 	}
 
 	err = tcppktlat_bpf__load(obj);

--- a/libbpf-tools/tcppktlat.h
+++ b/libbpf-tools/tcppktlat.h
@@ -7,7 +7,7 @@
 struct event {
 	__u32 saddr[4];
 	__u32 daddr[4];
-        __u64 delta_us;
+	__u64 delta_us;
 	pid_t pid;
 	pid_t tid;
 	__u16 dport;


### PR DESCRIPTION
Currently, tcppktlat can only run on kernel v5.12+ because of the usages of bpf_get_socket_cookie().
This commit gets the tool run on old kernels in a CO-RE way. While at it, also adds tcp_destroy_sock tracepoint. This is necessary since there are cases where the socket does not get the chance to reach the tcp_rcv_space_adjust tracepoint and entries in start map never get removed.

cc @ethercflow 