### PR TITLE
Explicitly declare dependency on LLVM header

### DIFF
--- a/SPECS/bcc.spec
+++ b/SPECS/bcc.spec
@@ -56,6 +56,7 @@ BuildRequires: llvm-static
 %endif
 %endif
 BuildRequires: pkgconfig ncurses-devel
+Requires: llvm-devel
 
 %description
 Python bindings for BPF Compiler Collection (BCC). Control a BPF program from

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Package: libbcc
 Architecture: any
 Provides: libbpfcc, libbpfcc-dev
 Conflicts: libbpfcc, libbpfcc-dev
-Depends: libc6, libstdc++6, libelf1
+Depends: libc6, libstdc++6, libelf1, llvm-12-dev
 # add 'libdebuginfod1' to Depends if built with libdebuginfod support
 Description: Shared Library for BPF Compiler Collection (BCC)
  Shared Library for BPF Compiler Collection to control BPF programs


### PR DESCRIPTION
With commit 6f11bf7e in #4737 bpf_module.h now includes llvm-config.h, hence tools building against libbcc may need the LLVM headers at build time.

Add the LLVM development package as a runtime requirement in the included package specifications to make such dependency explicit.

Context: this problem was encountered when building [procmon](https://github.com/Sysinternals/ProcMon-for-Linux) on openSUSE, and we had to add such dependency for the bcc-devel package https://build.opensuse.org/request/show/1152316

CC @chantra @jeromemarchand  