### PR TITLE
Filter by PID list when tracing TCP connections

### DIFF
--- a/tools/tcpaccept_example.txt
+++ b/tools/tcpaccept_example.txt
@@ -48,23 +48,26 @@ usage: tcpaccept.py [-h] [-T] [-t] [-p PID] [-P PORT] [-4 | -6] [--cgroupmap CGR
 
 Trace TCP accepts
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -T, --time            include time column on output (HH:MM:SS)
   -t, --timestamp       include timestamp on output
-  -p PID, --pid PID     trace this PID only
+  -p PID, --pid PID     comma-separated list of PIDs to trace
   -P PORT, --port PORT  comma-separated list of local ports to trace
   -4, --ipv4            trace IPv4 family only
   -6, --ipv6            trace IPv6 family only
   --cgroupmap CGROUPMAP
                         trace cgroups in this BPF map only
+  --mntnsmap MNTNSMAP   trace mount namespaces in this BPF map only
 
 examples:
-    ./tcpaccept           # trace all TCP accept()s
-    ./tcpaccept -t        # include timestamps
-    ./tcpaccept -P 80,81  # only trace port 80 and 81
-    ./tcpaccept -p 181    # only trace PID 181
+    ./tcpaccept             # trace all TCP accept()s
+    ./tcpaccept -t          # include timestamps
+    ./tcpaccept -p 181      # only trace PID 181
+    ./tcpaccept -p 181,182  # only trace PID 181 and 182
+    ./tcpaccept -P 80       # only trace port 80
+    ./tcpaccept -P 80,81    # only trace port 80 and 81
     ./tcpaccept --cgroupmap mappath  # only trace cgroups in this BPF map
     ./tcpaccept --mntnsmap mappath   # only trace mount namespaces in the map
-    ./tcpaccept -4        # trace IPv4 family only
-    ./tcpaccept -6        # trace IPv6 family only
+    ./tcpaccept -4          # trace IPv4 family only
+    ./tcpaccept -6          # trace IPv6 family only

--- a/tools/tcpconnect_example.txt
+++ b/tools/tcpconnect_example.txt
@@ -111,10 +111,10 @@ usage: tcpconnect.py [-h] [-t] [-p PID] [-P PORT] [-4 | -6] [-L] [-U] [-u UID]
 
 Trace TCP connects
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -t, --timestamp       include timestamp on output
-  -p PID, --pid PID     trace this PID only
+  -p PID, --pid PID     comma-separated list of PIDs to trace
   -P PORT, --port PORT  comma-separated list of destination ports to trace.
   -4, --ipv4            trace IPv4 family only
   -6, --ipv6            trace IPv6 family only
@@ -128,17 +128,18 @@ optional arguments:
   -d, --dns             include likely DNS query associated with each connect
 
 examples:
-    ./tcpconnect           # trace all TCP connect()s
-    ./tcpconnect -t        # include timestamps
-    ./tcpconnect -d        # include DNS queries associated with connects
-    ./tcpconnect -p 181    # only trace PID 181
-    ./tcpconnect -P 80     # only trace port 80
-    ./tcpconnect -P 80,81  # only trace port 80 and 81
-    ./tcpconnect -4        # only trace IPv4 family
-    ./tcpconnect -6        # only trace IPv6 family
-    ./tcpconnect -U        # include UID
-    ./tcpconnect -u 1000   # only trace UID 1000
-    ./tcpconnect -c        # count connects per src ip and dest ip/port
-    ./tcpconnect -L        # include LPORT while printing outputs
+    ./tcpconnect             # trace all TCP connect()s
+    ./tcpconnect -t          # include timestamps
+    ./tcpconnect -d          # include DNS queries associated with connects
+    ./tcpconnect -p 181      # only trace PID 180
+    ./tcpconnect -p 181,182  # only trace PID 180 and 181
+    ./tcpconnect -P 80       # only trace port 80
+    ./tcpconnect -P 80,81    # only trace port 80 and 81
+    ./tcpconnect -4          # only trace IPv4 family
+    ./tcpconnect -6          # only trace IPv6 family
+    ./tcpconnect -U          # include UID
+    ./tcpconnect -u 1000     # only trace UID 1000
+    ./tcpconnect -c          # count connects per src ip and dest ip/port
+    ./tcpconnect -L          # include LPORT while printing outputs
     ./tcpconnect --cgroupmap mappath  # only trace cgroups in this BPF map
     ./tcpconnect --mntnsmap mappath   # only trace mount namespaces in the map

--- a/tools/tcpconnlat_example.txt
+++ b/tools/tcpconnlat_example.txt
@@ -41,21 +41,22 @@ Trace TCP connects and show connection latency
 positional arguments:
   duration_ms        minimum duration to trace (ms)
 
-optional arguments:
+options:
   -h, --help         show this help message and exit
   -t, --timestamp    include timestamp on output
-  -p PID, --pid PID  trace this PID only
+  -p PID, --pid PID  comma-separated list of PIDs to trace
   -L, --lport        include LPORT on output
   -4, --ipv4         trace IPv4 family only
-  -6  --ipv6         trace IPv6 family only
+  -6, --ipv6         trace IPv6 family only
   -v, --verbose      print the BPF program for debugging purposes
 
 examples:
-    ./tcpconnlat           # trace all TCP connect()s
-    ./tcpconnlat 1         # trace connection latency slower than 1 ms
-    ./tcpconnlat 0.1       # trace connection latency slower than 100 us
-    ./tcpconnlat -t        # include timestamps
-    ./tcpconnlat -p 181    # only trace PID 181
-    ./tcpconnlat -L        # include LPORT while printing outputs
-    ./tcpconnlat -4        # trace IPv4 family only
-    ./tcpconnlat -6        # trace IPv6 family only
+    ./tcpconnlat             # trace all TCP connect()s
+    ./tcpconnlat 1           # trace connection latency slower than 1 ms
+    ./tcpconnlat 0.1         # trace connection latency slower than 100 us
+    ./tcpconnlat -t          # include timestamps
+    ./tcpconnlat -p 181      # only trace PID 181
+    ./tcpconnlat -p 181,182  # only trace PID 181 and 182
+    ./tcpconnlat -L          # include LPORT while printing outputs
+    ./tcpconnlat -4          # trace IPv4 family only
+    ./tcpconnlat -6          # trace IPv6 family only

--- a/tools/tcpdrop_example.txt
+++ b/tools/tcpdrop_example.txt
@@ -65,10 +65,10 @@ usage: tcpdrop.py [-4 | -6] [-h]
 
 Trace TCP drops by the kernel
 
-optional arguments:
+options:
+  -h, --help  show this help message and exit
   -4, --ipv4  trace IPv4 family only
   -6, --ipv6  trace IPv6 family only
-  -h, --help  show this help message and exit
 
 examples:
     ./tcpdrop           # trace kernel TCP drops

--- a/tools/tcplife_example.txt
+++ b/tools/tcplife_example.txt
@@ -112,13 +112,13 @@ usage: tcplife.py [-h] [-T] [-t] [-w] [-s] [-p PID] [-L LOCALPORT]
 
 Trace the lifespan of TCP sessions and summarize
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -T, --time            include time column on output (HH:MM:SS)
   -t, --timestamp       include timestamp on output (seconds)
   -w, --wide            wide column output (fits IPv6 addresses)
   -s, --csv             comma separated values output
-  -p PID, --pid PID     trace this PID only
+  -p PID, --pid PID     comma-separated list of PIDs to trace
   -L LOCALPORT, --localport LOCALPORT
                         comma-separated list of local ports to trace.
   -D REMOTEPORT, --remoteport REMOTEPORT
@@ -127,13 +127,15 @@ optional arguments:
   -6, --ipv6            trace IPv6 family only
 
 examples:
-    ./tcplife           # trace all TCP connect()s
-    ./tcplife -t        # include time column (HH:MM:SS)
-    ./tcplife -w        # wider columns (fit IPv6)
-    ./tcplife -stT      # csv output, with times & timestamps
-    ./tcplife -p 181    # only trace PID 181
-    ./tcplife -L 80     # only trace local port 80
-    ./tcplife -L 80,81  # only trace local ports 80 and 81
-    ./tcplife -D 80     # only trace remote port 80
-    ./tcplife -4        # only trace IPv4 family
-    ./tcplife -6        # only trace IPv6 family
+    ./tcplife             # trace all TCP connect()s
+    ./tcplife -T          # include time column (HH:MM:SS)
+    ./tcplife -t          # include timestamp column (seconds)
+    ./tcplife -w          # wider columns (fit IPv6)
+    ./tcplife -stT        # csv output, with times & timestamps
+    ./tcplife -p 181      # only trace PID 181
+    ./tcplife -p 181,182  # only trace PID 181 and 182
+    ./tcplife -L 80       # only trace local port 80
+    ./tcplife -L 80,81    # only trace local ports 80 and 81
+    ./tcplife -D 80       # only trace remote port 80
+    ./tcplife -4          # only trace IPv4 family
+    ./tcplife -6          # only trace IPv6 family

--- a/tools/tcptop_example.txt
+++ b/tools/tcptop_example.txt
@@ -113,21 +113,23 @@ positional arguments:
   interval              output interval, in seconds (default 1)
   count                 number of outputs
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -C, --noclear         don't clear the screen
   -S, --nosummary       skip system summary line
-  -p PID, --pid PID     trace this PID only
+  -p PID, --pid PID     comma-separated list of PIDs to trace
   --cgroupmap CGROUPMAP
                         trace cgroups in this BPF map only
+  --mntnsmap MNTNSMAP   trace mount namespaces in this BPF map only
   -4, --ipv4            trace IPv4 family only
   -6, --ipv6            trace IPv6 family only
 
 examples:
-    ./tcptop           # trace TCP send/recv by host
-    ./tcptop -C        # don't clear the screen
-    ./tcptop -p 181    # only trace PID 181
-    ./tcptop --cgroupmap ./mappath  # only trace cgroups in this BPF map
+    ./tcptop             # trace TCP send/recv by host
+    ./tcptop -C          # don't clear the screen
+    ./tcptop -p 181      # only trace PID 181
+    ./tcptop -p 181,182  # only trace PID 181 and 182
+    ./tcptop --cgroupmap mappath  # only trace cgroups in this BPF map
     ./tcptop --mntnsmap mappath   # only trace mount namespaces in the map
-    ./tcptop -4        # trace IPv4 family only
-    ./tcptop -6        # trace IPv6 family only
+    ./tcptop -4          # trace IPv4 family only
+    ./tcptop -6          # trace IPv6 family only


### PR DESCRIPTION
For some network components with multiple processes, such as Nginx and Envoy, it is often necessary to track multiple processes simultaneously, which means multiple PIDs need to be used to trace together. Therefore, a logic for filtering by PID list is added without changing the original usage.

```
root@hostname:~/bcc/tools# ./tcpaccept.py -p 8597,8598,8599,8600
PID     COMM         IP RADDR            RPORT LADDR            LPORT
8597    nginx        4  127.0.0.1        45650 127.0.0.1        80
...
8598    nginx        4  127.0.0.1        45666 127.0.0.1        80
...
8599    nginx        4  127.0.0.1        52534 127.0.0.1        80
...
8600    nginx        4  127.0.0.1        52612 127.0.0.1        80
```

In addition, a transformation has been made to IPv4-mapped IPv6 address format to increase readability.

```
root@hostname:~/bcc/tools# ./tcpaccept.py
PID     COMM         IP RADDR            RPORT LADDR            LPORT
585329  coredns      6  10.244.0.1       53434 10.244.0.2       8181
585329  coredns      6  127.0.0.1        34478 127.0.0.1        8080
584442  kube-apiserv 6  192.168.49.2     39056 192.168.49.2     8443
584412  kube-schedul 4  127.0.0.1        53306 127.0.0.1        10259
```