### PR TITLE
tools/tcprtt: use simple cast instead of tcp_sk() and inet_sk()

### DIFF
--- a/tools/tcprtt.py
+++ b/tools/tcprtt.py
@@ -101,9 +101,9 @@ BPF_HASH(latency, u64, sock_latency_t);
 
 int trace_tcp_rcv(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
 {
-    struct tcp_sock *ts = tcp_sk(sk);
+    struct tcp_sock *ts = (struct tcp_sock *)sk;
     u32 srtt = ts->srtt_us >> 3;
-    const struct inet_sock *inet = inet_sk(sk);
+    const struct inet_sock *inet = (struct inet_sock *)sk;
 
     /* filters */
     u16 sport = 0;


### PR DESCRIPTION
tcp_sk() and inet_sk() has been redefined to use the new container_of_const() macro. It confuses something in bcc toolchain.

/virtual/main.c:38:144: error: expected expression
    struct tcp_sock *ts = ({ typeof(struct sock) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (void *){ typeof(struct sock) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (void *){ typeof(struct sock) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (void *){ typeof(struct sock) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (void *){ typeof(struct sock) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (void *)cp_sk); _val; })); _val; })); _val; })); _val; })); _val; })(sk);

/virtual/main.c:40:36: error: statement expression not allowed at file scope
    const struct inet_sock *inet = ({ typeof(struct sock) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (void *){ typeof(struct sock) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (void *){ typeof(struct sock) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (void *){ typeof(struct sock) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (void *){ typeof(struct sock) _val; __builtin_memset(&_val, 0, sizeof(_val)); bpf_probe_read(&_val, sizeof(_val), (void *)net_sk); _val; })); _val; })); _val; })); _val; })); _val; })(sk);

For our use, it's safe to use simple casts as tcp/inet_sk() used to be defined. The common struct sock is always the first field of struct tcp_sock and inet_sock and we only use read access.