### PR TITLE
Drop support for LLVM 10 and below

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if(NOT PYTHON_ONLY)
 
     # clang is linked as a library, but the library path searching is
     # primitively supported, unlike libLLVM
-    set(CLANG_SEARCH "/opt/local/llvm/lib;/usr/lib/llvm-3.7/lib;${LLVM_LIBRARY_DIRS}")
+    set(CLANG_SEARCH "/opt/local/llvm/lib;${LLVM_LIBRARY_DIRS}")
     find_library(libclangAnalysis NAMES clangAnalysis clang-cpp HINTS ${CLANG_SEARCH})
     find_library(libclangAST NAMES clangAST clang-cpp HINTS ${CLANG_SEARCH})
     find_library(libclangBasic NAMES clangBasic clang-cpp HINTS ${CLANG_SEARCH})

--- a/cmake/clang_libs.cmake
+++ b/cmake/clang_libs.cmake
@@ -2,7 +2,7 @@ if(ENABLE_LLVM_SHARED)
 set(llvm_libs "LLVM")
 else()
 set(llvm_raw_libs bitwriter bpfcodegen debuginfodwarf irreader linker
-  mcjit objcarcopts option passes lto)
+  mcjit objcarcopts option passes lto bpfasmparser bpfdisassembler)
 if(ENABLE_LLVM_NATIVECODEGEN)
 set(llvm_raw_libs ${llvm_raw_libs} nativecodegen)
 endif()
@@ -17,10 +17,6 @@ endif()
 list(FIND LLVM_AVAILABLE_LIBS "LLVMFrontendOpenMP" _llvm_frontendOpenMP)
 if (${_llvm_frontendOpenMP} GREATER -1)
   list(APPEND llvm_raw_libs frontendopenmp)
-endif()
-if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 6 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 6)
-  list(APPEND llvm_raw_libs bpfasmparser)
-  list(APPEND llvm_raw_libs bpfdisassembler)
 endif()
 if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 15 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 15)
   list(APPEND llvm_raw_libs windowsdriver)
