### PR TITLE
*.py: fix "SyntaxWarning: invalid escape sequence" when using Python3.12

### DIFF
--- a/examples/tracing/task_switch.py
+++ b/examples/tracing/task_switch.py
@@ -6,7 +6,7 @@ from bcc import BPF
 from time import sleep
 
 b = BPF(src_file="task_switch.c")
-b.attach_kprobe(event_re="^finish_task_switch$|^finish_task_switch\.isra\.\d$",
+b.attach_kprobe(event_re=r'^finish_task_switch$|^finish_task_switch.isra.d$',
                 fn_name="count_sched")
 
 # generate many schedule events

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -755,7 +755,7 @@ class BPF(object):
                 elif fn.startswith(b'__SCT__'):
                     continue
                 # Exclude all gcc 8's extra .cold functions
-                elif re.match(b'^.*\.cold(\.\d+)?$', fn):
+                elif re.match(b'^.*.cold(.d+)?$', fn):
                     continue
                 if (t.lower() in [b't', b'w']) and re.fullmatch(event_re, fn) \
                     and fn not in blacklist \

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -64,7 +64,7 @@ class SmokeTests(TestCase):
 
     def kmod_loaded(self, mod):
         with open("/proc/modules", "r") as mods:
-            reg = re.compile("^%s\s" % mod)
+            reg = re.compile(r'^%s\s' % mod)
             for line in mods:
                 if reg.match(line):
                     return 1

--- a/tests/python/test_trace2.py
+++ b/tests/python/test_trace2.py
@@ -30,9 +30,9 @@ int count_sched(struct pt_regs *ctx) {
 class TestTracingEvent(TestCase):
     def setUp(self):
         b = BPF(text=text, debug=0)
-        self.stats = b.get_table(b"stats")
-        b.attach_kprobe(event_re=b"^finish_task_switch$|^finish_task_switch\.isra\.\d$",
-                        fn_name=b"count_sched")
+        self.stats = b.get_table(b'stats')
+        b.attach_kprobe(event_re=b'^finish_task_switch$|^finish_task_switch.isra.d$',
+                        fn_name=b'count_sched')
 
     def test_sched1(self):
         for i in range(0, 100):

--- a/tools/exitsnoop.py
+++ b/tools/exitsnoop.py
@@ -204,7 +204,7 @@ def initialize(arg_list = sys.argv[1:]):
         Global.args.timestamp = True
     if not Global.args.ebpf and os.geteuid() != 0:
         return (os.EX_NOPERM, "Need sudo (CAP_SYS_ADMIN) for BPF() system call")
-    if re.match('^3\.10\..*el7.*$', platform.release()): # Centos/Red Hat
+    if re.match(r'^3.10..*el7.*$', platform.release()): # Centos/Red Hat
         Global.args.timespec = True
     for _ in range(2):
         c = _embedded_c(Global.args)


### PR DESCRIPTION

Fixes: https://github.com/iovisor/bcc/issues/4823

