### PR TITLE
Remove unneeded error.h include from examples/cpp/KModRetExample.cc to allow build with musl libc

### DIFF
--- a/examples/cpp/KModRetExample.cc
+++ b/examples/cpp/KModRetExample.cc
@@ -20,7 +20,6 @@
 #include <iomanip>
 #include <string>
 
-#include <error.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>


### PR DESCRIPTION
musl libc has no error.h, but luckily the include is not needed at all and can just be removed.

Previously reported in https://github.com/iovisor/bcc/issues/4594 and more recently in Gentoo at https://bugs.gentoo.org/939453.

