### PR TITLE
elf: Detect if Elf is PIE

### DIFF
--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -77,6 +77,7 @@ int bcc_elf_get_text_scn_info(const char *path, uint64_t *addr,
                               uint64_t *offset);
 
 int bcc_elf_get_type(const char *path);
+int bcc_elf_is_pie(const char *path);
 int bcc_elf_is_shared_obj(const char *path);
 int bcc_elf_is_exe(const char *path);
 int bcc_elf_is_vdso(const char *name);

--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -78,7 +78,7 @@ bool Probe::in_shared_object(const std::string &bin_path) {
 
 bool Probe::resolve_global_address(uint64_t *global, const std::string &bin_path,
                                    const uint64_t addr) {
-  if (in_shared_object(bin_path)) {
+  if (in_shared_object(bin_path) || bcc_elf_is_pie(bin_path.c_str())) {
     return (pid_ &&
             !bcc_resolve_global_addr(*pid_, bin_path.c_str(), addr, mod_match_inode_only_, global));
   }

--- a/src/cc/usdt/usdt_args.cc
+++ b/src/cc/usdt/usdt_args.cc
@@ -58,7 +58,8 @@ bool Argument::get_global_address(uint64_t *address, const std::string &binpath,
         .resolve_name(binpath.c_str(), deref_ident_->c_str(), address);
   }
 
-  if (!bcc_elf_is_shared_obj(binpath.c_str())) {
+  if (!bcc_elf_is_shared_obj(binpath.c_str()) ||
+      bcc_elf_is_pie(binpath.c_str())) {
     struct bcc_symbol sym;
     if (bcc_resolve_symname(binpath.c_str(), deref_ident_->c_str(), 0x0, -1, nullptr, &sym) == 0) {
       *address = sym.offset;


### PR DESCRIPTION
It is not sufficient to determine whether Elf is ET_DYN or not to be a dynamic library in bcc_elf_is_shared_obj() function, because the executable Elf of the PIE type is also ET_DYN.

For example, on fedora 40, /usr/bin/bash is PIE:

```
    $ readelf -h /usr/bin/bash
    ELF Header:
      ...
      Type:                     DYN (Position-Independent Executable file)
      ...
```

bcc_elf_is_shared_obj() should not return 'true' for /usr/bin/bash.

This commit add a function bcc_elf_is_pie(), maybe we can provide API in bcc_elf.h.