### PR TITLE
libbpf-tools/profile: Add additional information to backtrace for -v option

### DIFF
--- a/libbpf-tools/profile.c
+++ b/libbpf-tools/profile.c
@@ -384,10 +384,10 @@ static bool print_user_stacktrace(struct key_t *event, int stack_map,
 		pr_format("[Missed User Stack]", f);
 	} else {
 		syms = syms_cache__get_syms(syms_cache, event->pid);
-		if (!syms && f->folded)
-			fprintf(stderr, "failed to get syms\n");
-		else
+		if (syms)
 			print_stacktrace(ip, usymname, f);
+		else if (!f->folded)
+			fprintf(stderr, "failed to get syms\n");
 	}
 
 	return true;


### PR DESCRIPTION
Add additional information and change format of backtrace
- add symbol base offset, dso name, dso base offset
- symbol and dso info is included if it's available in target binary
- changed format:
ADDR [SYMBOL+OFFSET] (MODULE+OFFSET)

before:
```
  # ./profile
      clocksource_watchdog
      call_timer_fn
      run_timer_softirq
      __softirqentry_text_start
      irq_exit_rcu
      sysvec_apic_timer_interrupt
      asm_sysvec_apic_timer_interrupt
      strlen
      b
      a
      main
      __libc_start_main
      -                test-strlen-abc (26209)
          1
```
After:
```
  # ./profile -v
      0xffffffff8111f594 clocksource_watchdog+0xd4
      0xffffffff81117454 call_timer_fn+0x24
      0xffffffff81117de4 run_timer_softirq+0x444
      0xffffffff81dd3493 __softirqentry_text_start+0xd3
      0xffffffff8108143c irq_exit_rcu+0x6c
      0xffffffff81dc738e sysvec_apic_timer_interrupt+0x3e
      0xffffffff81e00d46 asm_sysvec_apic_timer_interrupt+0x16
      0x00007f71fc0f8bc6 strlen+0x106 (/lib/x86_64-linux-gnu/libc-2.19.so+0x88bc6)
      0x0000560e13e006e1 b+0x9 (/root/es/test_utils/test-strlen-abc+0x6e1)
      0x0000560e13e006d3 a+0x9 (/root/es/test_utils/test-strlen-abc+0x6d3)
      0x0000560e13e00755 main+0x14 (/root/es/test_utils/test-strlen-abc+0x755)
      0x00007f71fc091ec5 __libc_start_main+0xf5 (/lib/x86_64-linux-gnu/libc-2.19.so+0x21ec5)
      -                test-strlen-abc (26209)
          1
```