### PR TITLE
Support for parsing USDT arguments to RISC-V

### DIFF
--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -84,6 +84,7 @@ public:
   friend class ArgumentParser_loongarch64;
   friend class ArgumentParser_powerpc64;
   friend class ArgumentParser_s390x;
+  friend class ArgumentParser_riscv64;
   friend class ArgumentParser_x64;
 };
 
@@ -156,6 +157,12 @@ class ArgumentParser_s390x : public ArgumentParser {
 public:
   bool parse(Argument *dest);
   ArgumentParser_s390x(const char *arg) : ArgumentParser(arg) {}
+};
+
+class ArgumentParser_riscv64 : public ArgumentParser {
+public:
+  bool parse(Argument *dest);
+  ArgumentParser_riscv64(const char *arg) : ArgumentParser(arg) {}
 };
 
 class ArgumentParser_x64 : public ArgumentParser {

--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -44,6 +44,8 @@ Location::Location(uint64_t addr, const std::string &bin_path, const char *arg_f
   ArgumentParser_powerpc64 parser(arg_fmt);
 #elif __s390x__
   ArgumentParser_s390x parser(arg_fmt);
+#elif __riscv
+  ArgumentParser_riscv64 parser(arg_fmt);
 #else
   ArgumentParser_x64 parser(arg_fmt);
 #endif

--- a/tests/cc/test_usdt_args.cc
+++ b/tests/cc/test_usdt_args.cc
@@ -55,7 +55,7 @@ static void verify_register(USDT::ArgumentParser &parser, int arg_size,
 /* supported arches only */
 #if defined(__aarch64__) || defined(__loongarch64) || \
     defined(__powerpc64__) || defined(__s390x__) || \
-    defined(__x86_64__)
+    defined(__x86_64__) || defined(__riscv)
 
 TEST_CASE("test usdt argument parsing", "[usdt]") {
   SECTION("parse failure") {
@@ -67,6 +67,8 @@ TEST_CASE("test usdt argument parsing", "[usdt]") {
     USDT::ArgumentParser_powerpc64 parser("4@-12(42)");
 #elif __s390x__
     USDT::ArgumentParser_s390x parser("4@-12(%r42)");
+#elif __riscv
+    USDT::ArgumentParser_riscv64 parser("4@20(s35)");
 #elif defined(__x86_64__)
     USDT::ArgumentParser_x64 parser("4@i%ra+1r");
 #endif
@@ -186,6 +188,15 @@ TEST_CASE("test usdt argument parsing", "[usdt]") {
     verify_register(parser, 2, 1097);
     verify_register(parser, 4, "gprs[7]", 108);
     verify_register(parser, -2, "gprs[6]", -4);
+#elif __riscv
+    USDT::ArgumentParser_riscv64 parser(
+	"-4@s5 -4@a0 4@20(s1) -4@-1 8@-72(s0) 8@0");
+    verify_register(parser, -4, "s5");
+    verify_register(parser, -4, "a0");
+    verify_register(parser, 4, "s1", 20);
+    verify_register(parser, -4, -1);
+    verify_register(parser, 8, "s0", -72);
+    verify_register(parser, 8, 0);
 #elif defined(__x86_64__)
     USDT::ArgumentParser_x64 parser(
         "-4@$0 8@$1234 %rdi %rax %rsi "


### PR DESCRIPTION
It is currently not possible to use USDT on risc-v due to lack of support for argument parsing. When trying to connect to USDT the following error occurs: [link](https://github.com/iovisor/bcc/blob/master/src/cc/usdt/usdt_args.cc#L136). This patch provides this implementation.