### PR TITLE
tools/statsnoop: bring back the syscall__ prefix

### DIFF
--- a/tools/statsnoop.py
+++ b/tools/statsnoop.py
@@ -74,12 +74,12 @@ static int trace_entry(struct pt_regs *ctx, const char __user *filename)
     return 0;
 };
 
-int stat_entry(struct pt_regs *ctx, const char __user *filename)
+int syscall__stat_entry(struct pt_regs *ctx, const char __user *filename)
 {
     return trace_entry(ctx, filename);
 }
 
-int statx_entry(struct pt_regs *ctx, int dfd, const char __user *filename)
+int syscall__statx_entry(struct pt_regs *ctx, int dfd, const char __user *filename)
 {
     return trace_entry(ctx, filename);
 }
@@ -129,9 +129,9 @@ def try_attach_syscall_probes(syscall):
     syscall_fnname = b.get_syscall_fnname(syscall)
     if BPF.ksymname(syscall_fnname) != -1:
         if syscall == "statx":
-            b.attach_kprobe(event=syscall_fnname, fn_name="statx_entry")
+            b.attach_kprobe(event=syscall_fnname, fn_name="syscall__statx_entry")
         else:
-            b.attach_kprobe(event=syscall_fnname, fn_name="stat_entry")
+            b.attach_kprobe(event=syscall_fnname, fn_name="syscall__stat_entry")
         b.attach_kretprobe(event=syscall_fnname, fn_name="trace_return")
 
 try_attach_syscall_probes("stat")


### PR DESCRIPTION
fn_name of a syscall should start with "syscall__".

See
https://github.com/iovisor/bcc/blob/v0.28.0/src/cc/frontends/clang/b_frontend_action.cc#L818

Without the patch, file names will not be printed.

Fixes: c743fcb17b46 ("tools/statsnoop: Add some stat() variants (#4367)")