### PR TITLE
libbpf-tools/futexctn: Fix compliation warning due to improper format…

### DIFF
--- a/libbpf-tools/futexctn.c
+++ b/libbpf-tools/futexctn.c
@@ -233,7 +233,7 @@ static int print_stack(struct futexctn_bpf *obj, struct hist_key *info)
 			fprintf(stderr, "failed to get syms\n");
 		} else {
 			for (i = 0; i < env.perf_max_stack_depth && ip[i]; i++)
-				printf("    #%-2d 0x%016llx [unknown]\n", idx++, ip[i]);
+				printf("    #%-2d 0x%016lx [unknown]\n", idx++, ip[i]);
 		}
 		goto cleanup;
 	}
@@ -246,7 +246,7 @@ static int print_stack(struct futexctn_bpf *obj, struct hist_key *info)
 				printf("    [unknown]\n");
 		} else {
 			sym = syms__map_addr_dso(syms, ip[i], &dso_name, &dso_offset);
-			printf("    #%-2d 0x%016llx", idx++, ip[i]);
+			printf("    #%-2d 0x%016lx", idx++, ip[i]);
 			if (sym)
 				printf(" %s+0x%lx", sym->name, sym->offset);
 			if (dso_name)


### PR DESCRIPTION
… specifier
```
futexctn.c:235:31: warning: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
     printf("    #%-2d 0x%016llx [unknown]\n", idx++, ip[i]);
                         ~~~~~~^                      ~~~~~
                         %016lx
futexctn.c:247:30: warning: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
    printf("    #%-2d 0x%016llx", idx++, ip[i]);
                        ~~~~~~^          ~~~~~
                        %016lx
```
Update the format specifier according to the data type of 'ip'.