### PR TITLE
Pid namespace support

### DIFF
--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 from bcc import BPF
 from time import sleep, strftime
 import argparse
+import os
 
 examples = """examples:
     cpudist              # summarize on-CPU time as a histogram
@@ -130,8 +131,17 @@ int sched_switch(struct pt_regs *ctx, struct task_struct *prev)
     u32 tgid = pid_tgid >> 32, pid = pid_tgid;
     u32 cpu = bpf_get_smp_processor_id();
 
+    struct bpf_pidns_info ns = {};
+    if (USE_PIDNS && !bpf_get_ns_current_pid_tgid(PIDNS_DEV, PIDNS_INO, &ns, sizeof(struct bpf_pidns_info))) {
+        PID_STORE
+
+        tgid = ns.tgid;
+        pid = ns.pid;
+    }
+
     u32 prev_pid = prev->pid;
     u32 prev_tgid = prev->tgid;
+    PID_TRANSLATE
 #ifdef ONCPU
     update_hist(prev_tgid, prev_pid, cpu, ts);
 #else
@@ -169,6 +179,32 @@ else:
 
 storage_str = ""
 store_str = ""
+pid_store = ""
+pid_translate = ""
+
+try:
+    devinfo = os.stat("/proc/self/ns/pid")
+    version = "".join([ver.zfill(2) for ver in os.uname().release.split(".")])
+    # Need Linux >= 5.7 to have helper bpf_get_ns_current_pid_tgid() available:
+    assert(version[:4] >= "0507")
+    bpf_text = bpf_text.replace('USE_PIDNS', "1")
+    bpf_text = bpf_text.replace('PIDNS_DEV', str(devinfo.st_dev))
+    bpf_text = bpf_text.replace('PIDNS_INO', str(devinfo.st_ino))
+    storage_str = "BPF_HASH(ns_pid, u32, u32, MAX_PID);\n"
+    pid_store = """ns_pid.update(&pid, &ns.pid);
+        ns_pid.update(&tgid, &ns.tgid);"""
+    pid_translate = """
+        u32 *ns_pid = ns_pid.lookup(&prev_pid);
+        u32 *ns_tgid = ns_pid.lookup(&prev_tgid);
+        if (ns_pid && ns_tgid) {
+            prev_pid = *ns_pid;
+            prev_tgid = *ns_tgid;
+        }
+    """
+except:
+    bpf_text = bpf_text.replace('USE_PIDNS', "0")
+    bpf_text = bpf_text.replace('PIDNS_DEV', "0")
+    bpf_text = bpf_text.replace('PIDNS_INO', "0")
 
 if args.pids or args.tids:
     section = "pid"
@@ -197,6 +233,8 @@ if args.extension:
     }
     """
 
+bpf_text = bpf_text.replace("PID_STORE", pid_store)
+bpf_text = bpf_text.replace("PID_TRANSLATE", pid_translate)
 bpf_text = bpf_text.replace("STORAGE", storage_str)
 bpf_text = bpf_text.replace("STORE", store_str)
 

--- a/tools/cpudist.py
+++ b/tools/cpudist.py
@@ -194,11 +194,11 @@ try:
     pid_store = """ns_pid.update(&pid, &ns.pid);
         ns_pid.update(&tgid, &ns.tgid);"""
     pid_translate = """
-        u32 *ns_pid = ns_pid.lookup(&prev_pid);
-        u32 *ns_tgid = ns_pid.lookup(&prev_tgid);
-        if (ns_pid && ns_tgid) {
-            prev_pid = *ns_pid;
-            prev_tgid = *ns_tgid;
+        u32 *ns_pid_val = ns_pid.lookup(&prev_pid);
+        u32 *ns_tgid_val = ns_pid.lookup(&prev_tgid);
+        if (ns_pid_val && ns_tgid_val) {
+            prev_pid = *ns_pid_val;
+            prev_tgid = *ns_tgid_val;
         }
     """
 except:


### PR DESCRIPTION
inspired by the https://github.com/iovisor/bcc/blob/6acb86effa7a6e8029b68eccb805dd1ee60ecc5a/tools/profile.py#L168

if the `cpudist` runs in a pid namespace, the filtered pid/tgid are not as expected.
since the kernel does not provide something like i`int bpf_get_ns_pid_tgid(u64 dev, u64 ino, struct bpf_pidns_info * ns_data, u32 size)`, we can create the mapping for the `current`, then find out the mapped ns pid by the real pid whenever the `prev` is refered.