### PR TITLE
Fix incorrect output information

### DIFF
--- a/tools/compactsnoop.py
+++ b/tools/compactsnoop.py
@@ -207,6 +207,7 @@ RAW_TRACEPOINT_PROBE(mm_compaction_suitable)
 {
     // TP_PROTO(struct zone *zone, int order, int ret)
     struct zone *zone = (struct zone *)ctx->args[0];
+    struct val_t val = { };
     int order = (int)ctx->args[1];
     int ret = (int)ctx->args[2];
     u64 id;
@@ -222,14 +223,13 @@ RAW_TRACEPOINT_PROBE(mm_compaction_suitable)
     if (valp == NULL) {
         // missed entry or order <= PAGE_ALLOC_COSTLY_ORDER, eg:
         // manual trigger echo 1 > /proc/sys/vm/compact_memory
-        struct val_t val = { .fragindex = -1000 };
+        val.fragindex = -1000;
         valp = &val;
-        start.update(&id, valp);
     }
     fill_compact_info(valp, zone, order);
     get_all_wmark_pages(zone, valp);
+    start.update(&id, valp);
 #else
-    struct val_t val = { };
     fill_compact_info(&val, zone, order);
     start.update(&id, &val);
 #endif


### PR DESCRIPTION
When we use the -e or --extended_fields option, compactsnoop.py will output some error information. The root cause is that we obtained zone and wmark information but did not update it to the hash table.

before the patch:

./compactsnoop.py -e and echo 1 > /proc/sys/vm/compact_memory
COMM           PID    NODE ZONE         ORDER MODE    FRAGIDX  MIN      LOW      HIGH     FREE       LAT(ms)           STATUS
bash           32559  0    ZONE_DMA     0     SYNC    -1.000   0        0        0        0            0.031         complete
bash           32559  0    ZONE_DMA     0     SYNC    -1.000   0        0        0        0            3.849         complete
bash           32559  0    ZONE_DMA     0     SYNC    -1.000   0        0        0        0           67.697         complete

after the patch:

./compactsnoop.py -e and echo 1 > /proc/sys/vm/compact_memory
COMM           PID    NODE ZONE         ORDER MODE    FRAGIDX  MIN      LOW      HIGH     FREE       LAT(ms)           STATUS
bash           32559  0    ZONE_DMA     -1    SYNC    -1.000   1        4        7        2816         0.033         complete
bash           32559  0    ZONE_DMA32   -1    SYNC    -1.000   218      642      1066     428437       3.850         complete
bash           32559  0    ZONE_NORMAL  -1    SYNC    -1.000   16675    49142    81609    21707362    62.608         complete

So let's fix it.