### PR TITLE
libbpf-tools/syncsnoop: Add more syscalls support

### DIFF
--- a/libbpf-tools/syncsnoop.bpf.c
+++ b/libbpf-tools/syncsnoop.bpf.c
@@ -10,13 +10,52 @@ struct {
 	__uint(value_size, sizeof(u32));
 } events SEC(".maps");
 
-SEC("tracepoint/syscalls/sys_enter_sync")
-void tracepoint__syscalls__sys_enter_sync(struct trace_event_raw_sys_enter *ctx)
+
+static void __syscall(struct trace_event_raw_sys_enter *ctx,
+		      enum sync_syscalls sys)
 {
 	struct event event = {};
 
+	bpf_get_current_comm(event.comm, sizeof(event.comm));
 	event.ts_us = bpf_ktime_get_ns() / 1000;
+	event.sys = sys;
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
+}
+
+SEC("tracepoint/syscalls/sys_enter_sync")
+void tracepoint__syscalls__sys_enter_sync(struct trace_event_raw_sys_enter *ctx)
+{
+	__syscall(ctx, SYS_SYNC);
+}
+
+SEC("tracepoint/syscalls/sys_enter_fsync")
+void tracepoint__syscalls__sys_enter_fsync(struct trace_event_raw_sys_enter *ctx)
+{
+	__syscall(ctx, SYS_FSYNC);
+}
+
+SEC("tracepoint/syscalls/sys_enter_fdatasync")
+void tracepoint__syscalls__sys_enter_fdatasync(struct trace_event_raw_sys_enter *ctx)
+{
+	__syscall(ctx, SYS_FDATASYNC);
+}
+
+SEC("tracepoint/syscalls/sys_enter_msync")
+void tracepoint__syscalls__sys_enter_msync(struct trace_event_raw_sys_enter *ctx)
+{
+	__syscall(ctx, SYS_MSYNC);
+}
+
+SEC("tracepoint/syscalls/sys_enter_sync_file_range")
+void tracepoint__syscalls__sys_enter_sync_file_range(struct trace_event_raw_sys_enter *ctx)
+{
+	__syscall(ctx, SYS_SYNC_FILE_RANGE);
+}
+
+SEC("tracepoint/syscalls/sys_enter_syncfs")
+void tracepoint__syscalls__sys_enter_syncfs(struct trace_event_raw_sys_enter *ctx)
+{
+	__syscall(ctx, SYS_SYNCFS);
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/syncsnoop.c
+++ b/libbpf-tools/syncsnoop.c
@@ -3,6 +3,7 @@
 //
 // Based on syncsnoop(8) from BCC by Brendan Gregg.
 // 08-Feb-2024   Tiago Ilieve   Created this.
+// 19-Jul-2024   Rong Tao       Support more sync syscalls
 #include <argp.h>
 #include <signal.h>
 #include <stdio.h>
@@ -69,7 +70,8 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	/* Copy data as alignment in the perf buffer isn't guaranteed. */
 	memcpy(&e, data, sizeof(e));
 
-	printf("%-18.9f sync()\n", (float) e.ts_us  / 1000000);
+	printf("%-18.9f %-16s %-16s\n", (float) e.ts_us  / 1000000, e.comm,
+	       sys_names[e.sys]);
 }
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
@@ -126,7 +128,7 @@ int main(int argc, char **argv)
 	}
 
 	/* print header */
-	printf("%-18s %s\n", "TIME(s)", "CALL");
+	printf("%-18s %-16s %s\n", "TIME(s)", "COMM", "CALL");
 
 	while (!exiting) {
 		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);

--- a/libbpf-tools/syncsnoop.h
+++ b/libbpf-tools/syncsnoop.h
@@ -2,8 +2,34 @@
 #ifndef __SYNCSNOOP_H
 #define __SYNCSNOOP_H
 
+#define TASK_COMM_LEN	16
+
+enum sync_syscalls {
+	SYS_T_MIN,
+	SYS_SYNC,
+	SYS_FSYNC,
+	SYS_FDATASYNC,
+	SYS_MSYNC,
+	SYS_SYNC_FILE_RANGE,
+	SYS_SYNCFS,
+	SYS_T_MAX,
+};
+
 struct event {
+	char comm[TASK_COMM_LEN];
 	__u64 ts_us;
+	int sys;
+};
+
+static const char *sys_names[] = {
+	"N/A",
+	"sync",
+	"fsync",
+	"fdatasync",
+	"msync",
+	"sync_file_range",
+	"syncfs",
+	"N/A",
 };
 
 #endif /* __SYNCSNOOP_H */


### PR DESCRIPTION
Add fsync(),fdatasync(),syncfs(),sync_file_range(),msync() syscalls to trace. For example:

    $ sudo ./syncsnoop
    TIME(s)            COMM             CALL
    7348.355957031     aria2c           fsync
    7350.032226562     ThreadPoolForeg  fdatasync