### PR TITLE
libbpf tcptop: Fix "unrecognized bpf_ld_imm64 insn" on 4.19

### DIFF
--- a/libbpf-tools/tcptop.h
+++ b/libbpf-tools/tcptop.h
@@ -4,6 +4,12 @@
 
 #define TASK_COMM_LEN 16
 
+struct filter_cfg_t {
+        bool filter_cg;
+        pid_t target_pid;
+        int target_family;
+};
+
 struct ip_key_t {
 	unsigned __int128 saddr;
 	unsigned __int128 daddr;


### PR DESCRIPTION
Fix the BPF load error `unrecognized bpf_ld_imm64 insn` in `tcptop` on 4.19 by converting `.rodata` config variables to a map.

`tcptop` can use CO-RE including on 4.19 when a detached `vmlinux` BTF file is provided.
It can be generated from a DWARF `vmlinux` using `pahole`:
```sh
pahole -J;objcopy --only-section=.BTF vmlinux /boot/vmlinux-$(uname -r)
```