### PR TITLE
tools: Remove manual definition of `KBUILD_MODNAME`

### DIFF
--- a/tools/nfsslower.py
+++ b/tools/nfsslower.py
@@ -70,9 +70,6 @@ bpf_text = """
 #include <linux/fs.h>
 #include <linux/sched.h>
 #include <linux/dcache.h>
-#ifndef KBUILD_MODNAME
-#define KBUILD_MODNAME "bcc"
-#endif
 #include <linux/nfs_fs.h>
 
 #define TRACE_READ 0

--- a/tools/rdmaucma.py
+++ b/tools/rdmaucma.py
@@ -35,9 +35,6 @@ args = parser.parse_args()
 
 # define BPF program
 bpf_text = """
-#ifndef KBUILD_MODNAME
-#define KBUILD_MODNAME "bcc"
-#endif
 #include <linux/bpf.h>
 #include <uapi/linux/ptrace.h>
 #include <rdma/rdma_cm.h>

--- a/tools/tcprtt.py
+++ b/tools/tcprtt.py
@@ -77,9 +77,6 @@ if not args.interval:
 
 # define BPF program
 bpf_text = """
-#ifndef KBUILD_MODNAME
-#define KBUILD_MODNAME "bcc"
-#endif
 #include <uapi/linux/ptrace.h>
 #include <linux/tcp.h>
 #include <net/sock.h>

--- a/tools/virtiostat.py
+++ b/tools/virtiostat.py
@@ -47,9 +47,6 @@ args = parser.parse_args()
 
 # define BPF program
 bpf_text = """
-#ifndef KBUILD_MODNAME
-#define KBUILD_MODNAME "bcc"
-#endif
 #include <linux/virtio.h>
 #include <bcc/proto.h>
 


### PR DESCRIPTION
Remove the manual definition of `KBUILD_MODNAME` as https://github.com/iovisor/bcc/pull/2974 added the default compiler flag `-DKBUILD_MODNAME="bcc"`

