### PR TITLE
Adding memory zones for Power server

### DIFF
--- a/tools/compactsnoop.py
+++ b/tools/compactsnoop.py
@@ -260,11 +260,12 @@ TRACEPOINT_PROBE(compaction, mm_compaction_end)
 }
 """
 
-if platform.machine() != 'x86_64':
+if platform.machine() != 'x86_64' and platform.machine() != 'ppc64le':
     print("""
-          Currently only support x86_64 servers, if you want to use it on
-          other platforms, please refer include/linux/mmzone.h to modify
-          zone_idex_to_str to get the right zone type
+          Currently only support x86_64 and power servers, if you want
+          to use it on other platforms(including power embedded processors),
+          please refer include/linux/mmzone.h to modify zone_idex_to_str to
+          get the right zone type
     """)
     exit()
 
@@ -296,13 +297,22 @@ def zone_idx_to_str(idx):
     # from include/linux/mmzone.h
     # NOTICE: consider only x86_64 servers
     zone_type = {
-        0: "ZONE_DMA",
-        1: "ZONE_DMA32",
-        2: "ZONE_NORMAL",
+            'x86_64':
+                    {
+                        0: "ZONE_DMA",
+                        1: "ZONE_DMA32",
+                        2: "ZONE_NORMAL"
+                    },
+            # Zones in Power server only
+            'ppc64le':
+                    {
+                        0: "ZONE_NORMAL",
+                        1: "ZONE_MOVABLE"
+                    }
     }
 
-    if idx in zone_type:
-        return zone_type[idx]
+    if idx in zone_type[platform.machine()]:
+        return zone_type[platform.machine()][idx]
     else:
         return str(idx)
 


### PR DESCRIPTION
config PPC_BOOK3S_64 skips setting ZONE_DMA for
server processors. NORMAL and MOVABLE zones are
available on Power.