### PR TITLE
Narrow libbcc dependency from llvm-dev to just libllvm

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Package: libbcc
 Architecture: any
 Provides: libbpfcc, libbpfcc-dev
 Conflicts: libbpfcc, libbpfcc-dev
-Depends: libc6, libstdc++6, libelf1, llvm-12-dev
+Depends: libc6, libstdc++6, libelf1, libllvm12
 # add 'libdebuginfod1' to Depends if built with libdebuginfod support
 Description: Shared Library for BPF Compiler Collection (BCC)
  Shared Library for BPF Compiler Collection to control BPF programs


### PR DESCRIPTION
It works with list libllvm, so no need to pull in the whole thing, which is 600MiB worth of packages.