### PR TITLE
Fix warning: multiple identical address spaces specified for type on x86

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -266,6 +266,7 @@ int ClangLoader::parse(
                                    "-Wno-address-of-packed-member",
                                    "-Wno-unknown-warning-option",
 #if defined(__x86_64__) || defined(__i386__)
+                                   "-Wno-duplicate-decl-specifier",
                                    "-fcf-protection",
 #endif
                                    "-fno-color-diagnostics",


### PR DESCRIPTION
The linux kernel [0] commit 0e3703630bd3 ("x86/percpu: Fix "const_pcpu_hot" version generation failure") introduce this_cpu_read_const(const_pcpu_hot.current_task) in arch/x86/include/asm/current.h, which will cause the following warnings:

    $ sudo ./opensnoop.py
    In file included from /virtual/main.c:14:
    In file included from include/uapi/linux/ptrace.h:183:
    In file included from arch/x86/include/asm/ptrace.h:175:
    In file included from arch/x86/include/asm/paravirt_types.h:12:
    In file included from arch/x86/include/asm/nospec-branch.h:15:
    arch/x86/include/asm/current.h:47:10: warning: multiple identical address spaces specified for type [-Wduplicate-decl-specifier]
      47 |                 return this_cpu_read_const(const_pcpu_hot.current_task);
          |                        ^
    arch/x86/include/asm/percpu.h:465:34: note: expanded from macro 'this_cpu_read_const'
      465 | #define this_cpu_read_const(pcp)        __raw_cpu_read(, pcp)
          |                                         ^
    arch/x86/include/asm/percpu.h:435:30: note: expanded from macro '__raw_cpu_read'
      435 |         *(qual __my_cpu_type(pcp) *)__my_cpu_ptr(&(pcp));               \
          |                                     ^
    arch/x86/include/asm/percpu.h:99:28: note: expanded from macro '__my_cpu_ptr'
      99 | #define __my_cpu_ptr(ptr)       (__my_cpu_type(*ptr)*)(__force uintptr_t)(ptr)
          |                                  ^
    arch/x86/include/asm/percpu.h:98:40: note: expanded from macro '__my_cpu_type'
      98 | #define __my_cpu_type(var)      typeof(var) __percpu_seg_override
          |                                             ^
    arch/x86/include/asm/percpu.h:45:31: note: expanded from macro '__percpu_seg_override'
      45 | #define __percpu_seg_override   __seg_gs
          |                                 ^
    <built-in>:354:33: note: expanded from macro '__seg_gs'
      354 | #define __seg_gs __attribute__((address_space(256)))
          |                                 ^
    In file included from /virtual/main.c:14:
    In file included from include/uapi/linux/ptrace.h:183:
    In file included from arch/x86/include/asm/ptrace.h:175:
    In file included from arch/x86/include/asm/paravirt_types.h:12:
    In file included from arch/x86/include/asm/nospec-branch.h:15:
    arch/x86/include/asm/current.h:47:10: warning: multiple identical address spaces specified for type [-Wduplicate-decl-specifier]
    arch/x86/include/asm/percpu.h:465:34: note: expanded from macro 'this_cpu_read_const'
      465 | #define this_cpu_read_const(pcp)        __raw_cpu_read(, pcp)
          |                                         ^
    arch/x86/include/asm/percpu.h:435:9: note: expanded from macro '__raw_cpu_read'
      435 |         *(qual __my_cpu_type(pcp) *)__my_cpu_ptr(&(pcp));               \
          |                ^
    arch/x86/include/asm/percpu.h:98:40: note: expanded from macro '__my_cpu_type'
      98 | #define __my_cpu_type(var)      typeof(var) __percpu_seg_override
          |                                             ^
    arch/x86/include/asm/percpu.h:45:31: note: expanded from macro '__percpu_seg_override'
      45 | #define __percpu_seg_override   __seg_gs
          |                                 ^
    <built-in>:354:33: note: expanded from macro '__seg_gs'
      354 | #define __seg_gs __attribute__((address_space(256)))
          |                                 ^
    In file included from /virtual/main.c:16:
    In file included from include/linux/sched.h:13:
    arch/x86/include/asm/processor.h:529:10: warning: multiple identical address spaces specified for type [-Wduplicate-decl-specifier]
      529 |                 return this_cpu_read_const(const_pcpu_hot.top_of_stack);
          |                        ^
    arch/x86/include/asm/percpu.h:465:34: note: expanded from macro 'this_cpu_read_const'
      465 | #define this_cpu_read_const(pcp)        __raw_cpu_read(, pcp)
          |                                         ^
    arch/x86/include/asm/percpu.h:435:30: note: expanded from macro '__raw_cpu_read'
      435 |         *(qual __my_cpu_type(pcp) *)__my_cpu_ptr(&(pcp));               \
          |                                     ^
    arch/x86/include/asm/percpu.h:99:28: note: expanded from macro '__my_cpu_ptr'
      99 | #define __my_cpu_ptr(ptr)       (__my_cpu_type(*ptr)*)(__force uintptr_t)(ptr)
          |                                  ^
    arch/x86/include/asm/percpu.h:98:40: note: expanded from macro '__my_cpu_type'
      98 | #define __my_cpu_type(var)      typeof(var) __percpu_seg_override
          |                                             ^
    arch/x86/include/asm/percpu.h:45:31: note: expanded from macro '__percpu_seg_override'
      45 | #define __percpu_seg_override   __seg_gs
          |                                 ^
    <built-in>:354:33: note: expanded from macro '__seg_gs'
      354 | #define __seg_gs __attribute__((address_space(256)))
          |                                 ^
    In file included from /virtual/main.c:16:
    In file included from include/linux/sched.h:13:
    arch/x86/include/asm/processor.h:529:10: warning: multiple identical address spaces specified for type [-Wduplicate-decl-specifier]
    arch/x86/include/asm/percpu.h:465:34: note: expanded from macro 'this_cpu_read_const'
      465 | #define this_cpu_read_const(pcp)        __raw_cpu_read(, pcp)
          |                                         ^
    arch/x86/include/asm/percpu.h:435:9: note: expanded from macro '__raw_cpu_read'
      435 |         *(qual __my_cpu_type(pcp) *)__my_cpu_ptr(&(pcp));               \
          |                ^
    arch/x86/include/asm/percpu.h:98:40: note: expanded from macro '__my_cpu_type'
      98 | #define __my_cpu_type(var)      typeof(var) __percpu_seg_override
          |                                             ^
    arch/x86/include/asm/percpu.h:45:31: note: expanded from macro '__percpu_seg_override'
      45 | #define __percpu_seg_override   __seg_gs
          |                                 ^
    <built-in>:354:33: note: expanded from macro '__seg_gs'
      354 | #define __seg_gs __attribute__((address_space(256)))
          |                                 ^
    4 warnings generated.

The kernel version:

    $ git describe 0e3703630bd3
    v6.5-11437-g0e3703630bd3

I'm test it on Fedora 40 with kernel 6.9.4-200.fc40.x86_64.

[0] https://github.com/torvalds/linux.git