### PR TITLE
tools/mountsnoop: Support fsopen(2), fsmount(2), fsconfig(2), move_mo…

### DIFF
--- a/tools/mountsnoop.py
+++ b/tools/mountsnoop.py
@@ -9,6 +9,8 @@
 # Licensed under the Apache License, Version 2.0 (the "License")
 #
 # 14-Oct-2016   Omar Sandoval   Created this.
+# 23-Jun-2024   Rong Tao        Add fsopen(2),fsconfig(2),fsmount(2),
+#                               move_mount(2) syscalls support
 
 from __future__ import print_function
 import argparse
@@ -70,6 +72,18 @@ enum event_type {
     EVENT_MOUNT_TYPE,
     EVENT_MOUNT_DATA,
     EVENT_MOUNT_RET,
+    EVENT_FSOPEN,
+    EVENT_FSOPEN_FS_NAME,
+    EVENT_FSOPEN_RET,
+    EVENT_FSMOUNT,
+    EVENT_FSMOUNT_PARAMS,
+    EVENT_FSMOUNT_RET,
+    EVENT_FSCONFIG,
+    EVENT_FSCONFIG_PARAMS,
+    EVENT_FSCONFIG_RET,
+    EVENT_MOVE_MOUNT,
+    EVENT_MOVE_MOUNT_PARAMS,
+    EVENT_MOVE_MOUNT_RET,
     EVENT_UMOUNT,
     EVENT_UMOUNT_TARGET,
     EVENT_UMOUNT_RET,
@@ -79,7 +93,10 @@ struct data_t {
     enum event_type type;
     pid_t pid, tgid;
     union {
-        /* EVENT_MOUNT, EVENT_UMOUNT */
+        /*
+         * EVENT_MOUNT, EVENT_UMOUNT, EVENT_FSOPEN, EVENT_FSMOUNT,
+         * EVENT_FSCONFIG, EVENT_MOVE_MOUNT
+         */
         struct {
             /* current->nsproxy->mnt_ns->ns.inum */
             unsigned int mnt_ns;
@@ -90,10 +107,34 @@ struct data_t {
         } enter;
         /*
          * EVENT_MOUNT_SOURCE, EVENT_MOUNT_TARGET, EVENT_MOUNT_TYPE,
-         * EVENT_MOUNT_DATA, EVENT_UMOUNT_TARGET
+         * EVENT_MOUNT_DATA, EVENT_UMOUNT_TARGET, EVENT_FSOPEN_FS_NAME
          */
         char str[MAX_STR_LEN];
-        /* EVENT_MOUNT_RET, EVENT_UMOUNT_RET */
+        /* EVENT_FSMOUNT_PARAMS */
+        struct {
+            int fs_fd;
+            int attr_flags;
+        } fsmount;
+        /* EVENT_FSCONFIG_PARAMS */
+        struct {
+            int fd;
+            unsigned int cmd;
+            char key[32];
+            char value[32];
+            int aux;
+        } fsconfig;
+        /* EVENT_MOVE_MOUNT_PARAMS */
+        struct {
+            int from_dfd;
+            char from_pathname[128];
+            int to_dfd;
+            char to_pathname[128];
+            unsigned int flags;
+        } move_mount;
+        /*
+         * EVENT_MOUNT_RET, EVENT_UMOUNT_RET, EVENT_FSOPEN_RET,
+         * EVENT_FSMOUNT_RET, EVENT_FSCONFIG_RET, EVENT_MOVE_MOUNT_RET
+         */
         int retval;
     };
 };
@@ -150,17 +191,197 @@ int syscall__mount(struct pt_regs *ctx, char __user *source,
     return 0;
 }
 
-int do_ret_sys_mount(struct pt_regs *ctx)
+int syscall__fsopen(struct pt_regs *ctx, char __user *fs_name,
+                    unsigned long flags)
+{
+    struct data_t event = {};
+    struct task_struct *task;
+    struct nsproxy *nsproxy;
+    struct mnt_namespace *mnt_ns;
+
+    if (container_should_be_filtered()) {
+        return 0;
+    }
+
+    event.pid = bpf_get_current_pid_tgid() & 0xffffffff;
+    event.tgid = bpf_get_current_pid_tgid() >> 32;
+
+    event.type = EVENT_FSOPEN;
+    bpf_get_current_comm(event.enter.comm, sizeof(event.enter.comm));
+    event.enter.flags = flags;
+    task = (struct task_struct *)bpf_get_current_task();
+    event.enter.ppid = task->real_parent->tgid;
+    bpf_probe_read_kernel_str(&event.enter.pcomm, TASK_COMM_LEN, task->real_parent->comm);
+    nsproxy = task->nsproxy;
+    mnt_ns = nsproxy->mnt_ns;
+    event.enter.mnt_ns = mnt_ns->ns.inum;
+    events.perf_submit(ctx, &event, sizeof(event));
+
+    event.type = EVENT_FSOPEN_FS_NAME;
+    __builtin_memset(event.str, 0, sizeof(event.str));
+    bpf_probe_read_user(event.str, sizeof(event.str), fs_name);
+    events.perf_submit(ctx, &event, sizeof(event));
+
+    return 0;
+}
+
+int syscall__fsmount(struct pt_regs *ctx, unsigned int fs_fd,
+                     unsigned int flags, unsigned int attr_flags)
+{
+    struct data_t event = {};
+    struct task_struct *task;
+    struct nsproxy *nsproxy;
+    struct mnt_namespace *mnt_ns;
+
+    if (container_should_be_filtered()) {
+        return 0;
+    }
+
+    event.pid = bpf_get_current_pid_tgid() & 0xffffffff;
+    event.tgid = bpf_get_current_pid_tgid() >> 32;
+
+    event.type = EVENT_FSMOUNT;
+    bpf_get_current_comm(event.enter.comm, sizeof(event.enter.comm));
+    event.enter.flags = flags;
+    task = (struct task_struct *)bpf_get_current_task();
+    event.enter.ppid = task->real_parent->tgid;
+    bpf_probe_read_kernel_str(&event.enter.pcomm, TASK_COMM_LEN, task->real_parent->comm);
+    nsproxy = task->nsproxy;
+    mnt_ns = nsproxy->mnt_ns;
+    event.enter.mnt_ns = mnt_ns->ns.inum;
+    events.perf_submit(ctx, &event, sizeof(event));
+
+    event.type = EVENT_FSMOUNT_PARAMS;
+    event.fsmount.fs_fd = fs_fd;
+    event.fsmount.attr_flags = attr_flags;
+    events.perf_submit(ctx, &event, sizeof(event));
+
+    return 0;
+}
+
+int syscall__fsconfig(struct pt_regs *ctx, int fd, unsigned int cmd,
+                      char *key, char *value, int aux)
+{
+    struct data_t event = {};
+    struct task_struct *task;
+    struct nsproxy *nsproxy;
+    struct mnt_namespace *mnt_ns;
+
+    if (container_should_be_filtered()) {
+        return 0;
+    }
+
+    event.pid = bpf_get_current_pid_tgid() & 0xffffffff;
+    event.tgid = bpf_get_current_pid_tgid() >> 32;
+
+    event.type = EVENT_FSCONFIG;
+    bpf_get_current_comm(event.enter.comm, sizeof(event.enter.comm));
+    task = (struct task_struct *)bpf_get_current_task();
+    event.enter.ppid = task->real_parent->tgid;
+    bpf_probe_read_kernel_str(&event.enter.pcomm, TASK_COMM_LEN, task->real_parent->comm);
+    nsproxy = task->nsproxy;
+    mnt_ns = nsproxy->mnt_ns;
+    event.enter.mnt_ns = mnt_ns->ns.inum;
+    events.perf_submit(ctx, &event, sizeof(event));
+
+    event.type = EVENT_FSCONFIG_PARAMS;
+    event.fsconfig.fd = fd;
+    event.fsconfig.cmd = cmd;
+    /*
+     * FIXME: fsconfig.key, fsconfig.value and fsconfig.aux can be used in
+     * different combinations, and perhaps we should distinguish between them.
+     */
+    __builtin_memset(event.fsconfig.key, 0, sizeof(event.fsconfig.key));
+    bpf_probe_read_user(event.fsconfig.key, sizeof(event.fsconfig.key), key);
+    __builtin_memset(event.fsconfig.value, 0, sizeof(event.fsconfig.value));
+    bpf_probe_read_user(event.fsconfig.value, sizeof(event.fsconfig.value), value);
+    event.fsconfig.aux = aux;
+    events.perf_submit(ctx, &event, sizeof(event));
+
+    return 0;
+}
+
+int syscall__move_mount(struct pt_regs *ctx,
+                        int from_dfd, char *from_pathname,
+                        int to_dfd, char *to_pathname,
+                        unsigned int flags)
+{
+    struct data_t event = {};
+    struct task_struct *task;
+    struct nsproxy *nsproxy;
+    struct mnt_namespace *mnt_ns;
+
+    if (container_should_be_filtered()) {
+        return 0;
+    }
+
+    event.pid = bpf_get_current_pid_tgid() & 0xffffffff;
+    event.tgid = bpf_get_current_pid_tgid() >> 32;
+
+    event.type = EVENT_MOVE_MOUNT;
+    bpf_get_current_comm(event.enter.comm, sizeof(event.enter.comm));
+    event.enter.flags = flags;
+    task = (struct task_struct *)bpf_get_current_task();
+    event.enter.ppid = task->real_parent->tgid;
+    bpf_probe_read_kernel_str(&event.enter.pcomm, TASK_COMM_LEN, task->real_parent->comm);
+    nsproxy = task->nsproxy;
+    mnt_ns = nsproxy->mnt_ns;
+    event.enter.mnt_ns = mnt_ns->ns.inum;
+    events.perf_submit(ctx, &event, sizeof(event));
+
+    event.type = EVENT_MOVE_MOUNT_PARAMS;
+    event.move_mount.from_dfd = from_dfd;
+    __builtin_memset(event.move_mount.from_pathname, 0,
+                     sizeof(event.move_mount.from_pathname));
+    bpf_probe_read_user(event.move_mount.from_pathname,
+                        sizeof(event.move_mount.from_pathname), from_pathname);
+    event.move_mount.to_dfd = to_dfd;
+    __builtin_memset(event.move_mount.to_pathname, 0,
+                     sizeof(event.move_mount.to_pathname));
+    bpf_probe_read_user(event.move_mount.to_pathname,
+                        sizeof(event.move_mount.to_pathname), to_pathname);
+    event.move_mount.flags = flags;
+    events.perf_submit(ctx, &event, sizeof(event));
+
+    return 0;
+}
+
+static int __do_ret_sys(struct pt_regs *ctx, int ret)
 {
     struct data_t event = {};
 
-    event.type = EVENT_MOUNT_RET;
+    event.type = ret;
     event.pid = bpf_get_current_pid_tgid() & 0xffffffff;
     event.tgid = bpf_get_current_pid_tgid() >> 32;
     event.retval = PT_REGS_RC(ctx);
     events.perf_submit(ctx, &event, sizeof(event));
 
     return 0;
+}
+
+int do_ret_sys_mount(struct pt_regs *ctx)
+{
+    return __do_ret_sys(ctx, EVENT_MOUNT_RET);
+}
+
+int do_ret_sys_fsopen(struct pt_regs *ctx)
+{
+    return __do_ret_sys(ctx, EVENT_FSOPEN_RET);
+}
+
+int do_ret_sys_fsmount(struct pt_regs *ctx)
+{
+    return __do_ret_sys(ctx, EVENT_FSMOUNT_RET);
+}
+
+int do_ret_sys_fsconfig(struct pt_regs *ctx)
+{
+    return __do_ret_sys(ctx, EVENT_FSCONFIG_RET);
+}
+
+int do_ret_sys_move_mount(struct pt_regs *ctx)
+{
+    return __do_ret_sys(ctx, EVENT_MOVE_MOUNT_RET);
 }
 
 int syscall__umount(struct pt_regs *ctx, char __user *target, int flags)
@@ -198,15 +419,7 @@ int syscall__umount(struct pt_regs *ctx, char __user *target, int flags)
 
 int do_ret_sys_umount(struct pt_regs *ctx)
 {
-    struct data_t event = {};
-
-    event.type = EVENT_UMOUNT_RET;
-    event.pid = bpf_get_current_pid_tgid() & 0xffffffff;
-    event.tgid = bpf_get_current_pid_tgid() >> 32;
-    event.retval = PT_REGS_RC(ctx);
-    events.perf_submit(ctx, &event, sizeof(event));
-
-    return 0;
+    return __do_ret_sys(ctx, EVENT_UMOUNT_RET);
 }
 """
 
@@ -241,6 +454,44 @@ MOUNT_FLAGS = [
     ('MS_ACTIVE', 1 << 30),
     ('MS_NOUSER', 1 << 31),
 ]
+
+MOUNT_ATTR_FLAGS = [
+    ('MOUNT_ATTR_RDONLY', 0x00000001),
+    ('MOUNT_ATTR_NOSUID', 0x00000002),
+    ('MOUNT_ATTR_NODEV', 0x00000004),
+    ('MOUNT_ATTR_NOEXEC', 0x00000008),
+    ('MOUNT_ATTR__ATIME', 0x00000070),
+    ('MOUNT_ATTR_RELATIME', 0x00000000),
+    ('MOUNT_ATTR_NOATIME', 0x00000010),
+    ('MOUNT_ATTR_STRICTATIME', 0x00000020),
+    ('MOUNT_ATTR_NODIRATIME', 0x00000080),
+    ('MOUNT_ATTR_IDMAP', 0x00100000),
+    ('MOUNT_ATTR_NOSYMFOLLOW', 0x00200000),
+]
+
+FSCONFIG_CMD = [
+    ('FSCONFIG_SET_FLAG', 0),
+    ('FSCONFIG_SET_STRING', 1),
+    ('FSCONFIG_SET_BINARY', 2),
+    ('FSCONFIG_SET_PATH', 3),
+    ('FSCONFIG_SET_PATH_EMPTY', 4),
+    ('FSCONFIG_SET_FD', 5),
+    ('FSCONFIG_CMD_CREATE', 6),
+    ('FSCONFIG_CMD_RECONFIGURE', 7),
+    ('FSCONFIG_CMD_CREATE_EXCL', 8),
+]
+
+MOVE_MOUNT_FLAGS = [
+    ('MOVE_MOUNT_F_SYMLINKS', 0x00000001),
+    ('MOVE_MOUNT_F_AUTOMOUNTS', 0x00000002),
+    ('MOVE_MOUNT_F_EMPTY_PATH', 0x00000004),
+    ('MOVE_MOUNT_T_SYMLINKS', 0x00000010),
+    ('MOVE_MOUNT_T_AUTOMOUNTS', 0x00000020),
+    ('MOVE_MOUNT_T_EMPTY_PATH', 0x00000040),
+    ('MOVE_MOUNT_SET_GROUP', 0x00000100),
+    ('MOVE_MOUNT_BENEATH', 0x00000200),
+]
+
 UMOUNT_FLAGS = [
     ('MNT_FORCE', 1),
     ('MNT_DETACH', 2),
@@ -252,6 +503,8 @@ UMOUNT_FLAGS = [
 TASK_COMM_LEN = 16  # linux/sched.h
 MAX_STR_LEN = 412
 
+# linux/fcntl.h
+AT_FDCWD = -100
 
 class EventType(object):
     EVENT_MOUNT = 0
@@ -260,9 +513,21 @@ class EventType(object):
     EVENT_MOUNT_TYPE = 3
     EVENT_MOUNT_DATA = 4
     EVENT_MOUNT_RET = 5
-    EVENT_UMOUNT = 6
-    EVENT_UMOUNT_TARGET = 7
-    EVENT_UMOUNT_RET = 8
+    EVENT_FSOPEN = 6
+    EVENT_FSOPEN_FS_NAME = 7
+    EVENT_FSOPEN_RET = 8
+    EVENT_FSMOUNT = 9
+    EVENT_FSMOUNT_PARAMS = 10
+    EVENT_FSMOUNT_RET = 11
+    EVENT_FSCONFIG = 12
+    EVENT_FSCONFIG_PARAMS = 13
+    EVENT_FSCONFIG_RET = 14
+    EVENT_MOVE_MOUNT = 15
+    EVENT_MOVE_MOUNT_PARAMS = 16
+    EVENT_MOVE_MOUNT_RET = 17
+    EVENT_UMOUNT = 18
+    EVENT_UMOUNT_TARGET = 19
+    EVENT_UMOUNT_RET = 20
 
 
 class EnterData(ctypes.Structure):
@@ -274,11 +539,37 @@ class EnterData(ctypes.Structure):
         ('flags', ctypes.c_ulong),
     ]
 
+class FsmountParam(ctypes.Structure):
+    _fields_ = [
+        ('fs_fd', ctypes.c_int),
+        ('attr_flags', ctypes.c_uint),
+    ]
+
+class FsconfigParam(ctypes.Structure):
+    _fields_ = [
+        ('fd', ctypes.c_int),
+        ('cmd', ctypes.c_uint),
+        ('key', ctypes.c_char * 32),
+        ('value', ctypes.c_char * 32),
+        ('aux', ctypes.c_uint),
+    ]
+
+class MoveMountParam(ctypes.Structure):
+    _fields_ = [
+        ('from_dfd', ctypes.c_int),
+        ('from_pathname', ctypes.c_char * 128),
+        ('to_dfd', ctypes.c_int),
+        ('to_pathname', ctypes.c_char * 128),
+        ('flags', ctypes.c_uint),
+    ]
 
 class DataUnion(ctypes.Union):
     _fields_ = [
         ('enter', EnterData),
         ('str', ctypes.c_char * MAX_STR_LEN),
+        ('fsmount', FsmountParam),
+        ('fsconfig', FsconfigParam),
+        ('move_mount', MoveMountParam),
         ('retval', ctypes.c_int),
     ]
 
@@ -302,6 +593,12 @@ def _decode_flags(flags, flag_list):
         str_flags.append('0x{:x}'.format(flags))
     return str_flags
 
+def _decode_cmd(cmd, cmd_list):
+    for str_cmd, cmd_val in cmd_list:
+        if cmd == cmd_val:
+            return str_cmd
+    return '0x{:x}'.format(cmd)
+
 
 def decode_flags(flags, flag_list):
     return '|'.join(_decode_flags(flags, flag_list))
@@ -315,10 +612,26 @@ def decode_mount_flags(flags):
     str_flags.extend(_decode_flags(flags, MOUNT_FLAGS))
     return '|'.join(str_flags)
 
+def decode_mount_attr_flags(flags):
+    str_flags = []
+    str_flags.extend(_decode_flags(flags, MOUNT_ATTR_FLAGS))
+    return '|'.join(str_flags)
+
+def decode_fsconfig_cmd(cmd):
+    return _decode_cmd(cmd, FSCONFIG_CMD)
+
+def decode_move_mount_flags(flags):
+    str_flags = []
+    str_flags.extend(_decode_flags(flags, MOVE_MOUNT_FLAGS))
+    return '|'.join(str_flags)
 
 def decode_umount_flags(flags):
     return decode_flags(flags, UMOUNT_FLAGS)
 
+def decode_special_fd(fd):
+    if fd == AT_FDCWD:
+        return 'AT_FDCWD'
+    return '{:d}'.format(fd)
 
 def decode_errno(retval):
     try:
@@ -362,7 +675,11 @@ def print_event(mounts, umounts, parent, cpu, data, size):
     event = ctypes.cast(data, ctypes.POINTER(Event)).contents
 
     try:
-        if event.type == EventType.EVENT_MOUNT:
+        if (event.type == EventType.EVENT_MOUNT or
+            event.type == EventType.EVENT_FSOPEN or
+            event.type == EventType.EVENT_FSMOUNT or
+            event.type == EventType.EVENT_FSCONFIG or
+            event.type == EventType.EVENT_MOVE_MOUNT):
             mounts[event.pid] = {
                 'pid': event.pid,
                 'tgid': event.tgid,
@@ -381,6 +698,23 @@ def print_event(mounts, umounts, parent, cpu, data, size):
         elif event.type == EventType.EVENT_MOUNT_DATA:
             # XXX: data is not always a NUL-terminated string
             mounts[event.pid]['data'] = event.union.str
+        elif event.type == EventType.EVENT_FSOPEN_FS_NAME:
+            mounts[event.pid]['fs_name'] = event.union.str
+        elif event.type == EventType.EVENT_FSMOUNT_PARAMS:
+            mounts[event.pid]['fs_fd'] = event.union.fsmount.fs_fd
+            mounts[event.pid]['attr_flags'] = event.union.fsmount.attr_flags
+        elif event.type == EventType.EVENT_FSCONFIG_PARAMS:
+            mounts[event.pid]['fd'] = event.union.fsconfig.fd
+            mounts[event.pid]['cmd'] = event.union.fsconfig.cmd
+            mounts[event.pid]['key'] = event.union.fsconfig.key
+            mounts[event.pid]['value'] = event.union.fsconfig.value
+            mounts[event.pid]['aux'] = event.union.fsconfig.aux
+        elif event.type == EventType.EVENT_MOVE_MOUNT_PARAMS:
+            mounts[event.pid]['from_dfd'] = event.union.move_mount.from_dfd
+            mounts[event.pid]['from_pathname'] = event.union.move_mount.from_pathname
+            mounts[event.pid]['to_dfd'] = event.union.move_mount.to_dfd
+            mounts[event.pid]['to_pathname'] = event.union.move_mount.to_pathname
+            mounts[event.pid]['flags'] = event.union.move_mount.flags
         elif event.type == EventType.EVENT_UMOUNT:
             umounts[event.pid] = {
                 'pid': event.pid,
@@ -394,7 +728,11 @@ def print_event(mounts, umounts, parent, cpu, data, size):
         elif event.type == EventType.EVENT_UMOUNT_TARGET:
             umounts[event.pid]['target'] = event.union.str
         elif (event.type == EventType.EVENT_MOUNT_RET or
-              event.type == EventType.EVENT_UMOUNT_RET):
+              event.type == EventType.EVENT_UMOUNT_RET or
+              event.type == EventType.EVENT_FSOPEN_RET or
+              event.type == EventType.EVENT_FSMOUNT_RET or
+              event.type == EventType.EVENT_FSCONFIG_RET or
+              event.type == EventType.EVENT_MOVE_MOUNT_RET):
             if event.type == EventType.EVENT_MOUNT_RET:
                 syscall = mounts.pop(event.pid)
                 call = ('mount({source}, {target}, {type}, {flags}, {data}) ' +
@@ -405,11 +743,47 @@ def print_event(mounts, umounts, parent, cpu, data, size):
                     flags=decode_mount_flags(syscall['flags']),
                     data=decode_mount_string(syscall['data']),
                     retval=decode_errno(event.union.retval))
-            else:
+            elif event.type == EventType.EVENT_UMOUNT_RET:
                 syscall = umounts.pop(event.pid)
                 call = 'umount({target}, {flags}) = {retval}'.format(
                     target=decode_mount_string(syscall['target']),
                     flags=decode_umount_flags(syscall['flags']),
+                    retval=decode_errno(event.union.retval))
+            elif event.type == EventType.EVENT_FSOPEN_RET:
+                syscall = mounts.pop(event.pid)
+                call = ('fsopen({fs_name}, {flags}) ' +
+                        '= {retval}').format(
+                    fs_name=decode_mount_string(syscall['fs_name']),
+                    flags=decode_mount_flags(syscall['flags']),
+                    retval=decode_errno(event.union.retval))
+            elif event.type == EventType.EVENT_FSMOUNT_RET:
+                syscall = mounts.pop(event.pid)
+                call = ('fsmount({fs_fd}, {flags}, {attr_flags}) ' +
+                        '= {retval}').format(
+                    fs_fd=syscall['fs_fd'],
+                    flags=decode_mount_flags(syscall['flags']),
+                    attr_flags=decode_mount_attr_flags(syscall['attr_flags']),
+                    retval=decode_errno(event.union.retval))
+            elif event.type == EventType.EVENT_FSCONFIG_RET:
+                syscall = mounts.pop(event.pid)
+                call = ('fsconfig({fd}, {cmd}, {key}, {value}, {aux}) ' +
+                        '= {retval}').format(
+                    fd=syscall['fd'],
+                    cmd=decode_fsconfig_cmd(syscall['cmd']),
+                    key=decode_mount_string(syscall['key']),
+                    value=decode_mount_string(syscall['value']),
+                    aux=syscall['aux'],
+                    retval=decode_errno(event.union.retval))
+            elif event.type == EventType.EVENT_MOVE_MOUNT_RET:
+                syscall = mounts.pop(event.pid)
+                call = ('move_mount({from_dfd}, {from_pathname}, {to_dfd}, {to_pathname}, {flags}) ' +
+                        '= {retval}').format(
+                    from_dfd=syscall['from_dfd'],
+                    from_pathname=decode_mount_string(syscall['from_pathname']),
+                    # maye to_dfd == AT_FDCWD
+                    to_dfd=decode_special_fd(syscall['to_dfd']),
+                    to_pathname=decode_mount_string(syscall['to_pathname']),
+                    flags=decode_move_mount_flags(syscall['flags']),
                     retval=decode_errno(event.union.retval))
             if parent:
                 print('{:16} {:<7} {:<7} {:16} {:<7} {:<11} {}'.format(
@@ -447,13 +821,52 @@ def main():
     if args.ebpf:
         print(bpf_text)
         exit()
+
     b = bcc.BPF(text=bpf_text)
+
     mount_fnname = b.get_syscall_fnname("mount")
+    # fsopne(2) syscall add since kernel commit 24dcb3d90a1f ("vfs: syscall:
+    # Add fsopen() to prepare for superblock creation") v5.1-rc1-5-g24dcb3d90a1f
+    fsopen_fnname = b.get_syscall_fnname("fsopen")
+    # fsconfig(2) syscall add since kernel commit ecdab150fddb ("vfs: syscall:
+    # Add fsconfig() for configuring and managing a context") v5.1-rc1-7-gecdab150fddb
+    fsconfig_fnname = b.get_syscall_fnname("fsconfig")
+    # fsmount(2) syscall add since kernel commit 93766fbd2696 ("vfs: syscall:
+    # Add fsmount() to create a mount for a superblock") v5.1-rc1-8-g93766fbd2696
+    fsmount_fnname = b.get_syscall_fnname("fsmount")
+    # move_mount(2) syscall add since kernel commit 2db154b3ea8e ("vfs: syscall:
+    # Add move_mount(2) to move mounts around"), v5.1-rc1-2-g2db154b3ea8e
+    move_mount_fnname = b.get_syscall_fnname("move_mount")
+    umount_fnname = b.get_syscall_fnname("umount")
+
+    if b.ksymname(fsopen_fnname) == -1:
+        fsopen_fnname = None
+    if b.ksymname(fsconfig_fnname) == -1:
+        fsconfig_fnname = None
+    if b.ksymname(fsmount_fnname) == -1:
+        fsmount_fnname = None
+    if b.ksymname(move_mount_fnname) == -1:
+        move_mount_fnname = None
+
     b.attach_kprobe(event=mount_fnname, fn_name="syscall__mount")
     b.attach_kretprobe(event=mount_fnname, fn_name="do_ret_sys_mount")
-    umount_fnname = b.get_syscall_fnname("umount")
+
+    if fsopen_fnname:
+        b.attach_kprobe(event=fsopen_fnname, fn_name="syscall__fsopen")
+        b.attach_kretprobe(event=fsopen_fnname, fn_name="do_ret_sys_fsopen")
+    if fsmount_fnname:
+        b.attach_kprobe(event=fsmount_fnname, fn_name="syscall__fsmount")
+        b.attach_kretprobe(event=fsmount_fnname, fn_name="do_ret_sys_fsmount")
+    if fsconfig_fnname:
+        b.attach_kprobe(event=fsconfig_fnname, fn_name="syscall__fsconfig")
+        b.attach_kretprobe(event=fsconfig_fnname, fn_name="do_ret_sys_fsconfig")
+    if move_mount_fnname:
+        b.attach_kprobe(event=move_mount_fnname, fn_name="syscall__move_mount")
+        b.attach_kretprobe(event=move_mount_fnname, fn_name="do_ret_sys_move_mount")
+
     b.attach_kprobe(event=umount_fnname, fn_name="syscall__umount")
     b.attach_kretprobe(event=umount_fnname, fn_name="do_ret_sys_umount")
+
     b['events'].open_perf_buffer(
         functools.partial(print_event, mounts, umounts, args.parent_process))
 

--- a/tools/mountsnoop_example.txt
+++ b/tools/mountsnoop_example.txt
@@ -11,16 +11,27 @@ running the following series of commands produces this output:
 
 # ./mountsnoop.py
 COMM             PID     TID     MNT_NS      CALL
-mount            710     710     4026531840  mount("/mnt", "/mnt", "", MS_MGC_VAL|MS_BIND, "") = 0
-umount           714     714     4026531840  umount("/mnt", 0x0) = 0
-unshare          717     717     4026532160  mount("none", "/", "", MS_REC|MS_PRIVATE, "") = 0
-mount            725     725     4026532160  mount("/mnt", "/mnt", "", MS_MGC_VAL|MS_BIND, "") = 0
-umount           728     728     4026532160  umount("/mnt", 0x0) = 0
+mount            13207   13207   4026531841  mount("/dev/loop0", "tmp-dir/", "ext4", 0x0, "") = 0
+mount            13207   13207   4026531841  umount("tmp-dir/", 0x0) = 0
+fsmount          13224   13224   4026531841  fsopen("ext4", 0x0) = 5
+fsmount          13224   13224   4026531841  fsconfig(5, FSCONFIG_SET_FLAG, "rw", "", 0) = 0
+fsmount          13224   13224   4026531841  fsconfig(5, FSCONFIG_SET_STRING, "source", "/dev/loop0", 0) = 0
+fsmount          13224   13224   4026531841  fsconfig(5, FSCONFIG_CMD_CREATE, "", "", 0) = 0
+fsmount          13224   13224   4026531841  fsmount(5, 0x0, MOUNT_ATTR_RDONLY) = 6
+fsmount          13224   13224   4026531841  move_mount(6, "", AT_FDCWD, "./tmp-dir/", MOVE_MOUNT_F_EMPTY_PATH) = 0
+fsmount          13224   13224   4026531841  umount("./tmp-dir/", 0x0) = 0
 
 # ./mountsnoop.py -P
 COMM             PID     TID     PCOMM            PPID    MNT_NS      CALL
-mount            51526   51526   bash             49313   3222937920  mount("/mnt", "/mnt", "", MS_MGC_VAL|MS_BIND, "", "") = 0
-umount           51613   51613   bash             49313   3222937920  umount("/mnt", 0x0) = 0
+mount            13393   13393   bash             13392   4026531841  mount("/dev/loop0", "tmp-dir/", "ext4", 0x0, "") = 0
+mount            13393   13393   bash             13392   4026531841  umount("tmp-dir/", 0x0) = 0
+fsmount          13409   13409   bash             13408   4026531841  fsopen("ext4", 0x0) = 5
+fsmount          13409   13409   bash             13408   4026531841  fsconfig(5, FSCONFIG_SET_FLAG, "rw", "", 0) = 0
+fsmount          13409   13409   bash             13408   4026531841  fsconfig(5, FSCONFIG_SET_STRING, "source", "/dev/loop0", 0) = 0
+fsmount          13409   13409   bash             13408   4026531841  fsconfig(5, FSCONFIG_CMD_CREATE, "", "", 0) = 0
+fsmount          13409   13409   bash             13408   4026531841  fsmount(5, 0x0, MOUNT_ATTR_RDONLY) = 6
+fsmount          13409   13409   bash             13408   4026531841  move_mount(6, "", AT_FDCWD, "./tmp-dir/", MOVE_MOUNT_F_EMPTY_PATH) = 0
+fsmount          13409   13409   bash             13408   4026531841  umount("./tmp-dir/", 0x0) = 0
 
 The output shows the calling command, its process ID and thread ID, the mount
 namespace the call was made in, and the call itself.


### PR DESCRIPTION
…unt(2)

Since kernel 5.1, fsopen,fsmount,fsconfig,move_mount syscalls were introduced (see links [1][2][3][4]). Then the mountsnoop tracking mount system call is not enough. This submission adds support for the above syscalls.

A tracking example:

```
    $ sudo ./mountsnoop.py
    COMM             PID     TID     MNT_NS      CALL
    fsmount          12373   12373   4026531841  fsopen("ext4", 0x0) = 5
    fsmount          12373   12373   4026531841  fsconfig(5, FSCONFIG_SET_FLAG, "rw", "", 0) = 0
    fsmount          12373   12373   4026531841  fsconfig(5, FSCONFIG_SET_STRING, "source", "/dev/loop0", 0) = 0
    fsmount          12373   12373   4026531841  fsconfig(5, FSCONFIG_CMD_CREATE, "", "", 0) = 0
    fsmount          12373   12373   4026531841  fsmount(5, 0x0, MOUNT_ATTR_RDONLY) = 6
    fsmount          12373   12373   4026531841  move_mount(6, "", AT_FDCWD, "./tmp-dir/", MOVE_MOUNT_F_EMPTY_PATH) = 0
    fsmount          12373   12373   4026531841  umount("./tmp-dir/", 0x0) = 0
```

In the above test, the C program is more complicated, so I will not show it here, but a test example is given in the link [5].

[1] kernel commit 24dcb3d90a1f ("vfs: syscall: Add fsopen() to prepare for superblock creation")
    v5.1-rc1-5-g24dcb3d90a1f
[2] kernel commit ecdab150fddb ("vfs: syscall: Add fsconfig() for configuring and managing a context")
    v5.1-rc1-7-gecdab150fddb
[3] kernel commit 93766fbd2696 ("vfs: syscall: Add fsmount() to create a mount for a superblock")
    v5.1-rc1-8-g93766fbd2696
[4] kernel commit 2db154b3ea8e ("vfs: syscall: Add move_mount(2) to move mounts around")
    v5.1-rc1-2-g2db154b3ea8e
[5] https://github.com/torvalds/linux/blob/master/samples/vfs/test-fsmount.c