### PR TITLE
examples/cpp/pyperf: Make external symbols match their definitions

### DIFF
--- a/examples/cpp/pyperf/PyPerfUtil.cc
+++ b/examples/cpp/pyperf/PyPerfUtil.cc
@@ -25,8 +25,8 @@
 namespace ebpf {
 namespace pyperf {
 
-extern OffsetConfig kPy36OffsetConfig;
-extern std::string PYPERF_BPF_PROGRAM;
+extern const OffsetConfig kPy36OffsetConfig;
+extern const std::string PYPERF_BPF_PROGRAM;
 
 const static int kPerfBufSizePages = 32;
 


### PR DESCRIPTION
This is not just good hygiene but also silences valid complaints about mismatched definitions when building with LTO.

This is one part of fixing #5091
