### PR TITLE
libbpf-tools: fix memory leak in capable.c

### DIFF
--- a/libbpf-tools/capable.c
+++ b/libbpf-tools/capable.c
@@ -404,6 +404,7 @@ int main(int argc, char **argv)
 	}
 
 cleanup:
+	perf_buffer__free(pb);
 	capable_bpf__destroy(obj);
 	syms_cache__free(syms_cache);
 	ksyms__free(ksyms);


### PR DESCRIPTION
This commit adds a cleanup step to free the perf_buffer, fixing a memory leak in the capable.c file.

This is detected by asan.