### PR TITLE
Allow for installing python as a non-system package

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT PYTHON_CMD)
   set(PYTHON_CMD "python3")
 endif()
 
-if(EXISTS "/etc/debian_version")
+if(EXISTS "/etc/debian_version" AND NOT PY_SKIP_DEB_LAYOUT)
   set(PYTHON_FLAGS "${PYTHON_FLAGS} --install-layout deb")
 endif()
 
@@ -37,10 +37,14 @@ foreach(PY_CMD ${PYTHON_CMD})
   )
   add_custom_target(bcc_py_${PY_CMD_ESCAPED} ALL DEPENDS ${PIP_INSTALLABLE})
 
+  if(NOT PYTHON_PREFIX)
+     set(PYTHON_PREFIX, ${CMAKE_INSTALL_PREFIX} )
+  endif()
+
   install(
     CODE "
       execute_process(
-        COMMAND ${PY_CMD} setup.py install -f ${PYTHON_FLAGS} --prefix=${CMAKE_INSTALL_PREFIX} --record ${CMAKE_BINARY_DIR}/install_manifest_python_bcc.txt
+        COMMAND ${PY_CMD} setup.py install -f ${PYTHON_FLAGS} --prefix=${PYTHON_PREFIX} --record ${CMAKE_BINARY_DIR}/install_manifest_python_bcc.txt
         WORKING_DIRECTORY ${PY_DIRECTORY})"
     COMPONENT python)
 endforeach()


### PR DESCRIPTION
Debian's python, unlike stock python, expects system packages to be installed in `/usr/local/lib/python3.X/dist-packages/` and not `/usr/local/lib/python3.X/site-packages/`. As such debian's python setuptools has a flag `--install-layout deb` which places library files in the correct place. `src/python/CMakeLists.txt` checks if the system is debian and adds this flag.

However, if you're trying to use BCC with a non-system version of python (for example miniconda) the different package layout (and setuptools flag) aren't there. Also, libraries aren't expected to be placed in /usr, but whatever prefix the alternative python install is using.

This PR adds two flags to the CMAke build:
* PY_SKIP_DEB_LAYOUT - which skips adding the `--install-layout deb` flag to the python install command
* PYTHON_PREFIX which (if set) takes the place of CMAKE_INSTALL_PREFIX as a target for installing python packages

Both are needed to allow installing python bindings into python installs that aren't the system install on debian hosts. For example, for a miniconda install on ubuntu:

With this PR, I can get a working install with miniconda on ubuntu 22 using:

```
cmake ..  -DPY_SKIP_DEB_LAYOUT=true  -DPYTHON_PREFIX=/home/vagrant/miniconda3/envs/ddpy3/
```

Fixes https://github.com/iovisor/bcc/issues/4717