### PR TITLE
fix deb build/docker ubuntu

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 9), cmake,
-    libllvm12
+    libllvm12,
     llvm-12-dev,
     libclang-12-dev,
     clang-format-12,

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -23,6 +23,7 @@ COPY --from=builder /root/bcc/*.deb /root/bcc/
 
 RUN \
   apt-get update -y && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python-is-python3 binutils libelf1 kmod  && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python-is-python3 binutils libelf1 kmod llvm-12-dev && \
   pip3 install dnslib cachetools pyelftools  && \
-  dpkg -i /root/bcc/*.deb
+  dpkg -i /root/bcc/*.deb && \
+  apt-get clean


### PR DESCRIPTION
- Fixes typo in `debian/control` which was causing deb builds to fail
- add llvm-12-dev package to ubuntu dockerfile