### PR TITLE
tools/threadsnoop: Fix unknown thread start address

### DIFF
--- a/tools/threadsnoop.py
+++ b/tools/threadsnoop.py
@@ -55,11 +55,11 @@ def print_event(cpu, data, size):
     event = b["events"].event(data)
     if start_ts == 0:
         start_ts = event.ts
-    func = b.sym(event.start, event.pid)
+    func = b.sym(event.start, event.pid).decode('utf-8', 'replace')
     if (func == "[unknown]"):
         func = hex(event.start)
     print("%-10d %-7d %-16s %s" % ((event.ts - start_ts) / 1000000,
-        event.pid, event.comm, func))
+        event.pid, event.comm.decode('utf-8', 'replace'), func))
 
 b["events"].open_perf_buffer(print_event)
 while 1:


### PR DESCRIPTION
`func == "[unknown]"` always return false, the output column `FUNC` prints `b'[unknown]'` instead of thread start address. 

```
TIME(ms)   PID     COMM             FUNC
3271       1       b'systemd'       b'[unknown]'
3271       1       b'systemd'       b'[unknown]'
3571       2945804 b'mysqld'        b'[unknown]'
3882       2945804 b'mysqld'        b'[unknown]'
3894       2945804 b'mysqld'        b'[unknown]'
3901       2945804 b'mysqld'        b'[unknown]'
3910       2945804 b'mysqld'        b'[unknown]'
3910       2945804 b'mysqld'        b'[unknown]'
```

after fix

```
TIME(ms)   PID     COMM             FUNC
7215       1       systemd          0x55acce4d4990
7215       1       systemd          0x55acce4d4990
7521       2949704 mysqld           0x55775c43c800
7842       2949704 mysqld           0x55775c43c800
7876       2949704 mysqld           0x55775c43c800
7885       2949704 mysqld           0x7f1a7acf5b00
7885       2949704 mysqld           0x7f1a7acf5b00
7892       2949704 mysqld           0x7f1a7acf5b00
7892       2949704 mysqld           0x7f1a7acf5b00
```

@yonghong-song  please take a look when you have a moment, thanks.