### PR TITLE
libbpf-tools: Fix misaligned pointer accesses in exitsnoop

### DIFF
--- a/libbpf-tools/exitsnoop.c
+++ b/libbpf-tools/exitsnoop.c
@@ -120,12 +120,19 @@ static void sig_int(int signo)
 
 static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 {
-	struct event *e = data;
+	struct event e;
 	time_t t;
 	struct tm *tm;
 	char ts[32];
 	double age;
 	int sig, coredump;
+
+	if (data_sz < sizeof(e)) {
+		printf("Error: packet too small\n");
+		return;
+	}
+	/* Copy data as alignment in the perf buffer isn't guaranteed. */
+	memcpy(&e, data, sizeof(e));
 
 	if (emit_timestamp) {
 		time(&t);
@@ -134,18 +141,18 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 		printf("%8s ", ts);
 	}
 
-	age = (e->exit_time - e->start_time) / 1e9;
+	age = (e.exit_time - e.start_time) / 1e9;
 	printf("%-16s %-7d %-7d %-7d %-7.2f ",
-	       e->comm, e->pid, e->ppid, e->tid, age);
+	       e.comm, e.pid, e.ppid, e.tid, age);
 
-	if (!e->sig) {
-		if (!e->exit_code)
+	if (!e.sig) {
+		if (!e.exit_code)
 			printf("0\n");
 		else
-			printf("code %d\n", e->exit_code);
+			printf("code %d\n", e.exit_code);
 	} else {
-		sig = e->sig & 0x7f;
-		coredump = e->sig & 0x80;
+		sig = e.sig & 0x7f;
+		coredump = e.sig & 0x80;
 		if (sig)
 			printf("signal %d (%s)", sig, strsignal(sig));
 		if (coredump)


### PR DESCRIPTION
The perf buffer in exit snoop doesn't maintain 8 byte alignment for start_time and exit_time in struct event. When building with "-fsanitize=alignment -fsanitize-undefined-trap-on-error" failures happen in handle_event. Fix these by copying the event from the perf buffer before accessing.