### PR TITLE
libbpf-tools/javagc: Fix fatal error: 'asm/errno.h' file not found on riscv64

### DIFF
--- a/libbpf-tools/javagc.bpf.c
+++ b/libbpf-tools/javagc.bpf.c
@@ -3,7 +3,6 @@
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
-#include <bpf/usdt.bpf.h>
 #include "javagc.h"
 
 struct {


### PR DESCRIPTION
On Debian12 riscv64, the kernel never has asm/errno.h for riscv64, we do not include usdt.bpf.h could solve this problem.

    $ make
    ...
      BPF      javagc.bpf.o
    In file included from javagc.bpf.c:6:
    In file included from /home/rongtao/bcc/libbpf-tools/.output/bpf/usdt.bpf.h:6:
    /usr/include/linux/errno.h:1:10: fatal error: 'asm/errno.h' file not found
    #include <asm/errno.h>
             ^~~~~~~~~~~~~
    1 error generated.
    make: *** [Makefile:204: /home/rongtao/bcc/libbpf-tools/.output/javagc.bpf.o] Error 1