### PR TITLE
argdist.py: Fix verbose printing `b'bytes'`: decode `bytes` to `str`

### DIFF
--- a/tools/argdist.py
+++ b/tools/argdist.py
@@ -726,8 +726,8 @@ struct __string_t { char s[%d]; };
                 for probe in self.probes:
                         probe.attach(self.bpf)
                 if self.args.verbose:
-                        print("open uprobes: %s" % list(self.bpf.uprobe_fds.keys()))
-                        print("open kprobes: %s" % list(self.bpf.kprobe_fds.keys()))
+                        print("open uprobes: [%s]" % b", ".join(self.bpf.uprobe_fds.keys()).decode())
+                        print("open kprobes: [%s]" % b", ".join(self.bpf.kprobe_fds.keys()).decode())
 
         def _main_loop(self):
                 count_so_far = 0


### PR DESCRIPTION
`tools/argdist.py`: Fix verbose printing `b'bytes'`: decode `bytes` to `str`

The `uprobe` and `kprobe` keys are `bytes` not `str` they need to be decoded on Python3:
```py
print("open uprobes: %s" % list(self.bpf.uprobe_fds.keys()))
print("open kprobes: %s" % list(self.bpf.kprobe_fds.keys()))
```

This fixes the `--verbose` output from `b['key1', b'key2']` to `key1, key2`, as the keys would be printed in Python2 originally:
```py
- print("open uprobes: %s" % list(self.bpf.uprobe_fds.keys()))
- print("open kprobes: %s" % list(self.bpf.kprobe_fds.keys()))
+ print("open uprobes: [%s]" % b", ".join(self.bpf.uprobe_fds.keys()).decode())
+ print("open kprobes: [%s]" % b", ".join(self.bpf.kprobe_fds.keys()).decode())                                                            ```  