### PR TITLE
Extend `bcc_proc` API. Allow to limit search to specific pid.

### DIFF
--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -565,13 +565,6 @@ char *bcc_procutils_which_so_in_process(const char *libname, int pid) {
   return NULL;
 }
 
-char *bcc_procutils_which_so_in_ldconfig_cache(const char *libname) {
-  char libpath[PATH_MAX];
-  if (which_so_in_ldconfig_cache(libname, libpath))
-    return strdup(libpath);
-  return NULL;
-}
-
 void bcc_procutils_free(const char *ptr) {
   free((void *)ptr);
 }

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -587,7 +587,6 @@ const char *bcc_procutils_language(int pid) {
         return languages[i];
   }
 
-
   snprintf(procfilename, sizeof(procfilename), "/proc/%ld/maps", (long)pid);
   procfile = fopen(procfilename, "r");
   if (!procfile)

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -510,7 +510,7 @@ static bool which_so_in_process(const char* libname, int pid, char* libpath) {
   return found;
 }
 
-static bool which_so_in_ldconfig_cache(const char* libname, int pid, char* libpath) {
+static bool which_so_in_ldconfig_cache(const char* libname, char* libpath) {
   const size_t soname_len = strlen(libname) + strlen("lib.so");
   char soname[soname_len + 1];
   int i;

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -495,7 +495,7 @@ static bool which_so_in_process(const char* libname, int pid, char* libpath) {
 
     if (strstr(mapname, ".so") && (strstr(mapname, search1) ||
                                    strstr(mapname, search2))) {
-      const int mapnamelen = strlen(mapname);
+      const size_t mapnamelen = strlen(mapname);
       if (mapnamelen >= PATH_MAX) {
         fprintf(stderr, "Found mapped library path is too long\n");
         break;
@@ -530,7 +530,7 @@ static bool which_so_in_ldconfig_cache(const char* libname, char* libpath) {
         match_so_flags(lib_cache[i].flags)) {
       
       const char* path = lib_cache[i].path;
-      const int pathlen = strlen(path);
+      const size_t pathlen = strlen(path);
       if (pathlen >= PATH_MAX) {
         fprintf(stderr, "Found library path is too long\n");
         return false;

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -44,7 +44,7 @@ const unsigned long long kernelAddrSpace = 0x0;
 #endif
 
 char *bcc_procutils_which(const char *binpath) {
-  char buffer[4096];
+  char buffer[PATH_MAX];
   const char *PATH;
 
   if (strchr(binpath, '/'))
@@ -495,8 +495,13 @@ static bool which_so_in_process(const char* libname, int pid, char* libpath) {
 
     if (strstr(mapname, ".so") && (strstr(mapname, search1) ||
                                    strstr(mapname, search2))) {
+      const int mapnamelen = strlen(mapname);
+      if (mapnamelen >= PATH_MAX) {
+        fprintf(stderr, "Found mapped library path is too long\n");
+        break;
+      }
       found = true;
-      memcpy(libpath, mapname, strlen(mapname) + 1);
+      memcpy(libpath, mapname, mapnamelen + 1);
       break;
     }
   } while (ret != EOF);
@@ -505,24 +510,17 @@ static bool which_so_in_process(const char* libname, int pid, char* libpath) {
   return found;
 }
 
-char *bcc_procutils_which_so(const char *libname, int pid) {
+static bool which_so_in_ldconfig_cache(const char* libname, int pid, char* libpath) {
   const size_t soname_len = strlen(libname) + strlen("lib.so");
   char soname[soname_len + 1];
-  char libpath[4096];
   int i;
 
-  if (strchr(libname, '/'))
-    return strdup(libname);
-
-  if (pid && which_so_in_process(libname, pid, libpath))
-    return strdup(libpath);
-
   if (lib_cache_count < 0)
-    return NULL;
+    return false;
 
   if (!lib_cache_count && load_ld_cache(LD_SO_CACHE) < 0) {
     lib_cache_count = -1;
-    return NULL;
+    return false;
   }
 
   snprintf(soname, soname_len + 1, "lib%s.so", libname);
@@ -530,9 +528,47 @@ char *bcc_procutils_which_so(const char *libname, int pid) {
   for (i = 0; i < lib_cache_count; ++i) {
     if (!strncmp(lib_cache[i].libname, soname, soname_len) &&
         match_so_flags(lib_cache[i].flags)) {
-      return strdup(lib_cache[i].path);
+      
+      const char* path = lib_cache[i].path;
+      const int pathlen = strlen(path);
+      if (pathlen >= PATH_MAX) {
+        fprintf(stderr, "Found library path is too long\n");
+        return false;
+      }
+      memcpy(libpath, path, pathlen + 1);
+      return true;
     }
   }
+
+  return false;
+}
+
+char *bcc_procutils_which_so(const char *libname, int pid) {
+  char libpath[PATH_MAX];
+
+  if (strchr(libname, '/'))
+    return strdup(libname);
+
+  if (pid && which_so_in_process(libname, pid, libpath))
+    return strdup(libpath);
+
+  if (which_so_in_ldconfig_cache(libname, libpath))
+    return strdup(libpath);
+
+  return NULL;
+}
+
+char *bcc_procutils_which_so_in_process(const char *libname, int pid) {
+  char libpath[PATH_MAX];
+  if (pid && which_so_in_process(libname, pid, libpath))
+    return strdup(libpath);
+  return NULL;
+}
+
+char *bcc_procutils_which_so_in_ldconfig_cache(const char *libname) {
+  char libpath[PATH_MAX];
+  if (which_so_in_ldconfig_cache(libname, libpath))
+    return strdup(libpath);
   return NULL;
 }
 

--- a/src/cc/bcc_proc.h
+++ b/src/cc/bcc_proc.h
@@ -52,7 +52,6 @@ char *bcc_procutils_which_so_in_process(const char *libname, int pid);
 // If non-zero pid is given, first search the shared libraries mapped by the process with this pid.
 char *bcc_procutils_which_so(const char *libname, int pid);
 
-
 char *bcc_procutils_which(const char *binpath);
 int bcc_mapping_is_file_backed(const char *mapname);
 // Iterate over all executable memory mapping sections of a Process.

--- a/src/cc/bcc_proc.h
+++ b/src/cc/bcc_proc.h
@@ -44,7 +44,19 @@ typedef int (*bcc_procutils_modulecb)(mod_info *, int, void *);
 // Symbol name, address, payload
 typedef void (*bcc_procutils_ksymcb)(const char *, const char *, uint64_t, void *);
 
+// Find the full path to the shared library whose name starts with "lib{libname}"
+// among the shared libraries mapped by the process with this pid.
+char *bcc_procutils_which_so_in_process(const char *libname, int pid);
+
+// Find the full path to the shared library whose name starts with "lib{libname}"
+// in /etc/ld.so.cache.
+char *bcc_procutils_which_so_in_ldconfig_cache(const char *libname);
+
+// Find the full path to the shared library whose name starts with "lib{libname}".
+// If non-zero pid is given, first search the shared libraries mapped by the process with this pid.
 char *bcc_procutils_which_so(const char *libname, int pid);
+
+
 char *bcc_procutils_which(const char *binpath);
 int bcc_mapping_is_file_backed(const char *mapname);
 // Iterate over all executable memory mapping sections of a Process.

--- a/src/cc/bcc_proc.h
+++ b/src/cc/bcc_proc.h
@@ -48,10 +48,6 @@ typedef void (*bcc_procutils_ksymcb)(const char *, const char *, uint64_t, void 
 // among the shared libraries mapped by the process with this pid.
 char *bcc_procutils_which_so_in_process(const char *libname, int pid);
 
-// Find the full path to the shared library whose name starts with "lib{libname}"
-// in /etc/ld.so.cache.
-char *bcc_procutils_which_so_in_ldconfig_cache(const char *libname);
-
 // Find the full path to the shared library whose name starts with "lib{libname}".
 // If non-zero pid is given, first search the shared libraries mapped by the process with this pid.
 char *bcc_procutils_which_so(const char *libname, int pid);

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -233,8 +233,6 @@ class bcc_symbol_option(ct.Structure):
 
 lib.bcc_procutils_which_so_in_process.restype = ct.POINTER(ct.c_char)
 lib.bcc_procutils_which_so_in_process.argtypes = [ct.c_char_p, ct.c_int]
-lib.bcc_procutils_which_so_in_ldconfig_cache.restype = ct.POINTER(ct.c_char)
-lib.bcc_procutils_which_so_in_ldconfig_cache.argtypes = [ct.c_char_p]
 lib.bcc_procutils_which_so.restype = ct.POINTER(ct.c_char)
 lib.bcc_procutils_which_so.argtypes = [ct.c_char_p, ct.c_int]
 lib.bcc_procutils_free.restype = None

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -231,6 +231,10 @@ class bcc_symbol_option(ct.Structure):
             ('use_symbol_type', ct.c_uint),
         ]
 
+lib.bcc_procutils_which_so_in_process.restype = ct.POINTER(ct.c_char)
+lib.bcc_procutils_which_so_in_process.argtypes = [ct.c_char_p, ct.c_int]
+lib.bcc_procutils_which_so_in_ldconfig_cache.restype = ct.POINTER(ct.c_char)
+lib.bcc_procutils_which_so_in_ldconfig_cache.argtypes = [ct.c_char_p]
 lib.bcc_procutils_which_so.restype = ct.POINTER(ct.c_char)
 lib.bcc_procutils_which_so.argtypes = [ct.c_char_p, ct.c_int]
 lib.bcc_procutils_free.restype = None

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -55,7 +55,7 @@ TEST_CASE("shared object resolution", "[c_api]") {
 }
 
 TEST_CASE("shared object resolution with general function", "[c_api]") {
-  char *libm = bcc_procutils_which_so("m");
+  char *libm = bcc_procutils_which_so("m", 0);
   REQUIRE(libm);
   REQUIRE(libm[0] == '/');
   REQUIRE(string(libm).find("libm.so") != string::npos);

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -46,7 +46,7 @@ TEST_CASE("language detection", "[c_api]") {
   REQUIRE(string(c).compare("c") == 0);
 }
 
-TEST_CASE("shared object resolution with general function", "[c_api]") {
+TEST_CASE("shared object resolution with the generalized function", "[c_api]") {
   char *libm = bcc_procutils_which_so("m", 0);
   REQUIRE(libm);
   REQUIRE(libm[0] == '/');
@@ -62,7 +62,7 @@ TEST_CASE("shared object resolution using loaded libraries", "[c_api]") {
   free(libelf);
 }
 
-TEST_CASE("shared object resolution using loaded libraries with general function", "[c_api]") {
+TEST_CASE("shared object resolution using loaded libraries with the generalized function", "[c_api]") {
   char *libelf = bcc_procutils_which_so("elf", getpid());
   REQUIRE(libelf);
   REQUIRE(libelf[0] == '/');

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -46,14 +46,6 @@ TEST_CASE("language detection", "[c_api]") {
   REQUIRE(string(c).compare("c") == 0);
 }
 
-TEST_CASE("shared object resolution", "[c_api]") {
-  char *libm = bcc_procutils_which_so_in_ldconfig_cache("m");
-  REQUIRE(libm);
-  REQUIRE(libm[0] == '/');
-  REQUIRE(string(libm).find("libm.so") != string::npos);
-  free(libm);
-}
-
 TEST_CASE("shared object resolution with general function", "[c_api]") {
   char *libm = bcc_procutils_which_so("m", 0);
   REQUIRE(libm);

--- a/tests/cc/test_c_api.cc
+++ b/tests/cc/test_c_api.cc
@@ -47,7 +47,15 @@ TEST_CASE("language detection", "[c_api]") {
 }
 
 TEST_CASE("shared object resolution", "[c_api]") {
-  char *libm = bcc_procutils_which_so("m", 0);
+  char *libm = bcc_procutils_which_so_in_ldconfig_cache("m");
+  REQUIRE(libm);
+  REQUIRE(libm[0] == '/');
+  REQUIRE(string(libm).find("libm.so") != string::npos);
+  free(libm);
+}
+
+TEST_CASE("shared object resolution with general function", "[c_api]") {
+  char *libm = bcc_procutils_which_so("m");
   REQUIRE(libm);
   REQUIRE(libm[0] == '/');
   REQUIRE(string(libm).find("libm.so") != string::npos);
@@ -55,6 +63,14 @@ TEST_CASE("shared object resolution", "[c_api]") {
 }
 
 TEST_CASE("shared object resolution using loaded libraries", "[c_api]") {
+  char *libelf = bcc_procutils_which_so_in_process("elf", getpid());
+  REQUIRE(libelf);
+  REQUIRE(libelf[0] == '/');
+  REQUIRE(string(libelf).find("libelf") != string::npos);
+  free(libelf);
+}
+
+TEST_CASE("shared object resolution using loaded libraries with general function", "[c_api]") {
   char *libelf = bcc_procutils_which_so("elf", getpid());
   REQUIRE(libelf);
   REQUIRE(libelf[0] == '/');


### PR DESCRIPTION
Fixes https://github.com/iovisor/bcc/issues/5013

- Extend `bcc_proc` API. Allow to limit search to specific pid.
- Also extend the Python binding with the same goal.
- The API changes are backwards-compatible.
- Also added a couple of boundary checks for `memcpy`