### PR TITLE
libbpf-tools: fix syscall tracepoints

### DIFF
--- a/libbpf-tools/execsnoop.bpf.c
+++ b/libbpf-tools/execsnoop.bpf.c
@@ -36,7 +36,7 @@ static __always_inline bool valid_uid(uid_t uid) {
 }
 
 SEC("tracepoint/syscalls/sys_enter_execve")
-int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter* ctx)
+int tracepoint__syscalls__sys_enter_execve(struct syscall_trace_enter* ctx)
 {
 	u64 id;
 	pid_t pid, tgid;
@@ -112,7 +112,7 @@ int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter* ctx
 }
 
 SEC("tracepoint/syscalls/sys_exit_execve")
-int tracepoint__syscalls__sys_exit_execve(struct trace_event_raw_sys_exit* ctx)
+int tracepoint__syscalls__sys_exit_execve(struct syscall_trace_exit* ctx)
 {
 	u64 id;
 	pid_t pid;

--- a/libbpf-tools/futexctn.bpf.c
+++ b/libbpf-tools/futexctn.bpf.c
@@ -49,7 +49,7 @@ struct {
 static struct hist initial_hist = {};
 
 SEC("tracepoint/syscalls/sys_enter_futex")
-int futex_enter(struct trace_event_raw_sys_enter *ctx)
+int futex_enter(struct syscall_trace_enter *ctx)
 {
 	struct val_t v = {};
 	u64 pid_tgid;
@@ -73,7 +73,7 @@ int futex_enter(struct trace_event_raw_sys_enter *ctx)
 }
 
 SEC("tracepoint/syscalls/sys_exit_futex")
-int futex_exit(struct trace_event_raw_sys_exit *ctx)
+int futex_exit(struct syscall_trace_exit *ctx)
 {
 	u64 pid_tgid, slot, ts, min, max;
 	struct hist_key hkey = {};

--- a/libbpf-tools/mountsnoop.bpf.c
+++ b/libbpf-tools/mountsnoop.bpf.c
@@ -92,7 +92,7 @@ cleanup:
 }
 
 SEC("tracepoint/syscalls/sys_enter_mount")
-int mount_entry(struct trace_event_raw_sys_enter *ctx)
+int mount_entry(struct syscall_trace_enter *ctx)
 {
 	const char *src = (const char *)ctx->args[0];
 	const char *dest = (const char *)ctx->args[1];
@@ -104,13 +104,13 @@ int mount_entry(struct trace_event_raw_sys_enter *ctx)
 }
 
 SEC("tracepoint/syscalls/sys_exit_mount")
-int mount_exit(struct trace_event_raw_sys_exit *ctx)
+int mount_exit(struct syscall_trace_exit *ctx)
 {
 	return probe_exit(ctx, (int)ctx->ret);
 }
 
 SEC("tracepoint/syscalls/sys_enter_umount")
-int umount_entry(struct trace_event_raw_sys_enter *ctx)
+int umount_entry(struct syscall_trace_enter *ctx)
 {
 	const char *dest = (const char *)ctx->args[0];
 	__u64 flags = (__u64)ctx->args[1];
@@ -119,7 +119,7 @@ int umount_entry(struct trace_event_raw_sys_enter *ctx)
 }
 
 SEC("tracepoint/syscalls/sys_exit_umount")
-int umount_exit(struct trace_event_raw_sys_exit *ctx)
+int umount_exit(struct syscall_trace_exit *ctx)
 {
 	return probe_exit(ctx, (int)ctx->ret);
 }

--- a/libbpf-tools/opensnoop.bpf.c
+++ b/libbpf-tools/opensnoop.bpf.c
@@ -47,7 +47,7 @@ bool trace_allowed(u32 tgid, u32 pid)
 }
 
 SEC("tracepoint/syscalls/sys_enter_open")
-int tracepoint__syscalls__sys_enter_open(struct trace_event_raw_sys_enter* ctx)
+int tracepoint__syscalls__sys_enter_open(struct syscall_trace_enter* ctx)
 {
 	u64 id = bpf_get_current_pid_tgid();
 	/* use kernel terminology here for tgid/pid: */
@@ -65,7 +65,7 @@ int tracepoint__syscalls__sys_enter_open(struct trace_event_raw_sys_enter* ctx)
 }
 
 SEC("tracepoint/syscalls/sys_enter_openat")
-int tracepoint__syscalls__sys_enter_openat(struct trace_event_raw_sys_enter* ctx)
+int tracepoint__syscalls__sys_enter_openat(struct syscall_trace_enter* ctx)
 {
 	u64 id = bpf_get_current_pid_tgid();
 	/* use kernel terminology here for tgid/pid: */
@@ -83,7 +83,7 @@ int tracepoint__syscalls__sys_enter_openat(struct trace_event_raw_sys_enter* ctx
 }
 
 static __always_inline
-int trace_exit(struct trace_event_raw_sys_exit* ctx)
+int trace_exit(struct syscall_trace_exit* ctx)
 {
 	struct event event = {};
 	struct args_t *ap;
@@ -122,13 +122,13 @@ cleanup:
 }
 
 SEC("tracepoint/syscalls/sys_exit_open")
-int tracepoint__syscalls__sys_exit_open(struct trace_event_raw_sys_exit* ctx)
+int tracepoint__syscalls__sys_exit_open(struct syscall_trace_exit* ctx)
 {
 	return trace_exit(ctx);
 }
 
 SEC("tracepoint/syscalls/sys_exit_openat")
-int tracepoint__syscalls__sys_exit_openat(struct trace_event_raw_sys_exit* ctx)
+int tracepoint__syscalls__sys_exit_openat(struct syscall_trace_exit* ctx)
 {
 	return trace_exit(ctx);
 }

--- a/libbpf-tools/sigsnoop.bpf.c
+++ b/libbpf-tools/sigsnoop.bpf.c
@@ -68,7 +68,7 @@ cleanup:
 }
 
 SEC("tracepoint/syscalls/sys_enter_kill")
-int kill_entry(struct trace_event_raw_sys_enter *ctx)
+int kill_entry(struct syscall_trace_enter *ctx)
 {
 	pid_t tpid = (pid_t)ctx->args[0];
 	int sig = (int)ctx->args[1];
@@ -77,13 +77,13 @@ int kill_entry(struct trace_event_raw_sys_enter *ctx)
 }
 
 SEC("tracepoint/syscalls/sys_exit_kill")
-int kill_exit(struct trace_event_raw_sys_exit *ctx)
+int kill_exit(struct syscall_trace_exit *ctx)
 {
 	return probe_exit(ctx, ctx->ret);
 }
 
 SEC("tracepoint/syscalls/sys_enter_tkill")
-int tkill_entry(struct trace_event_raw_sys_enter *ctx)
+int tkill_entry(struct syscall_trace_enter *ctx)
 {
 	pid_t tpid = (pid_t)ctx->args[0];
 	int sig = (int)ctx->args[1];
@@ -92,13 +92,13 @@ int tkill_entry(struct trace_event_raw_sys_enter *ctx)
 }
 
 SEC("tracepoint/syscalls/sys_exit_tkill")
-int tkill_exit(struct trace_event_raw_sys_exit *ctx)
+int tkill_exit(struct syscall_trace_exit *ctx)
 {
 	return probe_exit(ctx, ctx->ret);
 }
 
 SEC("tracepoint/syscalls/sys_enter_tgkill")
-int tgkill_entry(struct trace_event_raw_sys_enter *ctx)
+int tgkill_entry(struct syscall_trace_enter *ctx)
 {
 	pid_t tpid = (pid_t)ctx->args[1];
 	int sig = (int)ctx->args[2];
@@ -107,7 +107,7 @@ int tgkill_entry(struct trace_event_raw_sys_enter *ctx)
 }
 
 SEC("tracepoint/syscalls/sys_exit_tgkill")
-int tgkill_exit(struct trace_event_raw_sys_exit *ctx)
+int tgkill_exit(struct syscall_trace_exit *ctx)
 {
 	return probe_exit(ctx, ctx->ret);
 }

--- a/libbpf-tools/statsnoop.bpf.c
+++ b/libbpf-tools/statsnoop.bpf.c
@@ -68,61 +68,61 @@ static int probe_return(void *ctx, int ret)
 }
 
 SEC("tracepoint/syscalls/sys_enter_statfs")
