### PR TITLE
Fix various build issues with latest llvm18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,10 @@ if(NOT PYTHON_ONLY)
       find_library(libclangSupport NAMES clangSupport clang-cpp HINTS ${CLANG_SEARCH})
     endif()
 
+    if(${LLVM_PACKAGE_VERSION} VERSION_EQUAL 18 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 18)
+      find_library(libclangAPINotes NAMES clangAPINotes clang-cpp HINTS ${CLANG_SEARCH})
+    endif()
+
     find_library(libclang-shared libclang-cpp.so HINTS ${CLANG_SEARCH})
 
     if(libclangBasic STREQUAL "libclangBasic-NOTFOUND")

--- a/cmake/clang_libs.cmake
+++ b/cmake/clang_libs.cmake
@@ -28,6 +28,9 @@ endif()
 if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 16 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 16)
   list(APPEND llvm_raw_libs frontendhlsl)
 endif()
+if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 18 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 18)
+  list(APPEND llvm_raw_libs frontenddriver)
+endif()
 
 llvm_map_components_to_libnames(_llvm_libs ${llvm_raw_libs})
 llvm_expand_dependencies(llvm_libs ${_llvm_libs})
@@ -59,6 +62,10 @@ list(APPEND clang_libs
 # if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 15 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 15)
   list(APPEND clang_libs ${libclangSupport})
 # endif()
+
+if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 18 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 18)
+  list(APPEND clang_libs ${libclangAPINotes})
+endif()
 
 list(APPEND clang_libs
   ${libclangBasic})


### PR DESCRIPTION
Latest llvm18 cannot build with bcc now. There are 3 issues:
  - In IRBuilder, getInt8PtrTy() renamed to getPtrTy().
  - Newly introdeuced clang library libclangAPINotes.a.
  - Newly introduced llvm library libLLVMFrontendDriver.a

This patch fixed the above three issues so bcc can be built with llvm18 successfully. I then tried a few bcc tools and they all works fine.