### PR TITLE
syms: Initialize ModulePath::fd_ to invalid FD

### DIFF
--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -130,7 +130,7 @@ class ProcSyms : SymbolCache {
     // process by storing a file descriptor created from openat(2) if possible
     // if openat fails, falls back to process-dependent path with /proc/.../root
    private:
-    int fd_;
+    int fd_ = -1;
     std::string proc_root_path_;
     std::string path_;
 


### PR DESCRIPTION
~ModulePath() does `if (fd_ > 0) close fd_;`. But ModulePath constructor has early return codepath for `!enter_ns` which does not initialize `fd_`.

So `fd_` can potentially have junk value. That junk value could be any FD downstream. bcc cannot be closing random FDs.

See https://dxuuu.xyz/flaky.html for a writeup for the implications.