### PR TITLE
libbpf-tools/offcputime: Print application starting message

### DIFF
--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -349,6 +349,11 @@ int main(int argc, char **argv)
 
 	signal(SIGINT, sig_handler);
 
+	printf("Tracing off-CPU time (us)");
+	if (env.duration < 99999999)
+		printf(" for %d secs.\n", env.duration);
+	else
+		printf("... Hit Ctrl-C to end.\n");
 	/*
 	 * We'll get sleep interrupted when someone presses Ctrl-C (which will
 	 * be "handled" with noop by sig_handler).


### PR DESCRIPTION
Print starting message like python version does
But not implement to print `thread_context` and `stack_context`


Python version starting message
```
  $ sudo python3 ./offcputime.py
  Tracing off-CPU time (us) of all threads by user + kernel stack... Hit Ctrl-C to end.

  $ sudo python3 ./offcputime.py 30
  Tracing off-CPU time (us) of all threads by user + kernel stack for 30 secs.
```

libbpf-tools version(with this patch) starting message
```
  $ sudo ./offcputime
  Tracing off-CPU time (us)... Hit Ctrl-C to end.

  $ sudo ./offcputime 30
  Tracing off-CPU time (us) for 30 secs.
```