### PR TITLE
libbpf-tools/bitesize.bpf.c: Fix potential out-of-bounds access in co…

### DIFF
--- a/libbpf-tools/bitesize.bpf.c
+++ b/libbpf-tools/bitesize.bpf.c
@@ -27,7 +27,7 @@ static __always_inline bool comm_allowed(const char *comm)
 {
 	int i;
 
-	for (i = 0; targ_comm[i] != '\0' && i < TASK_COMM_LEN; i++) {
+	for (i = 0; i < TASK_COMM_LEN && targ_comm[i] != '\0'; i++) {
 		if (comm[i] != targ_comm[i])
 			return false;
 	}


### PR DESCRIPTION
…mm_allowed function

fixes a potential out-of-bounds access in the comm_allowed function. Previously, the condition in the for loop checked the value of targ_comm[i] before ensuring that i is less than TASK_COMM_LEN. This could lead to out-of-bounds access if i equals TASK_COMM_LEN.

The condition in the for loop has been updated to check that i is less than TASK_COMM_LEN before accessing targ_comm[i]. This ensures that targ_comm is not accessed out-of-bounds.