@@ -43,11 +39,8 @@ else()
 set(clang_libs
   ${libclangFrontend}
   ${libclangSerialization}
-  ${libclangDriver})
-
-if (${LLVM_PACKAGE_VERSION} VERSION_EQUAL 8 OR ${LLVM_PACKAGE_VERSION} VERSION_GREATER 8)
-  list(APPEND clang_libs ${libclangASTMatchers})
-endif()
+  ${libclangDriver}
+  ${libclangASTMatchers})
 
 list(APPEND clang_libs
   ${libclangParse}

--- a/src/cc/bcc_debug.h
+++ b/src/cc/bcc_debug.h
@@ -29,14 +29,6 @@ class SourceDebugger {
         prog_func_info_(prog_func_info),
         mod_src_(mod_src),
         src_dbg_fmap_(src_dbg_fmap) {}
-// Only support dump for llvm 6.x and later.
-//
-// The llvm 5.x, but not earlier versions, also supports create
-// a dwarf context for source debugging based
-// on a set of in-memory sections with slightly different interfaces.
-// FIXME: possibly to support 5.x
-//
-#if LLVM_VERSION_MAJOR >= 6
   void dump();
 
  private:
@@ -47,10 +39,6 @@ class SourceDebugger {
                    uint32_t &CurrentSrcLine, llvm::raw_ostream &os);
   void getDebugSections(
       llvm::StringMap<std::unique_ptr<llvm::MemoryBuffer>> &DebugSections);
-#else
-  void dump() {
-  }
-#endif
 
  private:
   llvm::Module *mod_;

--- a/src/cc/frontends/clang/b_frontend_action.cc
+++ b/src/cc/frontends/clang/b_frontend_action.cc
@@ -758,11 +758,7 @@ bool ProbeVisitor::IsContextMemberExpr(Expr *E) {
 
 SourceRange
 ProbeVisitor::expansionRange(SourceRange range) {
-#if LLVM_VERSION_MAJOR >= 7
   return rewriter_.getSourceMgr().getExpansionRange(range).getAsRange();
-#else
-  return rewriter_.getSourceMgr().getExpansionRange(range);
-#endif
 }
 
 SourceLocation
@@ -1431,11 +1427,7 @@ bool BTypeVisitor::VisitImplicitCastExpr(ImplicitCastExpr *E) {
 
 SourceRange
 BTypeVisitor::expansionRange(SourceRange range) {
-#if LLVM_VERSION_MAJOR >= 7
   return rewriter_.getSourceMgr().getExpansionRange(range).getAsRange();
-#else
-  return rewriter_.getSourceMgr().getExpansionRange(range);
-#endif
 }
 
 template <unsigned N>
@@ -1454,17 +1446,10 @@ int64_t BTypeVisitor::getFieldValue(VarDecl *Decl, FieldDecl *FDecl, int64_t Ori
   unsigned idx = FDecl->getFieldIndex();
 
   if (auto I = dyn_cast_or_null<InitListExpr>(Decl->getInit())) {
-#if LLVM_VERSION_MAJOR >= 8
     Expr::EvalResult res;
     if (I->getInit(idx)->EvaluateAsInt(res, C)) {
       return res.Val.getInt().getExtValue();
     }
-#else
-    llvm::APSInt res;
-    if (I->getInit(idx)->EvaluateAsInt(res, C)) {
-      return res.getExtValue();
-    }
-#endif
   }
 
   return OrigFValue;
@@ -1871,17 +1856,10 @@ void BFrontendAction::EndSourceFileAction() {
 
   if (flags_ & DEBUG_PREPROCESSOR)
     rewriter_->getEditBuffer(rewriter_->getSourceMgr().getMainFileID()).write(llvm::errs());
-#if LLVM_VERSION_MAJOR >= 9
+
   llvm::raw_string_ostream tmp_os(mod_src_);
   rewriter_->getEditBuffer(rewriter_->getSourceMgr().getMainFileID())
       .write(tmp_os);
-#else
-  if (flags_ & DEBUG_SOURCE) {
-    llvm::raw_string_ostream tmp_os(mod_src_);
-    rewriter_->getEditBuffer(rewriter_->getSourceMgr().getMainFileID())
-        .write(tmp_os);
-  }
-#endif
 
   for (auto func : func_range_) {
     auto f = func.first;

--- a/src/cc/frontends/clang/frontend_action_common.h
+++ b/src/cc/frontends/clang/frontend_action_common.h
@@ -15,10 +15,5 @@
  */
 #include <llvm/Config/llvm-config.h>
 
-#if LLVM_VERSION_MAJOR >= 8
 #define GET_BEGINLOC(E)  ((E)->getBeginLoc())
 #define GET_ENDLOC(E)  ((E)->getEndLoc())
-#else
-#define GET_BEGINLOC(E)  ((E)->getLocStart())
-#define GET_ENDLOC(E)    ((E)->getLocEnd())
-#endif

--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -179,13 +179,7 @@ static int CreateFromArgs(clang::CompilerInvocation &invocation,
                           const llvm::opt::ArgStringList &ccargs,
                           clang::DiagnosticsEngine &diags)
 {
-#if LLVM_VERSION_MAJOR >= 10
   return clang::CompilerInvocation::CreateFromArgs(invocation, ccargs, diags);
-#else
-  return clang::CompilerInvocation::CreateFromArgs(
-              invocation, const_cast<const char **>(ccargs.data()),
-              const_cast<const char **>(ccargs.data()) + ccargs.size(), diags);
-#endif
 }
 
 }
@@ -288,13 +282,10 @@ int ClangLoader::parse(
   vector<string> kflags;
   if (kbuild_helper.get_flags(un.machine, &kflags))
     return -1;
-#if LLVM_VERSION_MAJOR >= 9
+
   flags_cstr.push_back("-g");
   flags_cstr.push_back("-gdwarf-4");
-#else
-  if (flags_ & DEBUG_SOURCE)
-    flags_cstr.push_back("-g");
-#endif
+
   for (auto it = kflags.begin(); it != kflags.end(); ++it)
     flags_cstr.push_back(it->c_str());
 
@@ -416,10 +407,8 @@ int ClangLoader::do_compile(
   string target_triple = get_clang_target();
   driver::Driver drv("", target_triple, diags);
 
-#if LLVM_VERSION_MAJOR >= 4
   if (target_triple == "x86_64-unknown-linux-gnu" || target_triple == "aarch64-unknown-linux-gnu")
     flags_cstr.push_back("-fno-jump-tables");
-#endif
 
   drv.setTitle("bcc-clang-driver");
   drv.setCheckInputsExist(false);


### PR DESCRIPTION
It has been 3 years since Dave propose to bump minimun LLVM version to 11.
The CI is ready. So let's move on.

Closes #3808.