### PR TITLE
Add the line "setlinebuf(stdout);" to avoid data output is not timely

### DIFF
--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -279,6 +279,8 @@ int main(int argc, char **argv)
 	int idx, cg_map_fd;
 	int cgfd = -1;
 
+	setlinebuf(stdout);
+
 	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
 	if (err)
 		return err;


### PR DESCRIPTION
It is recommended to add "setlinebuf(stdout);" to all tools.In order to avoid data output is not timely.If I can, I'll add this line of code to the other tools.