### PR TITLE
tools/statsnoop: Add more stat() variansts

### DIFF
--- a/tools/statsnoop.py
+++ b/tools/statsnoop.py
@@ -128,7 +128,7 @@ b = BPF(text=bpf_text)
 def try_attach_syscall_probes(syscall):
     syscall_fnname = b.get_syscall_fnname(syscall)
     if BPF.ksymname(syscall_fnname) != -1:
-        if syscall == "statx":
+        if syscall in ["statx", "fstatat64", "newfstatat"]:
             b.attach_kprobe(event=syscall_fnname, fn_name="syscall__statx_entry")
         else:
             b.attach_kprobe(event=syscall_fnname, fn_name="syscall__stat_entry")
@@ -139,6 +139,8 @@ try_attach_syscall_probes("statx")
 try_attach_syscall_probes("statfs")
 try_attach_syscall_probes("newstat")
 try_attach_syscall_probes("newlstat")
+try_attach_syscall_probes("fstatat64")
+try_attach_syscall_probes("newfstatat")
 
 start_ts = 0
 prev_ts = 0


### PR DESCRIPTION
The underlying system call employed by the Golang Stat() wrapper function is newfstatat().
See https://cs.opensource.google/go/go/+/refs/heads/master:src/syscall/zsyscall_linux_amd64.go;l=1453;drc=94e40d5603797fe4d9302421682bb5b997d9c568