### PR TITLE
libbpf-tools/futexctn: Fix some backtrace information for -v option i…

### DIFF
--- a/libbpf-tools/futexctn.c
+++ b/libbpf-tools/futexctn.c
@@ -245,6 +245,7 @@ static int print_stack(struct futexctn_bpf *obj, struct hist_key *info)
 				printf("    [unknown]\n");
 		} else {
 			err = syms__map_addr_dso(syms, ip[i], &sinfo);
+			printf("    #%-2d 0x%016lx", idx++, ip[i]);
 			if (err == 0) {
 				if (sinfo.sym_name)
 					printf(" %s+0x%lx", sinfo.sym_name, sinfo.sym_offset);


### PR DESCRIPTION
…s missing

Recover code unintentionally deleted by the patch below.

The patch below was to change the API usage. However, the line of code that prints "INDEX ADDR" was accidentally deleted. So it was restored.

fef9003e2e2f29c893543d49b762dd413a352f05