-int handle_statfs_entry(struct trace_event_raw_sys_enter *ctx)
+int handle_statfs_entry(struct syscall_trace_enter *ctx)
 {
 	return probe_entry(ctx, (const char *)ctx->args[0]);
 }
 
 SEC("tracepoint/syscalls/sys_exit_statfs")
-int handle_statfs_return(struct trace_event_raw_sys_exit *ctx)
+int handle_statfs_return(struct syscall_trace_exit *ctx)
 {
 	return probe_return(ctx, (int)ctx->ret);
 }
 
 SEC("tracepoint/syscalls/sys_enter_newstat")
-int handle_newstat_entry(struct trace_event_raw_sys_enter *ctx)
+int handle_newstat_entry(struct syscall_trace_enter *ctx)
 {
 	return probe_entry(ctx, (const char *)ctx->args[0]);
 }
 
 SEC("tracepoint/syscalls/sys_exit_newstat")
-int handle_newstat_return(struct trace_event_raw_sys_exit *ctx)
+int handle_newstat_return(struct syscall_trace_exit *ctx)
 {
 	return probe_return(ctx, (int)ctx->ret);
 }
 
 SEC("tracepoint/syscalls/sys_enter_statx")
-int handle_statx_entry(struct trace_event_raw_sys_enter *ctx)
+int handle_statx_entry(struct syscall_trace_enter *ctx)
 {
 	return probe_entry(ctx, (const char *)ctx->args[1]);
 }
 
 SEC("tracepoint/syscalls/sys_exit_statx")
