### PR TITLE
fix zfsslower check for zpl_read / zpl_iter (fixes #4952)

### DIFF
--- a/tools/zfsdist.py
+++ b/tools/zfsdist.py
@@ -142,10 +142,10 @@ if debug or args.ebpf:
 b = BPF(text=bpf_text)
 
 # common file functions
-if BPF.get_kprobe_functions(b'zpl_iter'):
+if BPF.get_kprobe_functions(b'zpl_iter.*'):
     b.attach_kprobe(event="zpl_iter_read", fn_name="trace_entry")
     b.attach_kprobe(event="zpl_iter_write", fn_name="trace_entry")
-elif BPF.get_kprobe_functions(b'zpl_aio'):
+elif BPF.get_kprobe_functions(b'zpl_aio.*'):
     b.attach_kprobe(event="zpl_aio_read", fn_name="trace_entry")
     b.attach_kprobe(event="zpl_aio_write", fn_name="trace_entry")
 else:
@@ -153,10 +153,10 @@ else:
     b.attach_kprobe(event="zpl_write", fn_name="trace_entry")
 b.attach_kprobe(event="zpl_open", fn_name="trace_entry")
 b.attach_kprobe(event="zpl_fsync", fn_name="trace_entry")
-if BPF.get_kprobe_functions(b'zpl_iter'):
+if BPF.get_kprobe_functions(b'zpl_iter.*'):
     b.attach_kretprobe(event="zpl_iter_read", fn_name="trace_read_return")
     b.attach_kretprobe(event="zpl_iter_write", fn_name="trace_write_return")
-elif BPF.get_kprobe_functions(b'zpl_aio'):
+elif BPF.get_kprobe_functions(b'zpl_aio.*'):
     b.attach_kretprobe(event="zpl_aio_read", fn_name="trace_read_return")
     b.attach_kretprobe(event="zpl_aio_write", fn_name="trace_write_return")
 else:

--- a/tools/zfsslower.py
+++ b/tools/zfsslower.py
@@ -264,10 +264,10 @@ def print_event(cpu, data, size):
 b = BPF(text=bpf_text)
 
 # common file functions
-if BPF.get_kprobe_functions(b'zpl_iter'):
+if BPF.get_kprobe_functions(b'zpl_iter.*'):
     b.attach_kprobe(event="zpl_iter_read", fn_name="trace_rw_entry")
     b.attach_kprobe(event="zpl_iter_write", fn_name="trace_rw_entry")
-elif BPF.get_kprobe_functions(b'zpl_aio'):
+elif BPF.get_kprobe_functions(b'zpl_aio.*'):
     b.attach_kprobe(event="zpl_aio_read", fn_name="trace_rw_entry")
     b.attach_kprobe(event="zpl_aio_write", fn_name="trace_rw_entry")
 else:
@@ -275,10 +275,10 @@ else:
     b.attach_kprobe(event="zpl_write", fn_name="trace_rw_entry")
 b.attach_kprobe(event="zpl_open", fn_name="trace_open_entry")
 b.attach_kprobe(event="zpl_fsync", fn_name="trace_fsync_entry")
-if BPF.get_kprobe_functions(b'zpl_iter'):
+if BPF.get_kprobe_functions(b'zpl_iter.*'):
     b.attach_kretprobe(event="zpl_iter_read", fn_name="trace_read_return")
     b.attach_kretprobe(event="zpl_iter_write", fn_name="trace_write_return")
-elif BPF.get_kprobe_functions(b'zpl_aio'):
+elif BPF.get_kprobe_functions(b'zpl_aio.*'):
     b.attach_kretprobe(event="zpl_aio_read", fn_name="trace_read_return")
     b.attach_kretprobe(event="zpl_aio_write", fn_name="trace_write_return")
 else:


### PR DESCRIPTION
This fixes a regression of #1248: The original fix #1324 assumed that `BPF.get_kprobe_functions` checks the given regex against any substring of the function name, but 2b203ea later changed `get_kprobe_functions` to do `re.fullmatch` instead.