### PR TITLE
docker: ubuntu: remove py2 package and build 22.04 docker image

### DIFF
--- a/SPECS/bcc+clang.spec
+++ b/SPECS/bcc+clang.spec
@@ -15,7 +15,7 @@ Source1:        http://llvm.org/releases/%{llvmver}/llvm-%{llvmver}.src.tar.xz
 Source2:        http://llvm.org/releases/%{llvmver}/cfe-%{llvmver}.src.tar.xz
 
 BuildArch:      x86_64
-BuildRequires:  bison, cmake >= 2.8.7, flex, gcc, gcc-c++, libxml2-devel, python2-devel, elfutils-libelf-devel-static
+BuildRequires:  bison, cmake >= 2.8.7, flex, gcc, gcc-c++, libxml2-devel, python3-devel, elfutils-libelf-devel-static
 
 %description
 Python bindings for BPF Compiler Collection (BCC). Control a BPF program from

--- a/SPECS/bcc.spec
+++ b/SPECS/bcc.spec
@@ -13,13 +13,6 @@
 %bcond_with llvm_shared
 %endif
 
-# Build python3 support for distributions that have it
-%if 0%{?fedora} >= 28 || 0%{?rhel} > 7
-%bcond_without python3
-%else
-%bcond_with python3
-%endif
-
 # Build with debuginfod support for Fedora >= 32
 %if 0%{?fedora} >= 32
 %bcond_without libdebuginfod
@@ -27,15 +20,9 @@
 %bcond_with libdebuginfod
 %endif
 
-%if %{with python3}
-%global __python %{__python3}
-%global python_bcc python3-bcc
-%global python_cmds python2;python3
-%else
-%global __python %{__python2}
-%global python_bcc python2-bcc
-%global python_cmds python2
-%endif
+%global __python3
+%global python_bcc
+%global python_cmds,python3
 
 %define debug_package %{nil}
 %define _unpackaged_files_terminate_build 0
@@ -57,11 +44,7 @@ BuildRequires: gcc gcc-c++ elfutils-libelf-devel-static
 %if %{with libdebuginfod}
 BuildRequires: elfutils-debuginfod-client-devel
 %endif
-%if %{with python3}
 BuildRequires: python3-devel
-%else
-BuildRequires: python2-devel
-%endif
 %if %{with_lua}
 BuildRequires: luajit luajit-devel
 %endif
@@ -116,21 +99,12 @@ Requires: elfutils-debuginfod-client
 %description -n libbcc
 Shared Library for BPF Compiler Collection (BCC)
 
-%package -n python2-bcc
-Summary: Python2 bindings for BPF Compiler Collection (BCC)
-Requires: libbcc = %{version}-%{release}
-%{?python_provide:%python_provide python2-bcc}
-%description -n python2-bcc
-Python bindings for BPF Compiler Collection (BCC)
-
-%if %{with python3}
-%package -n python3-bcc
+%package -n python-bcc
 Summary: Python3 bindings for BPF Compiler Collection (BCC)
 Requires: libbcc = %{version}-%{release}
-%{?python_provide:%python_provide python3-bcc}
-%description -n python3-bcc
+%{?python_provide:%python_provide python-bcc}
+%description -n python-bcc
 Python bindings for BPF Compiler Collection (BCC)
-%endif
 
 %if %{with_lua}
 %package -n bcc-lua
