### PR TITLE
Fix another btf_type_tag issue with llvm 15

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -787,7 +787,7 @@ void BTypeVisitor::genParamDirectAssign(FunctionDecl *D, string& preamble,
       arg->addAttr(UnavailableAttr::CreateImplicit(C, "ptregs"));
       size_t d = idx - 1;
       const char *reg = calling_conv_regs[d];
-      preamble += " " + text + " = (" + arg->getType().getAsString() + ")" +
+      preamble += " " + text + " = (" + FixBTFTypeTag(arg->getType().getAsString()) + ")" +
                   fn_args_[0]->getName().str() + "->" + string(reg) + ";";
     }
   }


### PR DESCRIPTION
Commit 57ca51bdd9c8 ("Fix btf_type_tag issue with llvm 15") fixed an issue where "btf_type_tag(rcu)" should be replaced with "__attribute__((btf_type_tag(\"rcu\")))".

I audited some other bcc tools and found another similar failure pattern during processing funciton arguments. Three tools are dirtop.py, fileslower.py and filetop.py.

The failure pattern for dirtop.py looks like:
```
  /virtual/main.c:79:72: error: expected ')'
   struct file *file = (struct file *)ctx->di; char __user *buf =
     (char  btf_type_tag(user)*)ctx->si; size_t count = (size_t)ctx->dx;
```
Again, the "btf_type_tag(user)" should be replaced with `"__attribute__((btf_type_tag(\"user\")))"`. This patch fixed this issue.