### PR TITLE
add sys.stdout.flush() during print

### DIFF
--- a/tools/tcpstates.py
+++ b/tools/tcpstates.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from bcc import BPF
 import argparse
 from socket import inet_ntop, AF_INET, AF_INET6
+import sys
 from time import strftime, time
 from os import getuid
 
@@ -434,6 +435,7 @@ b["ipv4_events"].open_perf_buffer(print_ipv4_event, page_cnt=64)
 b["ipv6_events"].open_perf_buffer(print_ipv6_event, page_cnt=64)
 while 1:
     try:
+        sys.stdout.flush()
         b.perf_buffer_poll()
     except KeyboardInterrupt:
         exit()


### PR DESCRIPTION
Like #3922, there is a use-case to use tcpstates with pipe, but pipe doesn't work well because of buffer.

Test: tcpstates | cat