### PR TITLE
examples/networking: sockmap.py: Fix invalid bpf_context access off=24 size=8

### DIFF
--- a/examples/networking/sockmap.py
+++ b/examples/networking/sockmap.py
@@ -39,8 +39,9 @@ struct sock_key {
 BPF_SOCKHASH(sock_hash, struct sock_key, MAX_SOCK_OPS_MAP_ENTRIES);
 
 static __always_inline void bpf_sock_ops_ipv4(struct bpf_sock_ops *skops) {
+    volatile __u32 remote_ip4 = skops->remote_ip4;
     struct sock_key skk = {
-        .remote_ip4 = skops->remote_ip4,
+        .remote_ip4 = remote_ip4,
         .local_ip4  = skops->local_ip4,
         .local_port = skops->local_port,
         .remote_port  = bpf_ntohl(skops->remote_port),


### PR DESCRIPTION
clang generates such patterns occasionally when it thinks only up to specific size is accessed anyway. Fix the following error:

    ; .remote_ip4 = skops->remote_ip4, @ main.c:29
    7: (79) r2 = *(u64 *)(r1 +24)

Error detail:

    $ sudo ./sockmap.py -c /path/to/cgroup/foo
    bpf: Failed to load program: Permission denied
    0: R1=ctx() R10=fp0
    ; if (skops->family != AF_INET) @ main.c:55
    0: (61) r2 = *(u32 *)(r1 +20)         ; R1=ctx() R2_w=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
    1: (55) if r2 != 0x2 goto pc+88       ; R2_w=2
    ; u32 op = skops->op; @ main.c:52
    2: (61) r2 = *(u32 *)(r1 +0)          ; R1=ctx() R2_w=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
    3: (18) r3 = 0xfffffffe               ; R3_w=0xfffffffe
    ; switch (op) { @ main.c:58
    5: (5f) r2 &= r3                      ; R2_w=scalar(smin=0,smax=umax=umax32=0xfffffffe,smax32=0x7ffffffe,var_off=(0x0; 0xfffffffe)) R3_w=0xfffffffe
    6: (55) if r2 != 0x4 goto pc+83       ; R2_w=4
    ; .remote_ip4 = skops->remote_ip4, @ main.c:29
    7: (79) r2 = *(u64 *)(r1 +24)
    invalid bpf_context access off=24 size=8
    processed 7 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0

    Traceback (most recent call last):
      File "/home/sda/git-repos/iovisor/bcc/examples/networking/./sockmap.py", line 110, in <module>
        func_sock_ops = bpf.load_func("bpf_sockhash", bpf.SOCK_OPS)
      File "/usr/lib/python3.13/site-packages/bcc/__init__.py", line 526, in load_func
        raise Exception("Failed to load BPF program %s: %s" %
                        (func_name, errstr))
    Exception: Failed to load BPF program b'bpf_sockhash': Permission denied