### PR TITLE
tools/bashreadline: Fix bashreadline

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -24,5 +24,5 @@ COPY --from=builder /root/bcc/*.deb /root/bcc/
 RUN \
   apt-get update -y && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python-is-python3 binutils libelf1 kmod  && \
-  pip3 install dnslib cachetools  && \
+  pip3 install dnslib cachetools pyelftools  && \
   dpkg -i /root/bcc/*.deb

--- a/docker/build/Dockerfile.fedora
+++ b/docker/build/Dockerfile.fedora
@@ -59,7 +59,7 @@ RUN dnf -y install \
 	iperf \
 	netperf
 
-RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1
+RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1 pyelftools==0.30
 
 RUN wget -O ruby-install-${RUBY_INSTALL_VERSION}.tar.gz \
          https://github.com/postmodern/ruby-install/archive/v${RUBY_INSTALL_VERSION}.tar.gz && \

--- a/docker/build/Dockerfile.ubuntu
+++ b/docker/build/Dockerfile.ubuntu
@@ -81,7 +81,7 @@ done \
 && \
       apt-get -y clean'
 
-RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1
+RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1 pyelftools==0.30
 
 # FIXME this is faster than building from source, but it seems there is a bug
 # in probing libruby.so rather than ruby binary

--- a/libbpf-tools/bashreadline.c
+++ b/libbpf-tools/bashreadline.c
@@ -90,6 +90,41 @@ static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
 }
 
+static char *find_readline_function_name(const char *bash_path)
+{
+  bool found = false;
+  int fd = -1;
+  Elf *elf = NULL;
+  Elf_Scn *scn = NULL;
+  GElf_Shdr shdr;
+
+
+  elf = open_elf(bash_path, &fd);
+
+  while ((scn = elf_nextscn(elf, scn)) != NULL && !found) {
+    gelf_getshdr(scn, &shdr);
+    if (shdr.sh_type == SHT_SYMTAB || shdr.sh_type == SHT_DYNSYM) {
+      Elf_Data *data = elf_getdata(scn, NULL);
+      if (data != NULL) {
+        GElf_Sym *symtab = (GElf_Sym *) data->d_buf;
+        int sym_count = shdr.sh_size / shdr.sh_entsize;
+        for (int i = 0; i < sym_count; ++i) {
+          if(strcmp("readline_internal_teardown", elf_strptr(elf, shdr.sh_link, symtab[i].st_name)) == 0){
+            found = true;
+            break;
+          }
+        }
+    	}
+    }
+  }
+
+  close_elf(elf,fd);
+  if (found)
+    return "readline_internal_teardown";
+  else
+    return "readline";
+}
+
 static char *find_readline_so()
 {
 	const char *bash_path = "/bin/bash";
@@ -100,7 +135,7 @@ static char *find_readline_so()
 	char path[128];
 	char *result = NULL;
 
-	func_off = get_elf_func_offset(bash_path, "readline");
+	func_off = get_elf_func_offset(bash_path, find_readline_function_name(bash_path));
 	if (func_off >= 0)
 		return strdup(bash_path);
 
@@ -159,7 +194,6 @@ int main(int argc, char **argv)
 	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
 	if (err)
 		return err;
-
 	if (libreadline_path) {
 		readline_so_path = libreadline_path;
 	} else if ((readline_so_path = find_readline_so()) == NULL) {
@@ -187,7 +221,7 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	func_off = get_elf_func_offset(readline_so_path, "readline");
+	func_off = get_elf_func_offset(readline_so_path, find_readline_function_name(readline_so_path));
 	if (func_off < 0) {
 		warn("cound not find readline in %s\n", readline_so_path);
 		goto cleanup;


### PR DESCRIPTION
This Pull Request fixes the issue where the bashreadline tool would lose the first bash command upon startup.

At runtime, bash blocks at the readline function in bash::readline.c. Upon receiving the Enter key signal, it calls the readline_internal_teardown function to retrieve the user's input. Therefore, changing the hook function from readline to readline_internal_teardown resolves the issue of losing the first bash command after startup of bashreadline.

The specific approach is to open the symbol table of bash and check if there is a symbol for readline_internal_teardown function. If not, continue to use the readline function as the hook position.