### PR TITLE
tools: Add hash table item batch operations support

### DIFF
--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -167,6 +167,10 @@ b = BPF(text=bpf_text)
 b.attach_kprobe(event="vfs_read", fn_name="trace_read_entry")
 b.attach_kprobe(event="vfs_write", fn_name="trace_write_entry")
 
+# check whether hash table batch ops is supported
+htab_batch_ops = True if BPF.kernel_struct_has_field(b'bpf_map_ops',
+        b'map_lookup_and_delete_batch') == 1 else False
+
 DNAME_INLINE_LEN = 32  # linux/dcache.h
 
 print('Tracing... Output every %d secs. Hit Ctrl-C to end' % interval)
@@ -198,7 +202,8 @@ while 1:
     # by-TID output
     counts = b.get_table("counts")
     line = 0
-    for k, v in reversed(sorted(counts.items(),
+    for k, v in reversed(sorted(counts.items_lookup_and_delete_batch()
+                                if htab_batch_ops else counts.items(),
                                 key=sort_fn)):
         name = k.name.decode('utf-8', 'replace')
         if k.name_len > DNAME_INLINE_LEN:
@@ -213,7 +218,9 @@ while 1:
         line += 1
         if line >= maxrows:
             break
-    counts.clear()
+
+    if not htab_batch_ops:
+        counts.clear()
 
     countdown -= 1
     if exiting or countdown == 0:

--- a/tools/klockstat.py
+++ b/tools/klockstat.py
@@ -413,7 +413,9 @@ def display(sort, maxs, totals, counts):
     global missing_stacks
     global has_enomem
 
-    for k, v in sorted(sort.items(), key=lambda sort: sort[1].value, reverse=True)[:args.locks]:
+    for k, v in sorted(sort.items_lookup_batch()
+                       if htab_batch_ops else sort.items(),
+                       key=lambda sort: sort[1].value, reverse=True)[:args.locks]:
         missing_stacks += int(stack_id_err(k.value))
         has_enomem      = has_enomem or (k.value == -errno.ENOMEM)
 
@@ -457,6 +459,10 @@ if not is_support_kfunc:
     else:
         b.attach_kretprobe(event="mutex_lock", fn_name="mutex_lock_return")
         b.attach_kprobe(event="mutex_lock", fn_name="mutex_lock_enter")
+
+# check whether hash table batch ops is supported
+htab_batch_ops = True if BPF.kernel_struct_has_field(b'bpf_map_ops',
+        b'map_lookup_and_delete_batch') == 1 else False
 
 enabled = b.get_table("enabled");
 
@@ -508,12 +514,20 @@ while (1):
         break;
 
     stack_traces.clear()
-    aq_counts.clear()
-    aq_maxs.clear()
-    aq_totals.clear()
-    hl_counts.clear()
-    hl_maxs.clear()
-    hl_totals.clear()
+    if htab_batch_ops:
+        aq_counts.items_delete_batch()
+        aq_maxs.items_delete_batch()
+        aq_totals.items_delete_batch()
+        hl_counts.items_delete_batch()
+        hl_maxs.items_delete_batch()
+        hl_totals.items_delete_batch()
+    else:
+        aq_counts.clear()
+        aq_maxs.clear()
+        aq_totals.clear()
+        hl_counts.clear()
+        hl_maxs.clear()
+        hl_totals.clear()
 
 if missing_stacks > 0:
     enomem_str = " Consider increasing --stack-storage-size."

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -319,6 +319,9 @@ class Tool(object):
             print("Tracing %d functions for \"%s\"... Hit Ctrl-C to end." %
                   (self.probe.matched, self.args.pattern))
         b = self.probe.bpf
+        # check whether hash table batch ops is supported
+        htab_batch_ops = True if BPF.kernel_struct_has_field(b'bpf_map_ops',
+                         b'map_lookup_and_delete_batch') == 1 else False
         exiting = 0 if self.args.interval else 1
         seconds = 0
         while True:
@@ -340,7 +343,8 @@ class Tool(object):
             counts = self.probe.bpf["counts"]
             stack_traces = self.probe.bpf["stack_traces"]
             self.comm_cache = {}
-            for k, v in sorted(counts.items(),
+            for k, v in sorted(counts.items_lookup_and_delete_batch()
+                               if htab_batch_ops else counts.items(),
                                key=lambda counts: counts[1].value):
                 user_stack = [] if k.user_stack_id < 0 else \
                     stack_traces.walk(k.user_stack_id)
@@ -368,7 +372,8 @@ class Tool(object):
                     if not self.args.pid and k.tgid != 0xffffffff:
                         self._print_comm(k.name, k.tgid)
                     print("    %d\n" % v.value)
-            counts.clear()
+            if not htab_batch_ops:
+                counts.clear()
 
             if exiting:
                 if not self.args.folded:

--- a/tools/swapin.py
+++ b/tools/swapin.py
@@ -62,6 +62,10 @@ if debug or args.ebpf:
     if args.ebpf:
         exit()
 
+# check whether hash table batch ops is supported
+htab_batch_ops = True if BPF.kernel_struct_has_field(b'bpf_map_ops',
+        b'map_lookup_and_delete_batch') == 1 else False
+
 print("Counting swap ins. Ctrl-C to end.");
 
 # output
@@ -76,10 +80,12 @@ while 1:
         print(strftime("%H:%M:%S"))
     print("%-16s %-7s %s" % ("COMM", "PID", "COUNT"))
     counts = b.get_table("counts")
-    for k, v in sorted(counts.items(),
+    for k, v in sorted(counts.items_lookup_and_delete_batch()
+                       if htab_batch_ops else counts.items(),
 		       key=lambda counts: counts[1].value):
         print("%-16s %-7d %d" % (k.comm, k.pid, v.value))
-    counts.clear()
+    if not htab_batch_ops:
+        counts.clear()
     print()
 
     countdown -= 1

--- a/tools/wakeuptime.py
+++ b/tools/wakeuptime.py
@@ -214,6 +214,10 @@ if not is_supported_raw_tp:
         print("0 functions traced. Exiting.")
         exit()
 
+# check whether hash table batch ops is supported
+htab_batch_ops = True if BPF.kernel_struct_has_field(b'bpf_map_ops',
+        b'map_lookup_and_delete_batch') == 1 else False
+
 # header
 if not folded:
     print("Tracing blocked time (us) by kernel stack", end="")
@@ -236,7 +240,9 @@ while (1):
     has_enomem = False
     counts = b.get_table("counts")
     stack_traces = b.get_table("stack_traces")
-    for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
+    for k, v in sorted(counts.items_lookup_and_delete_batch()
+                        if htab_batch_ops else counts.items(),
+                        key=lambda counts: counts[1].value):
         # handle get_stackid errors
         # check for an ENOMEM error
         if k.w_k_stack_id == -errno.ENOMEM:
@@ -261,7 +267,9 @@ while (1):
                 printb(b"    %-16x %s" % (addr, b.ksym(addr)))
             printb(b"    %-16s %s" % (b"waker:", k.waker))
             print("        %d\n" % v.value)
-    counts.clear()
+
+    if not htab_batch_ops:
+        counts.clear()
 
     if missing_stacks > 0:
         enomem_str = " Consider increasing --stack-storage-size."


### PR DESCRIPTION
Hash table batch operations are supported, but no tools use this feature for now.
I patch tools directly, maybe there is a better way.

Improvement can be test with the belove commands:
```
  # filetop
  # syscount --syscall bpf -i 1
  # mkdir test; for i in `seq 1 100000`;do touch test/$i;done
```

Before patch filetop, syscall counts are more than 2k.
```
  [16:58:42]
  SYSCALL                   COUNT
  bpf                          55

  [16:58:43]
  SYSCALL                   COUNT
  bpf                        2735

  [16:58:44]
  SYSCALL                   COUNT
  bpf                        2263
```
After patch batch operations, result shows except 1 syscall for syscount
itself, filetop syscall count is reduced to 1.
```
  Tracing syscall 'bpf'... Ctrl+C to quit.
  [17:00:36]
  SYSCALL                   COUNT
  bpf                           1

  [17:00:37]
  SYSCALL                   COUNT
  bpf                           2

  [17:00:38]
  SYSCALL                   COUNT
  bpf                           2
```