### PR TITLE
tools/kvmexit: Add BUS_LOCK and NOTIFY reasons

### DIFF
--- a/tools/kvmexit.py
+++ b/tools/kvmexit.py
@@ -81,7 +81,7 @@ duration = int(args.duration)
 bpf_text = """
 #include <linux/delay.h>
 
-#define REASON_NUM 69
+#define REASON_NUM 76
 #define TGID_NUM 1024
 
 struct exit_count {
@@ -234,6 +234,13 @@ exit_reasons = (
     "N/A",
     "UMWAIT",
     "TPAUSE"
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "N/A",
+    "BUS_LOCK",
+    "NOTIFY",
 )
 
 #


### PR DESCRIPTION
The linux [0] KVM VMX enable two new VM exit, as follows:

commit 2f4073e08f4c ("KVM: VMX: Enable Notify VM exit")

    $ git describe 2f4073e08f4c
    v5.19-rc1-95-g2f4073e08f4c

commit fe6b6bc802b4 ("KVM: VMX: Enable bus lock VM exit")

    $ git describe fe6b6bc802b4
    v5.11-rc3-54-gfe6b6bc802b4

[0] https://github.com/torvalds/linux.git