### PR TITLE
libbpf-tools/filelife: Check btf struct field for CO-RE

### DIFF
--- a/libbpf-tools/core_fixes.bpf.h
+++ b/libbpf-tools/core_fixes.bpf.h
@@ -117,16 +117,28 @@ static __always_inline struct gendisk *get_disk(void *request)
  * way, determine whether there is a `old_mnt_userns` field for `struct
  * renamedata` to decide which input parameter of the vfs_create() to use as
  * `dentry`.
+ * commit abf08576afe3("fs: port vfs_*() helpers to struct mnt_idmap") use
+ * `struct mnt_idmap *new_mnt_idmap` instead of `struct user_namespace *
+ * old_mnt_userns`.
  * see:
  *     https://github.com/torvalds/linux/commit/6521f8917082
+ *     https://github.com/torvalds/linux/commit/abf08576afe3
  */
 struct renamedata___x {
 	struct user_namespace *old_mnt_userns;
+	struct new_mnt_idmap *new_mnt_idmap;
 } __attribute__((preserve_access_index));
 
 static __always_inline bool renamedata_has_old_mnt_userns_field(void)
 {
 	if (bpf_core_field_exists(struct renamedata___x, old_mnt_userns))
+		return true;
+	return false;
+}
+
+static __always_inline bool renamedata_has_new_mnt_idmap_field(void)
+{
+	if (bpf_core_field_exists(struct renamedata___x, new_mnt_idmap))
 		return true;
 	return false;
 }

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -4,6 +4,7 @@
 // Based on filelife(8) from BCC by Brendan Gregg & Allan McAleavy.
 // 20-Mar-2020   Wenbo Zhang   Created this.
 // 13-Nov-2022   Rong Tao      Check btf struct field for CO-RE and add vfs_open()
+// 23-Aug-2023   Rong Tao      Add vfs_* 'struct mnt_idmap' support.(CO-RE)
 #include <argp.h>
 #include <signal.h>
 #include <stdio.h>


### PR DESCRIPTION
commit abf08576afe3("fs: port vfs_*() helpers to struct mnt_idmap") [0] use `struct mnt_idmap *new_mnt_idmap` instead of `struct user_namespace * old_mnt_userns`.

[0] https://github.com/torvalds/linux/commit/abf08576afe3