-int handle_statx_return(struct trace_event_raw_sys_exit *ctx)
+int handle_statx_return(struct syscall_trace_exit *ctx)
 {
 	return probe_return(ctx, (int)ctx->ret);
 }
 
 SEC("tracepoint/syscalls/sys_enter_newfstatat")
-int handle_newfstatat_entry(struct trace_event_raw_sys_enter *ctx)
+int handle_newfstatat_entry(struct syscall_trace_enter *ctx)
 {
 	return probe_entry(ctx, (const char *)ctx->args[1]);
 }
 
 SEC("tracepoint/syscalls/sys_exit_newfstatat")
-int handle_newfstatat_return(struct trace_event_raw_sys_exit *ctx)
+int handle_newfstatat_return(struct syscall_trace_exit *ctx)
 {
 	return probe_return(ctx, (int)ctx->ret);
 }
 
 SEC("tracepoint/syscalls/sys_enter_newlstat")
-int handle_newlstat_entry(struct trace_event_raw_sys_enter *ctx)
+int handle_newlstat_entry(struct syscall_trace_enter *ctx)
 {
 	return probe_entry(ctx, (const char *)ctx->args[0]);
 }
 
 SEC("tracepoint/syscalls/sys_exit_newlstat")
-int handle_newlstat_return(struct trace_event_raw_sys_exit *ctx)
+int handle_newlstat_return(struct syscall_trace_exit *ctx)
 {
 	return probe_return(ctx, (int)ctx->ret);
 }


### PR DESCRIPTION
In BPF programs, syscall tracepoints returns a local syscall_tp_t structure that's meant to mimic syscall_trace_enter/exit structures. It just happen to have the same offsets for nr and args fields as struct trace_event_raw_sys_enter/exit. However, a change in the trace_entry structure in the linux-rt broke that assumption (ea622076b76f "sched: Add support for lazy preemption").

Program calling syscall tracepoint should have used the right structure in the first place. This patch replace the trace_event_raw_sys_* by their syscall_trace_* counterpart when calling a syscall tracepoint.