### PR TITLE
tools/threadsnoop: Add -h option

### DIFF
--- a/tools/threadsnoop.py
+++ b/tools/threadsnoop.py
@@ -14,6 +14,20 @@
 
 from __future__ import print_function
 from bcc import BPF
+import argparse
+
+examples = """examples:
+    ./threadsnoop        # list new thread creation
+"""
+
+description = """
+List new thread creation.
+"""
+
+parser = argparse.ArgumentParser(description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=examples)
+args = parser.parse_args()
 
 # load BPF program
 b = BPF(text="""

--- a/tools/threadsnoop_example.txt
+++ b/tools/threadsnoop_example.txt
@@ -25,3 +25,16 @@ The output shows a dockerd process creating several threads with the start
 routine threadentry(), and docker-containe (truncated) and systemd-journal
 also starting threads: in their cases, the function had no symbol information
 available, so their addresses are printed in hex.
+
+USAGE message:
+
+# ./threadsnoop.py -h
+usage: threadsnoop.py [-h]
+
+List new thread creation.
+
+options:
+  -h, --help  show this help message and exit
+
+examples:
+    ./threadsnoop        # list new thread creation


### PR DESCRIPTION
Import argparser and add basic implementation for this. Now user can use `-h` option for threadsnoop tool.