### PR TITLE
libbpf-tools/offcputime, futexctn: Fix incorrect DSO information in s…

### DIFF
--- a/libbpf-tools/futexctn.c
+++ b/libbpf-tools/futexctn.c
@@ -245,6 +245,8 @@ static int print_stack(struct futexctn_bpf *obj, struct hist_key *info)
 			else
 				printf("    [unknown]\n");
 		} else {
+			dso_name = NULL;
+			dso_offset = 0;
 			sym = syms__map_addr_dso(syms, ip[i], &dso_name, &dso_offset);
 			printf("    #%-2d 0x%016lx", idx++, ip[i]);
 			if (sym)

--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -262,6 +262,8 @@ print_ustack:
 				else
 					printf("    [unknown]\n");
 			} else {
+				dso_name = NULL;
+				dso_offset = 0;
 				sym = syms__map_addr_dso(syms, ip[i], &dso_name, &dso_offset);
 				printf("    #%-2d 0x%016lx", idx++, ip[i]);
 				if (sym)


### PR DESCRIPTION
…tacktrace

offcputime may display inaccurate DSO information in the stacktrace. Here's an example of the issue:

It shows the same DSO offset for different addresses, which is incorrect.
```
  $ ./offcputime -v
    ..
    #14 0x00007f8b912a8c (/usr/lib/libcbe.so_0x22afa8c)
    #15 0x000044000a3ee0 (/usr/lib/libcbe.so_0x22afa8c)
    #16 0x000044001fc56c (/usr/lib/libcbe.so_0x22afa8c)
```

This is why syms__map_addr_dso simply returns NULL when syms__find_dso also returns NULL. In that case, the values of dso_name and dso_offset are not changed. If the dso_name and dso_offset variables have a garbage value before calling syms__map_addr_dso, those garbage values are maintained after calling syms__map_addr_dso.

This patch fixes the issue by reinitializing dso_name and dso_offset variables before calling syms__map_addr_dso.

FYI, there is another PR(https://github.com/iovisor/bcc/pull/4862) to fix the issue by changing syms__map_addr_dso API. 
This PR is to fix the issue in a simple way as the above PR is pending now.