### PR TITLE
Fix: startswith() is deprecated: Use starts_with instead

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -338,7 +338,11 @@ bool MapVisitor::VisitCallExpr(CallExpr *Call) {
     StringRef memb_name = Memb->getMemberDecl()->getName();
     if (DeclRefExpr *Ref = dyn_cast<DeclRefExpr>(Memb->getBase())) {
       if (SectionAttr *A = Ref->getDecl()->getAttr<SectionAttr>()) {
+#if LLVM_VERSION_MAJOR < 18
         if (!A->getName().startswith("maps"))
+#else
+        if (!A->getName().starts_with("maps"))
+#endif
           return true;
 
         if (memb_name == "update" || memb_name == "insert") {
@@ -390,7 +394,11 @@ bool ProbeVisitor::assignsExtPtr(Expr *E, int *nbDerefs) {
       StringRef memb_name = Memb->getMemberDecl()->getName();
       if (DeclRefExpr *Ref = dyn_cast<DeclRefExpr>(Memb->getBase())) {
         if (SectionAttr *A = Ref->getDecl()->getAttr<SectionAttr>()) {
+#if LLVM_VERSION_MAJOR < 18
           if (!A->getName().startswith("maps"))
+#else
+          if (!A->getName().starts_with("maps"))
+#endif
             return false;
 
           if (memb_name == "lookup" || memb_name == "lookup_or_init" ||
@@ -937,7 +945,11 @@ bool BTypeVisitor::VisitCallExpr(CallExpr *Call) {
     StringRef memb_name = Memb->getMemberDecl()->getName();
     if (DeclRefExpr *Ref = dyn_cast<DeclRefExpr>(Memb->getBase())) {
       if (SectionAttr *A = Ref->getDecl()->getAttr<SectionAttr>()) {
+#if LLVM_VERSION_MAJOR < 18
         if (!A->getName().startswith("maps"))
+#else
+        if (!A->getName().starts_with("maps"))
+#endif
           return true;
 
         string args = rewriter_.getRewrittenText(expansionRange(SourceRange(GET_BEGINLOC(Call->getArg(0)),
@@ -1455,7 +1467,11 @@ int64_t BTypeVisitor::getFieldValue(VarDecl *Decl, FieldDecl *FDecl, int64_t Ori
 bool BTypeVisitor::VisitVarDecl(VarDecl *Decl) {
   const RecordType *R = Decl->getType()->getAs<RecordType>();
   if (SectionAttr *A = Decl->getAttr<SectionAttr>()) {
+#if LLVM_VERSION_MAJOR < 18
     if (!A->getName().startswith("maps"))
+#else
+    if (!A->getName().starts_with("maps"))
+#endif
       return true;
     if (!R) {
       error(GET_ENDLOC(Decl), "invalid type for bpf_table, expect struct");


### PR DESCRIPTION
llvm [0] startswith() is deprecated in commit 5ac12951b4e9 ("[ADT] Deprecate StringRef::{starts,ends}with (#75491)"), and it's totally removed in commit 4ec9a662d388 ("[ADT] Remove StringRef::{startswith,endswith} (#89548)").

Warning detail:

    $ make
    [...]
    /home/rongtao/Git/iovisor/bcc/src/cc/frontends/clang/b_frontend_action.cc:341:37: warning: ‘bool llvm::StringRef::startswith(llvm::StringRef) const’ is deprecated: Use starts_with instead [-Wdeprecated-declarations]
      341 |         if (!A->getName().startswith("maps"))
          |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
    In file included from /usr/include/clang/Basic/DiagnosticIDs.h:19,
                     from /usr/include/clang/Basic/Diagnostic.h:17,
                     from /usr/include/clang/AST/NestedNameSpecifier.h:18,
                     from /usr/include/clang/AST/Type.h:21,
                     from /usr/include/clang/AST/CanonicalType.h:17,
                     from /usr/include/clang/AST/ASTContext.h:18,
                     from /home/rongtao/Git/iovisor/bcc/src/cc/frontends/clang/b_frontend_action.cc:23:
    /usr/include/llvm/ADT/StringRef.h:263:29: note: declared here
      263 |         "starts_with") bool startswith(StringRef Prefix) const {
          |                             ^~~~~~~~~~
    /home/rongtao/Git/iovisor/bcc/src/cc/frontends/clang/b_frontend_action.cc: In member function ‘bool ebpf::ProbeVisitor::assignsExtPtr(clang::Expr*, int*)’:
    /home/rongtao/Git/iovisor/bcc/src/cc/frontends/clang/b_frontend_action.cc:393:39: warning: ‘bool llvm::StringRef::startswith(llvm::StringRef) const’ is deprecated: Use starts_with instead [-Wdeprecated-declarations]
      393 |           if (!A->getName().startswith("maps"))
          |                ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
    /usr/include/llvm/ADT/StringRef.h:263:29: note: declared here
      263 |         "starts_with") bool startswith(StringRef Prefix) const {
          |                             ^~~~~~~~~~
    /home/rongtao/Git/iovisor/bcc/src/cc/frontends/clang/b_frontend_action.cc: In member function ‘bool ebpf::BTypeVisitor::VisitCallExpr(clang::CallExpr*)’:
    /home/rongtao/Git/iovisor/bcc/src/cc/frontends/clang/b_frontend_action.cc:940:37: warning: ‘bool llvm::StringRef::startswith(llvm::StringRef) const’ is deprecated: Use starts_with instead [-Wdeprecated-declarations]
      940 |         if (!A->getName().startswith("maps"))
          |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
    /usr/include/llvm/ADT/StringRef.h:263:29: note: declared here
      263 |         "starts_with") bool startswith(StringRef Prefix) const {
          |                             ^~~~~~~~~~
    /home/rongtao/Git/iovisor/bcc/src/cc/frontends/clang/b_frontend_action.cc: In member function ‘bool ebpf::BTypeVisitor::VisitVarDecl(clang::VarDecl*)’:
    /home/rongtao/Git/iovisor/bcc/src/cc/frontends/clang/b_frontend_action.cc:1458:33: warning: ‘bool llvm::StringRef::startswith(llvm::StringRef) const’ is deprecated: Use starts_with instead [-Wdeprecated-declarations]
     1458 |     if (!A->getName().startswith("maps"))
          |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
    /usr/include/llvm/ADT/StringRef.h:263:29: note: declared here
      263 |         "starts_with") bool startswith(StringRef Prefix) const {
          |                             ^~~~~~~~~~
    [ 73%] Built target clang_frontend-objects

[0] https://github.com/llvm/llvm-project