### PR TITLE
python/cmake: remove extraneous comma between variables

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -38,7 +38,7 @@ foreach(PY_CMD ${PYTHON_CMD})
   add_custom_target(bcc_py_${PY_CMD_ESCAPED} ALL DEPENDS ${PIP_INSTALLABLE})
 
   if(NOT PYTHON_PREFIX)
-     set(PYTHON_PREFIX, ${CMAKE_INSTALL_PREFIX} )
+     set(PYTHON_PREFIX ${CMAKE_INSTALL_PREFIX})
   endif()
 
   install(


### PR DESCRIPTION
The spurious comma prevents the expression from working as intended.

Fixes: https://github.com/iovisor/bcc/commit/6813fbce8718bede5075272cdc3ab9314eb91b5c
Fixes: https://github.com/iovisor/bcc/issues/4830
