### PR TITLE
libbpf-tools/futexctn: Hint program is running

### DIFF
--- a/libbpf-tools/futexctn.c
+++ b/libbpf-tools/futexctn.c
@@ -367,6 +367,8 @@ int main(int argc, char **argv)
 
 	signal(SIGINT, sig_handler);
 
+	fprintf(stderr, "Summarize futex contention latency, hit ctrl-c to exit\n");
+
 	/* main: poll */
 	while (1) {
 		sleep(env.interval);


### PR DESCRIPTION
The program should be prompted to start running:

    $ sudo ./futexctn
    Summarize futex contention latency, hit ctrl-c to exit