### PR TITLE
tools: Fixes explanation about -F option in biolatency_example.txt

### DIFF
--- a/tools/biolatency_example.txt
+++ b/tools/biolatency_example.txt
@@ -289,7 +289,7 @@ flags = Priority-Metadata-Write
      msecs               : count     distribution
          0 -> 1          : 9        |****************************************|
 
-These can be handled differently by the storage device, and this mode lets us
+These can be handled differently by the request flags, and this mode lets us
 examine their performance in isolation.
 
 


### PR DESCRIPTION
`-F` option prints a separate histogram for each unique set of request flags. But the explanation right after the `-F` option example is not about this option.