### PR TITLE
libbpf-tools: Ignore f2fsdist and f2fsslower

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -19,6 +19,8 @@
 /exitsnoop
 /ext4dist
 /ext4slower
+/f2fsdist
+/f2fsslower
 /filelife
 /filetop
 /fsdist


### PR DESCRIPTION
commit 5f520fc94005("Added support for f2fs to fsdist and fsslower tools.") add f2fsdist and f2fsslower tools.