### PR TITLE
tools/cachestat: Fix add_to_page_cache_lru/mark_page_accessed not correct since kernel 5.16

### DIFF
--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -17,6 +17,7 @@
 # 13-Jan-2016   Allan McAleavy  run pep8 against program
 # 02-Feb-2019   Brendan Gregg   Column shuffle, bring back %ratio
 # 15-Feb-2023   Rong Tao        Add writeback_dirty_{folio,page} tracepoints
+# 17-Nov-2024   Rocky Xing      Added filemap_add_folio/folio_mark_accessed kprobes
 
 from __future__ import print_function
 from bcc import BPF
@@ -118,8 +119,14 @@ if debug or args.ebpf:
 
 # load BPF program
 b = BPF(text=bpf_text)
-b.attach_kprobe(event="add_to_page_cache_lru", fn_name="do_count_apcl")
-b.attach_kprobe(event="mark_page_accessed", fn_name="do_count_mpa")
+if BPF.get_kprobe_functions(b'filemap_add_folio'):
+    b.attach_kprobe(event="filemap_add_folio", fn_name="do_count_apcl")
+else:
+    b.attach_kprobe(event="add_to_page_cache_lru", fn_name="do_count_apcl")
+if BPF.get_kprobe_functions(b'folio_mark_accessed'):
+    b.attach_kprobe(event="folio_mark_accessed", fn_name="do_count_mpa")
+else:
+    b.attach_kprobe(event="mark_page_accessed", fn_name="do_count_mpa")
 
 # Function account_page_dirtied() is changed to folio_account_dirtied() in 5.15.
 # Both folio_account_dirtied() and account_page_dirtied() are


### PR DESCRIPTION
Since kernel 5.16, `add_to_page_cache_lru/mark_page_accessed` were moved to in mm/folio-compat.c, actually defined in `filemap_add_folio/folio_mark_accessed`:
```
int add_to_page_cache_lru(struct page *page, struct address_space *mapping, pgoff_t index, gfp_t gfp)
{
    return filemap_add_folio(mapping, page_folio(page), index, gfp);
}

void mark_page_accessed(struct page *page)
{
    folio_mark_accessed(page_folio(page));
}
```

When running on kernel > 5.15, the output is not correct: column `MISSES` always 0 due to `add_to_page_cache_lru` not counted, and `mark_page_accessed` counter less than `folio_mark_accessed`.

Use bpftrace do a simple test (during traced, read a large un-cached file):
```
# bpftrace -e 'k:add_to_page_cache_lru,k:filemap_add_folio,k:mark_page_accessed,k:folio_mark_accessed { @[func] = count();}'
Attaching 4 probes...
^C

@[filemap_add_folio]: 34623
@[mark_page_accessed]: 113760
@[folio_mark_accessed]: 148986
```

So, we should use filemap_add_folio/folio_mark_accessed instead. Please take a review, thanks @yonghong-song 