### PR TITLE
Fix compilation for LLVM >= 15

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -19,6 +19,8 @@
 #include <tuple>
 #include <vector>
 
+#include "bcc_debug.h"
+
 #if LLVM_VERSION_MAJOR >= 15
 #include <llvm/DebugInfo/DWARF/DWARFCompileUnit.h>
 #endif
@@ -40,8 +42,6 @@
 #else
 #include <llvm/Support/TargetRegistry.h>
 #endif
-
-#include "bcc_debug.h"
 
 namespace ebpf {
 


### PR DESCRIPTION
In #4737 I added support for using LLVM_VERSION_MAJOR from llvm-config.h instead of inferred LLVM_MAJOR_VERSION.
This went through CI just fine because CI uses LLVM 14 as the latest LLVM version (through the fedora 36 build).

`bcc_debug.cc` was using LLVM_VERSION_MAJOR before any include that would actually define it, causing LLVM_VERSION_MAJOR to default to 0. This was fine for builds using LLVM < 15, but does not work for LLVM >= 15.

On Ubuntu 23.04, using
```
-- Found LLVM: /usr/lib/llvm-15/include 15.0.7 (Use LLVM_ROOT envronment variable for another version of LLVM)
```

compilation of bcc_debug.cc would fail with:
https://gist.github.com/chantra/d2277d500d150ec2cc863dd412bd3264

This change moves the include of `bpf_module.h` up the file to make sure LLVM_VERSION_MAJOR is defined.

After this change, compilation goes through just fine.