### PR TITLE
bcc-lua: enable deterministic bytecode generation

### DIFF
--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -15,7 +15,7 @@ if (LUAJIT_LIBRARIES AND LUAJIT)
 
 	ADD_CUSTOM_COMMAND(
 		OUTPUT bcc.o
-		COMMAND ${LUAJIT} -bg bcc.lua bcc.o
+		COMMAND ${LUAJIT} -bgd bcc.lua bcc.o
 		DEPENDS bcc.lua
 	)
 


### PR DESCRIPTION
LuaJIT does not generate bytecode deterministically by default, which makes the build of bcc-lua unreproducible. However, support for deterministic bytecode was added to LuaJIT some time ago. This change enables it for bcc-lua.

- https://bugzilla.suse.com/show_bug.cgi?id=1236871
- https://github.com/LuaJIT/LuaJIT/issues/1008
- https://reproducible-builds.org/