### PR TITLE
libbpf-tools/profile: Fix the help message for multi process/thread

### DIFF
--- a/libbpf-tools/profile.c
+++ b/libbpf-tools/profile.c
@@ -107,8 +107,8 @@ const char argp_program_doc[] =
 "    profile -K          # only show kernel space stacks (no user)\n";
 
 static const struct argp_option opts[] = {
-	{ "pid", 'p', "PID", 0, "profile process with this PID only", 0 },
-	{ "tid", 'L', "TID", 0, "profile thread with this TID only", 0 },
+	{ "pid", 'p', "PID", 0, "profile processes with one or more comma-separated PIDs only", 0 },
+	{ "tid", 'L', "TID", 0, "profile threads with one or more comma-separated TIDs only", 0 },
 	{ "user-stacks-only", 'U', NULL, 0,
 	  "show stacks from user space only (no kernel space stacks)", 0 },
 	{ "kernel-stacks-only", 'K', NULL, 0,

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -90,9 +90,9 @@ parser = argparse.ArgumentParser(
     epilog=examples)
 thread_group = parser.add_mutually_exclusive_group()
 thread_group.add_argument("-p", "--pid", type=positive_int_list,
-    help="profile process with one or more comma separated PIDs only")
+    help="profile processes with one or more comma-separated PIDs only")
 thread_group.add_argument("-L", "--tid", type=positive_int_list,
-    help="profile thread with one or more comma separated TIDs only")
+    help="profile threads with one or more comma-separated TIDs only")
 # TODO: add options for user/kernel threads only
 stack_group = parser.add_mutually_exclusive_group()
 stack_group.add_argument("-U", "--user-stacks-only", action="store_true",


### PR DESCRIPTION
Modify the help message for multi-process/thread support in libbpf-tools/profile and tools/profile.