### PR TITLE
libbpf-tools: add futexctn

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -24,6 +24,7 @@
 /fsdist
 /fsslower
 /funclatency
+/futexctn
 /gethostlatency
 /hardirqs
 /javagc

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -31,6 +31,7 @@ $(error Architecture $(ARCH) is not supported yet. Please open an issue)
 endif
 
 BZ_APPS = \
+	futexctn \
 	memleak \
 	opensnoop \
 	#

--- a/libbpf-tools/futexctn.bpf.c
+++ b/libbpf-tools/futexctn.bpf.c
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2023 Wenbo Zhang */
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#include "futexctn.h"
+#include "bits.bpf.h"
+#include "maps.bpf.h"
+
+#define MAX_ENTRIES	10240
+
+#define FUTEX_WAIT		0
+#define FUTEX_PRIVATE_FLAG	128
+#define FUTEX_CLOCK_REALTIME	256
+#define FUTEX_CMD_MASK		~(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME)
+
+const volatile bool targ_summary = false;
+const volatile bool targ_ms = false;
+const volatile __u64 targ_lock = 0;
+const volatile pid_t targ_pid = 0;
+const volatile pid_t targ_tid = 0;
+
+struct val_t {
+	u64 ts;
+	u64 uaddr;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, u64);
+	__type(value, struct val_t);
+} start SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
+	__uint(key_size, sizeof(u32));
+} stackmap SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, struct hist_key);
+	__type(value, struct hist);
+} hists SEC(".maps");
+
+static struct hist initial_hist = {};
+
+SEC("tracepoint/syscalls/sys_enter_futex")
+int futex_enter(struct trace_event_raw_sys_enter *ctx)
+{
+	struct val_t v = {};
+	u64 pid_tgid;
+	u32 tid;
+
+	if (((int)ctx->args[1] & FUTEX_CMD_MASK) != FUTEX_WAIT)
+		return 0;
+
+	pid_tgid = bpf_get_current_pid_tgid();
+	tid = (__u32)pid_tgid;
+	if (targ_pid && targ_pid != pid_tgid >> 32)
+		return 0;
+	if (targ_tid && targ_tid != tid)
+		return 0;
+	v.uaddr = ctx->args[0];
+	if (targ_lock && targ_lock != v.uaddr)
+		return 0;
+	v.ts = bpf_ktime_get_ns();
+	bpf_map_update_elem(&start, &pid_tgid, &v, BPF_ANY);
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_futex")
+int futex_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	u64 pid_tgid, slot, ts, min, max;
+	struct hist_key hkey = {};
+	struct hist *histp;
+	struct val_t *vp;
+	s64 delta;
+
+	ts = bpf_ktime_get_ns();
+	pid_tgid = bpf_get_current_pid_tgid();
+	vp = bpf_map_lookup_elem(&start, &pid_tgid);
+	if (!vp)
+		return 0;
+	if ((int)ctx->ret < 0)
+		goto cleanup;
+
+	delta = (s64)(ts - vp->ts);
+	if (delta < 0)
+		goto cleanup;
+
+	hkey.pid_tgid = pid_tgid;
+	hkey.uaddr = vp->uaddr;
+	if (!targ_summary)
+		hkey.user_stack_id = bpf_get_stackid(ctx, &stackmap, BPF_F_USER_STACK);
+	else
+		hkey.pid_tgid >>= 32;
+
+	histp = bpf_map_lookup_or_try_init(&hists, &hkey, &initial_hist);
+	if (!histp)
+		goto cleanup;
+
+	if (targ_ms)
+		delta /= 1000000U;
+	else
+		delta /= 1000U;
+
+	slot = log2l(delta);
+	if (slot >= MAX_SLOTS)
+		slot = MAX_SLOTS - 1;
+	__sync_fetch_and_add(&histp->slots[slot], 1);
+	__sync_fetch_and_add(&histp->contended, 1);
+	__sync_fetch_and_add(&histp->total_elapsed, delta);
+	min = __sync_fetch_and_add(&histp->min, 0);
+	if (!min || min > delta)
+		__sync_val_compare_and_swap(&histp->min, min, delta);
+	max = __sync_fetch_and_add(&histp->max, 0);
+	if (max < delta)
+		__sync_val_compare_and_swap(&histp->max, max, delta);
+	bpf_get_current_comm(&histp->comm, sizeof(histp->comm));
+
+cleanup:
+	bpf_map_delete_elem(&start, &pid_tgid);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/futexctn.c
+++ b/libbpf-tools/futexctn.c
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2023 Wenbo Zhang
+//
+// Based on https://sourceware.org/systemtap/wiki/WSFutexContention
+// 10-Jul-2023   Wenbo Zhang   Created this.
+#include <argp.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <time.h>
+#include <bpf/libbpf.h>
+#include <sys/resource.h>
+#include <bpf/bpf.h>
+#include "futexctn.h"
+#include "futexctn.skel.h"
+#include "trace_helpers.h"
+#ifdef USE_BLAZESYM
+#include "blazesym.h"
+#endif
+
+#ifdef USE_BLAZESYM
+static blazesym *symbolizer;
+#else
+static struct syms_cache *syms_cache;
+#endif
+
+static struct env {
+	pid_t pid;
+	pid_t tid;
+	__u64 lock;
+	time_t interval;
+	int times;
+	int stack_storage_size;
+	int perf_max_stack_depth;
+	bool summary;
+	bool timestamp;
+	bool milliseconds;
+	bool verbose;
+} env = {
+	.interval = 99999999,
+	.times = 99999999,
+	.stack_storage_size = 1024,
+	.perf_max_stack_depth = 127,
+};
+
+static volatile sig_atomic_t exiting = 0;
+
+const char *argp_program_version = "futexctn 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] =
+"Summarize futex contention latency as a histogram.\n"
+"\n"
+"USAGE: futexctn [--help] [-T] [-m] [-s] [-p pid] [-t tid] [-l lock] [interval] [count]\n"
+"\n"
+"EXAMPLES:\n"
+"    futexctn              # summarize futex contention latency as a histogram\n"
+"    futexctn 1 10         # print 1 second summaries, 10 times\n"
+"    futexctn -mT 1        # 1s summaries, milliseconds, and timestamps\n"
+"    futexctn -s 1         # 1s summaries, without stack traces\n"
+"    futexctn -l 0x8187bb8 # only trace lock 0x8187bb8\n"
+"    futexctn -p 123       # only trace threads for PID 123\n"
+"    futexctn -t 125       # only trace thread 125\n";
+
+#define OPT_PERF_MAX_STACK_DEPTH	1 /* --pef-max-stack-depth */
+#define OPT_STACK_STORAGE_SIZE		2 /* --stack-storage-size */
+
+static const struct argp_option opts[] = {
+	{ "pid", 'p', "PID", 0, "Trace this PID only" },
+	{ "tid", 't', "TID", 0, "Trace this TID only" },
+	{ "lock", 'l', "LOCK", 0, "Trace this lock only" },
+	{ "timestamp", 'T', NULL, 0, "Include timestamp on output" },
+	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram" },
+	{ "perf-max-stack-depth", OPT_PERF_MAX_STACK_DEPTH,
+	  "PERF-MAX-STACK-DEPTH", 0, "the limit for the stack traces (default 127)" },
+	{ "stack-storage-size", OPT_STACK_STORAGE_SIZE, "STACK-STORAGE-SIZE", 0,
+	  "the number of unique stack traces that can be stored and displayed (default 1024)" },
+	{ "summary", 's', NULL, 0, "Summary futex contention latency" },
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	static int pos_args;
+
+	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'm':
+		env.milliseconds = true;
+		break;
+	case 's':
+		env.summary = true;
+		break;
+	case 'T':
+		env.timestamp = true;
+		break;
+	case 'p':
+		errno = 0;
+		env.pid = strtol(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "invalid PID: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 't':
+		errno = 0;
+		env.tid = strtol(arg, NULL, 10);
+		if (errno || env.tid <= 0) {
+			fprintf(stderr, "Invalid TID: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case 'l':
+		errno = 0;
+		env.lock = strtol(arg, NULL, 16);
+		if (errno || env.lock <= 0) {
+			fprintf(stderr, "Invalid lock: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case OPT_PERF_MAX_STACK_DEPTH:
+		errno = 0;
+		env.perf_max_stack_depth = strtol(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "invalid perf max stack depth: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case OPT_STACK_STORAGE_SIZE:
+		errno = 0;
+		env.stack_storage_size = strtol(arg, NULL, 10);
+		if (errno) {
+			fprintf(stderr, "invalid stack storage size: %s\n", arg);
+			argp_usage(state);
+		}
+		break;
+	case ARGP_KEY_ARG:
+		errno = 0;
+		if (pos_args == 0) {
+			env.interval = strtol(arg, NULL, 10);
+			if (errno) {
+				fprintf(stderr, "invalid internal\n");
+				argp_usage(state);
+			}
+		} else if (pos_args == 1) {
+			env.times = strtol(arg, NULL, 10);
+			if (errno) {
+				fprintf(stderr, "invalid times\n");
+				argp_usage(state);
+			}
+		} else {
+			fprintf(stderr,
+				"unrecognized positional argument: %s\n", arg);
+			argp_usage(state);
+		}
+		pos_args++;
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_handler(int sig)
+{
+	exiting = true;
+}
+
+static int print_stack(struct futexctn_bpf *obj, struct hist_key *info)
+{
+#ifdef USE_BLAZESYM
+	sym_src_cfg cfgs[] = {
+		{ .src_type = SRC_T_PROCESS, .params = { .process = { .pid = info->pid_tgid >> 32 }}},
+	};
+	const blazesym_result *result = NULL;
+	const blazesym_csym *sym;
+#else
+	const struct syms *syms;
+	const struct sym *sym;
+	char *dso_name;
+	unsigned long dso_offset;
+	int idx = 0;
+#endif
+	int i, err = 0, fd;
+	uint64_t *ip;
+
+	ip = calloc(env.perf_max_stack_depth, sizeof(*ip));
+	if (!ip) {
+		fprintf(stderr, "failed to alloc ip\n");
+		return -1;
+	}
+
+	fd = bpf_map__fd(obj->maps.stackmap);
+	err = bpf_map_lookup_elem(fd, &info->user_stack_id, ip);
+	if (err != 0) {
+		fprintf(stderr, "    [Missed User Stack]\n");
+		goto cleanup;
+	}
+
+#ifdef USE_BLAZESYM
+	result = blazesym_symbolize(symbolizer, cfgs, 1, ip, env.perf_max_stack_depth);
+
+	for (i = 0; result && i < result->size; i++) {
+		if (result->entries[i].size == 0)
+			continue;
+		sym = &result->entries[i].syms[0];
+		if (sym->line_no)
+			printf("    %s:%lu\n", sym->symbol, sym->line_no);
+		else
+			printf("    %s\n", sym->symbol);
+	}
+#else
+	syms = syms_cache__get_syms(syms_cache, info->pid_tgid >> 32);
+	if (!syms) {
+		if (!env.verbose) {
+			fprintf(stderr, "failed to get syms\n");
+		} else {
+			for (i = 0; i < env.perf_max_stack_depth && ip[i]; i++)
+				printf("    #%-2d 0x%016llx [unknown]\n", idx++, ip[i]);
+		}
+		goto cleanup;
+	}
+	for (i = 0; i < env.perf_max_stack_depth && ip[i]; i++) {
+		if (!env.verbose) {
+			sym = syms__map_addr(syms, ip[i]);
+			if (sym)
+				printf("    %s\n", sym->name);
+			else
+				printf("    [unknown]\n");
+		} else {
+			sym = syms__map_addr_dso(syms, ip[i], &dso_name, &dso_offset);
+			printf("    #%-2d 0x%016llx", idx++, ip[i]);
+			if (sym)
+				printf(" %s+0x%lx", sym->name, sym->offset);
+			if (dso_name)
+				printf(" (%s+0x%lx)", dso_name, dso_offset);
+			printf("\n");
+		}
+	}
+#endif
+
+cleanup:
+#ifdef USE_BLAZESYM
+	blazesym_result_free(result);
+#endif
+
+	free(ip);
+
+	return 0;
+}
+
+static int print_map(struct futexctn_bpf *obj)
+{
+	struct hist_key lookup_key = { .pid_tgid = -1 }, next_key;
+	const char *units = env.milliseconds ? "msecs" : "usecs";
+	int err,fd = bpf_map__fd(obj->maps.hists);
+	struct hist hist;
+
+	while (!bpf_map_get_next_key(fd, &lookup_key, &next_key)) {
+		err = bpf_map_lookup_elem(fd, &next_key, &hist);
+		if (err < 0) {
+			fprintf(stderr, "failed to lookup hist: %d\n", err);
+			return -1;
+		}
+		printf("\n\n");
+		printf(
+		    "%s[%u] lock 0x%llx contended %llu times, %llu avg %s "
+		    "[max: %llu %s, min %llu %s]\n",
+		    hist.comm, (__u32)next_key.pid_tgid, next_key.uaddr,
+		    hist.contended, hist.total_elapsed / hist.contended, units,
+		    hist.max, units, hist.min, units);
+		if (!env.summary) {
+			printf("    -\n");
+			print_stack(obj, &next_key);
+			printf("    -\n");
+		}
+		print_log2_hist(hist.slots, MAX_SLOTS, units);
+		lookup_key = next_key;
+	}
+
+	lookup_key.pid_tgid = -1;
+	while (!bpf_map_get_next_key(fd, &lookup_key, &next_key)) {
+		err = bpf_map_delete_elem(fd, &next_key);
+		if (err < 0) {
+			fprintf(stderr, "failed to cleanup hist : %d\n", err);
+			return -1;
+		}
+		lookup_key = next_key;
+	}
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct futexctn_bpf *obj;
+	struct tm *tm;
+	char ts[32];
+	time_t t;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	obj = futexctn_bpf__open();
+	if (!obj) {
+		fprintf(stderr, "failed to open BPF object\n");
+		return 1;
+	}
+
+	/* initialize global data (filtering options) */
+	obj->rodata->targ_pid = env.pid;
+	obj->rodata->targ_tid = env.tid;
+	obj->rodata->targ_lock = env.lock;
+	obj->rodata->targ_ms = env.milliseconds;
+	obj->rodata->targ_summary = env.summary;
+
+	bpf_map__set_value_size(obj->maps.stackmap,
+				env.perf_max_stack_depth * sizeof(unsigned long));
+	bpf_map__set_max_entries(obj->maps.stackmap, env.stack_storage_size);
+
+	err = futexctn_bpf__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF programs\n");
+		goto cleanup;
+	}
+	err = futexctn_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+
+#ifdef USE_BLAZESYM
+	symbolizer = blazesym_new();
+#else
+	syms_cache = syms_cache__new(0);
+	if (!syms_cache) {
+		fprintf(stderr, "failed to create syms_cache\n");
+		goto cleanup;
+	}
+#endif
+
+	signal(SIGINT, sig_handler);
+
+	/* main: poll */
+	while (1) {
+		sleep(env.interval);
+		printf("\n");
+
+		if (env.timestamp) {
+			time(&t);
+			tm = localtime(&t);
+			strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+			printf("%-8s\n", ts);
+		}
+
+		print_map(obj);
+
+		if (exiting || --env.times == 0)
+			break;
+	}
+
+cleanup:
+	futexctn_bpf__destroy(obj);
+#ifdef USE_BLAZESYM
+	blazesym_free(symbolizer);
+#else
+	syms_cache__free(syms_cache);
+#endif
+	return err != 0;
+}

--- a/libbpf-tools/futexctn.h
+++ b/libbpf-tools/futexctn.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __FUTEXCTN_H
+#define __FUTEXCTN_H
+
+#define TASK_COMM_LEN	16
+#define MAX_SLOTS	36
+
+struct hist_key {
+	__u64 pid_tgid;
+	__u64 uaddr;
+	int user_stack_id;
+};
+
+struct hist {
+	__u32 slots[MAX_SLOTS];
+	char comm[TASK_COMM_LEN];
+	__u64 contended;
+	__u64 total_elapsed;
+	__u64 min;
+	__u64 max;
+};
+
+#endif /* FUTEXCTN_H_ */


### PR DESCRIPTION
Although systemtap already has a futexes.stp tool, it doesn't feel very easy to use. For example, there are only maximum, minimum and average values, but no delay distribution information. In addition, although the mutex address is behind, there is no call stack information, which is inconvenient to check when you cannot use gdb to attach the process.

This tool identifies lock contention information by filtering futex `FUTEX_WAIT` operations and retrieves the call stack information when entering lock contention. The lock contention counter is partitioned based on the call stack, enabling users to locate all path information involved in this lock contention using the printed lock address, which serves as the basis for optimization.

```
➜ ✗ sudo ./futexctn -p 381676 1 1 -mT

15:07:13


fmu[381694] lock 0x55bb40a44060 contended 61 times, 16 avg msecs [max: 21 msecs, min 16 msecs]
    -
    __lll_lock_wait_private
    bar
    foo
    thread_func
    pthread_condattr_setpshared
    -
     msecs               : count    distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 61       |****************************************|


fmu[381689] lock 0x55bb40a44060 contended 61 times, 16 avg msecs [max: 21 msecs, min 16 msecs]
    -
    __lll_lock_wait_private
    bar
    foo
    thread_func
    pthread_condattr_setpshared
    -
     msecs               : count    distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 61       |****************************************|
```