### PR TITLE
libbpf-tools: Fixes for 32-bit platforms

### DIFF
--- a/libbpf-tools/bindsnoop.c
+++ b/libbpf-tools/bindsnoop.c
@@ -168,9 +168,9 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 		i++;
 	}
 	if (e->ver == 4) {
-		inet_ntop(AF_INET, &e->addr, addr, sizeof(addr));
+		inet_ntop(AF_INET, e->addr, addr, sizeof(addr));
 	} else {
-		inet_ntop(AF_INET6, &e->addr, addr, sizeof(addr));
+		inet_ntop(AF_INET6, e->addr, addr, sizeof(addr));
 	}
 	printf("%-7d %-16s %-3d %-5s %-5s %-4d %-5d %-48s\n",
 	       e->pid, e->task, e->ret, proto, opts, e->bound_dev_if, e->port, addr);

--- a/libbpf-tools/bindsnoop.h
+++ b/libbpf-tools/bindsnoop.h
@@ -5,7 +5,7 @@
 #define TASK_COMM_LEN	16
 
 struct bind_event {
-	unsigned __int128 addr;
+	__u8 addr[16];
 	__u64 ts_us;
 	__u32 pid;
 	__u32 bound_dev_if;

--- a/libbpf-tools/fsslower.c
+++ b/libbpf-tools/fsslower.c
@@ -326,7 +326,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 		if (e->size == LLONG_MAX)
 			printf("LL_MAX,");
 		else
-			printf("%ld,", e->size);
+			printf("%zd,", e->size);
 		printf("%lld,%lld,%s\n", e->offset, e->delta_us, e->file);
 		return;
 	}
@@ -339,7 +339,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	if (e->size == LLONG_MAX)
 		printf("%-7s ", "LL_MAX");
 	else
-		printf("%-7ld ", e->size);
+		printf("%-7zd ", e->size);
 	printf("%-8lld %7.2f %s\n", e->offset / 1024, (double)e->delta_us / 1000, e->file);
 }
 

--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -7,6 +7,7 @@
 #define _GNU_SOURCE
 #endif
 #include <ctype.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -552,8 +553,9 @@ static int create_tmp_vdso_image(struct dso *dso)
 		return -1;
 
 	while (true) {
-		ret = fscanf(f, "%lx-%lx %*s %*x %*x:%*x %*u%[^\n]",
-			     &start_addr, &end_addr, buf);
+		ret = fscanf(f, "%llx-%llx %*s %*x %*x:%*x %*u%[^\n]",
+			     (long long*)&start_addr, (long long*)&end_addr,
+			     buf);
 		if (ret == EOF && feof(f))
 			break;
 		if (ret != 3)
@@ -669,10 +671,13 @@ struct syms *syms__load_file(const char *fname)
 		goto err_out;
 
 	while (true) {
-		ret = fscanf(f, "%lx-%lx %4s %lx %lx:%lx %lu%[^\n]",
-			     &map.start_addr, &map.end_addr, perm,
-			     &map.file_off, &map.dev_major,
-			     &map.dev_minor, &map.inode, buf);
+		ret = fscanf(f, "%llx-%llx %4s %llx %llx:%llx %llu%[^\n]",
+			     (long long*)&map.start_addr,
+			     (long long*)&map.end_addr, perm,
+			     (long long*)&map.file_off,
+			     (long long*)&map.dev_major,
+			     (long long*)&map.dev_minor,
+			     (long long*)&map.inode, buf);
 		if (ret == EOF && feof(f))
 			break;
 		if (ret != 8)	/* perf-<PID>.map */


### PR DESCRIPTION
Fix build errors when compiling for 32-bit platforms by making the code more portable.