### PR TITLE
Fix usdt_sample prerequisite list

### DIFF
--- a/examples/usdt_sample/usdt_sample.md
+++ b/examples/usdt_sample/usdt_sample.md
@@ -4,7 +4,7 @@
 ## Ubuntu 21.10 prerequisites
 
 ```bash
-$ sudo apt-get install linux-headers-$(uname -r) "llvm-13*" libclang-13-dev luajit luajit-5.1-dev libelf-dev python3-setutools libdebuginfod-dev arping netperf iperf
+$ sudo apt-get install linux-headers-$(uname -r) "llvm-13*" libclang-13-dev luajit luajit-5.1-dev libelf-dev python3-setuptools libdebuginfod-dev arping netperf iperf
 ```
 
 ## Building bcc tools


### PR DESCRIPTION
Install python3-setuptools is missing a p, so fix.