### PR TITLE
cc/python-api: Add PID parameter to `perf_event_open`

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -610,7 +610,7 @@ StatusTuple BPF::detach_perf_event_raw(void* perf_event_attr) {
 }
 
 StatusTuple BPF::open_perf_event(const std::string& name, uint32_t type,
-                                 uint64_t config) {
+                                 uint64_t config, int pid) {
   if (perf_event_arrays_.find(name) == perf_event_arrays_.end()) {
     TableStorage::iterator it;
     if (!bpf_module_->table_storage().Find(Path({bpf_module_->id(), name}), it))
@@ -619,7 +619,7 @@ StatusTuple BPF::open_perf_event(const std::string& name, uint32_t type,
     perf_event_arrays_[name] = new BPFPerfEventArray(it->second);
   }
   auto table = perf_event_arrays_[name];
-  TRY2(table->open_all_cpu(type, config));
+  TRY2(table->open_all_cpu(type, config, pid));
   return StatusTuple::OK();
 }
 

--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -305,7 +305,7 @@ class BPF {
   bool add_module(std::string module);
 
   StatusTuple open_perf_event(const std::string& name, uint32_t type,
-                              uint64_t config);
+                              uint64_t config, int pid = -1);
 
   StatusTuple close_perf_event(const std::string& name);
 

--- a/src/cc/api/BPFTable.h
+++ b/src/cc/api/BPFTable.h
@@ -437,11 +437,11 @@ class BPFPerfEventArray : public BPFTableBase<int, int> {
   BPFPerfEventArray(const TableDesc& desc);
   ~BPFPerfEventArray();
 
-  StatusTuple open_all_cpu(uint32_t type, uint64_t config);
+  StatusTuple open_all_cpu(uint32_t type, uint64_t config, int pid = -1);
   StatusTuple close_all_cpu();
 
  private:
-  StatusTuple open_on_cpu(int cpu, uint32_t type, uint64_t config);
+  StatusTuple open_on_cpu(int cpu, uint32_t type, uint64_t config, int pid = -1);
   StatusTuple close_on_cpu(int cpu);
 
   std::map<int, int> cpu_fds_;

--- a/src/python/bcc/table.py
+++ b/src/python/bcc/table.py
@@ -1016,14 +1016,14 @@ class PerfEventArray(ArrayBase):
         # The actual fd is held by the perf reader, add to track opened keys
         self._open_key_fds[cpu] = -1
 
-    def _open_perf_event(self, cpu, typ, config):
-        fd = lib.bpf_open_perf_event(typ, config, -1, cpu)
+    def _open_perf_event(self, cpu, typ, config, pid=-1):
+        fd = lib.bpf_open_perf_event(typ, config, pid, cpu)
         if fd < 0:
             raise Exception("bpf_open_perf_event failed")
         self[self.Key(cpu)] = self.Leaf(fd)
         self._open_key_fds[cpu] = fd
 
-    def open_perf_event(self, typ, config):
+    def open_perf_event(self, typ, config, pid=-1):
         """open_perf_event(typ, config)
 
         Configures the table such that calls from the bpf program to
@@ -1031,7 +1031,7 @@ class PerfEventArray(ArrayBase):
         counter denoted by event ev on the local cpu.
         """
         for i in get_online_cpus():
-            self._open_perf_event(i, typ, config)
+            self._open_perf_event(i, typ, config, pid)
 
 
 class PerCpuHash(HashTable):

--- a/tests/cc/test_perf_event.cc
+++ b/tests/cc/test_perf_event.cc
@@ -59,8 +59,9 @@ TEST_CASE("test read perf event", "[bpf_perf_event]") {
       BPF_PROGRAM,
       {"-DNUM_CPUS=" + std::to_string(sysconf(_SC_NPROCESSORS_ONLN))}, {});
   REQUIRE(res.ok());
+  int pid = getpid();
   res =
-      bpf.open_perf_event("cnt", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_CPU_CLOCK);
+      bpf.open_perf_event("cnt", PERF_TYPE_SOFTWARE, PERF_COUNT_SW_CPU_CLOCK, pid);
   REQUIRE(res.ok());
   std::string getuid_fnname = bpf.get_syscall_fnname("getuid");
   res = bpf.attach_kprobe(getuid_fnname, "on_sys_getuid");

--- a/tests/python/test_perf_event.py
+++ b/tests/python/test_perf_event.py
@@ -40,6 +40,7 @@ int do_ret_sys_getuid(void *ctx) {
     return 0;
 }
 """
+        mypid = os.getpid()
         b = bcc.BPF(text=text, debug=0,
                 cflags=["-DNUM_CPUS=%d" % multiprocessing.cpu_count()])
         event_name = b.get_syscall_fnname(b"getuid")
@@ -47,7 +48,8 @@ int do_ret_sys_getuid(void *ctx) {
         b.attach_kretprobe(event=event_name, fn_name=b"do_ret_sys_getuid")
         cnt1 = b[b"cnt1"]
         try:
-            cnt1.open_perf_event(bcc.PerfType.HARDWARE, bcc.PerfHWConfig.CPU_CYCLES)
+            cnt1.open_perf_event(bcc.PerfType.HARDWARE,
+                                 bcc.PerfHWConfig.CPU_CYCLES, pid=mypid)
         except:
             if ctypes.get_errno() == 2:
                 raise self.skipTest("hardware events unsupported")


### PR DESCRIPTION
Related to the discussion here: https://github.com/iovisor/bcc/discussions/4673#discussion-5405903

The first commit in this PR adds the `pid` parameter to the `perf_event_open` in both cc and python API.   
The second commit in this PR edits the existing cc and python tests to pass in the PID of the test process as an argument to `perf_event_open`.