### PR TITLE
doc: Fix the build guide for the Arch Linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -735,7 +735,7 @@ git clone https://github.com/iovisor/bcc.git
 pushd .
 mkdir bcc/build
 cd bcc/build
-cmake .. -DPYTHON_CMD=python3 # for python3 support
+cmake -DENABLE_LLVM_SHARED=on .. -DPYTHON_CMD=python3 # for python3 support
 make -j$(nproc)
 sudo make install
 cd src/python


### PR DESCRIPTION
After LLVM 15.0.7.2 on the Arch Linux, the package maintainer remove the static library default, FYI https://gitlab.archlinux.org/archlinux/packaging/packages/llvm/-/commit/3e452a15b68d156a9ef5608e8f6e1870d192d954


So we need add `-DENABLE_LLVM_SHARED=on` default for the Arch Linux