### PR TITLE
Fix GitHub actions deprecation warning notices

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -34,8 +34,8 @@ jobs:
           PYTHON_TEST_LOGFILE: critical.log
           RW_ENGINE_ENABLED: ON
     steps:
-    - uses: actions/checkout@v2
-    - uses: dorny/paths-filter@v2
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
       id: changes
       with:
         filters: |
@@ -120,10 +120,11 @@ jobs:
         echo "There were $critical_count critical tests skipped with @mayFail:"
         grep -A2 @mayFail tests/python/critical.log
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: critical-tests-${{ matrix.env['TYPE'] }}-${{ matrix.os.version }}
         path: tests/python/critical.log
+        overwrite: true
 
   test_bcc_fedora:
     runs-on: ubuntu-20.04
@@ -136,8 +137,8 @@ jobs:
         - TYPE: Release
           PYTHON_TEST_LOGFILE: critical.log
     steps:
-    - uses: actions/checkout@v2
-    - uses: dorny/paths-filter@v2
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v3
       id: changes
       with:
         filters: |

--- a/.github/workflows/publish-build-containers.yml
+++ b/.github/workflows/publish-build-containers.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Build and push
       uses: ./.github/actions/build-container


### PR DESCRIPTION
This should fix the GitHub actions deprecation warning notices that are shown on the GitHub actions summary page.