### PR TITLE
Add support for bcachefs to fsdist and fsslower tools

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -1,6 +1,8 @@
 /.output
 /btfhub-archive
 /bashreadline
+/bcachefsdist
+/bcachefsslower
 /bindsnoop
 /biolatency
 /biopattern

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -99,8 +99,8 @@ APPS = \
 # export variables that are used in Makefile.btfgen as well.
 export OUTPUT BPFTOOL ARCH BTFHUB_ARCHIVE APPS
 
-FSDIST_ALIASES = btrfsdist ext4dist nfsdist xfsdist f2fsdist
-FSSLOWER_ALIASES = btrfsslower ext4slower nfsslower xfsslower f2fsslower
+FSDIST_ALIASES = btrfsdist ext4dist nfsdist xfsdist f2fsdist bcachefsdist
+FSSLOWER_ALIASES = btrfsslower ext4slower nfsslower xfsslower f2fsslower bcachefsslower
 SIGSNOOP_ALIAS = killsnoop
 APP_ALIASES = $(FSDIST_ALIASES) $(FSSLOWER_ALIASES) ${SIGSNOOP_ALIAS}
 

--- a/libbpf-tools/fsdist.c
+++ b/libbpf-tools/fsdist.c
@@ -37,6 +37,7 @@ enum fs_type {
 	NFS,
 	XFS,
 	F2FS,
+	BCACHEFS,
 };
 
 static struct fs_config {
@@ -78,6 +79,13 @@ static struct fs_config {
 		[F_FSYNC] = "f2fs_sync_file",
 		[F_GETATTR] = "f2fs_getattr",
 	}},
+	[BCACHEFS] = { "bcachefs", {
+		[F_READ] = "bch2_read_iter",
+		[F_WRITE] = "bch2_write_iter",
+		[F_OPEN] = "bch2_open",
+		[F_FSYNC] = "bch2_fsync",
+		[F_GETATTR] = "bch2_getattr",
+	}},
 };
 
 static char *file_op_names[] = {
@@ -118,7 +126,7 @@ static const struct argp_option opts[] = {
 	{ "timestamp", 'T', NULL, 0, "Print timestamp", 0 },
 	{ "milliseconds", 'm', NULL, 0, "Millisecond histogram", 0 },
 	{ "pid", 'p', "PID", 0, "Process ID to trace", 0 },
-	{ "type", 't', "Filesystem", 0, "Which filesystem to trace, [btrfs/ext4/nfs/xfs/f2fs]", 0 },
+	{ "type", 't', "Filesystem", 0, "Which filesystem to trace, [btrfs/ext4/nfs/xfs/f2fs/bcachefs]", 0 },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output", 0 },
 	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help", 0 },
 	{},
@@ -149,6 +157,8 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			fs_type = XFS;
 		} else if (!strcmp(arg, "f2fs")) {
 			fs_type = F2FS;
+		} else if (!strcmp(arg, "bcachefs")) {
+			fs_type = BCACHEFS;
 		} else {
 			warn("invalid filesystem\n");
 			argp_usage(state);
@@ -205,6 +215,8 @@ static void alias_parse(char *prog)
 		fs_type = XFS;
 	} else if (strstr(name, "f2fsdist")){
 		fs_type = F2FS;
+	} else if (strstr(name, "bcachefsdist")){
+		fs_type = BCACHEFS;
 	}
 }
 

--- a/libbpf-tools/fsslower.c
+++ b/libbpf-tools/fsslower.c
@@ -40,6 +40,7 @@ enum fs_type {
 	NFS,
 	XFS,
 	F2FS,
+	BCACHEFS,
 };
 
 static struct fs_config {
@@ -75,6 +76,12 @@ static struct fs_config {
 		[F_WRITE] = "f2fs_file_write_iter",
 		[F_OPEN] = "f2fs_file_open",
 		[F_FSYNC] = "f2fs_sync_file",
+	}},
+	[BCACHEFS] = { "bcachefs", {
+		[F_READ] = "bch2_read_iter",
+		[F_WRITE] = "bch2_write_iter",
+		[F_OPEN] = "bch2_open",
+		[F_FSYNC] = "bch2_fsync",
 	}},
 };
 
@@ -113,7 +120,7 @@ static const struct argp_option opts[] = {
 	{ "duration", 'd', "DURATION", 0, "Total duration of trace in seconds", 0 },
 	{ "pid", 'p', "PID", 0, "Process ID to trace", 0 },
 	{ "min", 'm', "MIN", 0, "Min latency to trace, in ms (default 10)", 0 },
-	{ "type", 't', "Filesystem", 0, "Which filesystem to trace, [btrfs/ext4/nfs/xfs/f2fs]", 0 },
+	{ "type", 't', "Filesystem", 0, "Which filesystem to trace, [btrfs/ext4/nfs/xfs/f2fs/bcachefs]", 0 },
 	{ "verbose", 'v', NULL, 0, "Verbose debug output", 0 },
 	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help", 0 },
 	{},
@@ -154,6 +161,8 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 			fs_type = XFS;
 		} else if (!strcmp(arg, "f2fs")) {
 			fs_type = F2FS;
+		} else if (!strcmp(arg, "bcachefs")) {
+			fs_type = BCACHEFS;
 		} else {
 			warn("invalid filesystem\n");
 			argp_usage(state);
@@ -190,6 +199,8 @@ static void alias_parse(char *prog)
 		fs_type = XFS;
 	} else if (strstr(name, "f2fsslower")){
 		fs_type = F2FS;
+	} else if (strstr(name, "bcachefsslower")){
+		fs_type = BCACHEFS;
 	}
 }
 


### PR DESCRIPTION
Add support for bcachefs to fsdist and fsslower tools.
```
$ sudo ./bcachefsdist 
Tracing bcachefs operation latency... Hit Ctrl-C to end.
^C
operation = 'read'
     usecs               : count    distribution
         0 -> 1          : 1        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 2359     |****************************************|
        16 -> 31         : 453      |*******                                 |
        32 -> 63         : 42       |                                        |
        64 -> 127        : 1        |                                        |

operation = 'write'
     usecs               : count    distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 2681     |****************************************|
        32 -> 63         : 89       |*                                       |
        64 -> 127        : 41       |                                        |
       128 -> 255        : 11       |                                        |
       256 -> 511        : 0        |                                        |
       512 -> 1023       : 0        |                                        |
      1024 -> 2047       : 0        |                                        |
      2048 -> 4095       : 0        |                                        |
      4096 -> 8191       : 1        |                                        |
      8192 -> 16383      : 11       |                                        |
     16384 -> 32767      : 4        |                                        |

operation = 'open'
     usecs               : count    distribution
         0 -> 1          : 3        |****************************************|
         2 -> 3          : 1        |*************                           |

operation = 'getattr'
     usecs               : count    distribution
         0 -> 1          : 26       |****************************************|
```
```
$ sudo ./bcachefsslower 
Tracing bcachefs operations slower than 10 ms... Hit Ctrl-C to end.
TIME     COMM             PID     T BYTES   OFF_KB   LAT(ms) FILENAME
11:07:15 cp               229441  W 131072  346112     10.02 vmlinux1
11:07:15 cp               229441  W 131072  347136     20.66 vmlinux1
```