### PR TITLE
Remove Byte String Prefix in Output

### DIFF
--- a/tools/klockstat.py
+++ b/tools/klockstat.py
@@ -431,7 +431,7 @@ def display(sort, maxs, totals, counts):
 
         avg = totals[k].value / counts[k].value
 
-        print("%40s %10lu %6lu %10lu %10lu" % (caller, avg, counts[k].value, maxs[k].value, totals[k].value))
+        print("%40s %10d %6d %10d %10d" % (caller.decode('utf-8', 'replace'), avg, counts[k].value, maxs[k].value, totals[k].value))
 
         for addr in stack[2:args.stacks]:
             print("%40s" %  b.ksym(addr, show_offset=True))


### PR DESCRIPTION
Byte strings are printed directly, leading to output with the 'b' prefix

example:
Caller   Avg Spin  Count   Max spin Total spin
b'ep_poll+0x16b'       1096  26576       8180   29145121
b'drm_fb_helper_damage_work+0x97'       1705     32       2870      54580
b'process_one_work+0x178'       1325     55       2520      72879
b'ext4_evict_inode+0x283'       1625     11       2400      17880

This fix decode the byte strings
After fix:
Caller   Avg Spin  Count   Max spin Total spin
process_one_work+0x178       1569     24       3530      37657
ep_poll+0x16b       1037     12       3090      12450
kthread+0xf2       2336      3       2830       7010
rcu_tasks_kthread+0xa4       1642      5       2490       8210