### PR TITLE
Set cpu=v1 explicitly

### DIFF
--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -574,6 +574,7 @@ int BPFModule::finalize() {
   builder.setMCJITMemoryManager(
       ebpf::make_unique<MyMemoryManager>(sections_p, &*prog_func_info_));
   builder.setMArch("bpf");
+  builder.setMCPU("v1");
 #if LLVM_VERSION_MAJOR <= 11
   builder.setUseOrcMCJITReplacement(false);
 #endif


### PR DESCRIPTION
Upstream patch
  https://github.com/llvm/llvm-project/pull/107008
makes cpu=v3 as the default. Previously cpu=v1 as the default for bcc. Let us mark cpu=v1 explicitly for bcc for now to keep it backword compatible.