### PR TITLE
readme: remove colons after subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pair of .c and .py files, and some are directories of files.
 
 ### Tracing
 
-#### Examples:
+#### Examples
 
 - examples/tracing/[bitehist.py](examples/tracing/bitehist.py): Block I/O size histogram. [Examples](examples/tracing/bitehist_example.txt).
 - examples/tracing/[disksnoop.py](examples/tracing/disksnoop.py): Trace block device I/O latency. [Examples](examples/tracing/disksnoop_example.txt).
@@ -80,7 +80,7 @@ pair of .c and .py files, and some are directories of files.
 - examples/tracing/[vfsreadlat.py](examples/tracing/vfsreadlat.py) examples/tracing/[vfsreadlat.c](examples/tracing/vfsreadlat.c): VFS read latency distribution. [Examples](examples/tracing/vfsreadlat_example.txt).
 - examples/tracing/[kvm_hypercall.py](examples/tracing/kvm_hypercall.py): Conditional static kernel tracepoints for KVM entry, exit and hypercall [Examples](examples/tracing/kvm_hypercall.txt).
 
-#### Tools:
+#### Tools
 <center><a href="images/bcc_tracing_tools_2019.png"><img src="images/bcc_tracing_tools_2019.png" border=0 width=700></a></center>
 
 
@@ -210,7 +210,7 @@ Examples:
 - examples/networking/[tunnel_monitor/](examples/networking/tunnel_monitor): Efficiently monitor traffic flows.
 - examples/networking/vlan_learning/[vlan_learning.py](examples/networking/vlan_learning/vlan_learning.py) examples/[vlan_learning.c](examples/networking/vlan_learning/vlan_learning.c): Demux Ethernet traffic into worker veth+namespaces.
 
-### BPF Introspection:
+### BPF Introspection
 
 Tools that help to introspect BPF programs.
 


### PR DESCRIPTION
because it is redundant
and table of contents looks better without colons.

ToC with colons looks weird:
Subtitle1:
Subtitle2:
Subtitle3: