### PR TITLE
libbpf-tools: Allow to install apps with prefixed names

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -13,6 +13,7 @@ CFLAGS := -g -O2 -Wall
 BPFCFLAGS := -g -O2 -Wall
 INSTALL ?= install
 prefix ?= /usr/local
+bindir := $(prefix)/bin
 ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' \
 			 | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' \
 			 | sed 's/riscv64/riscv/' | sed 's/loongarch.*/loongarch/' \
@@ -222,21 +223,21 @@ $(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch]) | $(OUTPUT)/libbpf
 
 $(FSSLOWER_ALIASES): fsslower
 	$(call msg,SYMLINK,$@)
-	$(Q)ln -f -s $^ $@
+	$(Q)ln -f -s $(APP_PREFIX)$^ $@
 
 $(FSDIST_ALIASES): fsdist
 	$(call msg,SYMLINK,$@)
-	$(Q)ln -f -s $^ $@
+	$(Q)ln -f -s $(APP_PREFIX)$^ $@
 
 $(SIGSNOOP_ALIAS): sigsnoop
 	$(call msg,SYMLINK,$@)
-	$(Q)ln -f -s $^ $@
+	$(Q)ln -f -s $(APP_PREFIX)$^ $@
 
 install: $(APPS) $(APP_ALIASES)
 	$(call msg, INSTALL libbpf-tools)
-	$(Q)$(INSTALL) -m 0755 -d $(DESTDIR)$(prefix)/bin
-	$(Q)$(INSTALL) $(APPS) $(DESTDIR)$(prefix)/bin
-	$(Q)cp -a $(APP_ALIASES) $(DESTDIR)$(prefix)/bin
+	$(Q)$(INSTALL) -m 0755 -d $(DESTDIR)$(bindir)
+	$(Q)$(foreach app,$(APPS),$(INSTALL) $(app) $(DESTDIR)$(bindir)/$(APP_PREFIX)$(app);)
+	$(Q)$(foreach alias,$(APP_ALIASES),cp -a $(alias) $(DESTDIR)$(bindir)/$(APP_PREFIX)$(alias);)
 
 .PHONY: force
 force:


### PR DESCRIPTION
Fedora adds prefix bpf- to the tool names, mainly to distinguish them from the old tools written in Python. Alpine Linux is going to do the same, but for a slightly different reason - there are dozens of these tools, so it's a good idea to add them a common prefix, to make it easier to recognize them among all other commands.

See-Also: https://github.com/iovisor/bcc/pull/3263

See-Also: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/35688