### PR TITLE
tools/*.py: fix invalid escape sequences in regexps

### DIFF
--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -208,7 +208,7 @@ if debug or args.ebpf:
 max_pid = int(open("/proc/sys/kernel/pid_max").read())
 
 b = BPF(text=bpf_text, cflags=["-DMAX_PID=%d" % max_pid])
-b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+b.attach_kprobe(event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
                 fn_name="sched_switch")
 
 print("Tracing %s-CPU time... Hit Ctrl-C to end." %

--- a/tools/dcsnoop.py
+++ b/tools/dcsnoop.py
@@ -137,7 +137,7 @@ if args.ebpf:
 # initialize BPF
 b = BPF(text=bpf_text)
 if args.all:
-    b.attach_kprobe(event_re="^lookup_fast$|^lookup_fast.constprop.*.\d$", fn_name="trace_fast")
+    b.attach_kprobe(event_re=r'^lookup_fast$|^lookup_fast.constprop.*.\d$', fn_name="trace_fast")
 
 mode_s = {
     0: 'M',

--- a/tools/dcstat.py
+++ b/tools/dcstat.py
@@ -88,7 +88,7 @@ void count_lookup(struct pt_regs *ctx) {
 
 # load BPF program
 b = BPF(text=bpf_text)
-b.attach_kprobe(event_re="^lookup_fast$|^lookup_fast.constprop.*.\d$", fn_name="count_fast")
+b.attach_kprobe(event_re=r'^lookup_fast$|^lookup_fast.constprop.*.\d$', fn_name="count_fast")
 b.attach_kretprobe(event="d_lookup", fn_name="count_lookup")
 
 # stat column labels and indexes

--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -267,7 +267,7 @@ if debug or args.ebpf:
 
 # initialize BPF
 b = BPF(text=bpf_text)
-b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+b.attach_kprobe(event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
                 fn_name="oncpu")
 matched = b.num_open_kprobes()
 if matched == 0:

--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -293,7 +293,7 @@ if args.ebpf:
 
 # initialize BPF
 b = BPF(text=bpf_text)
-b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+b.attach_kprobe(event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
                 fn_name="oncpu")
 b.attach_kprobe(event="try_to_wake_up", fn_name="waker")
 matched = b.num_open_kprobes()

--- a/tools/runqlat.py
+++ b/tools/runqlat.py
@@ -294,7 +294,7 @@ b = BPF(text=bpf_text)
 if not is_support_raw_tp:
     b.attach_kprobe(event="ttwu_do_wakeup", fn_name="trace_ttwu_do_wakeup")
     b.attach_kprobe(event="wake_up_new_task", fn_name="trace_wake_up_new_task")
-    b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+    b.attach_kprobe(event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
                     fn_name="trace_run")
 
 print("Tracing run queue latency... Hit Ctrl-C to end.")

--- a/tools/runqslower.py
+++ b/tools/runqslower.py
@@ -275,7 +275,7 @@ b = BPF(text=bpf_text, cflags=["-DMAX_PID=%d" % max_pid])
 if not is_support_raw_tp:
     b.attach_kprobe(event="ttwu_do_wakeup", fn_name="trace_ttwu_do_wakeup")
     b.attach_kprobe(event="wake_up_new_task", fn_name="trace_wake_up_new_task")
-    b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+    b.attach_kprobe(event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
                     fn_name="trace_run")
 
 print("Tracing run queue latency higher than %d us" % min_us)


### PR DESCRIPTION
With python >=3.8 many tools emit warnings on startup:
```
/usr/sbin/dcstat:91: SyntaxWarning: invalid escape sequence '\d'
  b.attach_kprobe(event_re="^lookup_fast$|^lookup_fast.constprop.*.\d$", fn_name="count_fast")
```
Fix this by ~properly escaping backslashes~ using raw strings for regular expressions.
