### PR TITLE
libbpf-tools: javagc: Hints for more information

### DIFF
--- a/libbpf-tools/javagc.c
+++ b/libbpf-tools/javagc.c
@@ -125,11 +125,19 @@ static int get_jvmso_path(char *path)
 	size_t seg_start, seg_end, seg_off;
 	FILE *f;
 	int i = 0;
+	bool found = false;
+
+	if (env.pid == -1) {
+		fprintf(stderr, "not specify pid, see --pid.\n");
+		return -1;
+	}
 
 	sprintf(buf, "/proc/%d/maps", env.pid);
 	f = fopen(buf, "r");
-	if (!f)
+	if (!f) {
+		fprintf(stderr, "open %s failed: %m\n", buf);
 		return -1;
+	}
 
 	while (fscanf(f, "%zx-%zx %s %zx %*s %*d%[^\n]\n",
 			&seg_start, &seg_end, mode, &seg_off, line) == 5) {
@@ -137,12 +145,18 @@ static int get_jvmso_path(char *path)
 		while (isblank(line[i]))
 			i++;
 		if (strstr(line + i, "libjvm.so")) {
+			found = true;
+			strcpy(path, line + i);
 			break;
 		}
 	}
 
-	strcpy(path, line + i);
 	fclose(f);
+
+	if (!found) {
+		fprintf(stderr, "Not found libjvm.so.\n");
+		return -ENOENT;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Prints a prompt message for not finding jvm.so and opening /proc/PID/maps incorrectly.