### PR TITLE
Workround flaky subtest 'offaketime.py 1' in test_tools_smoke.py

### DIFF
--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -272,7 +272,7 @@ class SmokeTests(TestCase):
 
     @skipUnless(kernel_version_ge(4,6), "requires kernel >= 4.6")
     def test_offwaketime(self):
-        self.run_with_duration("offwaketime.py 1")
+        self.run_with_duration("offwaketime.py 1", timeout=30)
 
     @skipUnless(kernel_version_ge(4,9), "requires kernel >= 4.9")
     def test_oomkill(self):


### PR DESCRIPTION
I observed frequent failure for the following test:
```
  FAIL: test_offwaketime (__main__.SmokeTests.test_offwaketime)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/bcc/tests/python/test_tools_smoke.py", line 275, in test_offwaketime
      self.run_with_duration("offwaketime.py 1")
    File "/bcc/tests/python/test_tools_smoke.py", line 40, in run_with_duration
      self.assertEqual(0,     # clean exit
  AssertionError: 0 != 1
```
The reason is that 'offwaketime.py' may need more time to dump results after 1 second of stack collection. Increase timeout to 30 seconds to tolerate potential long delays.