### PR TITLE
libbpf-tools: Modify error message on uprobe_helpers

### DIFF
--- a/libbpf-tools/uprobe_helpers.c
+++ b/libbpf-tools/uprobe_helpers.c
@@ -65,7 +65,7 @@ int get_pid_lib_path(pid_t pid, const char *lib, char *path, size_t path_sz)
 	}
 	maps = fopen(proc_pid_maps, "r");
 	if (!maps) {
-		warn("No such pid %d\n", pid);
+		warn("Failed to open %s\n", proc_pid_maps);
 		return -1;
 	}
 	while (fgets(line_buf, sizeof(line_buf), maps)) {


### PR DESCRIPTION
function `get_pid_lib_path` on file `libbpf-tools/uprobe_helpers.c` prints error message like followings if it failed to open `proc_pid_maps`
"No such pid 1234"
But fopen can be failed even though pid `1234` is alive. So change error message to
"Failed to open /proc/1234/maps"