### PR TITLE
Add zombie memcgroup observation tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[rdmaucma](tools/rdmaucma.py): Trace RDMA Userspace Connection Manager Access events. [Examples](tools/rdmaucma_example.txt).
 - tools/[shmsnoop](tools/shmsnoop.py): Trace System V shared memory syscalls. [Examples](tools/shmsnoop_example.txt).
 - tools/[slabratetop](tools/slabratetop.py): Kernel SLAB/SLUB memory cache allocation rate top. [Examples](tools/slabratetop_example.txt).
+- tools/[zombiememcgstat](tools/zombiememcgstat.py): Display zombie memory cgroups. [Examples](tools/zombiememcgstat_example.txt).
 
 ##### Performance and Time Tools
 

--- a/man/man8/zombiememcgstat.8
+++ b/man/man8/zombiememcgstat.8
@@ -1,0 +1,103 @@
+.TH zombiememcgstat 8 "2025-01-23" "USER COMMANDS"
+.SH NAME
+zombiememcgstat \- Show zombie memcgroups on a system, along with creator and offline duration.
+.SH SYNOPSIS
+.B zombiememcgstat [\-h] [\-p PID] [\-c COMM] [\-o OLDER] [interval] [count]
+.SH DESCRIPTION
+zombiememcgstat traces and matches the creation and destruction of memory cgroup(memcg)
+related objects in the kernel and using this information it, tracks and reports zombie
+memcgs along with information about creator and offline duration of these zombie memcgs.
+
+This tool uses in-kernel eBPF maps for storing timestamps and other information, for efficiency.
+
+This tool traces mem_cgroup_css_online, mem_cgroup_css_offline and mem_cgroup_css_free with
+kprobes to track the time when a memory cgroup gets online, gets offline and when its kernel
+objects are freed. From the time of being offline till the time its kernel objects are freed,
+a memcg exists as zombie and taking the difference between any instant of time and time when
+memcg was offlined, this tool reports for how long the memcg has existed as zombie till then.
+
+Please note that this tool has been tested with kernel 5.4 and later versions.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.
+.SH OPTIONS
+\-h
+Print usage message.
+.TP
+\-p PID
+Report zombie memcgs created by this pid only.
+.TP
+\-c COMM
+Report zombie memcgs created by this comm only.
+.TP
+\-o OLDER
+Report zombie memcgs that are offline for more than these many secs.
+.TP
+interval
+Output interval, in seconds.
+.TP
+count
+Number of outputs.
+.SH EXAMPLES
+.TP
+List all zombie memcgs at 30 secs interval:
+#
+.B zombiememcgstat
+.TP
+List all zombie memcgs at 5 secs interval:
+#
+.B zombiememcgstat 5
+.TP
+List all zombie memcgs at 30 secs interval, 10 times:
+#
+.B zombiememcgstat 30 10
+.TP
+List zombie memcgs created by pid 100
+#
+.B zombiememcgstat -p 100
+.TP
+List zombie memcgs created by task with comm "foo"
+#
+.B zombiememcgstat -c foo
+.TP
+List zombie memcgs that have been offline for more than 100 secs
+#
+.B zombiememcgstat -o 100
+.SH FIELDS
+.TP
+MEMCG
+pointer to mem_cgroup object
+.TP
+NAME
+name of memory cgroup
+.TP
+COMM
+comm of task that created this memory cgroup
+.TP
+PID
+pid of task that created this memory cgroup
+.TP
+AGE(secs)
+time in seconds, for which this memcg has been offline for
+.SH OVERHEAD
+This traces memcgroup online, offline and destruction functions, which typically
+are not very frequent, at least not frequent enough to cause any noticeable overhead.
+Further it uses in-kernel maps for efficiency, so overall this tool has negligible
+overhead.
+.SH SOURCE
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Imran Khan
+.SH SEE ALSO
+memleak(8)
+

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -428,6 +428,10 @@ class SmokeTests(TestCase):
     def test_wqlat(self):
         self.run_with_int("wqlat.py 1 1", allow_early=True)
 
+    @skipUnless(kernel_version_ge(5,4), "requires kernel >= 5.4")
+    def test_zombiememcgstat(self):
+        self.run_with_duration("zombiememcgstat.py 1 1")
+
     def test_xfsdist(self):
         # Doesn't work on build bot because xfs functions not present in the
         # kernel image.

