### PR TITLE
Fix slabratetop.py for 6.8 kernel

### DIFF
--- a/src/cc/libbpf.h
+++ b/src/cc/libbpf.h
@@ -126,6 +126,7 @@ int bpf_attach_lsm(int prog_fd);
 bool bpf_has_kernel_btf(void);
 
 int kernel_struct_has_field(const char *struct_name, const char *field_name);
+unsigned long long kernel_struct_field_size_offset(const char *struct_name, const char *field_name);
 
 void * bpf_open_perf_buffer(perf_reader_raw_cb raw_cb,
                             perf_reader_lost_cb lost_cb, void *cb_cookie,

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1212,6 +1212,14 @@ class BPF(object):
         field_name = _assert_is_bytes(field_name)
         return lib.kernel_struct_has_field(struct_name, field_name)
 
+    @staticmethod
+    def kernel_struct_field_size_offset(struct_name, field_name):
+        struct_name = _assert_is_bytes(struct_name)
+        field_name = _assert_is_bytes(field_name)
+        # return a ulonglong with bit size (top 32) and bit offset (lower 32).
+        # -1 indicates not finding.
+        return lib.kernel_struct_field_size_offset(struct_name, field_name)
+
     def detach_tracepoint(self, tp=b""):
         """detach_tracepoint(tp="")
 

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -133,6 +133,8 @@ lib.bpf_has_kernel_btf.restype = ct.c_bool
 lib.bpf_has_kernel_btf.argtypes = None
 lib.kernel_struct_has_field.restype = ct.c_int
 lib.kernel_struct_has_field.argtypes = [ct.c_char_p, ct.c_char_p]
+lib.kernel_struct_field_size_offset.restype = ct.c_ulonglong
+lib.kernel_struct_field_size_offset.argtypes = [ct.c_char_p, ct.c_char_p]
 lib.bpf_open_perf_buffer.restype = ct.c_void_p
 lib.bpf_open_perf_buffer.argtypes = [_RAW_CB_TYPE, _LOST_CB_TYPE, ct.py_object, ct.c_int, ct.c_int, ct.c_int]
 


### PR DESCRIPTION
slabratetop.py failed with 6.8 kernel with
```    
      /virtual/main.c:100:10: fatal error: 'linux/slub_def.h' file not found
        100 | #include <linux/slub_def.h>
            |          ^~~~~~~~~~~~~~~~~~
      1 error generated.
```
    
Actually 'kmem_cache' is also not available to bcc any more.
We already copied 'slab' data structure to bcc, copying yet
another one (probably with others) will make things too
complex and error prone.
    
Let us use newly introduced kernel_struct_field_size_offset() API.
We could get some data structure (field, size) information
from kernel BTF. This enables us to work around header file
not available issue.
