### PR TITLE
Test multiple LLVM versions

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -11,6 +11,10 @@ inputs:
   os_nick:
     description: "Nickname of the OS. Ex: focal"
     required: true
+  llvm_versions:
+    description: "Space separated list of llvm versions to install in the container. Only supported for Ubuntu containers."
+    type: string
+    default: "11"
   registry:
     description: "Registry where to push images"
     default: ghcr.io
@@ -42,6 +46,7 @@ runs:
         build-args: |
           VERSION=${{ inputs.os_version }}
           SHORTNAME=${{ inputs.os_nick }}
+          LLVM_VERSION=${{ inputs.llvm_versions }}
         file: docker/build/Dockerfile.${{ inputs.os_distro }}
         tags: ${{ inputs.registry }}/${{ github.repository }}:${{ inputs.os_distro }}-${{ inputs.os_version }}
 

--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [{distro: "fedora", version: "34", nick: "f34"}, {distro: "fedora", version: "36", nick: "f36"}]
+        os: [{distro: "fedora", version: "38", nick: "f38"}]
         env:
         - TYPE: Debug
           PYTHON_TEST_LOGFILE: critical.log

--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -21,7 +21,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [{distro: "ubuntu", version: "18.04", nick: bionic}, {distro: "ubuntu", version: "20.04", nick: focal}]
+        os: [{distro: "ubuntu", version: "18.04", nick: bionic, installed_llvm_versions: "11 12"}, {distro: "ubuntu", version: "20.04", nick: focal, installed_llvm_versions: "11 12 15"}]
+        llvm_version: [11, 12, 15]
         env:
         - TYPE: Debug
           PYTHON_TEST_LOGFILE: critical.log
@@ -32,6 +33,9 @@ jobs:
         - TYPE: Release
           PYTHON_TEST_LOGFILE: critical.log
           RW_ENGINE_ENABLED: ON
+        exclude:
+          - os: {distro: "ubuntu", version: "18.04", nick: bionic, installed_llvm_versions: "11 12"}
+            llvm_version: 15
     steps:
     - uses: actions/checkout@v2
     - uses: dorny/paths-filter@v2
@@ -55,10 +59,11 @@ jobs:
         os_distro: ${{ matrix.os.distro }}
         os_version: ${{ matrix.os.version }}
         os_nick: ${{ matrix.os.nick }}
+        llvm_versions: ${{ matrix.os.installed_llvm_versions }}
     - name: Tag docker container
       run: |
         docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os.distro }}-${{ matrix.os.version }} bcc-docker
-    - name: Run bcc build
+    - name: Run bcc build - llvm-${{ matrix.llvm_version }}
       env: ${{ matrix.env }}
       run: |
         /bin/bash -c \
@@ -72,7 +77,7 @@ jobs:
                    bcc-docker \
                    /bin/bash -c \
                    'mkdir -p /bcc/build && cd /bcc/build && \
-                    cmake -DCMAKE_BUILD_TYPE=${TYPE} -DENABLE_LLVM_NATIVECODEGEN=${RW_ENGINE_ENABLED} .. && make -j9'"
+                    LLVM_ROOT=/usr/lib/llvm-${{ matrix.llvm_version }} cmake -DCMAKE_BUILD_TYPE=${TYPE} -DENABLE_LLVM_NATIVECODEGEN=${RW_ENGINE_ENABLED} .. && make -j9'"
     - name: Run bcc's cc tests
       env: ${{ matrix.env }}
       # tests are wrapped with `script` as a hack to get a TTY as github actions doesn't provide this

--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os: [{distro: "ubuntu", version: "18.04", nick: bionic, installed_llvm_versions: "11 12"}, {distro: "ubuntu", version: "20.04", nick: focal, installed_llvm_versions: "11 12 15"}]
+        os: [{distro: "ubuntu", version: "18.04", nick: bionic}, {distro: "ubuntu", version: "20.04", nick: focal}]
         llvm_version: [11, 12, 15]
         env:
         - TYPE: Debug
@@ -34,7 +34,7 @@ jobs:
           PYTHON_TEST_LOGFILE: critical.log
           RW_ENGINE_ENABLED: ON
         exclude:
-          - os: {distro: "ubuntu", version: "18.04", nick: bionic, installed_llvm_versions: "11 12"}
+          - os: {distro: "ubuntu", version: "18.04", nick: bionic}
             llvm_version: 15
     steps:
     - uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
         os_distro: ${{ matrix.os.distro }}
         os_version: ${{ matrix.os.version }}
         os_nick: ${{ matrix.os.nick }}
-        llvm_versions: ${{ matrix.os.installed_llvm_versions }}
+        llvm_versions: ${{ matrix.llvm_version }}
     - name: Tag docker container
       run: |
         docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.os.distro }}-${{ matrix.os.version }} bcc-docker

--- a/.github/workflows/publish-build-containers.yml
+++ b/.github/workflows/publish-build-containers.yml
@@ -24,10 +24,10 @@ jobs:
     strategy:
       matrix:
         os: [
-          {distro: "ubuntu", version: "18.04", nick: bionic},
-          {distro: "ubuntu", version: "20.04", nick: focal},
-          {distro: "fedora", version: "34", nick: "f34"},
-          {distro: "fedora", version: "36", nick: "f36"}
+          {distro: "ubuntu", version: "18.04", nick: bionic, installed_llvm_versions: "11 12"},
+          {distro: "ubuntu", version: "20.04", nick: focal, installed_llvm_versions: "11 12 15"},
+          {distro: "fedora", version: "34", nick: "f34", installed_llvm_versions: "this is not used"},
+          {distro: "fedora", version: "36", nick: "f36", installed_llvm_versions: "this is not used"}
         ]
 
     steps:
