### PR TITLE
tools/trace: don't raise an exception in a ctype callback

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -43,6 +43,7 @@ class Probe(object):
         build_id_enabled = False
         aggregate = False
         symcount = {}
+        done = False
 
         @classmethod
         def configure(cls, args):
@@ -635,7 +636,7 @@ BPF_PERF_OUTPUT(%s);
                     if self.aggregate:
                         self.print_aggregate_events()
                     sys.stdout.flush()
-                    exit()
+                    Probe.done = True;
 
         def attach(self, bpf, verbose):
                 if len(self.library) == 0:
@@ -895,7 +896,7 @@ trace -s /lib/x86_64-linux-gnu/libc.so.6,/bin/ping 'p:c:inet_pton' -U
                       "-" if not all_probes_trivial else ""))
                 sys.stdout.flush()
 
-                while True:
+                while not Probe.done:
                         self.bpf.perf_buffer_poll()
 
         def run(self):


### PR DESCRIPTION
To exit the tool when the maximal number of event is reached (-M option), the tool currently call exit(), which raise a SystemExit exception. The handling of exception from ctype callback doesn't seem straightforward and dependent on python version.

This patch avoid the issue altogether by using a global variable instead.

Closes #3049