### PR TITLE
libpf-tools/readahead: Fix attachment failure since v5.16

### DIFF
--- a/libbpf-tools/readahead.bpf.c
+++ b/libbpf-tools/readahead.bpf.c
@@ -64,6 +64,12 @@ int BPF_PROG(filemap_alloc_folio_ret, gfp_t gfp, unsigned int order,
 	return alloc_done(&ret->page);
 }
 
+SEC("fexit/filemap_alloc_folio_noprof")
+int BPF_PROG(filemap_alloc_folio_noprof_ret, gfp_t gfp, unsigned int order,
+	struct folio *ret)
+{
+	return alloc_done(&ret->page);
+}
 
 SEC("fexit/do_page_cache_ra")
 int BPF_PROG(do_page_cache_ra_ret)

--- a/libbpf-tools/readahead.bpf.c
+++ b/libbpf-tools/readahead.bpf.c
@@ -34,8 +34,8 @@ int BPF_PROG(do_page_cache_ra)
 	return 0;
 }
 
-SEC("fexit/__page_cache_alloc")
-int BPF_PROG(page_cache_alloc_ret, gfp_t gfp, struct page *ret)
+static __always_inline
+int alloc_done(struct page *page)
 {
 	u32 pid = bpf_get_current_pid_tgid();
 	u64 ts;
@@ -44,12 +44,26 @@ int BPF_PROG(page_cache_alloc_ret, gfp_t gfp, struct page *ret)
 		return 0;
 
 	ts = bpf_ktime_get_ns();
-	bpf_map_update_elem(&birth, &ret, &ts, 0);
+	bpf_map_update_elem(&birth, &page, &ts, 0);
 	__sync_fetch_and_add(&hist.unused, 1);
 	__sync_fetch_and_add(&hist.total, 1);
 
 	return 0;
 }
+
+SEC("fexit/__page_cache_alloc")
+int BPF_PROG(page_cache_alloc_ret, gfp_t gfp, struct page *ret)
+{
+	return alloc_done(ret);
+}
+
+SEC("fexit/filemap_alloc_folio")
+int BPF_PROG(filemap_alloc_folio_ret, gfp_t gfp, unsigned int order,
+	struct folio *ret)
+{
+	return alloc_done(&ret->page);
+}
+
 
 SEC("fexit/do_page_cache_ra")
 int BPF_PROG(do_page_cache_ra_ret)


### PR DESCRIPTION
Close #4700. cc @jeromemarchand who opened the issue. 

This PR accounts for the rename/refactor of the following functions
- `__do_page_cache_readahead` -> `do_page_cache_ra` -> `page_cache_ra_order` by https://github.com/torvalds/linux/commit/8238287eadb2 and https://github.com/torvalds/linux/commit/56a4d67c264e
- `__page_cache_alloc` -> `filemap_alloc_folio` -> `filemap_alloc_folio_noprof` by https://github.com/torvalds/linux/commit/bb3c579e25e5 and https://github.com/torvalds/linux/commit/b951aaff5035. 

Kudos to @Rtoax for the fix for the Python tools: #4457, #5083 