### PR TITLE
usdt: Fix bare register dereference on aarch64

### DIFF
--- a/src/cc/usdt/usdt_args.cc
+++ b/src/cc/usdt/usdt_args.cc
@@ -211,6 +211,8 @@ bool ArgumentParser_aarch64::parse_mem(ssize_t pos, ssize_t &new_pos,
       dest->scale_ = 1;
       dest->deref_offset_ = 0;
     }
+  } else if (arg_[new_pos] == ']') {
+    dest->deref_offset_ = 0;
   }
   if (arg_[new_pos] != ']')
     return error_return(new_pos, new_pos);


### PR DESCRIPTION
This change fixes parsing of USDT arguments like [x8].

When a memory dereference has no offset or index register, the parsing code skips setting an offset, which causes the argument to be interpreted as simply a register.  This is causes the argument value to not be dereferenced as required.

This change sets an offset constant of 0 so that the address will still be dereferenced.