### PR TITLE
biolatency: Fix kernel version check.

### DIFF
--- a/libbpf-tools/biolatency.bpf.c
+++ b/libbpf-tools/biolatency.bpf.c
@@ -76,7 +76,7 @@ static int handle_block_rq_insert(__u64 *ctx)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0))
+	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 10, 137))
 		return trace_rq_start((void *)ctx[1], false);
 	else
 		return trace_rq_start((void *)ctx[0], false);
@@ -89,7 +89,7 @@ static int handle_block_rq_issue(__u64 *ctx)
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
 	 */
-	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0))
+	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 10, 137))
 		return trace_rq_start((void *)ctx[1], true);
 	else
 		return trace_rq_start((void *)ctx[0], true);


### PR DESCRIPTION
The tracepoint definition change in v5.11-rc1 mentioned in the biolatency program seems to have been [backported into v5.10.137](https://elixir.bootlin.com/linux/v5.10.137/source/include/trace/events/block.h#L206).
This small fix allows the program to load and work on kernels between v5.10.137 and v5.11.