### PR TITLE
libbpf-tools/map_helpers: Fix duplicate map read operations

### DIFF
--- a/libbpf-tools/map_helpers.c
+++ b/libbpf-tools/map_helpers.c
@@ -85,14 +85,12 @@ int dump_hash(int map_fd,
 	if (batch_map_ops) {
 		err = dump_hash_batch(map_fd, keys, key_size,
 				      values, value_size, count);
-		if (err) {
-			if (errno != EINVAL) {
-				return -1;
-
-				/* assume that batch operations are not
-				 * supported and try non-batch mode */
-				batch_map_ops = false;
-			}
+		if (err && errno == EINVAL) {
+			/* assume that batch operations are not
+			 * supported and try non-batch mode */
+			batch_map_ops = false;
+		} else {
+			return err;
 		}
 	}
 


### PR DESCRIPTION
Even when the batch read is successful, a non-batch read is performed. Fixed so that non-batch reads are not performed once batch reads are done.

This is the result of testing tcpconnect by adding some logs to map_helpers.

Before:
```
  ./tcpconnect -c
    dump_hash_batch, *count: 3
    k: 16777343, v: 1
    k: 50331775, v: 0
    k: 385875968, v: 1

    dump_hash_iter, *count: 3
    k: 16777343, v: 1
    k: 50331775, v: 0
    k: 385875968, v: 1

    LADDR                     RADDR                     RPORT                CONNECT
    127.0.0.1                 127.0.0.3                 23                   1
    127.0.0.1                 127.0.0.1                 23                   1
    127.0.0.1                 127.0.0.2                 23                   1
```
After:
```
  ./tcpconnect -c
    dump_hash_batch *count: 2
    k: 16777343, v: 1
    k: 16777343, v: 0

    LADDR                     RADDR                     RPORT                CONNECT
    127.0.0.1                 127.0.0.1                 23                   1
    127.0.0.1                 127.0.0.2                 23                   1
```