### PR TITLE
libbpf-tools: Fix fsdist, fsslower, and sigsnoop aliases when installed with APP_PREFIX

### DIFF
--- a/libbpf-tools/fsdist.c
+++ b/libbpf-tools/fsdist.c
@@ -195,15 +195,15 @@ static void alias_parse(char *prog)
 {
 	char *name = basename(prog);
 
-	if (!strcmp(name, "btrfsdist")) {
+	if (strstr(name, "btrfsdist")) {
 		fs_type = BTRFS;
-	} else if (!strcmp(name, "ext4dist")) {
+	} else if (strstr(name, "ext4dist")) {
 		fs_type = EXT4;
-	} else if (!strcmp(name, "nfsdist")) {
+	} else if (strstr(name, "nfsdist")) {
 		fs_type = NFS;
-	} else if (!strcmp(name, "xfsdist")) {
+	} else if (strstr(name, "xfsdist")) {
 		fs_type = XFS;
-	} else if (!strcmp(name, "f2fsdist")){
+	} else if (strstr(name, "f2fsdist")){
 		fs_type = F2FS;
 	}
 }

--- a/libbpf-tools/fsslower.c
+++ b/libbpf-tools/fsslower.c
@@ -180,15 +180,15 @@ static void alias_parse(char *prog)
 {
 	char *name = basename(prog);
 
-	if (!strcmp(name, "btrfsslower")) {
+	if (strstr(name, "btrfsslower")) {
 		fs_type = BTRFS;
-	} else if (!strcmp(name, "ext4slower")) {
+	} else if (strstr(name, "ext4slower")) {
 		fs_type = EXT4;
-	} else if (!strcmp(name, "nfsslower")) {
+	} else if (strstr(name, "nfsslower")) {
 		fs_type = NFS;
-	} else if (!strcmp(name, "xfsslower")) {
+	} else if (strstr(name, "xfsslower")) {
 		fs_type = XFS;
-	} else if (!strcmp(name, "f2fsslower")){
+	} else if (strstr(name, "f2fsslower")){
 		fs_type = F2FS;
 	}
 }

--- a/libbpf-tools/sigsnoop.c
+++ b/libbpf-tools/sigsnoop.c
@@ -146,7 +146,7 @@ static void alias_parse(char *prog)
 {
 	char *name = basename(prog);
 
-	if (!strcmp(name, "killsnoop")) {
+	if (strstr(name, "killsnoop")) {
 		kill_only = true;
 	}
 }


### PR DESCRIPTION
Support for prefixed installs with an `APP_PREFIX` variable was added in https://github.com/iovisor/bcc/pull/4848.

`fsdist`, `fsslower`, and `sigsnoop` support aliased execution but that only works as intended if `basename(prog)` matches the non-prefixed alias exactly:

```
root@test:~# foo-prefix-ext4slower
filesystem must be specified using -t option.
```

This PR simply relaxes that behavior to only find a string match:

```
root@test:~# foo-prefix-ext4slower
Tracing ext4 operations slower than 10 ms... Hit Ctrl-C to end.
...
```