### PR TITLE
fix. backport compilation with llvm9 and earlier

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -122,10 +122,17 @@ class MyMemoryManager : public SectionMemoryManager {
       if (!section)
         continue;
 
+#if LLVM_MAJOR_VERSION >= 10
       auto sec_name = section.get()->getName();
       if (!sec_name)
         continue;
+#else
+      llvm::StringRef sec_name_obj;
+      if (!section.get()->getName(sec_name_obj))
+        continue;
 
+      auto sec_name = &sec_name_obj;
+#endif
       info->section_ = sec_name->str();
       info->size_ = ss.second;
     }


### PR DESCRIPTION
llvm::SectionRef changed the `getName` interface since LLVM10, in particular, in commit llvm/llvm-project@a11d302fa0.

In llvm-9 and early version, `getName` required a StringRef reference as a parameter, and returned a std::error_code.