### PR TITLE
libbpf-tools/ksnoop: perf buffer fix unnecessary junk bits output

### DIFF
--- a/libbpf-tools/ksnoop.h
+++ b/libbpf-tools/ksnoop.h
@@ -96,6 +96,7 @@ struct trace {
 	struct btf *btf;
 	struct btf_dump *dump;
 	struct func func;
+	struct bpf_link *links[2];
 	__u8 nr_traces;
 	__u32 filter_pid;
 	__u64 prev_ip; /* these are used in stack-mode tracing */
@@ -112,7 +113,6 @@ struct trace {
 	__u16 buf_len;
 	char buf[MAX_TRACE_BUF];
 	char buf_end[0];
-	struct bpf_link *links[2];
 };
 
 #define PAGES_DEFAULT	16


### PR DESCRIPTION
In output_trace() bpf_perf_event_output determins its even size
 (trace_len in this function) based on the fact that trace->buf
is at the end of struct trace:
> trace_len = sizeof(*trace) + trace->buf_len - MAX_TRACE_BUF;

Commit e9f140f0fea0 ("libbpf-tools: Fix memory leaks in ksnoop/gethostlatency") breaks that rule and we will put 2 pointers size more junk bits into perf buffer. Fix this by moving forward the new added tailing pointers to its proper place(commented as readonly segment).