### PR TITLE
Fix bcc python script run warning: 'nocf_check' attribute ignored

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -265,6 +265,9 @@ int ClangLoader::parse(
                                    "-Wno-pragma-once-outside-header",
                                    "-Wno-address-of-packed-member",
                                    "-Wno-unknown-warning-option",
+#if defined(__x86_64__) || defined(__i386__)
+                                   "-fcf-protection",
+#endif
                                    "-fno-color-diagnostics",
                                    "-fno-unwind-tables",
                                    "-fno-asynchronous-unwind-tables",


### PR DESCRIPTION
If bcc running on v5.17-rc8-13-g156ff4a544ae, '__attribute__((nocf_check))' will be used indirectly in '/virtual/main.c', which requires the compilation option -fcf-protection, otherwise an alarm will be generated at runtime, see linux kernel commit 156ff4a544ae ("x86/ibt: Base IBT bits")

```
    // arch/x86/include/asm/ibt.h
    #define __noendbr       __attribute__((nocf_check))
```

Warning:

```
    $ sudo ./execsnoop.py
    In file included from /virtual/main.c:14:
    In file included from include/uapi/linux/ptrace.h:183:
    In file included from arch/x86/include/asm/ptrace.h:5:
    In file included from arch/x86/include/asm/segment.h:7:
    arch/x86/include/asm/ibt.h:77:8: warning: 'nocf_check' attribute ignored;
    use -fcf-protection to enable the attribute [-Wignored-attributes]
    extern __noendbr u64 ibt_save(bool disable);
        ^
    arch/x86/include/asm/ibt.h:32:34: note: expanded from macro '__noendbr'
    #define __noendbr       __attribute__((nocf_check))
                                        ^
    arch/x86/include/asm/ibt.h:78:8: warning: 'nocf_check' attribute ignored;
    use -fcf-protection to enable the attribute [-Wignored-attributes]
    extern __noendbr void ibt_restore(u64 save);
        ^
    arch/x86/include/asm/ibt.h:32:34: note: expanded from macro '__noendbr'
    #define __noendbr       __attribute__((nocf_check))
                                        ^
    2 warnings generated.

    PCOMM            PID     PPID    RET ARGS
```