### PR TITLE
memleak: use tid instead of tgid as map key

### DIFF
--- a/libbpf-tools/memleak.bpf.c
+++ b/libbpf-tools/memleak.bpf.c
@@ -18,7 +18,7 @@ const volatile bool wa_missing_free = false;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, pid_t);
+	__type(key, u32);
 	__type(value, u64);
 	__uint(max_entries, 10240);
 } sizes SEC(".maps");
@@ -96,8 +96,8 @@ static int gen_alloc_enter(size_t size)
 			return 0;
 	}
 
-	const pid_t pid = bpf_get_current_pid_tgid() >> 32;
-	bpf_map_update_elem(&sizes, &pid, &size, BPF_ANY);
+	const u32 tid = bpf_get_current_pid_tgid();
+	bpf_map_update_elem(&sizes, &tid, &size, BPF_ANY);
 
 	if (trace_all)
 		bpf_printk("alloc entered, size = %lu\n", size);
@@ -107,17 +107,17 @@ static int gen_alloc_enter(size_t size)
 
 static int gen_alloc_exit2(void *ctx, u64 address)
 {
-	const pid_t pid = bpf_get_current_pid_tgid() >> 32;
+	const u32 tid = bpf_get_current_pid_tgid();
 	struct alloc_info info;
 
-	const u64* size = bpf_map_lookup_elem(&sizes, &pid);
+	const u64* size = bpf_map_lookup_elem(&sizes, &tid);
 	if (!size)
 		return 0; // missed alloc entry
 
 	__builtin_memset(&info, 0, sizeof(info));
 
 	info.size = *size;
-	bpf_map_delete_elem(&sizes, &pid);
+	bpf_map_delete_elem(&sizes, &tid);
 
 	if (address != 0) {
 		info.timestamp_ns = bpf_ktime_get_ns();
@@ -227,8 +227,8 @@ SEC("uprobe")
 int BPF_KPROBE(posix_memalign_enter, void **memptr, size_t alignment, size_t size)
 {
 	const u64 memptr64 = (u64)(size_t)memptr;
-	const u64 pid = bpf_get_current_pid_tgid() >> 32;
-	bpf_map_update_elem(&memptrs, &pid, &memptr64, BPF_ANY);
+	const u32 tid = bpf_get_current_pid_tgid();
+	bpf_map_update_elem(&memptrs, &tid, &memptr64, BPF_ANY);
 
 	return gen_alloc_enter(size);
 }
@@ -236,15 +236,15 @@ int BPF_KPROBE(posix_memalign_enter, void **memptr, size_t alignment, size_t siz
 SEC("uretprobe")
 int BPF_KRETPROBE(posix_memalign_exit)
 {
-	const u64 pid = bpf_get_current_pid_tgid() >> 32;
 	u64 *memptr64;
 	void *addr;
+	const u32 tid = bpf_get_current_pid_tgid();
 
-	memptr64 = bpf_map_lookup_elem(&memptrs, &pid);
+	memptr64 = bpf_map_lookup_elem(&memptrs, &tid);
 	if (!memptr64)
 		return 0;
 
-	bpf_map_delete_elem(&memptrs, &pid);
+	bpf_map_delete_elem(&memptrs, &tid);
 
 	if (bpf_probe_read_user(&addr, sizeof(void*), (void*)(size_t)*memptr64))
 		return 0;


### PR DESCRIPTION
some of the maps were using tgid as key but should really be using tid so that multithreaded programs can record consistent allocation data.

fixes #4741 