### PR TITLE
ksnoop: use bpf_get_func_ip() where helper is available

### DIFF
--- a/libbpf-tools/ksnoop.bpf.c
+++ b/libbpf-tools/ksnoop.bpf.c
@@ -89,7 +89,11 @@ static struct trace *get_trace(struct pt_regs *ctx, bool entry)
 		return NULL;
 
 	if (entry) {
-		ip = KSNOOP_IP_FIX(PT_REGS_IP_CORE(ctx));
+		if (bpf_core_enum_value_exists(enum bpf_func_id,
+					       BPF_FUNC_get_func_ip))
+			ip = bpf_get_func_ip(ctx);
+		else
+			ip = KSNOOP_IP_FIX(PT_REGS_IP_CORE(ctx));
 		if (stack_depth >= FUNC_MAX_STACK_DEPTH - 1)
 			return NULL;
 		/* verifier doesn't like using "stack_depth - 1" as array index


### PR DESCRIPTION
bpf_get_func_ip(ctx) will get the function address; use it where available using the BPF core enum value check for the function. This avoids needing to get the caller IP via KSNOOP_IP_FIX() for more up-to-date kernels.

This fixes issue #4746 for kernels newer than 5.13; an additional followup will be needed to address this for older kernels.

Kindly tested by https://github.com/matthew-olson-intel on a recent kernel.

Reported-by: dubeyabhishek (https://github.com/dubeyabhishek)