### PR TITLE
Reomove "-nopie" option workaround for old clang.

### DIFF
--- a/cmake/FindCompilerFlag.cmake
+++ b/cmake/FindCompilerFlag.cmake
@@ -3,20 +3,16 @@
 
 if (ENABLE_NO_PIE)
 
-if (CMAKE_C_COMPILER_ID MATCHES "Clang")
-	set(COMPILER_NOPIE_FLAG "-nopie")
+set(_backup_c_flags "${CMAKE_REQUIRED_FLAGS}")
+set(CMAKE_REQUIRED_FLAGS "-no-pie")
+CHECK_CXX_SOURCE_COMPILES("int main() {return 0;}"
+			  HAVE_NO_PIE_FLAG)
+if (HAVE_NO_PIE_FLAG)
+	set(COMPILER_NOPIE_FLAG "-no-pie")
 else()
-	set(_backup_c_flags "${CMAKE_REQUIRED_FLAGS}")
-	set(CMAKE_REQUIRED_FLAGS "-no-pie")
-	CHECK_CXX_SOURCE_COMPILES("int main() {return 0;}"
-				  HAVE_NO_PIE_FLAG)
-	if (HAVE_NO_PIE_FLAG)
-		set(COMPILER_NOPIE_FLAG "-no-pie")
-	else()
-		set(COMPILER_NOPIE_FLAG "")
-	endif()
-	set(CMAKE_REQUIRED_FLAGS "${_backup_c_flags}")
+	set(COMPILER_NOPIE_FLAG "")
 endif()
+set(CMAKE_REQUIRED_FLAGS "${_backup_c_flags}")
 
 endif(ENABLE_NO_PIE)
 


### PR DESCRIPTION
fix: https://github.com/iovisor/bcc/issues/4931