### PR TITLE
Mark slabratetop.py not supported for >= 6.8 kernel

### DIFF
--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -22,8 +22,14 @@ from __future__ import print_function
 from bcc import BPF
 from bcc.utils import printb
 from time import sleep, strftime
-import argparse
+import argparse, platform
 from subprocess import call
+
+rel = platform.release().split('.')
+if int(rel[0]) > 6 or (int(rel[0]) == 6 and int(rel[1]) >= 8):
+    print("Linux 6.8 and later are not supported due to kernel internal data structure changes.")
+    print("Please use libbpf-tool version of slabratetop instead.")
+    exit()
 
 # arguments
 examples = """examples:


### PR DESCRIPTION
slabratetop.py failed with 6.8 kernel with
```
      /virtual/main.c:100:10: fatal error: 'linux/slub_def.h' file not found
        100 | #include <linux/slub_def.h>
            |          ^~~~~~~~~~~~~~~~~~
      1 error generated.
```
Actually 'kmem_cache' is also not available to bcc any more. Either copying 'kmem_cache' or using mini-CORE like logic are too complex and error prone ([1]). So let us mark the tool is not supported for >= 6.8 kernel and suggest to use libbpf-tool version of slabratetop if needed.

  [1]. https://github.com/iovisor/bcc/pull/4940