### PR TITLE
Offload xdp_drop_count.py error

### DIFF
--- a/examples/networking/xdp/xdp_drop_count.py
+++ b/examples/networking/xdp/xdp_drop_count.py
@@ -11,6 +11,7 @@ from bcc import BPF
 import pyroute2
 import time
 import sys
+import ctypes
 
 flags = 0
 def usage():
@@ -41,7 +42,7 @@ if len(sys.argv) == 3:
     if "-H" in sys.argv:
         # XDP_FLAGS_HW_MODE
         maptype = "array"
-        offload_device = device
+        offload_device = ctypes.c_char_p(device.encode('utf-8'))
         flags |= BPF.XDP_FLAGS_HW_MODE
 
 mode = BPF.XDP


### PR DESCRIPTION
When trying to offload an ebpf xdp program to a Netronome SmartNIC a ctypes error is given. This can be seen when running xdp_drop_count.py:

![error](https://github.com/iovisor/bcc/assets/67588637/c47543b7-3285-4439-a958-65cffdf5416f)

This is also noted in: https://stackoverflow.com/questions/66628566/trying-to-load-xdp-on-nic-offloaded. However, no solution is provided. According to the merge: https://github.com/iovisor/bcc/pull/2502, this should not be the error given in case of the nic not supporting offload.

The issue is fixable by casting the device interface name to a _const char pointer_. This allows the programs to load correctly:

![success](https://github.com/iovisor/bcc/assets/67588637/07800056-0136-410a-9376-24d68f5890f4)
