### PR TITLE
libbpf-tools/opensnoop: Display mode for extended fields

### DIFF
--- a/libbpf-tools/opensnoop.h
+++ b/libbpf-tools/opensnoop.h
@@ -9,6 +9,7 @@
 struct args_t {
 	const char *fname;
 	int flags;
+	__u32 mode;
 };
 
 struct event {
@@ -18,6 +19,7 @@ struct event {
 	uid_t uid;
 	int ret;
 	int flags;
+	__u32 mode;
 	__u64 callers[2];
 	char comm[TASK_COMM_LEN];
 	char fname[NAME_MAX];


### PR DESCRIPTION
Do the same thing of [1] and add tracepoint/syscalls/sys_enter_openat2 support.

Link: https://github.com/iovisor/bcc/commit/e80ad4d859d4f6bf16709cb664c97f41e3136558 [1]