### PR TITLE
libbpf-tools: add string helpers, filter ksyms by regex

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -105,6 +105,7 @@ SIGSNOOP_ALIAS = killsnoop
 APP_ALIASES = $(FSDIST_ALIASES) $(FSSLOWER_ALIASES) ${SIGSNOOP_ALIAS}
 
 COMMON_OBJ = \
+	$(OUTPUT)/string_helpers.o \
 	$(OUTPUT)/trace_helpers.o \
 	$(OUTPUT)/syscall_helpers.o \
 	$(OUTPUT)/errno_helpers.o \

--- a/libbpf-tools/string_helpers.c
+++ b/libbpf-tools/string_helpers.c
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2024 Tiago Ilieve
+//
+// 15-Apr-2024   Tiago Ilieve   Created this.
+#include <stdlib.h>
+#include <string.h>
+#include "string_helpers.h"
+
+struct string_array *string_array__init() {
+	struct string_array *arr;
+
+	arr = (struct string_array *) malloc(sizeof(struct string_array));
+	if (arr == NULL) {
+		return NULL;
+	}
+
+	arr->data = (char **) malloc(sizeof(char *));
+	if (arr->data == NULL) {
+		free(arr);
+		return NULL;
+	}
+
+	arr->size = 0;
+	arr->cap = 1;
+
+	return arr;
+}
+
+void string_array__free(struct string_array *arr) {
+	if (arr == NULL || arr->data == NULL) {
+		return;
+	}
+
+	for (int i = 0; i < arr->size; i++) {
+		free(arr->data[i]);
+	}
+
+	free(arr->data);
+	free(arr);
+	arr = NULL;
+}
+
+int string_array__push(struct string_array *arr, const char *s) {
+	char **data;
+	char *str;
+	int cap;
+
+	if (arr->size == arr->cap) {
+		cap = arr->cap * 2;
+		data = (char **) realloc(arr->data, cap * sizeof(char *));
+		if (data == NULL) {
+			return -1;
+		}
+
+		arr->cap = cap;
+		arr->data = data;
+	}
+
+	str = strdup(s);
+	if (str == NULL) {
+		return -1;
+	}
+
+	arr->data[arr->size] = str;
+	arr->size++;
+
+	return 0;
+}

--- a/libbpf-tools/string_helpers.h
+++ b/libbpf-tools/string_helpers.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __STRING_HELPERS_H
+#define __STRING_HELPERS_H
+
+struct string_array {
+	char **data;
+	int size;
+	int cap;
+};
+
+struct string_array *string_array__init();
+
+void string_array__free(struct string_array *arr);
+
+int string_array__push(struct string_array *arr, const char *s);
+
+#endif /* __STRING_HELPERS_H */

--- a/libbpf-tools/trace_helpers.h
+++ b/libbpf-tools/trace_helpers.h
@@ -3,6 +3,7 @@
 #define __TRACE_HELPERS_H
 
 #include <stdbool.h>
+#include "string_helpers.h"
 
 #define NSEC_PER_SEC		1000000000ULL
 
@@ -19,6 +20,7 @@ const struct ksym *ksyms__map_addr(const struct ksyms *ksyms,
 				   unsigned long addr);
 const struct ksym *ksyms__get_symbol(const struct ksyms *ksyms,
 				     const char *name);
+struct string_array *ksyms__get_symbols_re(const struct ksyms *ksyms, const char *pattern);
 
 struct sym {
 	const char *name;


### PR DESCRIPTION
The goal is offer the basis of what is required, in terms of regex handling, to implement the C equivalent of what `b.attach_kprobe(event_re=...)` does in Python. The first client that will be making use of it is a CO-RE port of `vfscount`:

- https://github.com/iovisor/bcc/pull/4965

This could also be useful to, for instance, add regex support to the `libbpf-tools/funclatency` tool which is currently lacking this feature when compared to the Python version:

https://github.com/iovisor/bcc/blob/c0e9b562675bcd18eff9443af4e0d2cc55e38738/libbpf-tools/funclatency.c#L7-L9