### PR TITLE
bcc/python: Fix get_syscall_prefix on riscv for linux-6.6

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -313,6 +313,7 @@ class BPF(object):
         b"__arm64_sys_",
         b"__s390x_sys_",
         b"__s390_sys_",
+        b"__riscv_sys_",
     ]
 
     # BPF timestamps come from the monotonic clock. To be able to filter


### PR DESCRIPTION
The upstream linux commit[1] implemented syscall wrappers. Currently `get_syscall_prefix` returns unmatched prefix.

The syscall wrappers generates three functions for each system call, one of them is `__riscv_<compat_>sys_<name>`.

So here it can be processed like x86/arm64.

[1] [08d0ce30e0e4](https://github.com/torvalds/linux/commit/08d0ce30e0e4fcb5f06c90fe40387b1ce9324833) ("riscv: Implement syscall wrappers")