### PR TITLE
tools/runqlat: fix data structure initialization with padding

### DIFF
--- a/tools/runqlat.py
+++ b/tools/runqlat.py
@@ -270,7 +270,7 @@ if args.pids or args.tids:
     bpf_text = bpf_text.replace('STORAGE',
         'BPF_HISTOGRAM(dist, pid_key_t);')
     bpf_text = bpf_text.replace('STORE',
-        'pid_key_t key = {.id = ' + pid + ', .slot = bpf_log2l(delta)}; ' +
+        'pid_key_t key = {}; key.id = ' + pid + '; key.slot = bpf_log2l(delta); ' +
         'dist.increment(key);')
 elif args.pidnss:
     section = "pidns"


### PR DESCRIPTION
ENV

    ubuntu 22.04
    kernel 6.2.0-26
    bcc: newest
    LLVM version 14

The issue seems related to data structures initialization with padding ([3651](https://github.com/iovisor/bcc/pull/3651) , [4051](https://github.com/iovisor/bcc/pull/4051))

ERROR:

```
$ sudo /usr/share/bcc/tools/runqlat -P
bpf: Failed to load program: Permission denied
0: R1=ctx(off=0,imm=0) R10=fp0
[...]
129: (7b) *(u64 *)(r10 -16) = r1      ; R1_w=scalar(umax=4294967295,var_off=(0x0; 0xffffffff)) R10=fp0 fp-16_w=
; pid_key_t key = {.id = tgid, .slot = bpf_log2l(delta)}; ({ typeof(dist.key) _key = key; typeof(dist.leaf) *_leaf = bpf_map_lookup_elem_(bpf_pseudo_fd(1, -2), &_key); if (_leaf) (*_leaf) += 1;else { typeof(dist
.leaf) _zleaf; __builtin_memset(&_zleaf, 0, sizeof(_zleaf)); _zleaf += 1;bpf_map_update_elem_(bpf_pseudo_fd(1, -2), &_key, &_zleaf, BPF_NOEXIST); } });
130: (18) r1 = 0xffff983057bef400     ; R1_w=map_ptr(off=0,ks=16,vs=8,imm=0)
132: (bf) r2 = r10                    ; R2_w=fp0 R10=fp0
; pid_key_t key = {.id = tgid, .slot = bpf_log2l(delta)}; ({ typeof(dist.key) _key = key; typeof(dist.leaf) *_leaf = bpf_map_lookup_elem_(bpf_pseudo_fd(1, -2), &_key); if (_leaf) (*_leaf) += 1;else { typeof(dist.leaf) _zleaf; __builtin_memset(&_zleaf, 0, sizeof(_zleaf)); _zleaf += 1;bpf_map_update_elem_(bpf_pseudo_fd(1, -2), &_key, &_zleaf, BPF_NOEXIST); } });
133: (07) r2 += -24                   ; R2_w=fp-24
; return bpf_map_lookup_elem((void *)map, key);
134: (85) call bpf_map_lookup_elem#1
invalid indirect read from stack R2 off -24+4 size 16
processed 261 insns (limit 1000000) max_states_per_insn 1 total_states 20 peak_states 20 mark_read 6

Traceback (most recent call last):
  File "/usr/share/bcc/tools/runqlat", line 293, in <module>
    b = BPF(text=bpf_text)
  File "/usr/lib/python3/dist-packages/bcc-0.28.0+8422cd44-py3.10.egg/bcc/__init__.py", line 487, in __init__
  File "/usr/lib/python3/dist-packages/bcc-0.28.0+8422cd44-py3.10.egg/bcc/__init__.py", line 1479, in _trace_autoload
  File "/usr/lib/python3/dist-packages/bcc-0.28.0+8422cd44-py3.10.egg/bcc/__init__.py", line 526, in load_func
Exception: Failed to load BPF program b'raw_tracepoint__sched_switch': Permission denied

```
