### PR TITLE
sanitizer: Fix UndefinedBehaviorSanitizer: non-positive-vla-index

### DIFF
--- a/src/cc/api/BPF.cc
+++ b/src/cc/api/BPF.cc
@@ -118,13 +118,14 @@ StatusTuple BPF::init(const std::string& bpf_program,
     }
   }
 
-  auto flags_len = cflags.size();
-  const char* flags[flags_len];
-  for (size_t i = 0; i < flags_len; i++)
-    flags[i] = cflags[i].c_str();
+  std::vector<const char*> flags;
+  for (const auto& c: cflags)
+    flags.push_back(c.c_str());
 
   all_bpf_program_ += bpf_program;
-  if (bpf_module_->load_string(all_bpf_program_, flags, flags_len) != 0) {
+  if (bpf_module_->load_string(all_bpf_program_,
+                               flags.data(),
+                               flags.size()) != 0) {
     init_fail_reset();
     return StatusTuple(-1, "Unable to initialize BPF program");
   }


### PR DESCRIPTION
When running a test leveraging bcc, and with sanitization enabled, the following error was triggered:
```
...
third-party/bcc/master/src/cc/api/BPF.cc:123:21: runtime error: variable length array bound evaluates to non-positive value 0
    #0 0x7f3fc6f06d13 in ebpf::BPF::init(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&, std::vector<ebpf::USDT, std::allocator<ebpf::USDT>> const&) third-party/bcc/master/src/cc/api/BPF.cc:123
...
...
SUMMARY: UndefinedBehaviorSanitizer: non-positive-vla-index third-party/bcc/master/src/cc/api/BPF.cc:123:21 in
...
```

This change uses a vector instead of initializing a possibly 0-length array.