### PR TITLE
libbpf-tools/klockstat: Search for correct stack offset when printing

### DIFF
--- a/libbpf-tools/klockstat.bpf.c
+++ b/libbpf-tools/klockstat.bpf.c
@@ -95,17 +95,7 @@ static void lock_contended(void *ctx, void *lock)
 
 	li->task_id = task_id;
 	li->lock_ptr = (u64)lock;
-	/*
-	 * Skip 4 frames, e.g.:
-	 *       __this_module+0x34ef
-	 *       __this_module+0x34ef
-	 *       __this_module+0x8c44
-	 *             mutex_lock+0x5
-	 *
-	 * Note: if you make major changes to this bpf program, double check
-	 * that you aren't skipping too many frames.
-	 */
-	li->stack_id = bpf_get_stackid(ctx, &stack_map, 4 | BPF_F_FAST_STACK_CMP);
+	li->stack_id = bpf_get_stackid(ctx, &stack_map, BPF_F_FAST_STACK_CMP);
 
 	/* Legit failures include EEXIST */
 	if (li->stack_id < 0)


### PR DESCRIPTION
The klockstat BPF code contains a hard-coded offset (of 4) for the
captured stack entries, which is supposed to get rid of the topmost
entries that are just locking functions. However, when running the
klockstat tool on RHEL, this offset is not correct, leading to output
like the following:

                               Caller  Avg Wait    Count   Max Wait   Total Wait
                       mutex_lock+0x5    1.1 us        3     1.8 us       3.2 us
                       mutex_lock+0x5    825 ns        5     1.6 us       4.1 us
                       mutex_lock+0x5    1.1 us        4     1.5 us       4.3 us

                               Caller  Avg Hold    Count   Max Hold   Total Hold
                       mutex_lock+0x5   18.0 ms        3    23.0 ms      54.0 ms
                       mutex_lock+0x5    1.7 ms       15     2.2 ms      25.1 ms
                       mutex_lock+0x5    1.7 ms       15     2.2 ms      25.1 ms

To fix this, add logic in the userspace component of the utility to
walk the stack frames, skipping any entries that correspond to any of
the kprobe hooks that the tool attaches to. This fixes the output
on RHEL, without affecting other systems where the offset works
correctly.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>