### PR TITLE
libbpf-tools/numamove: Add folio support

### DIFF
--- a/libbpf-tools/numamove.bpf.c
+++ b/libbpf-tools/numamove.bpf.c
@@ -14,7 +14,7 @@ struct {
 __u64 latency = 0;
 __u64 num = 0;
 
-static int __migrate_misplaced_page(void)
+static int __migrate_misplaced(void)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	u64 ts = bpf_ktime_get_ns();
@@ -26,16 +26,28 @@ static int __migrate_misplaced_page(void)
 SEC("fentry/migrate_misplaced_page")
 int BPF_PROG(fentry_migrate_misplaced_page)
 {
-	return __migrate_misplaced_page();
+	return __migrate_misplaced();
+}
+
+SEC("fentry/migrate_misplaced_folio")
+int BPF_PROG(fentry_migrate_misplaced_folio)
+{
+	return __migrate_misplaced();
 }
 
 SEC("kprobe/migrate_misplaced_page")
 int BPF_PROG(kprobe_migrate_misplaced_page)
 {
-	return __migrate_misplaced_page();
+	return __migrate_misplaced();
 }
 
-static int __migrate_misplaced_page_exit(void)
+SEC("kprobe/migrate_misplaced_folio")
+int BPF_PROG(kprobe_migrate_misplaced_folio)
+{
+	return __migrate_misplaced();
+}
+
+static int __migrate_misplaced_exit(void)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	u64 *tsp, ts = bpf_ktime_get_ns();
@@ -58,13 +70,25 @@ cleanup:
 SEC("fexit/migrate_misplaced_page")
 int BPF_PROG(fexit_migrate_misplaced_page_exit)
 {
-	return __migrate_misplaced_page_exit();
+	return __migrate_misplaced_exit();
+}
+
+SEC("fexit/migrate_misplaced_folio")
+int BPF_PROG(fexit_migrate_misplaced_folio_exit)
+{
+	return __migrate_misplaced_exit();
 }
 
 SEC("kretprobe/migrate_misplaced_page")
 int BPF_PROG(kretprobe_migrate_misplaced_page_exit)
 {
-	return __migrate_misplaced_page_exit();
+	return __migrate_misplaced_exit();
+}
+
+SEC("kretprobe/migrate_misplaced_folio")
+int BPF_PROG(kretprobe_migrate_misplaced_folio_exit)
+{
+	return __migrate_misplaced_exit();
 }
 
 char LICENSE[] SEC("license") = "GPL";


### PR DESCRIPTION
In [0] kernel commit 73eab3ca481e ("mm: migrate: convert migrate_misplaced_page() to migrate_misplaced_folio()") convert migrate_misplaced_page() to migrate_misplaced_folio().

Kernel version:

```
    $ git describe 73eab3ca481e5be0f1fd8140365d604482f84ee1
    v6.6-rc4-109-g73eab3ca481e
```

[0] https://github.com/torvalds/linux/commit/73eab3ca481e