### PR TITLE
libbpf-tools/profile: Add support for PID-namespacing

### DIFF
--- a/libbpf-tools/profile.c
+++ b/libbpf-tools/profile.c
@@ -511,6 +511,9 @@ static int set_pidns(const struct profile_bpf *obj)
 {
 	struct stat statbuf;
 
+	if (!probe_bpf_ns_current_pid_tgid())
+		return -EPERM;
+
 	if (stat("/proc/self/ns/pid", &statbuf) == -1)
 		return -errno;
 

--- a/libbpf-tools/profile.c
+++ b/libbpf-tools/profile.c
@@ -17,6 +17,7 @@
 #include <asm/unistd.h>
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
+#include <sys/stat.h>
 #include "profile.h"
 #include "profile.skel.h"
 #include "trace_helpers.h"
@@ -506,6 +507,20 @@ cleanup:
 	return ret;
 }
 
+static int set_pidns(const struct profile_bpf *obj)
+{
+	struct stat statbuf;
+
+	if (stat("/proc/self/ns/pid", &statbuf) == -1)
+		return -errno;
+
+	obj->rodata->use_pidns = true;
+	obj->rodata->pidns_dev = statbuf.st_dev;
+	obj->rodata->pidns_ino = statbuf.st_ino;
+
+	return 0;
+}
+
 static void print_headers()
 {
 	int i;
@@ -594,6 +609,10 @@ int main(int argc, char **argv)
 	bpf_map__set_value_size(obj->maps.stackmap,
 				env.perf_max_stack_depth * sizeof(unsigned long));
 	bpf_map__set_max_entries(obj->maps.stackmap, env.stack_storage_size);
+
+	err = set_pidns(obj);
+	if (err && env.verbose)
+		fprintf(stderr, "failed to translate pidns: %s\n", strerror(-err));
 
 	err = profile_bpf__load(obj);
 	if (err) {

--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -1248,6 +1248,28 @@ bool probe_ringbuf()
 	return true;
 }
 
+bool probe_bpf_ns_current_pid_tgid(void)
+{
+	int fd, insn_cnt;
+	struct bpf_insn insns[] = {
+		{ .code = BPF_ALU64 | BPF_MOV | BPF_X, .dst_reg = 3, .src_reg = BPF_REG_10 },
+		{ .code = BPF_ALU64 | BPF_ADD | BPF_K, .dst_reg = 3, .imm = -8 },
+		{ .code = BPF_ALU64 | BPF_MOV | BPF_K, .dst_reg = 1, .imm = 0 },
+		{ .code = BPF_ALU64 | BPF_MOV | BPF_K, .dst_reg = 2, .imm = 0 },
+		{ .code = BPF_ALU64 | BPF_MOV | BPF_K, .dst_reg = 4, .imm = 8 },
+		{ .code = BPF_JMP | BPF_CALL, .imm = BPF_FUNC_get_ns_current_pid_tgid },
+		{ .code = BPF_JMP | BPF_EXIT },
+	};
+
+	insn_cnt = sizeof(insns) / sizeof(insns[0]);
+
+	fd = bpf_prog_load(BPF_PROG_TYPE_KPROBE, NULL, "GPL", insns, insn_cnt, NULL);
+	if (fd >= 0)
+		close(fd);
+
+	return fd >= 0;
+}
+
 int split_convert(char *s, const char* delim, void *elems, size_t elems_size,
 		  size_t elem_size, convert_fn_t convert)
 {

--- a/libbpf-tools/trace_helpers.h
+++ b/libbpf-tools/trace_helpers.h
@@ -107,6 +107,7 @@ bool module_btf_exists(const char *mod);
 
 bool probe_tp_btf(const char *name);
 bool probe_ringbuf();
+bool probe_bpf_ns_current_pid_tgid(void);
 
 typedef int (*convert_fn_t)(const char *src, void *dest);
 int split_convert(char *s, const char* delim, void *elems, size_t elems_size,


### PR DESCRIPTION
Support PID namespace translation as memleak.py does.