### PR TITLE
Fix llvm20 compilation error

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -1380,7 +1380,11 @@ bool BTypeVisitor::VisitBinaryOperator(BinaryOperator *E) {
             }
 
             uint64_t ofs = C.getFieldOffset(F);
+#if LLVM_VERSION_MAJOR >= 20
+            uint64_t sz = F->isBitField() ? F->getBitWidthValue() : C.getTypeSize(F->getType());
+#else
             uint64_t sz = F->isBitField() ? F->getBitWidthValue(C) : C.getTypeSize(F->getType());
+#endif
             string base = rewriter_.getRewrittenText(expansionRange(Base->getSourceRange()));
             string text = "bpf_dins_pkt(" + fn_args_[0]->getName().str() + ", (u64)" + base + "+" + to_string(ofs >> 3)
                 + ", " + to_string(ofs & 0x7) + ", " + to_string(sz) + ",";
@@ -1410,7 +1414,11 @@ bool BTypeVisitor::VisitImplicitCastExpr(ImplicitCastExpr *E) {
             return false;
           }
           uint64_t ofs = C.getFieldOffset(F);
+#if LLVM_VERSION_MAJOR >= 20
+          uint64_t sz = F->isBitField() ? F->getBitWidthValue() : C.getTypeSize(F->getType());
+#else
           uint64_t sz = F->isBitField() ? F->getBitWidthValue(C) : C.getTypeSize(F->getType());
+#endif
           string text = "bpf_dext_pkt(" + fn_args_[0]->getName().str() + ", (u64)" + Ref->getDecl()->getName().str() + "+"
               + to_string(ofs >> 3) + ", " + to_string(ofs & 0x7) + ", " + to_string(sz) + ")";
           rewriter_.ReplaceText(expansionRange(E->getSourceRange()), text);

--- a/src/cc/json_map_decl_visitor.cc
+++ b/src/cc/json_map_decl_visitor.cc
@@ -86,8 +86,13 @@ void BMapDeclVisitor::genJSONForField(FieldDecl *F) {
 #else
     result_ += ", [" + T->getSize().toString(10, false) + "]";
 #endif
-  if (F->isBitField())
+  if (F->isBitField()) {
+#if LLVM_VERSION_MAJOR >= 20
+    result_ += ", " + to_string(F->getBitWidthValue());
+#else
     result_ += ", " + to_string(F->getBitWidthValue(C));
+#endif
+  }
   result_ += "], ";
 }
 


### PR DESCRIPTION
The following is the error message:
```
/home/yhs/work/bcc/src/cc/frontends/clang/b_frontend_action.cc: In member function
     ‘bool ebpf::BTypeVisitor::VisitBinaryOperator(clang::BinaryOperator*)’:
/home/yhs/work/bcc/src/cc/frontends/clang/b_frontend_action.cc:1383:64: error:
     no matching function for call to ‘clang::FieldDecl::getBitWidthValue(clang::ASTContext&)’
 1383 |             uint64_t sz = F->isBitField() ? F->getBitWidthValue(C) : C.getTypeSize(F->getType());
      |                                             ~~~~~~~~~~~~~~~~~~~^~~
```
This is due to upstream llvm patch:
  https://github.com/llvm/llvm-project/pull/122289
This patch fixed the above compilation error.