### PR TITLE
Fix compilation issues of bcc on Alibaba Cloud Linux 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if(NOT PYTHON_ONLY)
 
     # clang is linked as a library, but the library path searching is
     # primitively supported, unlike libLLVM
-    set(CLANG_SEARCH "/opt/local/llvm/lib;/usr/lib/llvm-3.7/lib;${LLVM_LIBRARY_DIRS}")
+    set(CLANG_SEARCH "/opt/local/llvm/lib;/usr/lib/llvm-3.7/lib;/usr/local/lib/;${LLVM_LIBRARY_DIRS}")
     find_library(libclangAnalysis NAMES clangAnalysis clang-cpp HINTS ${CLANG_SEARCH})
     find_library(libclangAST NAMES clangAST clang-cpp HINTS ${CLANG_SEARCH})
     find_library(libclangBasic NAMES clangBasic clang-cpp HINTS ${CLANG_SEARCH})

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,6 +11,7 @@
   - [RHEL](#rhel---binary)
   - [Amazon Linux 1](#amazon-linux-1---binary)
   - [Amazon Linux 2](#amazon-linux-2---binary)
+  - [Alibaba Cloud Linux 3](#alibaba-cloud-linux-3---binary)
   - [Alpine](#alpine---binary)
   - [WSL](#wslwindows-subsystem-for-linux---binary)
 * [Source](#source)
@@ -22,6 +23,7 @@
   - [Centos](#centos---source)
   - [Amazon Linux 1](#amazon-linux-1---source)
   - [Amazon Linux 2](#amazon-linux-2---source)
+  - [Alibaba Cloud Linux 3](#alibaba-cloud-linux-3---source)
   - [Alpine](#alpine---source)
   - [Arch](#arch---source)
 * [Older Instructions](#older-instructions)
@@ -246,6 +248,14 @@ Use case 1. Install BCC for your AMI's default kernel (no reboot required):
    Tested on Amazon Linux AMI release 2021.11 (kernel 5.10.75-79.358.amzn2.x86_64)
 ```
 sudo amazon-linux-extras install BCC
+```
+
+## Alibaba Cloud Linux 3 - Binary
+
+Tested on Alibaba Cloud Linux 3(Linux 5.10.134-14.1.al8.x86_64):
+
+```
+yum install kernel-headers kernel-devel bcc-tools
 ```
 
 ## Alpine - Binary
@@ -689,6 +699,45 @@ sudo mount -t debugfs debugfs /sys/kernel/debug
 ### Test
 ```
 sudo /usr/share/bcc/tools/execsnoop
+```
+
+## Alibaba Cloud Linux 3 - Source
+
+### Install and compile LLVM
+
+You could compile LLVM from source code
+
+```
+curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/llvm-10.0.1.src.tar.xz
+curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/clang-10.0.1.src.tar.xz
+tar -xf clang-10.0.1.src.tar.xz
+tar -xf llvm-10.0.1.src.tar.xz
+
+mkdir clang-build
+mkdir llvm-build
+
+cd llvm-build
+cmake3 -G "Unix Makefiles" -DLLVM_TARGETS_TO_BUILD="BPF;X86" \
+  -DCMAKE_BUILD_TYPE=Release ../llvm-10.0.1.src
+make
+sudo make install
+
+cd ../clang-build
+cmake3 -G "Unix Makefiles" -DLLVM_TARGETS_TO_BUILD="BPF;X86" \
+  -DCMAKE_BUILD_TYPE=Release ../clang-10.0.1.src
+make
+sudo make install
+cd ..
+```
+
+### Install and compile BCC
+
+```
+git clone https://github.com/iovisor/bcc.git
+mkdir bcc/build; cd bcc/build
+cmake3 ..
+make
+sudo make install
 ```
 
 ## Alpine - Source

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -37,14 +37,10 @@ foreach(PY_CMD ${PYTHON_CMD})
   )
   add_custom_target(bcc_py_${PY_CMD_ESCAPED} ALL DEPENDS ${PIP_INSTALLABLE})
 
-  if(NOT PYTHON_PREFIX)
-     set(PYTHON_PREFIX, ${CMAKE_INSTALL_PREFIX} )
-  endif()
-
   install(
     CODE "
       execute_process(
-        COMMAND ${PY_CMD} setup.py install -f ${PYTHON_FLAGS} --prefix=${PYTHON_PREFIX} --record ${CMAKE_BINARY_DIR}/install_manifest_python_bcc.txt
+        COMMAND ${PY_CMD} setup.py install -f ${PYTHON_FLAGS} --record ${CMAKE_BINARY_DIR}/install_manifest_python_bcc.txt
         WORKING_DIRECTORY ${PY_DIRECTORY})"
     COMPONENT python)
 endforeach()


### PR DESCRIPTION
When trying to compile bcc on Alibaba Cloud Linux 3, I found several issues that I've fixed in this PR:

- **LLVM10 Compilation**: Alibaba Cloud Linux 3 is compatible with CentOS 8 and does not support epel-release and centos-release-scl. This means we need to manually compile llvm10.
- **Clang Search Directory**: There was a problem with the search directory for clang. I've added `/usr/local/lib/` to fix this.
- **Python Environment with Conda**: I use conda to manage my Python environment. I found that bcc would install to `/usr/lib/python3.9/site-packages/` by default, not `/root/miniconda3/lib/python3.9/site-packages/`. By removing the `--prefix` argument, bcc now installs correctly in different environments. Without this change, bcc would end up in the wrong Python directory and using `python setup.py install --prefix " "`.

I appreciate any review and feedback.