### PR TITLE
libbpf-tools/softirqs: Fix logarithmic calculation issue

### DIFF
--- a/libbpf-tools/softirqs.bpf.c
+++ b/libbpf-tools/softirqs.bpf.c
@@ -66,7 +66,7 @@ static int handle_exit(unsigned int vec_nr)
 		u64 slot;
 
 		hist = &hists[vec_nr];
-		slot = log2(delta);
+		slot = log2l(delta);
 		if (slot >= MAX_SLOTS)
 			slot = MAX_SLOTS - 1;
 		__sync_fetch_and_add(&hist->slots[slot], 1);


### PR DESCRIPTION
Should use log2l.
When there is a function call, R1 unbounded memory access problem occurs, so inline is used.