### PR TITLE
libbpf-tools: add cpu filter for hardirqs/softirqs

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -11,6 +11,7 @@ LIBBLAZESYM_SRC := $(abspath blazesym/target/release/libblazesym.a)
 INCLUDES := -I$(OUTPUT) -I../src/cc/libbpf/include/uapi
 CFLAGS := -g -O2 -Wall -Wmissing-field-initializers -Werror -Werror=undef
 BPFCFLAGS := -g -O2 -Wall -Werror=undef
+BPFCFLAGS_softirqs := $(BPFCFLAGS) -mcpu=v3
 INSTALL ?= install
 prefix ?= /usr/local
 bindir := $(prefix)/bin
@@ -198,6 +199,8 @@ $(OUTPUT)/%.o: %.c $(wildcard %.h) $(LIBBPF_OBJ) | $(OUTPUT)
 $(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
 	$(call msg,GEN-SKEL,$@)
 	$(Q)$(BPFTOOL) gen skeleton $< > $@
+
+$(OUTPUT)/softirqs.bpf.o: BPFCFLAGS = $(BPFCFLAGS_softirqs)
 
 $(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(ARCH)/vmlinux.h | $(OUTPUT)
 	$(call msg,BPF,$@)

--- a/libbpf-tools/softirqs.bpf.c
+++ b/libbpf-tools/softirqs.bpf.c
@@ -9,6 +9,7 @@
 
 const volatile bool targ_dist = false;
 const volatile bool targ_ns = false;
+const volatile int targ_cpu = -1;
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
@@ -21,8 +22,18 @@ __u64 counts[NR_SOFTIRQS] = {};
 __u64 time[NR_SOFTIRQS] = {};
 struct hist hists[NR_SOFTIRQS] = {};
 
+static bool is_target_cpu() {
+	if (targ_cpu < 0)
+		return true;
+
+	return bpf_get_smp_processor_id() == targ_cpu;
+}
+
 static int handle_entry(unsigned int vec_nr)
 {
+	if (!is_target_cpu())
+		return 0;
+
 	u64 ts = bpf_ktime_get_ns();
 	u32 key = 0;
 
@@ -32,6 +43,9 @@ static int handle_entry(unsigned int vec_nr)
 
 static int handle_exit(unsigned int vec_nr)
 {
+	if (!is_target_cpu())
+		return 0;
+
 	u64 delta, *tsp;
 	u32 key = 0;
 


### PR DESCRIPTION
Since tools/hardirqs and tools/softirqs supports a `--cpu` option, it's reasonable to support  a same option in libbpf version.