### PR TITLE
libbpf-tools/gethostlatency: correct section name

### DIFF
--- a/libbpf-tools/gethostlatency.bpf.c
+++ b/libbpf-tools/gethostlatency.bpf.c
@@ -60,13 +60,13 @@ static int probe_return(struct pt_regs *ctx)
 	return 0;
 }
 
-SEC("kprobe/handle_entry")
+SEC("uprobe")
 int BPF_KPROBE(handle_entry)
 {
 	return probe_entry(ctx);
 }
 
-SEC("kretprobe/handle_return")
+SEC("uretprobe")
 int BPF_KRETPROBE(handle_return)
 {
 	return probe_return(ctx);


### PR DESCRIPTION
`handle_entry` and `handle_return` are attached to uprobes `getaddrinfo`, `gethostbyname`, and `gethostbyname2`, so it doesn't make sense to have the section name be `kprobe`