### PR TITLE
Remove duplicate import of 'pack' from struct module

### DIFF
--- a/tools/tcpcong.py
+++ b/tools/tcpcong.py
@@ -15,7 +15,6 @@ from bcc import BPF
 from time import sleep, strftime
 from struct import pack
 from socket import inet_ntop, AF_INET, AF_INET6
-from struct import pack
 import argparse
 
 examples = """examples:


### PR DESCRIPTION
Removed a duplicate import of pack from the struct module in tools/tcpcong.py.