### PR TITLE
tools/{biolatency,biosnoop,biotop}: Use tracepoint first

### DIFF
--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -273,21 +273,29 @@ else:
     bpf_text = bpf_text.replace('FILTER_PID', '0')
 
 b = BPF(text=bpf_text)
-if BPF.get_kprobe_functions(b'__blk_account_io_start'):
+if BPF.tracepoint_exists("block", "block_io_start"):
+    b.attach_tracepoint(tp="block:block_io_start", fn_name="trace_pid_start_tp")
+elif BPF.get_kprobe_functions(b'__blk_account_io_start'):
     b.attach_kprobe(event="__blk_account_io_start", fn_name="trace_pid_start")
 elif BPF.get_kprobe_functions(b'blk_account_io_start'):
     b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
 else:
-    b.attach_tracepoint(tp="block:block_io_start", fn_name="trace_pid_start_tp")
+    print("ERROR: No found any block io start probe/tp.")
+    exit()
+
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
-if BPF.get_kprobe_functions(b'__blk_account_io_done'):
+
+if BPF.tracepoint_exists("block", "block_io_done"):
+    b.attach_tracepoint(tp="block:block_io_done", fn_name="trace_req_completion_tp")
+elif BPF.get_kprobe_functions(b'__blk_account_io_done'):
     b.attach_kprobe(event="__blk_account_io_done", fn_name="trace_req_completion")
 elif BPF.get_kprobe_functions(b'blk_account_io_done'):
     b.attach_kprobe(event="blk_account_io_done", fn_name="trace_req_completion")
 else:
-    b.attach_tracepoint(tp="block:block_io_done", fn_name="trace_req_completion_tp")
+    print("ERROR: No found any block io done probe/tp.")
+    exit()
 
 # check whether hash table batch ops is supported
 htab_batch_ops = True if BPF.kernel_struct_has_field(b'bpf_map_ops',


### PR DESCRIPTION
Since kernel introduce block:block_io_{start,done}, we should use tracepoint first, just like the follow error i got on Fedora 39

```
    $ sudo ./biolatency.py
    ...
    cannot attach kprobe, Invalid argument
    Traceback (most recent call last):
      File "/home/sda/git-repos/bcc/tools/./biolatency.py", line 291, in <module>
        b.attach_kprobe(event="blk_account_io_done", fn_name="trace_req_done")
      File "/usr/lib/python3.12/site-packages/bcc/__init__.py", line 845, in attach_kprobe
        raise Exception("Failed to attach BPF program %s to kprobe %s"
    Exception: Failed to attach BPF program b'trace_req_done' to kprobe b'blk_account_io_done',
    it's not traceable (either non-existing, inlined, or marked as "notrace")
```

# Fedora 39

```
rongtao@RT-NUC:~/Git/bcc$ cat /etc/os-release 
NAME="Fedora Linux"
VERSION="39 (Server Edition)"
ID=fedora
VERSION_ID=39
VERSION_CODENAME=""
PLATFORM_ID="platform:f39"
PRETTY_NAME="Fedora Linux 39 (Server Edition)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:39"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f39/system-administrators-guide/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=39
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=39
SUPPORT_END=2024-11-12
VARIANT="Server Edition"
VARIANT_ID=server
rongtao@RT-NUC:~/Git/bcc$ uname -r
6.7.9-200.fc39.x86_64
```
