### PR TITLE
tools/shmsnoop: Print shmctl command string

### DIFF
--- a/tools/shmsnoop.py
+++ b/tools/shmsnoop.py
@@ -238,6 +238,28 @@ shmat_flags = [
   { 'name' : 'SHM_EXEC',   'value' : 0o100000 },
 ]
 
+shmctl_cmds = [
+    ('IPC_RMID',     0),
+    ('IPC_SET',      1),
+    ('IPC_STAT',     2),
+    ('IPC_INFO',     3),
+    ('SHM_LOCK',     11),
+    ('SHM_UNLOCK',   12),
+    ('SHM_STAT',     13),
+    ('SHM_INFO',     14),
+    ('SHM_STAT_ANY', 15),
+]
+
+def _decode_cmd(cmd, cmd_list):
+    for str_cmd, cmd_val in cmd_list:
+        if cmd == cmd_val:
+            return str_cmd
+    return '0x{:x}'.format(cmd)
+
+def shmctl_cmd(cmd):
+    return _decode_cmd(cmd, shmctl_cmds)
+
+
 def shmflg_str(val, flags):
     cur = filter(lambda x : x['value'] & val, flags)
     str = "0x%x" % val
@@ -293,7 +315,8 @@ def print_event(cpu, data, size):
         print("shmaddr: 0x%lx" % (event.shmaddr))
 
     if event.sys == SYS_SHMCTL:
-        print("shmid: 0x%lx, cmd: %lu, buf: 0x%x" % (event.shmid, event.cmd, event.buf))
+        print("shmid: 0x%lx, cmd: %lu (%s), buf: 0x%x" % (event.shmid,
+              event.cmd, shmctl_cmd(event.cmd), event.buf))
 
 # loop with callback to print_event
 b["events"].open_perf_buffer(print_event, page_cnt=64)

--- a/tools/shmsnoop_example.txt
+++ b/tools/shmsnoop_example.txt
@@ -10,7 +10,7 @@ PID    COMM                SYS              RET ARGs
 19816  client            SHMAT     7f4fd8ee7000 shmid: 0x10000, shmaddr: 0x0, shmflg: 0x0
 19816  client            SHMDT                0 shmaddr: 0x7f4fd8ee7000
 19813  server            SHMDT                0 shmaddr: 0x7f1cf8b1f000
-19813  server           SHMCTL                0 shmid: 0x10000, cmd: 0, buf: 0x0
+19813  server           SHMCTL                0 shmid: 0x10000, cmd: 0 (IPC_RMID), buf: 0x0
 
 
 Every call the shm* syscall (SHM column) is displayed
@@ -32,7 +32,7 @@ containing "server" with timestamps:
 # ./shmsnoop.py -T -n server
 TIME(s)       PID    COMM                SYS              RET ARGs
 0.563194000   19825  server            SHMDT                0 shmaddr: 0x7f74362e4000
-0.563237000   19825  server           SHMCTL                0 shmid: 0x18000, cmd: 0, buf: 0x0
+0.563237000   19825  server           SHMCTL                0 shmid: 0x18000, cmd: 0 (IPC_RMID), buf: 0x0
 
 
 A -p option can be used to trace only selected process:
@@ -40,7 +40,7 @@ A -p option can be used to trace only selected process:
 # ./shmsnoop.py -p 19855
 PID    COMM                SYS              RET ARGs
 19855  server            SHMDT                0 shmaddr: 0x7f4329ff8000
-19855  server           SHMCTL                0 shmid: 0x20000, cmd: 0, buf: 0x0
+19855  server           SHMCTL                0 shmid: 0x20000, cmd: 0 (IPC_RMID), buf: 0x0
 
 USAGE message:
 # ./shmsnoop.py -h


### PR DESCRIPTION
Print shmctl command:

    $ sudo ./shmsnoop.py
    PID    COMM        SYS           RET ARGs
    16413  writer   SHMGET            31 key: 0xd2032983, size: 4194304, shmflg: 0x3a4 (IPC_CREAT|0644)
    16413  writer    SHMAT  7f7f572b8000 shmid: 0x31, shmaddr: 0x0, shmflg: 0x0
    16413  writer    SHMDT             0 shmaddr: 0x7f7f572b8000
    16418  reader   SHMGET            31 key: 0xd2032983, size: 4194304, shmflg: 0x1a4 (0644)
    16418  reader    SHMAT  7f28e81a4000 shmid: 0x31, shmaddr: 0x0, shmflg: 0x0
    16418  reader    SHMDT             0 shmaddr: 0x7f28e81a4000
    16418  reader   SHMCTL             0 shmid: 0x31, cmd: 0 (IPC_RMID), buf: 0x0
                                                             ^^^^^^^^^^