### PR TITLE
tools/memleak: Use compact size of key for sizes and memptrs maps

### DIFF
--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -161,9 +161,9 @@ struct combined_alloc_info_t {
         u64 number_of_allocs;
 };
 
-BPF_HASH(sizes, u64);
+BPF_HASH(sizes, u32, u64);
 BPF_HASH(allocs, u64, struct alloc_info_t, 1000000);
-BPF_HASH(memptrs, u64, u64);
+BPF_HASH(memptrs, u32, u64);
 BPF_STACK_TRACE(stack_traces, 10240);
 BPF_HASH(combined_allocs, u64, struct combined_alloc_info_t, 10240);
 
@@ -208,9 +208,9 @@ static inline int gen_alloc_enter(struct pt_regs *ctx, size_t size) {
                         return 0;
         }
 
-        u64 pid = bpf_get_current_pid_tgid();
+        u32 tid = bpf_get_current_pid_tgid();
         u64 size64 = size;
-        sizes.update(&pid, &size64);
+        sizes.update(&tid, &size64);
 
         if (SHOULD_PRINT)
                 bpf_trace_printk("alloc entered, size = %u\\n", size);
@@ -218,15 +218,15 @@ static inline int gen_alloc_enter(struct pt_regs *ctx, size_t size) {
 }
 
 static inline int gen_alloc_exit2(struct pt_regs *ctx, u64 address) {
-        u64 pid = bpf_get_current_pid_tgid();
-        u64* size64 = sizes.lookup(&pid);
+        u32 tid = bpf_get_current_pid_tgid();
+        u64* size64 = sizes.lookup(&tid);
         struct alloc_info_t info = {0};
 
         if (size64 == 0)
                 return 0; // missed alloc entry
 
         info.size = *size64;
-        sizes.delete(&pid);
+        sizes.delete(&tid);
 
         if (address != 0) {
                 info.timestamp_ns = bpf_ktime_get_ns();
@@ -307,21 +307,21 @@ int munmap_enter(struct pt_regs *ctx, void *address) {
 int posix_memalign_enter(struct pt_regs *ctx, void **memptr, size_t alignment,
                          size_t size) {
         u64 memptr64 = (u64)(size_t)memptr;
-        u64 pid = bpf_get_current_pid_tgid();
+        u32 tid = bpf_get_current_pid_tgid();
 
-        memptrs.update(&pid, &memptr64);
+        memptrs.update(&tid, &memptr64);
         return gen_alloc_enter(ctx, size);
 }
 
 int posix_memalign_exit(struct pt_regs *ctx) {
-        u64 pid = bpf_get_current_pid_tgid();
-        u64 *memptr64 = memptrs.lookup(&pid);
+        u32 tid = bpf_get_current_pid_tgid();
+        u64 *memptr64 = memptrs.lookup(&tid);
         void *addr;
 
         if (memptr64 == 0)
                 return 0;
 
-        memptrs.delete(&pid);
+        memptrs.delete(&tid);
 
         if (bpf_probe_read_user(&addr, sizeof(void*), (void*)(size_t)*memptr64))
                 return 0;


### PR DESCRIPTION
As `sizes` and `memptrs` map are to store the temporal information of each thread, use only `tid` portion of the return value of `bpf_get_current_pid_tgid` as a key of `sizes` and `memptrs` map. This change could reduce the key size of each map from 64 bits to 32 bits. The lower 32 bits portion of the return value of `bpf_get_current_pid_tgid` is kernel's view of the `pid`, which in user space is usually presented as the `tid`.

Please refer this document for further information:
https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#4-bpf_get_current_pid_tgid