--- a/tools/zombiememcgstat.py
+++ b/tools/zombiememcgstat.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+# @lint-avoid-python-3-compatibility-imports
+#
+# zombiememcgstat Dump info about zombie memcgroups
+#           For Linux, uses BCC, eBPF.
+#
+# USAGE: zombiememcgstat [-h] [-p] [-c] [-o] [interval] [count]
+#
+# Copyright 2025 Oracle and/or its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License")
+#
+# 01-Jan-2025   Imran Khan     Created this.
+
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from __future__ import print_function
+from bcc import BPF
+from time import sleep, strftime
+import argparse
+import sys
+
+# arguments
+examples = """examples:
+    ./zombiememcgstat            # list all zombie memcgs at 30 secs interval
+    ./zombiememcgstat 5          # list all zombie memcgs at 5 secs interval
+    ./zombiememcgstat 30 10      # print 30 second summaries, 10 times
+    ./zombiememcgstat -p 1       # list zombie memcgs created by pid 1
+    ./zombiememcgstat -c systemd # list zombie memcgs created by systemd
+    ./zombiememcgstat -o 600     # list zombie memcgs older than 600 secs
+"""
+
+parser = argparse.ArgumentParser(
+    description="""
+    Zombie memory cgroups (memcgs) are cgroups that have  been removed
+    from user space but still exist in kernel space due to non-zero refcounts.
+    List such zombie memcgs on a system along with their creator and
+    offline duration.
+    """,
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("-p", "--pid", type=int,
+    help="show zombie memcgs created by specified pid")
+parser.add_argument("-c", "--comm", type=str,
+    help="show zombie memcgs created by specified comm")
+parser.add_argument("-o", "--older", default=60, type=int,
+    help="show zombie memcgs that are offline for more than these many secs.")
+parser.add_argument("interval", nargs="?", default=30,
+    help="output interval, in seconds")
+parser.add_argument("count", nargs="?", default=99999999,
+    help="number of outputs")
+parser.add_argument("--ebpf", action="store_true",
+    help=argparse.SUPPRESS)
+args = parser.parse_args()
+countdown = int(args.count)
+min_offline_time = args.older
+debug = 0
+
+if args.pid and int(args.pid) <= 0:
+    print("specified task pid should be greater than 0.")
+    exit(-1)
+
+# define BPF program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <linux/sched.h> /* For TASK_COMM_LEN */
+#include <linux/memcontrol.h> /* For mem_cgroup_from_css */
+
+#define MAX_NAME_LEN	(256)
+
+typedef struct memcg_info {
+    u64 online_ts;
+    u64 offline_ts;
+    u32 pid;
+    u8 offline;
+    char comm[TASK_COMM_LEN];
+    char name[MAX_NAME_LEN];
+    u64 memcg_ptr;
+} memcg_info_t;
+
+BPF_HASH(offline_memcg_info, u64, memcg_info_t);
+
+static int cmp_comms(const char *comm1, const char *comm2, int len)
+{
+    unsigned char n1, n2;
+    while (len-- > 0) {
+        n1 = *comm1++;
+        n2 = *comm2++;
+        if (n1 != n2)
+            return n1 - n2;
+        if (!n1)
+            break;
+    }
+    return 0;
+}
+
+int mem_cgroup_css_online_probe(struct pt_regs *ctx,
+                                struct cgroup_subsys_state *css)
+{
+    struct kernfs_node *kn;
+    struct mem_cgroup *memcg_ptr = (struct mem_cgroup *)PT_REGS_PARM1(ctx);
+    memcg_info_t memcg_val = {};
+    memcg_val.pid = bpf_get_current_pid_tgid() >> 32;
+    FILTER_PID
+    bpf_get_current_comm(&memcg_val.comm, sizeof(memcg_val.comm));
+    FILTER_COMM
+    kn = memcg_ptr->css.cgroup->kn;
+    bpf_probe_read_kernel_str(&memcg_val.name,
+                              sizeof(memcg_val.name), kn->name);
+    memcg_val.offline = 0;
+    memcg_val.memcg_ptr = (u64)memcg_ptr;
+    memcg_val.online_ts = bpf_ktime_get_ns();
+    offline_memcg_info.update(&memcg_val.memcg_ptr, &memcg_val);
+    return 0;
+}
+
+int mem_cgroup_css_offline_probe(struct pt_regs *ctx,
+                                 struct cgroup_subsys_state *css)
+{
+    u64 memcg_ptr = (u64)PT_REGS_PARM1(ctx);
+    memcg_info_t *memcg_val_p = offline_memcg_info.lookup(&memcg_ptr);
+    if (memcg_val_p == 0) {
+        return 0; //data absent
+    }
+    memcg_val_p->offline = 1;
+    memcg_val_p->offline_ts = bpf_ktime_get_ns();
+    return 0;
+}
+
+int mem_cgroup_css_free_probe(struct pt_regs *ctx,
+                              struct cgroup_subsys_state *css)
+{
+    u64 memcg_ptr = (u64)PT_REGS_PARM1(ctx);
+    offline_memcg_info.delete(&memcg_ptr);
+    return 0;
+}
+"""
+
+# code substitutions
+if args.pid:
+    filter_pid_text = """
+    if (memcg_val.pid != %d) {
+        return 0;
+    }
+    """ % (args.pid)
+    bpf_text = bpf_text.replace('FILTER_PID', filter_pid_text)
+else:
+    bpf_text = bpf_text.replace('FILTER_PID', '')
+
+if args.comm:
+    filter_comm_text = """
+    if (cmp_comms(memcg_val.comm, "%s", TASK_COMM_LEN)) {
+        return 0;
+    }
+    """ % (args.comm)
+    bpf_text = bpf_text.replace('FILTER_COMM', filter_comm_text)
+else:
+    bpf_text = bpf_text.replace('FILTER_COMM', '')
+
+# load BPF program
+b = BPF(text=bpf_text)
+b.attach_kprobe(event="mem_cgroup_css_online",
+                fn_name="mem_cgroup_css_online_probe")
+b.attach_kprobe(event="mem_cgroup_css_offline",
+                fn_name="mem_cgroup_css_offline_probe")
+b.attach_kprobe(event="mem_cgroup_css_free",
+                fn_name="mem_cgroup_css_free_probe")
+
+print("Show zombie memcgroups at specified intervals... Hit Ctrl-C to end.")
+
+# header
+print(f'{"MEMCG":<20} {"NAME":<22} {"COMM":<16} {"PID":<8} {"AGE(secs)":<8}')
+# output
+exiting = 0 if args.interval else 1
+memcgs = b["offline_memcg_info"]
+while (1):
+    try:
+        sleep(int(args.interval))
+    except KeyboardInterrupt:
+        exiting = 1
+
+    print()
+    for address, info in sorted(memcgs.items(),
+                                key=lambda memcgs: memcgs[1].offline_ts):
+        try:
+            if not info.offline:
+                continue
+            curr_time = BPF.monotonic_time()
+            offline_age = (curr_time - info.offline_ts) // 1000000000
+            if offline_age < min_offline_time:
+                continue
+            print("0x%-18x %-22s %-16s %-8d %-8d" %
+                    (address.value, info.name.decode()[:22],
+                     info.comm.decode()[:16], info.pid,
+                     offline_age))
+        except KeyboardInterrupt:
+            exiting = 1
+
+    countdown -= 1
+    if exiting or countdown == 0:
+        exit()

--- a/tools/zombiememcgstat_example.txt
+++ b/tools/zombiememcgstat_example.txt
@@ -1,0 +1,190 @@
+Demonstrations of zombiememcgstat, the Linux eBPF/bcc version.
+
+zombiememcgstat traces and matches the creation and destruction of memory
+cgroup(memcg) related objects in the kernel and using this information it
+tracks and reports zombie memcgs.
+For example:
+# ./zombiememcgstat.py
+Show zombie memcgroups at specified intervals... Hit Ctrl-C to end.
+MEMCG                NAME                   COMM             PID      AGE(secs)
+
+
+
+0xffff9efd798ce000   session-8047.scope     systemd          1        84
+0xffff9f017b3c3000   session-8049.scope     systemd          1        84
+0xffff9f06bd247000   session-8054.scope     systemd          1        83
+0xffff9eff7b553000   session-8060.scope     systemd          1        82
+0xffff9efdbfd58000   session-8065.scope     systemd          1        81
+0xffff9efd7e9db000   session-8070.scope     systemd          1        80
+0xffff9f05bbdcc000   session-8076.scope     systemd          1        79
+0xffff9f037f493000   session-8081.scope     systemd          1        78
+0xffff9f073f484000   dummy                  python3          473782   66
+0xffff9f073f481000   dummy                  python3          473782   66
+0xffff9f00bea49000   dummy                  python3          473782   66
+0xffff9f00bea4e000   dummy                  python3          473782   66
+0xffff9f00bea4c000   dummy                  python3          473782   66
+
+When a memcg is removed from user space (e.g. rmdir /sys/fs/cgroup/memory/foo),
+memcg related kernel objects are not necessarily freed right away and can exist
+in memory as long as some page(s) (charged earlier for the now offline memcg)
+hold a refcount to it.
+Such memcg(s) are called zombie memcgs. Due to significant memory footprint
+(100s of KBs on systems with > 100 cpus) of memcg related kernel objects,
+zombie memcgs can waste lots of memory.
+zombiememcgstat attaches probes to kernel functions that gets invoked
+when a memcg becomes online, offline and when corresponding kernel
+objects are freed. So for each unique memcg, using a mem_cgroup pointer as
+key,it tracks the time when memcg was created/became online, the time when it
+was removed/became offline and the time when the mem_cgroup object was freed
+(last step in destruction of memcg related kernel objects).
+If a memcg has not been offlined yet, it is still active and needs no
+reporting. If a memcg has been offlined and its kernel objects have been freed
+as well, it too needs no reporting. But if a memcg has been offlined and its
+kernel objects still exist, then it is a zombie memcg and needs reporting.
+zombiememcgstat reports such memcgs. As shown in the above example, the
+information provided consists of pointer to corresponding mem_cgroup object
+(MEMCG), name of memory cgroup(NAME), name(COMM) and pid(PID) of task that
+created it and the time difference between the current time and the time at
+which it was offlined(AGE(secs)). This is the duration for which this memcg has
+existed as zombie.
+
+By default, zombiememcgstat prints its output every 30 secs. But you can
+change this by passing interval as positional parameter and you can also
+control the number of times the output will be printed before exiting.
+For example:
+
+# ./zombiememcgstat.py 30 5
+
+...will print the zombie memcg information, every 30 secs, for 5 times and
+then exit.
+
+zombie memcgs that don't last for long can be ignored usually, because they
+don't hold system memory for long. Hence, zombiememcg stat by default shows
+only those zombie memcgs that have were removed (have been offline for)
+more than 30 secs ago.
+So while specifying output interval one needs to be aware of this.
+For example:
+
+# ./zombiememcgstat.py 5 5
+
+...will print only 5 blank lines because during its entire run time of 25
+secs, it will not find any zombie memcg that has been offlined for more
+than 30 secs.
+
+One can change the offline duration threshold using the -o switch.
+For example:
+
+# ./zombiememcgstat.py -o 120 130
+
+... will print its output every 130 secs and it will show only those zombie
+memcgs that have been offline for more than 120 secs, as shown below:
+
+# ./zombiememcgstat.py -o 120 130
+Show zombie memcgroups at specified intervals... Hit Ctrl-C to end.
+MEMCG                NAME                   COMM             PID      AGE(secs)
+
+
+0xffff9f02bdbf4000   pmie_check.service     systemd          1        218
+0xffff9f06bd3cd000   pmie_farm_check.servic systemd          1        218
+0xffff9f0276548000   session-11465.scope    systemd          1        218
+0xffff9f06bd3c8000   session-11467.scope    systemd          1        218
+0xffff9f06bd1a2000   session-11472.scope    systemd          1        217
+0xffff9efbfafbf000   session-11473.scope    systemd          1        217
+0xffff9efcffaa3000   session-11474.scope    systemd          1        217
+
+0xffff9f02bdbf4000   pmie_check.service     systemd          1        348
+0xffff9f06bd3cd000   pmie_farm_check.servic systemd          1        348
+0xffff9f0276548000   session-11465.scope    systemd          1        348
+0xffff9f06bd3c8000   session-11467.scope    systemd          1        348
+0xffff9efbfafbf000   session-11473.scope    systemd          1        347
+0xffff9efcffaa3000   session-11474.scope    systemd          1        347
+0xffff9f02bdbf0000   sysstat-collect.servic systemd          1        248
+0xffff9efbfaf5a000   user-runtime-dir@0.ser systemd          1        222
+0xffff9f05bf768000   session-c3388.scope    systemd          1        222
+0xffff9f03bbf80000   init.scope             systemd          605258   212
+0xffff9f06bf2bb000   user@0.service         systemd          1        212
+
+Usually cgroup creation and management is done by systemd, but if you have
+some application doing cgroup creation/removal, you can track memcgroups
+created by a particular pid using -p switch.
+For example:
+
+# ./zombiememcgstat.py -p 1
+Show zombie memcgroups at specified intervals... Hit Ctrl-C to end.
+MEMCG                NAME                   COMM             PID      AGE(secs)
+
+
+
+0xffff9f06bd3ca000   session-11455.scope    systemd          1        67
+0xffff9f06bd3cc000   session-11457.scope    systemd          1        67
+0xffff9efbfaf5e000   session-11458.scope    systemd          1        67
+0xffff9f04be4ab000   session-11459.scope    systemd          1        67
+0xffff9f06bd335000   session-11460.scope    systemd          1        66
+0xffff9f06bd336000   session-11461.scope    systemd          1        66
+0xffff9f06bd2b0000   session-11462.scope    systemd          1        66
+0xffff9f06bd2b3000   session-11463.scope    systemd          1        66
+0xffff9f06bd333000   session-11464.scope    systemd          1        66
+
+0xffff9f06bd3ca000   session-11455.scope    systemd          1        97
+0xffff9f06bd3cc000   session-11457.scope    systemd          1        97
+0xffff9efbfaf5e000   session-11458.scope    systemd          1        97
+0xffff9f04be4ab000   session-11459.scope    systemd          1        97
+0xffff9f06bd335000   session-11460.scope    systemd          1        96
+0xffff9f06bd336000   session-11461.scope    systemd          1        96
+
+shows all cgroups created by pid 1 i.e. systemd (usually).
+
+Similarly using -c switch, one can track all zombie memcgs created by
+a task of particular name(comm).
+For example:
+
+# ./zombiememcgstat.py -c python3
+Show zombie memcgroups at specified intervals... Hit Ctrl-C to end.
+MEMCG                NAME                   COMM             PID      AGE(secs)
+
+
+
+0xffff9f06bd1b3000   dummy                  python3          603701   86
+0xffff9efdfe4f6000   dummy                  python3          603701   86
+0xffff9efdfe4f4000   dummy                  python3          603701   86
+0xffff9efdba624000   dummy                  python3          603701   86
+0xffff9efdba621000   dummy                  python3          603701   86
+
+0xffff9f06bd1b3000   dummy                  python3          603701   116
+0xffff9efdfe4f6000   dummy                  python3          603701   116
+0xffff9efdfe4f4000   dummy                  python3          603701   116
+0xffff9efdba624000   dummy                  python3          603701   116
+
+shows all cgroups created by a python script.
+
+USAGE message:
+
+# ./zombiememcgstat.py -h
+usage: zombiememcgstat.py [-h] [-p PID] [-c COMM] [-o OLDER]
+                          [interval] [count]
+
+    Zombie memory cgroups (memcgs) are cgroups that have  been removed
+    from user space but still exist in kernel space due to non-zero refcounts.
+    List such zombie memcgs on a system along with their creator and
+    offline duration.
+
+
+positional arguments:
+  interval              output interval, in seconds
+  count                 number of outputs
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PID, --pid PID     show zombie memcgs created by specified pid
+  -c COMM, --comm COMM  show zombie memcgs created by specified comm
+  -o OLDER, --older OLDER
+                        show zombie memcgs that are offline for more than
+                        these many secs.
+
+examples:
+    ./zombiememcgstat            # list all zombie memcgs at 30 secs interval
+    ./zombiememcgstat 5          # list all zombie memcgs at 5 secs interval
+    ./zombiememcgstat 30 10      # print 30 second summaries, 10 times
+    ./zombiememcgstat -p 1       # list zombie memcgs created by pid 1
+    ./zombiememcgstat -c systemd # list zombie memcgs created by systemd
+    ./zombiememcgstat -o 600     # list zombie memcgs older than 600 secs


### PR DESCRIPTION
This tool reports zombie memory cgroups of a system and hence helps in avoiding memory wastage caused by zombie memory cgroups.