### PR TITLE
Fix debian changelog and Python3 library path

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+bcc (0.29.1-1) unstable; urgency=low
+
+  * Fix Ubuntu 22.04 deb build
+  * Fix Ubuntu 22.04 Docker image build
+
+ -- Adrian Vladu <avladu@cloudbasesolutions.com>  Thu, 14 Dec 2023 17:00:00 +0000
+
 bcc (0.29.0-1) unstable; urgency=low
 
   * Support for kernel up to 6.6.

--- a/debian/python-bcc.install
+++ b/debian/python-bcc.install
@@ -1,1 +1,1 @@
-lib/python3*
+usr/lib/python3*


### PR DESCRIPTION
When the tag 0.29.1 was added to the repo, the debian changelog file needed one entry as well, otherwise the .deb build fails.
Also, in github actions environment, the Python3 library path is usr/lib/python3*.

Fixes: https://github.com/iovisor/bcc/issues/4842