### PR TITLE
arm64: unbreak bcc tools on arm64 kasan-enabled kernels

### DIFF
--- a/src/cc/export/bpf_workaround.h
+++ b/src/cc/export/bpf_workaround.h
@@ -8,4 +8,21 @@ R"********(
 #ifndef __HAVE_BUILTIN_BSWAP64__
 #define __HAVE_BUILTIN_BSWAP64__
 #endif
+
+/**
+ * commit b2f557eae9ed ("kasan, arm64: adjust shadow size for tag-based mode")
+ * KASAN_SHADOW_SCALE_SHIFT moved from headers to the arm64 Makefile
+ * see:
+ *     https://github.com/torvalds/linux/commit/b2f557eae9ed
+ */
+#ifdef __aarch64__
+#if defined(CONFIG_KASAN) && !defined(KASAN_SHADOW_SCALE_SHIFT)
+#ifdef CONFIG_KASAN_SW_TAGS
+#define KASAN_SHADOW_SCALE_SHIFT 4
+#endif
+#ifdef CONFIG_KASAN_GENERIC
+#define KASAN_SHADOW_SCALE_SHIFT 3
+#endif
+#endif
+#endif
 )********"


### PR DESCRIPTION
commit b2f557eae9ed ("kasan, arm64: adjust shadow size for tag-based mode") [0] moved KASAN_SHADOW_SCALE_SHIFT definition from kernel headers to arm64 Makefile. This causes compile errors with "undeclared identifier" error for BPF programs on arm64 kasan-enabled kernels as the kernel headers still reference KASAN_SHADOW_SCALE_SHIFT, but the clang frontend does not pass this definition on the commandline unlike Kbuild.

Fixes #3648

[0]: https://github.com/torvalds/linux/commit/b2f557eae9ed