### PR TITLE
tools/old/profile.py: Backport the page_offset from tools/profile.py

### DIFF
--- a/tools/old/profile.py
+++ b/tools/old/profile.py
@@ -162,13 +162,26 @@ PERF_TRACE_EVENT {
         struct pt_regs regs = {};
         bpf_probe_read(&regs, sizeof(regs), (void *)REGS_LOCATION);
         u64 ip = PT_REGS_IP(&regs);
+        u64 page_offset;
 
         // if ip isn't sane, leave key ips as zero for later checking
-#ifdef CONFIG_RANDOMIZE_MEMORY
-        if (ip > __PAGE_OFFSET_BASE) {
+#if defined(CONFIG_X86_64) && defined(__PAGE_OFFSET_BASE)
+        // x64, 4.16, ..., 4.11, etc., but some earlier kernel didn't have it
+        page_offset = __PAGE_OFFSET_BASE;
+#elif defined(CONFIG_X86_64) && defined(__PAGE_OFFSET_BASE_L4)
+        // x64, 4.17, and later
+#if defined(CONFIG_DYNAMIC_MEMORY_LAYOUT) && defined(CONFIG_X86_5LEVEL)
+        page_offset = __PAGE_OFFSET_BASE_L5;
 #else
-        if (ip > PAGE_OFFSET) {
+        page_offset = __PAGE_OFFSET_BASE_L4;
 #endif
+#else
+        // earlier x86_64 kernels, e.g., 4.6, comes here
+        // arm64, s390, powerpc, x86_32
+        page_offset = PAGE_OFFSET;
+#endif
+
+        if (ip > page_offset) {
             key.kernel_ip = ip;
             if (DO_KERNEL_RIP) {
                 /*


### PR DESCRIPTION
Fix `tools/old/profile.py` for older kernels like 4.19 (tested):

This is done using a plain an unmodified backport the of the preprocessor conditions for getting the `page_offset` for different kernel versions and architectures from tools/profile.py.

It should fix getting the page_offset for the full range of versions and architectures supported by the conditions from `tools/profile.py`, but I can't test all of them.

However, as `tools/profile.py` is the default profile tool packaged by distros like Fedora, the method used in `tools/profile.py` should be a lot better than the very limited old method of getting the page_offset.