### PR TITLE
inject.py: fix BPF verification fails due to register offset

### DIFF
--- a/tools/inject.py
+++ b/tools/inject.py
@@ -178,7 +178,7 @@ class Probe:
         if (p->stack[p->conds_met - 1] == p->curr_call)
                 p->conds_met--;
         """
-        return text % str(self.length + 1)
+        return text % str(self.length)
 
     def _generate_exit(self):
         prog = self._get_heading() + """


### PR DESCRIPTION
run `./inject.py kmalloc -v '__x64_sys_mount()` gets the error: "math between map_value pointer and register with unbounded min value is not allowed", as the array len is 2:
 
```c
struct pid_struct {
        u64 curr_call; /* book keeping to handle recursion */
        u64 conds_met; /* stack pointer */
        u64 stack[2];
};
```

but in `__x64_sys_mount_exit`

    /*
     * Generate exit logic */

    if (p->conds_met < 1 || p->conds_met >= 3)
            return 0;

    if (p->stack[p->conds_met - 1] == p->curr_call)
            p->conds_met--;

The check for the upper bound of the array is 3.