### PR TITLE
cc: remove a spurious check for UID 0

### DIFF
--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -262,10 +262,6 @@ int bcc_procutils_each_ksym(bcc_procutils_ksymcb callback, void *payload) {
   FILE *kallsyms;
   unsigned long long addr;
 
-  /* root is needed to list ksym addresses */
-  if (geteuid() != 0)
-    return -1;
-
   kallsyms = fopen("/proc/kallsyms", "r");
   if (!kallsyms)
     return -1;


### PR DESCRIPTION
This drops an hardcoded check for the root user-ID before accessing `/proc/kallsyms`, fixing a bug which is preventing proper kernel symbols resolution by non-root users.
The `/proc/kallsyms` file is generally available to non-privileged users:
```
> runuser -u nobody -- wc -l /proc/kallsyms

217514 /proc/kallsyms
```

Its content is further controlled by the `CAP_SYSLOG` capability
through `/proc/sys/kernel/kptr_restrict`:
https://man7.org/linux/man-pages/man7/capabilities.7.html

As such, it is better to directly open it and rely on `fopen()`
for privileges checking.