### PR TITLE
fix(disksnoop): register to blk_mq_complete_request

### DIFF
--- a/examples/tracing/disksnoop.py
+++ b/examples/tracing/disksnoop.py
@@ -43,13 +43,19 @@ void trace_completion(struct pt_regs *ctx, struct request *req) {
 }
 """)
 
-if BPF.get_kprobe_functions(b'blk_start_request'):
-        b.attach_kprobe(event="blk_start_request", fn_name="trace_start")
 b.attach_kprobe(event="blk_mq_start_request", fn_name="trace_start")
+if BPF.get_kprobe_functions(b'blk_start_request'):
+    b.attach_kprobe(event="blk_start_request", fn_name="trace_start")
+
 if BPF.get_kprobe_functions(b'__blk_account_io_done'):
     b.attach_kprobe(event="__blk_account_io_done", fn_name="trace_completion")
-else:
+elif BPF.get_kprobe_functions(b'blk_account_io_done'):
     b.attach_kprobe(event="blk_account_io_done", fn_name="trace_completion")
+elif BPF.get_kprobe_functions(b'blk_mq_complete_request'):
+    b.attach_kprobe(event="blk_mq_complete_request", fn_name="trace_completion")
+else:
+    print("No kprobes available for block request completion")
+    exit()
 
 # header
 print("%-18s %-2s %-7s %8s" % ("TIME(s)", "T", "BYTES", "LAT(ms)"))


### PR DESCRIPTION
As mentioned in #4691, `disksnoop`, like `biosnoop`, rely on functions that can be inlined, like `blk_account_io_done`. This change adds a new function `blk_mq_complete_request` as a fallback in case that the others were inlined. I haven't changed this to support tracepoint because the tutorial guide would have to be considerably rearranged to make it follow a logical order, as the first mention of tracepoint is on lesson 12. 