### PR TITLE
bcc/python: add perf_custom_event_open

### DIFF
--- a/src/python/bcc/perf.py
+++ b/src/python/bcc/perf.py
@@ -190,3 +190,9 @@ class Perf(object):
 
                 for cpu in get_online_cpus():
                         Perf._open_for_cpu(cpu, attr)
+
+        @staticmethod
+        def perf_custom_event_open(attr, pid=-1):
+                attr.pid = pid
+                for cpu in get_online_cpus():
+                        Perf._open_for_cpu(cpu, attr)


### PR DESCRIPTION
Allow for the creation of custom perf events.
In my case I need access to the attributes sample_type and branch_sample_type which is not allowed with the current api.
I have tried skipping perf_event_open() and just using _open_for_cpu().
However doing so generates warning as the pid is set outside of the Perf class and it is not part of perf_event_attr's ctypes.