### PR TITLE
Fix two CI issues

### DIFF
--- a/src/cc/bpf_module_rw_engine.cc
+++ b/src/cc/bpf_module_rw_engine.cc
@@ -125,8 +125,17 @@ static void finish_sscanf(IRBuilder<> &B, vector<Value *> *args, string *fmt,
 
   B.SetInsertPoint(label_false);
   // s = &s[nread];
+#if LLVM_VERSION_MAJOR >= 15
+  // cast `sptr` from `ptr`(an opaque pointer rather than `i8*`) to `i8`, so that
+  // CreateInBoundsGEP can work properly, i.e. the offset is in bytes not in pointer-size
+  B.CreateStore(
+      B.CreateInBoundsGEP(B.getInt8Ty(), createLoad(B, sptr), {createLoad(B, nread, true)}),
+      sptr
+  );
+#else
   B.CreateStore(
       createInBoundsGEP(B, createLoad(B, sptr), {createLoad(B, nread, true)}), sptr);
+#endif
 
   args->resize(2);
   fmt->clear();

--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -584,7 +584,7 @@ int test(struct pt_regs *ctx, struct sock *skp) {
 struct sock {
     u32 *sk_daddr;
 };
-int test(struct pt_regs *ctx, struct sock *skp) {
+u32 *test(struct pt_regs *ctx, struct sock *skp) {
     return *(&skp->sk_daddr);
 }
 """


### PR DESCRIPTION
Two tests `test_probe_read_nested_member3`and `test_sscanf_string`  keep failing after we adopt Fedora 38 in CI.
The first one is trival and just fix in place. The second one is much interesting.

The leaf_sscanf function generated does not work properly. See https://github.com/iovisor/bcc/actions/runs/6793034116/job/18475356742?pr=4799 for example:
```
16: ======================================================================
16: FAIL: test_sscanf_string (__main__.TestClang.test_sscanf_string)
16: ----------------------------------------------------------------------
16: Traceback (most recent call last):
16:   File "/bcc/tests/python/test_clang.py", line 226, in test_sscanf_string
16:     self.assertEqual(l.stack[0].name, name)
16: AssertionError: b' ' != b'libxyz'
16: 
16: ----------------------------------------------------------------------
```

After some investigations, I found that the IR generated by LLVM/clang 15/16 are a bit different than its pervious versions.
For LLVM/clang 13, we have:
```
14:                                               ; preds = %2
  %15 = load volatile i32, i32* %3, align 4
  %16 = load i8*, i8** %4, align 8
  %17 = getelementptr inbounds i8, i8* %16, i32 %15
  store i8* %17, i8** %4, align 8
  store i32 0, i32* %3, align 4
  %18 = load i8*, i8** %4, align 8
  %19 = tail call i32 (i8*, i8*, ...) @sscanf(i8* %18, i8* getelementptr inbounds ([8 x i8], [8 x i8]* @fmt.2, i64 0, i64 0), [128 x i8]* %9, i32* %3)
  %20 = icmp slt i32 %19, 0
  br i1 %20, label %21, label %22
```

For LLVM/clang 15, we have:
```
14:                                               ; preds = %2
  %15 = load ptr, ptr %4, align 8
  %16 = load volatile i32, ptr %3, align 4
  %17 = getelementptr inbounds ptr, ptr %15, i32 %16
  store ptr %17, ptr %4, align 8
  store i32 0, ptr %3, align 4
  %18 = load ptr, ptr %4, align 8
  %19 = tail call i32 (ptr, ptr, ...) @sscanf(ptr %18, ptr @fmt.2, ptr %9, ptr %3)
  %20 = icmp slt i32 %19, 0
  br i1 %20, label %21, label %22
```

Note the differences in getelementptr instructions, the pointer is changed from `i8*` to a plain `ptr`([0], [1]).
For C code `s = &s[nread];`, the GEP offset change from 1 byte to 8 byte (pointer size). Like:
```
(char *)ptr++
(void *)ptr++
```

The fix explicitly cast the pointer mentioned above to `i8` type, just like what clang generated for the same C code:
```c
int main()
{
	const char *str = "hello world";
	int n = 10;

	str = &str[n];
	return 0;
}
```
```llvm
; ModuleID = 'main.c'
source_filename = "main.c"
target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
target triple = "aarch64-unknown-linux-gnu"

@.str = private unnamed_addr constant [12 x i8] c"hello world\00", align 1

; Function Attrs: noinline nounwind optnone uwtable
define dso_local i32 @main() #0 {
  %1 = alloca i32, align 4
  %2 = alloca ptr, align 8
  %3 = alloca i32, align 4
  store i32 0, ptr %1, align 4
  store ptr @.str, ptr %2, align 8
  store i32 10, ptr %3, align 4
  %4 = load ptr, ptr %2, align 8
  %5 = load i32, ptr %3, align 4
  %6 = sext i32 %5 to i64
  %7 = getelementptr inbounds i8, ptr %4, i64 %6
  store ptr %7, ptr %2, align 8
  ret i32 0
}

attributes #0 = { noinline nounwind optnone uwtable "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="generic" "target-features"="+fp-armv8,+neon,+outline-atomics,+v8a,-fmv" }

!llvm.module.flags = !{!0, !1, !2, !3, !4}
!llvm.ident = !{!5}

!0 = !{i32 1, !"wchar_size", i32 4}
!1 = !{i32 8, !"PIC Level", i32 2}
!2 = !{i32 7, !"PIE Level", i32 2}
!3 = !{i32 7, !"uwtable", i32 2}
!4 = !{i32 7, !"frame-pointer", i32 1}
!5 = !{!"Ubuntu clang version 16.0.6 (++20230710042027+7cbf1a259152-1~exp1~20230710162048.105)"}
```

cc @yonghong-song 

  [0]: https://llvm.org/docs/OpaquePointers.html
  [1]: https://github.com/iovisor/bcc/pull/3956