### PR TITLE
clang: Fix file_exists_and_ownedby return value

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -143,8 +143,8 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
 static inline int file_exists_and_ownedby(const char *f, uid_t uid)
 {
   struct stat buffer;
-  int ret;
-  if ((ret = stat(f, &buffer)) == 0) {
+  int ret = stat(f, &buffer) == 0;
+  if (ret) {
     if (buffer.st_uid != uid) {
       std::cout << "ERROR: header file ownership unexpected: " << std::string(f) << "\n";
       return -1;


### PR DESCRIPTION
commit 008ea09 (clang: check header ownership) updates file_exists() to file_exists_and_ownedby(), add verifies onwer, but the return value is different from before, causing problems with the original code.

After commit 008ea09 (clang: check header ownership)， `/usr/share/bcc/examples/hello_world.py --help` output is different: (left: old  | right: new)
![image](https://github.com/iovisor/bcc/assets/48231204/10bdb2ab-ca22-4c5a-9cfe-b9abf6dd8ddd)

Because commit 008ea09  changed the return value：
**Old: If file exists, file_exists() return 1;**
```c
static inline int file_exists(const char *f)
{
  struct stat buffer;
  return (stat(f, &buffer) == 0);  //ret = stat(f, &buffer) == 0
}
```

**New: If file exists, file_exists_and_ownedby() return 0;**
```c
static inline int file_exists_and_ownedby(const char *f, uid_t uid)
{
  struct stat buffer;
  int ret;
  if ((ret = stat(f, &buffer)) == 0) {   //ret = stat(f, &buffer)) 
    if (buffer.st_uid != uid) {
      std::cout << "ERROR: header file ownership unexpected: " << std::string(f) << "\n";
      return -1;
    }
  }
  return ret;
}
```
