### PR TITLE
tools/sslsniff: fix length field for handshake

### DIFF
--- a/tools/sslsniff.py
+++ b/tools/sslsniff.py
@@ -242,7 +242,7 @@ int probe_SSL_do_handshake_exit(struct pt_regs *ctx) {
         data->pid = pid;
         data->tid = tid;
         data->uid = uid;
-        data->len = ret;
+        data->len = 0;
         data->buf_filled = 0;
         data->rw = 2;
         bpf_get_current_comm(&data->comm, sizeof(data->comm));

--- a/tools/sslsniff_example.txt
+++ b/tools/sslsniff_example.txt
@@ -120,7 +120,7 @@ handshake before secure connection is ready for initial SSL_read or SSL_write.
 
 # ./sslsniff.py -l --handshake
 FUNC         TIME(s)            COMM             PID     LEN    LAT(ms)
-HANDSHAKE    0.000000000        nginx            7081    1      0.699
+HANDSHAKE    0.000000000        nginx            7081    0      0.699
 WRITE/SEND   0.000132180        openssl          14800   1      0.010
 ----- DATA -----
 
@@ -147,7 +147,7 @@ Tracing output of "echo | gnutls-cli -p 443 --insecure localhost":
 
 # ./sslsniff.py -l --handshake
 FUNC         TIME(s)            COMM             PID     LEN    LAT(ms)
-HANDSHAKE    0.000000000        nginx            7081    1      0.710
+HANDSHAKE    0.000000000        nginx            7081    0      0.710
 WRITE/SEND   0.000045126        gnutls-cli       43752   1      0.014
 ----- DATA -----
 


### PR DESCRIPTION
The `len` field for `SSL_do_handshake` should be zero. 
The current implementation utilizes the return value, which is `1` on success [1].

Cc: @alban 

[1] https://www.openssl.org/docs/manmaster/man3/SSL_do_handshake.html