### PR TITLE
libbpf-tools/wakeuptime: Add offset to kernel stack trace

### DIFF
--- a/libbpf-tools/wakeuptime.c
+++ b/libbpf-tools/wakeuptime.c
@@ -186,7 +186,10 @@ static void print_map(struct ksyms *ksyms, struct wakeuptime_bpf *obj)
 		}
 		for (i = 0; i < env.perf_max_stack_depth && ip[i]; i++) {
 			ksym = ksyms__map_addr(ksyms, ip[i]);
-			printf("	%-16lx %s\n", ip[i], ksym ? ksym->name: "Unknown");
+			if (ksym)
+				printf("	%-16lx %s+0x%lx\n", ip[i], ksym->name, ip[i] - ksym->addr);
+			else
+				printf("	%-16lx Unknown\n", ip[i]);
 		}
 		printf("	%16s %s\n","waker:", next_key.waker);
 		/*to convert val in microseconds*/


### PR DESCRIPTION
Include symbol base offset in the kernel stack trace to accurately pinpoint the location of function calls.
The offset is commonly used in various debugging tools, including those for the Linux kernel.

Before:
```
  # ./wakeuptime
    target:          kworker/1:0
    ffffffffc0001239 bpf_prog_01d43570d6219d0c_sched_wakeup
    ffffffffc0001239 bpf_prog_01d43570d6219d0c_sched_wakeup
    ffffffff8118ca87 bpf_trace_run1
    ffffffff810a9804 __traceiter_sched_wakeup
    ffffffff810b5dcb ttwu_do_activate.isra.141
    ffffffff810b5ec6 sched_ttwu_pending
    ffffffff81132c16 __flush_smp_call_function_queue
    ffffffff8104ffa3 __sysvec_call_function_single
    ffffffff81dc72d9 sysvec_call_function_single
    ffffffff81e00dc6 asm_sysvec_call_function_single
              waker: test-strlen-abc
    77
```
After:
```
  # ./wakeuptime
    target:          kworker/1:0
    ffffffffc0001279 bpf_prog_01d43570d6219d0c_sched_wakeup+0xe5
    ffffffffc0001279 bpf_prog_01d43570d6219d0c_sched_wakeup+0xe5
    ffffffff8118ca87 bpf_trace_run1+0x47
    ffffffff810a9804 __traceiter_sched_wakeup+0x24
    ffffffff810b5dcb ttwu_do_activate.isra.141+0x11b
    ffffffff810b5ec6 sched_ttwu_pending+0x96
    ffffffff81132c16 __flush_smp_call_function_queue+0x146
    ffffffff8104ffa3 __sysvec_call_function_single+0x13
    ffffffff81dc72d9 sysvec_call_function_single+0x39
    ffffffff81e00dc6 asm_sysvec_call_function_single+0x16
              waker: test-strlen-abc
    237
```