@@ -159,13 +133,8 @@ Command line tools for BPF Compiler Collection (BCC)
 /usr/lib64/*
 /usr/include/bcc/*
 
-%files -n python2-bcc
-%{python2_sitelib}/bcc*
-
-%if %{with python3}
-%files -n python3-bcc
+%files -n python-bcc
 %{python3_sitelib}/bcc*
-%endif
 
 %if %{with_lua}
 %files -n bcc-lua

--- a/debian/control
+++ b/debian/control
@@ -4,14 +4,15 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 9), cmake,
-    libllvm9 | libllvm8 | libllvm6.0 | libllvm3.8 [!arm64] | libllvm3.7 [!arm64],
-    llvm-9-dev | llvm-8-dev | llvm-6.0-dev | llvm-3.8-dev [!arm64] | llvm-3.7-dev [!arm64],
-    libclang-9-dev | libclang-8-dev | libclang-6.0-dev | libclang-3.8-dev [!arm64] | libclang-3.7-dev [!arm64],
-    clang-format-9 | clang-format-8 | clang-format-6.0 | clang-format-3.8 [!arm64] | clang-format-3.7 [!arm64] | clang-format,
+    libllvm11,
+    llvm-11-dev,
+    libclang-11-dev,
+    clang-format-11,
     libelf-dev, bison, flex, libfl-dev, libedit-dev, zlib1g-dev, git,
-    python (>= 2.7), python-netaddr, python-pyroute2 | python3-pyroute2, luajit,
+    python3, python3-netaddr, python3-pyroute2, python3-setuptools, python3-pip,
+    luajit,
     libluajit-5.1-dev, arping, inetutils-ping | iputils-ping, iperf, netperf,
-    ethtool, devscripts, python3, dh-python
+    ethtool, devscripts, dh-python, zip
 # add 'libdebuginfod-dev' to Build-Depends for libdebuginfod support
 Homepage: https://github.com/iovisor/bcc
 
@@ -33,14 +34,6 @@ Description: Examples for BPF Compiler Collection (BCC)
 Package: python-bcc
 Architecture: all
 Provides: python-bpfcc
-Conflicts: python-bpfcc
-Depends: libbcc (= ${binary:Version}), python, binutils
-Description: Python wrappers for BPF Compiler Collection (BCC)
-
-Package: python3-bcc
-Architecture: all
-Provides: python3-bpfcc
-Conflicts: python3-bpfcc
 Depends: libbcc (= ${binary:Version}), python3, binutils
 Description: Python3 wrappers for BPF Compiler Collection (BCC)
 

--- a/debian/python-bcc.install
+++ b/debian/python-bcc.install
@@ -1,1 +1,1 @@
-usr/lib/python2*
+lib/python3*

--- a/debian/python3-bcc.install
+++ b/debian/python3-bcc.install
@@ -1,1 +1,0 @@
-usr/lib/python3*

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ DEBIAN_REVISION := $(shell dpkg-parsechangelog | sed -rne "s,^Version: ([0-9.]+)
 UPSTREAM_VERSION := $(shell dpkg-parsechangelog | sed -rne "s,^Version: ([0-9.]+)(~|-)(.*),\1,p")
 
 %:
-	dh $@ --buildsystem=cmake --parallel --with python2,python3
+	dh $@ --buildsystem=cmake --parallel --with python3
 
 # tests cannot be run in parallel
 override_dh_auto_test:
@@ -17,4 +17,4 @@ override_dh_auto_test:
 
 # FIXME: LLVM_DEFINITIONS is broken somehow in LLVM cmake upstream
 override_dh_auto_configure:
-	dh_auto_configure -- -DREVISION_LAST=$(UPSTREAM_VERSION) -DREVISION=$(UPSTREAM_VERSION) -DLLVM_DEFINITIONS="-D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" -DPYTHON_CMD="python2;python3"
+	dh_auto_configure -- -DREVISION_LAST=$(UPSTREAM_VERSION) -DREVISION=$(UPSTREAM_VERSION) -DLLVM_DEFINITIONS="-D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" -DPYTHON_CMD="python3"

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-ARG OS_TAG=18.04
+ARG OS_TAG=22.04
 FROM ubuntu:${OS_TAG} as builder
 
 ARG OS_TAG
@@ -23,10 +23,6 @@ COPY --from=builder /root/bcc/*.deb /root/bcc/
 
 RUN \
   apt-get update -y && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y python python3 python3-pip binutils libelf1 kmod  && \
-  if [ ${OS_TAG} = "18.04" ];then \
-    apt-get -y install python-pip && \
-    pip install dnslib cachetools ; \
-  fi ; \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python-is-python3 binutils libelf1 kmod  && \
   pip3 install dnslib cachetools  && \
   dpkg -i /root/bcc/*.deb


### PR DESCRIPTION
This change was required because current stable Ubuntu versions have
limited support for Python 2.7 (EOL 2020) and the upcoming ones do
not even have Python 2.7 (Ubuntu 23 and Ubuntu 24 do not support it).

Code changes:

  * remove python3-bcc package and use python 3 for the python-bcc
  * remove python2 packages
  * remove Ubuntu 18/20 deb Dockerfile support and add 22.04 support
  * use clang / llvm 11, supported by Ubuntu 22.04