### PR TITLE
libbpf-tools/mountsnoop: Support fsopen,fsconfig,fsmount,move_mount syscalls

### DIFF
--- a/libbpf-tools/mountsnoop.bpf.c
+++ b/libbpf-tools/mountsnoop.bpf.c
@@ -19,8 +19,7 @@ struct {
 	__type(value, struct arg);
 } args SEC(".maps");
 
-static int probe_entry(const char *src, const char *dest, const char *fs,
-		       __u64 flags, const char *data, enum op op)
+static int probe_entry(union sys_arg *sys_arg, enum op op)
 {
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	__u32 pid = pid_tgid >> 32;
@@ -35,18 +34,19 @@ static int probe_entry(const char *src, const char *dest, const char *fs,
 
 	switch (op) {
 	case MOUNT:
-		arg.mount.flags = flags;
-		arg.mount.src = src;
-		arg.mount.dest = dest;
-		arg.mount.fs = fs;
-		arg.mount.data= data;
-		break;
 	case UMOUNT:
-		arg.umount.flags = flags;
-		arg.umount.dest = dest;
+	case FSOPEN:
+	case FSCONFIG:
+	case FSMOUNT:
+	case MOVE_MOUNT:
+		__builtin_memcpy(&arg.sys, sys_arg, sizeof(*sys_arg));
 		break;
+	default:
+		goto skip;
 	}
+
 	bpf_map_update_elem(&args, &tid, &arg, BPF_ANY);
+skip:
 	return 0;
 };
 
@@ -78,15 +78,57 @@ static int probe_exit(void *ctx, int ret)
 
 	switch (argp->op) {
 	case MOUNT:
-		eventp->mount.flags = argp->mount.flags;
-		bpf_probe_read_user_str(eventp->mount.src, sizeof(eventp->mount.src), argp->mount.src);
-		bpf_probe_read_user_str(eventp->mount.dest, sizeof(eventp->mount.dest), argp->mount.dest);
-		bpf_probe_read_user_str(eventp->mount.fs, sizeof(eventp->mount.fs), argp->mount.fs);
-		bpf_probe_read_user_str(eventp->mount.data, sizeof(eventp->mount.data), argp->mount.data);
+		eventp->mount.flags = argp->sys.mount.flags;
+		bpf_probe_read_user_str(eventp->mount.src,
+					sizeof(eventp->mount.src),
+					argp->sys.mount.src);
+		bpf_probe_read_user_str(eventp->mount.dest,
+					sizeof(eventp->mount.dest),
+					argp->sys.mount.dest);
+		bpf_probe_read_user_str(eventp->mount.fs,
+					sizeof(eventp->mount.fs),
+					argp->sys.mount.fs);
+		bpf_probe_read_user_str(eventp->mount.data,
+					sizeof(eventp->mount.data),
+					argp->sys.mount.data);
 		break;
 	case UMOUNT:
-		eventp->umount.flags = argp->umount.flags;
-		bpf_probe_read_user_str(eventp->umount.dest, sizeof(eventp->umount.dest), argp->umount.dest);
+		eventp->umount.flags = argp->sys.umount.flags;
+		bpf_probe_read_user_str(eventp->umount.dest,
+					sizeof(eventp->umount.dest),
+					argp->sys.umount.dest);
+		break;
+	case FSOPEN:
+		eventp->fsopen.flags = argp->sys.fsopen.flags;
+		bpf_probe_read_user_str(eventp->fsopen.fs,
+					sizeof(eventp->fsopen.fs),
+					argp->sys.fsopen.fs);
+		break;
+	case FSCONFIG:
+		eventp->fsconfig.fd = argp->sys.fsconfig.fd;
+		eventp->fsconfig.cmd = argp->sys.fsconfig.cmd;
+		bpf_probe_read_user_str(eventp->fsconfig.key,
+					sizeof(eventp->fsconfig.key),
+					argp->sys.fsconfig.key);
+		bpf_probe_read_user_str(eventp->fsconfig.value,
+					sizeof(eventp->fsconfig.value),
+					argp->sys.fsconfig.value);
+		eventp->fsconfig.aux = argp->sys.fsconfig.aux;
+		break;
+	case FSMOUNT:
+		eventp->fsmount.fs_fd = argp->sys.fsmount.fs_fd;
+		eventp->fsmount.flags = argp->sys.fsmount.flags;
+		eventp->fsmount.attr_flags = argp->sys.fsmount.attr_flags;
+		break;
+	case MOVE_MOUNT:
+		eventp->move_mount.from_dfd = argp->sys.move_mount.from_dfd;
+		bpf_probe_read_user_str(eventp->move_mount.from_pathname,
+					sizeof(eventp->move_mount.from_pathname),
+					argp->sys.move_mount.from_pathname);
+		eventp->move_mount.to_dfd = argp->sys.move_mount.to_dfd;
+		bpf_probe_read_user_str(eventp->move_mount.to_pathname,
+					sizeof(eventp->move_mount.to_pathname),
+					argp->sys.move_mount.to_pathname);
 		break;
 	}
 
@@ -100,13 +142,15 @@ cleanup:
 SEC("tracepoint/syscalls/sys_enter_mount")
 int mount_entry(struct syscall_trace_enter *ctx)
 {
-	const char *src = (const char *)ctx->args[0];
-	const char *dest = (const char *)ctx->args[1];
-	const char *fs = (const char *)ctx->args[2];
-	__u64 flags = (__u64)ctx->args[3];
-	const char *data = (const char *)ctx->args[4];
+	union sys_arg arg = {};
 
-	return probe_entry(src, dest, fs, flags, data, MOUNT);
+	arg.mount.src = (const char *)ctx->args[0];
+	arg.mount.dest = (const char *)ctx->args[1];
+	arg.mount.fs = (const char *)ctx->args[2];
+	arg.mount.flags = (__u64)ctx->args[3];
+	arg.mount.data = (const char *)ctx->args[4];
+
+	return probe_entry(&arg, MOUNT);
 }
 
 SEC("tracepoint/syscalls/sys_exit_mount")
@@ -118,14 +162,90 @@ int mount_exit(struct syscall_trace_exit *ctx)
 SEC("tracepoint/syscalls/sys_enter_umount")
 int umount_entry(struct syscall_trace_enter *ctx)
 {
-	const char *dest = (const char *)ctx->args[0];
-	__u64 flags = (__u64)ctx->args[1];
+	union sys_arg arg = {};
 
-	return probe_entry(NULL, dest, NULL, flags, NULL, UMOUNT);
+	arg.umount.dest = (const char *)ctx->args[0];
+	arg.umount.flags = (__u64)ctx->args[1];
+
+	return probe_entry(&arg, UMOUNT);
 }
 
 SEC("tracepoint/syscalls/sys_exit_umount")
 int umount_exit(struct syscall_trace_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_fsopen")
+int fsopen_entry(struct syscall_trace_enter *ctx)
+{
+	union sys_arg arg = {};
+
+	arg.fsopen.fs = (const char *)ctx->args[0];
+	arg.fsopen.flags = (__u32)ctx->args[1];
+
+	return probe_entry(&arg, FSOPEN);
+}
+
+SEC("tracepoint/syscalls/sys_exit_fsopen")
+int fsopen_exit(struct syscall_trace_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_fsconfig")
+int fsconfig_entry(struct syscall_trace_enter *ctx)
+{
+	union sys_arg arg = {};
+
+	arg.fsconfig.fd = (int)ctx->args[0];
+	arg.fsconfig.cmd = (int)ctx->args[1];
+	arg.fsconfig.key = (const char *)ctx->args[2];
+	arg.fsconfig.value = (const char *)ctx->args[3];
+	arg.fsconfig.aux = (int)ctx->args[4];
+
+	return probe_entry(&arg, FSCONFIG);
+}
+
+SEC("tracepoint/syscalls/sys_exit_fsconfig")
+int fsconfig_exit(struct syscall_trace_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_fsmount")
+int fsmount_entry(struct syscall_trace_enter *ctx)
+{
+	union sys_arg arg = {};
+
+	arg.fsmount.fs_fd = (__u32)ctx->args[0];
+	arg.fsmount.flags = (__u32)ctx->args[1];
+	arg.fsmount.attr_flags = (__u32)ctx->args[2];
+
+	return probe_entry(&arg, FSMOUNT);
+}
+
+SEC("tracepoint/syscalls/sys_exit_fsmount")
+int fsmount_exit(struct syscall_trace_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_move_mount")
+int move_mount_entry(struct syscall_trace_enter *ctx)
+{
+	union sys_arg arg = {};
+
+	arg.move_mount.from_dfd = (int)ctx->args[0];
+	arg.move_mount.from_pathname = (const char *)ctx->args[1];
+	arg.move_mount.to_dfd = (int)ctx->args[2];
+	arg.move_mount.to_pathname = (const char *)ctx->args[3];
+
+	return probe_entry(&arg, MOVE_MOUNT);
+}
+
+SEC("tracepoint/syscalls/sys_exit_move_mount")
+int move_mount_exit(struct syscall_trace_exit *ctx)
 {
 	return probe_exit(ctx, (int)ctx->ret);
 }

--- a/libbpf-tools/mountsnoop.c
+++ b/libbpf-tools/mountsnoop.c
@@ -1,16 +1,20 @@
 /* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
 
 /*
- * mountsnoop  Trace mount and umount[2] syscalls
+ * mountsnoop  Trace mount(2), umount(2), fsopen(2), fsconfig(2), fsmount(2)
+ *             move_mount(2) syscalls
  *
  * Copyright (c) 2021 Hengqi Chen
  * 30-May-2021   Hengqi Chen   Created this.
+ * 20-Dec-2024   Rong Tao      Support fsopen(2), fsconfig(2), fsmount(2),
+ *                             move_mount(2) syscalls.
  */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
 #include <argp.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <signal.h>
 #include <string.h>
 #include <time.h>
@@ -25,6 +29,7 @@
 #include "trace_helpers.h"
 
 #define warn(...) fprintf(stderr, __VA_ARGS__)
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
 
 /* https://www.gnu.org/software/gnulib/manual/html_node/strerrorname_005fnp.html */
 #if !defined(__GLIBC__) || __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 32)
@@ -40,7 +45,8 @@ static pid_t target_pid = 0;
 static bool emit_timestamp = false;
 static bool output_vertically = false;
 static bool verbose = false;
-static const char *flag_names[] = {
+
+static const char *mnt_flags_names[] = {
 	[0] = "MS_RDONLY",
 	[1] = "MS_NOSUID",
 	[2] = "MS_NODEV",
@@ -74,18 +80,73 @@ static const char *flag_names[] = {
 	[30] = "MS_ACTIVE",
 	[31] = "MS_NOUSER",
 };
-static const int flag_count = sizeof(flag_names) / sizeof(flag_names[0]);
+
+static const struct fsmount_flags_names {
+	unsigned long value;
+	const char *name;
+} fsmount_flags_names[] = {
+	{ 0x00000001, "FSMOUNT_CLOEXEC" },
+};
+
+/**
+ * See /usr/include/sys/mount.h fsmount(2)
+ */
+static const struct fsmount_attr_flags_names {
+	unsigned long value;
+	const char *name;
+} fsmount_attr_flags_names[] = {
+	{ 0x00000001, "MOUNT_ATTR_RDONLY" },
+	{ 0x00000002, "MOUNT_ATTR_NOSUID" },
+	{ 0x00000004, "MOUNT_ATTR_NODEV" },
+	{ 0x00000008, "MOUNT_ATTR_NOEXEC" },
+	{ 0x00000070, "MOUNT_ATTR__ATIME" },
+	{ 0x00000000, "MOUNT_ATTR_RELATIME" },
+	{ 0x00000010, "MOUNT_ATTR_NOATIME" },
+	{ 0x00000020, "MOUNT_ATTR_STRICTATIME" },
+	{ 0x00000080, "MOUNT_ATTR_NODIRATIME" },
+	{ 0x00100000, "MOUNT_ATTR_IDMAP" },
+	{ 0x00200000, "MOUNT_ATTR_NOSYMFOLLOW" },
+};
+
+static const char *fsconfig_cmd_names[] = {
+	[0] = "FSCONFIG_SET_FLAG",
+	[1] = "FSCONFIG_SET_STRING",
+	[2] = "FSCONFIG_SET_BINARY",
+	[3] = "FSCONFIG_SET_PATH",
+	[4] = "FSCONFIG_SET_PATH_EMPTY",
+	[5] = "FSCONFIG_SET_FD",
+	[6] = "FSCONFIG_CMD_CREATE",
+	[7] = "FSCONFIG_CMD_RECONFIGURE",
+	[8] = "FSCONFIG_CMD_CREATE_EXCL",
+};
+
+/**
+ * See /usr/include/sys/mount.h move_mount(2)
+ */
+static const struct move_mount_flags_names {
+	unsigned long value;
+	const char *name;
+} move_mount_flags_names[] = {
+	{ 0x00000001, "MOVE_MOUNT_F_SYMLINKS" },
+	{ 0x00000002, "MOVE_MOUNT_F_AUTOMOUNTS" },
+	{ 0x00000004, "MOVE_MOUNT_F_EMPTY_PATH" },
+	{ 0x00000010, "MOVE_MOUNT_T_SYMLINKS" },
+	{ 0x00000020, "MOVE_MOUNT_T_AUTOMOUNTS" },
+	{ 0x00000040, "MOVE_MOUNT_T_EMPTY_PATH" },
+	{ 0x00000100, "MOVE_MOUNT_SET_GROUP" },
+	{ 0x00000200, "MOVE_MOUNT_BENEATH" },
+};
 
 const char *argp_program_version = "mountsnoop 0.1";
 const char *argp_program_bug_address =
 	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
 const char argp_program_doc[] =
-"Trace mount and umount syscalls.\n"
+"Trace mount, umount, fsopen, fsconfig, fsmount, move_mount syscalls.\n"
 "\n"
 "USAGE: mountsnoop [-h] [-t] [-p PID] [-v]\n"
 "\n"
 "EXAMPLES:\n"
-"    mountsnoop         # trace mount and umount syscalls\n"
+"    mountsnoop         # trace mount relative syscalls\n"
 "    mountsnoop -d      # detailed output (one line per column value)\n"
 "    mountsnoop -p 1216 # only trace PID 1216\n";
 
@@ -142,7 +203,19 @@ static void sig_int(int signo)
 	exiting = 1;
 }
 
-static const char *strflags(__u64 flags)
+/**
+ * Used to print special fd, such as AT_FDCWD.
+ */
+const char *strfd(int fd)
+{
+	static char buf[8];
+	if (fd == AT_FDCWD)
+		return "AT_FDCWD";
+	snprintf(buf, 8, "%d", fd);
+	return buf;
+}
+
+static const char *strmountflags(__u64 flags)
 {
 	static char str[512];
 	int i;
@@ -151,14 +224,85 @@ static const char *strflags(__u64 flags)
 		return "0x0";
 
 	str[0] = '\0';
-	for (i = 0; i < flag_count; i++) {
+	for (i = 0; i < ARRAY_SIZE(mnt_flags_names); i++) {
 		if (!((1 << i) & flags))
 			continue;
 		if (str[0])
 			strcat(str, " | ");
-		strcat(str, flag_names[i]);
+		strcat(str, mnt_flags_names[i]);
 	}
 	return str;
+}
+
+/**
+ * Print fsmount(2) flags
+ */
+static const char *strfsmntflags(__u32 flags)
+{
+	static char str[512];
+	int i;
+
+	if (!flags)
+		return "0x0";
+
+	str[0] = '\0';
+	for (i = 0; i < ARRAY_SIZE(fsmount_flags_names); i++) {
+		if (!(fsmount_flags_names[i].value & flags))
+			continue;
+		if (str[0])
+			strcat(str, " | ");
+		strcat(str, fsmount_flags_names[i].name);
+	}
+	return str;
+}
+
+/**
+ * Print fsmount(2) attr_flags
+ */
+static const char *strfsmntattrflags(__u32 attr_flags)
+{
+	static char str[512];
+	int i;
+
+	str[0] = '\0';
+	for (i = 0; i < ARRAY_SIZE(fsmount_attr_flags_names); i++) {
+		if (!(fsmount_attr_flags_names[i].value & attr_flags))
+			continue;
+		if (str[0])
+			strcat(str, " | ");
+		strcat(str, fsmount_attr_flags_names[i].name);
+	}
+	return str;
+}
+
+/**
+ * Print move_mount(2) flags
+ */
+static const char *strmovemntflags(__u32 flags)
+{
+	static char str[512];
+	int i;
+
+	str[0] = '\0';
+	for (i = 0; i < ARRAY_SIZE(move_mount_flags_names); i++) {
+		if (!(move_mount_flags_names[i].value & flags))
+			continue;
+		if (str[0])
+			strcat(str, " | ");
+		strcat(str, move_mount_flags_names[i].name);
+	}
+	return str;
+}
+
+static const char *strcmd(int cmd)
+{
+	/**
+	 * 0: FSCONFIG_SET_FLAG
+	 * 8: FSCONFIG_CMD_CREATE_EXCL
+	 */
+	if (cmd >= 0 && cmd <= 8)
+		return fsconfig_cmd_names[cmd];
+	return "UNKNOWN";
 }
 
 static const char *strerrno(int errnum)
@@ -188,13 +332,37 @@ static const char *gen_call(const struct event *e)
 	switch (e->op) {
 	case UMOUNT:
 		snprintf(call, sizeof(call), "umount(\"%s\", %s) = %s",
-			 e->umount.dest, strflags(e->umount.flags),
+			 e->umount.dest, strmountflags(e->umount.flags),
 			 strerrno(e->ret));
 		break;
 	case MOUNT:
 		snprintf(call, sizeof(call), "mount(\"%s\", \"%s\", \"%s\", %s, \"%s\") = %s",
 			 e->mount.src, e->mount.dest, e->mount.fs,
-			 strflags(e->mount.flags), e->mount.data,
+			 strmountflags(e->mount.flags), e->mount.data,
+			 strerrno(e->ret));
+		break;
+	case FSOPEN:
+		snprintf(call, sizeof(call), "fsopen(\"%s\", %s) = %s",
+			 e->fsopen.fs, strmountflags(e->fsopen.flags),
+			 strerrno(e->ret));
+		break;
+	case FSCONFIG:
+		snprintf(call, sizeof(call), "fsconfig(%d, \"%s\", \"%s\", \"%s\", %d) = %s",
+			 e->fsconfig.fd, strcmd(e->fsconfig.cmd),
+			 e->fsconfig.key, e->fsconfig.value, e->fsconfig.aux,
+			 strerrno(e->ret));
+		break;
+	case FSMOUNT:
+		snprintf(call, sizeof(call), "fsmount(%d, \"%s\", \"%s\") = %s",
+			 e->fsmount.fs_fd, strfsmntflags(e->fsmount.flags),
+			 strfsmntattrflags(e->fsmount.attr_flags),
+			 strerrno(e->ret));
+		break;
+	case MOVE_MOUNT:
+		snprintf(call, sizeof(call), "move_mount(%d, \"%s\", %s, \"%s\", \"%s\") = %s",
+			 e->move_mount.from_dfd, e->move_mount.from_pathname,
+			 strfd(e->move_mount.to_dfd), e->move_mount.to_pathname,
+			 strmovemntflags(e->move_mount.flags),
 			 strerrno(e->ret));
 		break;
 	default:
@@ -213,6 +381,10 @@ static int handle_event(void *ctx, void *data, size_t len)
 	static const char *op_name[] = {
 		[MOUNT] = "MOUNT",
 		[UMOUNT] = "UMOUNT",
+		[FSOPEN] = "FSOPEN",
+		[FSCONFIG] = "FSCONFIG",
+		[FSMOUNT] = "FSMOUNT",
+		[MOVE_MOUNT] = "MOVE_MOUNT",
 	};
 
 	if (emit_timestamp) {
@@ -244,11 +416,33 @@ static int handle_event(void *ctx, void *data, size_t len)
 		printf("%sSOURCE: %s\n", indent, e->mount.src);
 		printf("%sTARGET: %s\n", indent, e->mount.dest);
 		printf("%sDATA:   %s\n", indent, e->mount.data);
-		printf("%sFLAGS:  %s\n", indent, strflags(e->mount.flags));
+		printf("%sFLAGS:  %s\n", indent, strmountflags(e->mount.flags));
 		break;
 	case UMOUNT:
 		printf("%sTARGET: %s\n", indent, e->umount.dest);
-		printf("%sFLAGS:  %s\n", indent, strflags(e->umount.flags));
+		printf("%sFLAGS:  %s\n", indent, strmountflags(e->umount.flags));
+		break;
+	case FSOPEN:
+		printf("%sFS:     %s\n", indent, e->fsopen.fs);
+		printf("%sFLAGS:  %s\n", indent, strmountflags(e->fsopen.flags));
+		break;
+	case FSCONFIG:
+		printf("%sFD:     %d\n", indent, e->fsconfig.fd);
+		printf("%sCMD:    %s\n", indent, strcmd(e->fsconfig.cmd));
+		printf("%sKEY:    %s\n", indent, e->fsconfig.key);
+		printf("%sVALUE:  %s\n", indent, e->fsconfig.value);
+		break;
+	case FSMOUNT:
+		printf("%sFS_FD:       %d\n", indent, e->fsmount.fs_fd);
+		printf("%sFLAGS:       %s\n", indent, strfsmntflags(e->fsmount.flags));
+		printf("%sATTR_FLAGS:  %s\n", indent, strfsmntattrflags(e->fsmount.attr_flags));
+		break;
+	case MOVE_MOUNT:
+		printf("%sFROM_DFD:       %d\n", indent, e->move_mount.from_dfd);
+		printf("%sFROM_PATHNAME:  %s\n", indent, e->move_mount.from_pathname);
+		printf("%sTO_DFD:         %d\n", indent, e->move_mount.to_dfd);
+		printf("%sTO_PATHNAME:    %s\n", indent, e->move_mount.to_pathname);
+		printf("%sFLAGS:          %s\n", indent, strmovemntflags(e->move_mount.flags));
 		break;
 	default:
 		break;
@@ -300,6 +494,42 @@ int main(int argc, char **argv)
 		err = -errno;
 		warn("failed to create ring/perf buffer: %d\n", err);
 		goto cleanup;
+	}
+
+	/**
+	 * kernel commit 24dcb3d90a1f ("vfs: syscall: Add fsopen() to prepare
+	 * for superblock creation") v5.1-rc1-5-g24dcb3d90a1f
+	 */
+	if (!tracepoint_exists("syscalls", "sys_enter_fsopen")) {
+		bpf_program__set_autoload(obj->progs.fsopen_entry, false);
+		bpf_program__set_autoload(obj->progs.fsopen_exit, false);
+	}
+
+	/**
+	 * kernel commit ecdab150fddb ("vfs: syscall: Add fsconfig() for
+	 * configuring and managing a context") v5.1-rc1-7-gecdab150fddb
+	 */
+	if (!tracepoint_exists("syscalls", "sys_enter_fsconfig")) {
+		bpf_program__set_autoload(obj->progs.fsconfig_entry, false);
+		bpf_program__set_autoload(obj->progs.fsconfig_exit, false);
+	}
+
+	/**
+	 * kernel commit 93766fbd2696 ("vfs: syscall: Add fsmount() to create
+	 * a mount for a superblock") v5.1-rc1-8-g93766fbd2696
+	 */
+	if (!tracepoint_exists("syscalls", "sys_enter_fsmount")) {
+		bpf_program__set_autoload(obj->progs.fsmount_entry, false);
+		bpf_program__set_autoload(obj->progs.fsmount_exit, false);
+	}
+
+	/**
+	 * kernel commit 2db154b3ea8e ("vfs: syscall: Add move_mount(2) to
+	 * move mounts around") v5.1-rc1-2-g2db154b3ea8e
+	 */
+	if (!tracepoint_exists("syscalls", "sys_enter_move_mount")) {
+		bpf_program__set_autoload(obj->progs.move_mount_entry, false);
+		bpf_program__set_autoload(obj->progs.move_mount_exit, false);
 	}
 
 	err = mountsnoop_bpf__load(obj);

--- a/libbpf-tools/mountsnoop.c
+++ b/libbpf-tools/mountsnoop.c
@@ -185,12 +185,20 @@ static const char *gen_call(const struct event *e)
 	static char call[10240];
 
 	memset(call, 0, sizeof(call));
-	if (e->op == UMOUNT) {
+	switch (e->op) {
+	case UMOUNT:
 		snprintf(call, sizeof(call), "umount(\"%s\", %s) = %s",
-			 e->dest, strflags(e->flags), strerrno(e->ret));
-	} else {
+			 e->umount.dest, strflags(e->umount.flags),
+			 strerrno(e->ret));
+		break;
+	case MOUNT:
 		snprintf(call, sizeof(call), "mount(\"%s\", \"%s\", \"%s\", %s, \"%s\") = %s",
-			 e->src, e->dest, e->fs, strflags(e->flags), e->data, strerrno(e->ret));
+			 e->mount.src, e->mount.dest, e->mount.fs,
+			 strflags(e->mount.flags), e->mount.data,
+			 strerrno(e->ret));
+		break;
+	default:
+		break;
 	}
 	return call;
 }
@@ -230,11 +238,21 @@ static int handle_event(void *ctx, void *data, size_t len)
 	printf("%sRET:    %s\n", indent, strerrno(e->ret));
 	printf("%sLAT:    %lldus\n", indent, e->delta / 1000);
 	printf("%sMNT_NS: %u\n", indent, e->mnt_ns);
-	printf("%sFS:     %s\n", indent, e->fs);
-	printf("%sSOURCE: %s\n", indent, e->src);
-	printf("%sTARGET: %s\n", indent, e->dest);
-	printf("%sDATA:   %s\n", indent, e->data);
-	printf("%sFLAGS:  %s\n", indent, strflags(e->flags));
+	switch (e->op) {
+	case MOUNT:
+		printf("%sFS:     %s\n", indent, e->mount.fs);
+		printf("%sSOURCE: %s\n", indent, e->mount.src);
+		printf("%sTARGET: %s\n", indent, e->mount.dest);
+		printf("%sDATA:   %s\n", indent, e->mount.data);
+		printf("%sFLAGS:  %s\n", indent, strflags(e->mount.flags));
+		break;
+	case UMOUNT:
+		printf("%sTARGET: %s\n", indent, e->umount.dest);
+		printf("%sFLAGS:  %s\n", indent, strflags(e->umount.flags));
+		break;
+	default:
+		break;
+	}
 	printf("\n");
 
 	return 0;

--- a/libbpf-tools/mountsnoop.h
+++ b/libbpf-tools/mountsnoop.h
@@ -8,33 +8,55 @@
 #define PATH_MAX	4096
 
 enum op {
+	OP_MIN, /* skip 0 */
 	MOUNT,
 	UMOUNT,
 };
 
 struct arg {
 	__u64 ts;
-	__u64 flags;
-	const char *src;
-	const char *dest;
-	const char *fs;
-	const char *data;
 	enum op op;
+
+	union {
+		/* op=MOUNT */
+		struct {
+			__u64 flags;
+			const char *src;
+			const char *dest;
+			const char *fs;
+			const char *data;
+		} mount;
+		/* op=UMOUNT */
+		struct {
+			__u64 flags;
+			const char *dest;
+		} umount;
+	};
 };
 
 struct event {
 	__u64 delta;
-	__u64 flags;
 	__u32 pid;
 	__u32 tid;
 	unsigned int mnt_ns;
 	int ret;
-	char comm[TASK_COMM_LEN];
-	char fs[FS_NAME_LEN];
-	char src[PATH_MAX];
-	char dest[PATH_MAX];
-	char data[DATA_LEN];
 	enum op op;
+	char comm[TASK_COMM_LEN];
+	union {
+		/* op=MOUNT */
+		struct {
+			__u64 flags;
+			char fs[FS_NAME_LEN];
+			char src[PATH_MAX];
+			char dest[PATH_MAX];
+			char data[DATA_LEN];
+		} mount;
+		/* op=UMOUNT */
+		struct {
+			__u64 flags;
+			char dest[PATH_MAX];
+		} umount;
+	};
 };
 
 #endif /* __MOUNTSNOOP_H */

--- a/libbpf-tools/mountsnoop.h
+++ b/libbpf-tools/mountsnoop.h
@@ -11,27 +11,59 @@ enum op {
 	OP_MIN, /* skip 0 */
 	MOUNT,
 	UMOUNT,
+	FSOPEN,
+	FSCONFIG,
+	FSMOUNT,
+	MOVE_MOUNT,
+};
+
+union sys_arg {
+	/* op=MOUNT */
+	struct {
+		__u64 flags;
+		const char *src;
+		const char *dest;
+		const char *fs;
+		const char *data;
+	} mount;
+	/* op=UMOUNT */
+	struct {
+		__u64 flags;
+		const char *dest;
+	} umount;
+	/* op=FSOPEN */
+	struct {
+		const char *fs;
+		__u32 flags;
+	} fsopen;
+	/* op=FSCONFIG */
+	struct {
+		int fd;
+		unsigned int cmd;
+		const char *key;
+		const char *value;
+		int aux;
+	} fsconfig;
+	/* op=FSMOUNT */
+	struct {
+		int fs_fd;
+		__u32 flags;
+		__u32 attr_flags;
+	} fsmount;
+	/* op=MOVE_MOUNT */
+	struct {
+		int from_dfd;
+		const char *from_pathname;
+		int to_dfd;
+		const char *to_pathname;
+		__u32 flags;
+	} move_mount;
 };
 
 struct arg {
 	__u64 ts;
 	enum op op;
-
-	union {
-		/* op=MOUNT */
-		struct {
-			__u64 flags;
-			const char *src;
-			const char *dest;
-			const char *fs;
-			const char *data;
-		} mount;
-		/* op=UMOUNT */
-		struct {
-			__u64 flags;
-			const char *dest;
-		} umount;
-	};
+	union sys_arg sys;
 };
 
 struct event {
@@ -56,6 +88,33 @@ struct event {
 			__u64 flags;
 			char dest[PATH_MAX];
 		} umount;
+		/* op=FSOPEN */
+		struct {
+			char fs[FS_NAME_LEN];
+			__u32 flags;
+		} fsopen;
+		/* op=FSCONFIG */
+		struct {
+			int fd;
+			unsigned int cmd;
+			char key[DATA_LEN];
+			char value[DATA_LEN];
+			int aux;
+		} fsconfig;
+		/* op=FSMOUNT */
+		struct {
+			int fs_fd;
+			__u32 flags;
+			__u32 attr_flags;
+		} fsmount;
+		/* op=MOVE_MOUNT */
+		struct {
+			int from_dfd;
+			char from_pathname[PATH_MAX];
+			int to_dfd;
+			char to_pathname[PATH_MAX];
+			__u32 flags;
+		} move_mount;
 	};
 };
 


### PR DESCRIPTION
Do the same thing of bcc commit 60ebaf47347a ("tools/mountsnoop: Support fsopen(2), fsmount(2), fsconfig(2), move_mount(2)")
    
        $ sudo ./mountsnoop
        COMM             PID     TID     MNT_NS      CALL
        fsmount          431216  431216  4026531841  fsopen("ext4", 0x0) = 5
        fsmount          431216  431216  4026531841  fsconfig(5, "FSCONFIG_SET_FLAG", "rw", "", 0) = 0
        fsmount          431216  431216  4026531841  fsconfig(5, "FSCONFIG_SET_STRING", "source", "/dev/loop0", 0) = 0
        fsmount          431216  431216  4026531841  fsconfig(5, "FSCONFIG_CMD_CREATE", "", "", 0) = 0
        fsmount          431216  431216  4026531841  fsmount(5, "0x0", "MOUNT_ATTR_RDONLY") = 6
        fsmount          431216  431216  4026531841  move_mount(6, "", AT_FDCWD, "./tmp-dir/", "") = 0
        fsmount          431216  431216  4026531841  umount("./tmp-dir/", 0x0) = 0
    
In the above test, the C program is more complicated, so I will not show it here, but a test example is given in the link 
 https://github.com/torvalds/linux/blob/master/samples/vfs/test-fsmount.c
