### PR TITLE
libbpf-tools/slabratetop: Fix failed to create kprobe error

### DIFF
--- a/libbpf-tools/slabratetop.bpf.c
+++ b/libbpf-tools/slabratetop.bpf.c
@@ -50,4 +50,10 @@ int BPF_KPROBE(kmem_cache_alloc, struct kmem_cache *cachep)
 	return probe_entry(cachep);
 }
 
+SEC("kprobe/kmem_cache_alloc_noprof")
+int BPF_KPROBE(kmem_cache_alloc_noprof, struct kmem_cache *cachep)
+{
+       return probe_entry(cachep);
+}
+
 char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/libbpf-tools/slabratetop.c
+++ b/libbpf-tools/slabratetop.c
@@ -261,6 +261,15 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if (kprobe_exists("kmem_cache_alloc"))
+		bpf_program__set_autoload(obj->progs.kmem_cache_alloc_noprof, false);
+	else if (kprobe_exists("kmem_cache_alloc_noprof"))
+		bpf_program__set_autoload(obj->progs.kmem_cache_alloc, false);
+	else {
+		warn("kmem_cache_alloc and kmem_cache_alloc_noprof function not found\n");
+		goto cleanup;
+	}
+
 	obj->rodata->target_pid = target_pid;
 
 	err = slabratetop_bpf__load(obj);


### PR DESCRIPTION
Convert kmem_cache_alloc() to kmem_cache_alloc_noprof() in commit 7bd230a26648 So the higher version will have the following issues: libbpf: prog 'kmem_cache_alloc': failed to create kprobe 'kmem_cache_alloc+0x0' perf event: No such file or directory libbpf: prog 'kmem_cache_alloc': failed to auto-attach: -2 Failed to attach BPF programs: -2