### PR TITLE
tools/wakeuptime: Add offset to kernel stack trace

### DIFF
--- a/tools/wakeuptime.py
+++ b/tools/wakeuptime.py
@@ -264,7 +264,7 @@ while (1):
             # print default multi-line stack output
             printb(b"    %-16s %s" % (b"target:", k.target))
             for addr in waker_kernel_stack:
-                printb(b"    %-16x %s" % (addr, b.ksym(addr)))
+                printb(b"    %-16x %s" % (addr, b.ksym(addr, False, True)))
             printb(b"    %-16s %s" % (b"waker:", k.waker))
             print("        %d\n" % v.value)
 


### PR DESCRIPTION
Include symbol base offset in the kernel stack trace to accurately pinpoint the location of function calls.
The offset is commonly used in various debugging tools, including those for the Linux kernel.

Before:
```
  # ./wakeuptime.py
    target:          kworker/u8:3
    ffffffffc0215f96 bpf_prog_6deef7357e7b4530_sd_fw_ingress
    ffffffff928e925d bpf_trace_run1
    ffffffff9274d7d9 __bpf_trace_sched_wakeup_template
    ffffffff9274611b __traceiter_sched_wakeup
    ffffffff9275e2c1 ttwu_do_activate
    ffffffff9275e4f1 sched_ttwu_pending
    ffffffff92827fb3 __flush_smp_call_function_queue
    ffffffff92828b3a flush_smp_call_function_queue
    ffffffff9277d5a7 do_idle
    ffffffff9277d80a cpu_startup_entry
    ffffffff926a7349 start_secondary
    ffffffff92600279 secondary_startup_64_no_verify
    waker:           swapper/3
        1508198
```
After:
```
  # ./wakeuptime.py
    target:          kworker/u8:0
    ffffffffc0215f9a bpf_prog_6deef7357e7b4530_sd_fw_ingress+0xfaf6
    ffffffff928e925d bpf_trace_run1+0x4d
    ffffffff9274d7d9 __bpf_trace_sched_wakeup_template+0x9
    ffffffff9274611b __traceiter_sched_wakeup+0x2b
    ffffffff9275e2c1 ttwu_do_activate+0x131
    ffffffff9275e4f1 sched_ttwu_pending+0xf1
    ffffffff92827fb3 __flush_smp_call_function_queue+0x143
    ffffffff92828b3a flush_smp_call_function_queue+0x3a
    ffffffff9277d5a7 do_idle+0xb7
    ffffffff9277d80a cpu_startup_entry+0x2a
    ffffffff926a7349 start_secondary+0x129
    ffffffff92600279 secondary_startup_64_no_verify+0x184
    waker:           swapper/2
        247368
```