### PR TITLE
Use llvm12 when building containers

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -14,7 +14,7 @@ inputs:
   llvm_versions:
     description: "Space separated list of llvm versions to install in the container. Only supported for Ubuntu containers."
     type: string
-    default: "11"
+    default: "12"
   registry:
     description: "Registry where to push images"
     default: ghcr.io

--- a/docker/build/Dockerfile.ubuntu
+++ b/docker/build/Dockerfile.ubuntu
@@ -58,6 +58,7 @@ RUN /bin/bash -c 'apt-get update && apt-get install -y \
       bridge-utils \
       libtinfo5 \
       libtinfo-dev \
+      libzstd-dev \
       xz-utils \
       zip && \
       read -ra versions <<<"${LLVM_VERSION}" && \


### PR DESCRIPTION
I already moved the minimum llvm version from 11 to 12 and this particular instance is missed.