@@ -40,5 +40,6 @@ jobs:
         os_distro: ${{ matrix.os.distro }}
         os_version: ${{ matrix.os.version }}
         os_nick: ${{ matrix.os.nick }}
+        llvm_versions: ${{ matrix.os.installed_llvm_versions }}
         password: ${{ secrets.GITHUB_TOKEN }}
         push: true

--- a/.github/workflows/publish-build-containers.yml
+++ b/.github/workflows/publish-build-containers.yml
@@ -26,8 +26,7 @@ jobs:
         os: [
           {distro: "ubuntu", version: "18.04", nick: bionic, installed_llvm_versions: "11 12"},
           {distro: "ubuntu", version: "20.04", nick: focal, installed_llvm_versions: "11 12 15"},
-          {distro: "fedora", version: "34", nick: "f34", installed_llvm_versions: "this is not used"},
-          {distro: "fedora", version: "36", nick: "f36", installed_llvm_versions: "this is not used"}
+          {distro: "fedora", version: "38", nick: "f38", installed_llvm_versions: "this is not used"},
         ]
 
     steps:

--- a/docker/build/Dockerfile.ubuntu
+++ b/docker/build/Dockerfile.ubuntu
@@ -12,19 +12,24 @@ ENV RUBY_INSTALL_VERSION=$RUBY_INSTALL_VERSION
 ARG RUBY_VERSION="3.1.2"
 ENV RUBY_VERSION=$RUBY_VERSION
 
-RUN apt-get update && apt-get install -y curl gnupg &&\
+RUN /bin/bash -c 'apt-get update && apt-get install -y curl gnupg &&\
     llvmRepository="\n\
 deb http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME} main\n\
-deb-src http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME} main\n\
-deb http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME}-${LLVM_VERSION} main\n\
-deb-src http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME}-${LLVM_VERSION} main\n" &&\
-    echo $llvmRepository >> /etc/apt/sources.list && \
-    curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+deb-src http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME} main\n" && \
+echo -e $llvmRepository >> /etc/apt/sources.list && \
+read -ra versions <<<"${LLVM_VERSION}" && \
+for version in ${versions[@]}; \
+do \
+    llvmRepository="\n\
+deb http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME}-${version} main\n\
+deb-src http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME}-${version} main\n" &&\
+    echo -e $llvmRepository >> /etc/apt/sources.list; done && \
+    curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -'
 
 ARG DEBIAN_FRONTEND="noninteractive"
 ENV TZ="Etc/UTC"
 
-RUN apt-get update && apt-get install -y \
+RUN /bin/bash -c 'apt-get update && apt-get install -y \
       util-linux \
       bison \
       binutils-dev \
@@ -40,14 +45,6 @@ RUN apt-get update && apt-get install -y \
       liblzma-dev \
       libbfd-dev \
       libedit-dev \
-      clang-${LLVM_VERSION} \
-      libclang-${LLVM_VERSION}-dev \
-      libclang-common-${LLVM_VERSION}-dev \
-      libclang1-${LLVM_VERSION} \
-      llvm-${LLVM_VERSION} \
-      llvm-${LLVM_VERSION}-dev \
-      llvm-${LLVM_VERSION}-runtime \
-      libllvm${LLVM_VERSION} \
       systemtap-sdt-dev \
       sudo \
       iproute2 \
@@ -63,7 +60,25 @@ RUN apt-get update && apt-get install -y \
       libtinfo-dev \
       xz-utils \
       zip && \
-      apt-get -y clean
+      read -ra versions <<<"${LLVM_VERSION}" && \
+for version in ${versions[@]}; \
+do \
+    apt-get install -y \
+      clang-${version} \
+      libclang-${version}-dev \
+      libclang-common-${version}-dev \
+      libclang1-${version} \
+      llvm-${version} \
+      llvm-${version}-dev \
+      llvm-${version}-runtime \
+      libllvm${version} && \
+      if [ "${version}" -ge "15" ]; \
+      then \
+        apt-get install -y libpolly-${version}-dev; \
+      fi; \
+done \ 
+&& \
+      apt-get -y clean'
 
 RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1
 


### PR DESCRIPTION
Currently, only llvm-11 get tested on Ubuntu, on Fedora, it is whatever is the default llvm package of that Fedora release.

Given the checks on LLVM versions in the code base, it would be useful to test different LLVM versions too.

This change allow installing multiple versions when building the Ubuntu docker image, and when building bcc, LLVM_ROOT is used to force building against a specific llvm version.

Ubuntu bionic had failure installing llvm 15, so I ma skipping it for that version of ubuntu.
On the other hand, I am not sure how much value testing on Bionic has. Given the tests are running in docker, the kernel bcc is tested against are the same so.
Also Bionic reached end of standard support https://ubuntu.com/18-04 .
Removing this Ubuntu flavor would make sense in my opinion. Happy to do this on top of this stack.