### PR TITLE
New examples/tracing/setuid_monitor.py: Fix #5211

### DIFF
--- a/examples/tracing/setuid_monitor.py
+++ b/examples/tracing/setuid_monitor.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+#
+# setuid_monitor    A setuid syscall monitor, as the example of
+#                   utilizing kernel tracepoint.
+#
+# Test by running the code. Meanwhile, run any command that introduces
+# the setuid syscall, such as su, sudo, passwd, etc.
+#
+# Copyright 2025 HardenedLinux
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+from __future__ import print_function
+from bcc import BPF
+from bcc.utils import printb
+
+# define BPF program
+b = BPF(text="""
+#include <linux/sched.h>
+
+// define output data structure in C
+struct data_t {
+    u32 pid;
+    u32 uid;
+    u64 ts;
+    char comm[TASK_COMM_LEN];
+};
+BPF_PERF_OUTPUT(events);
+
+TRACEPOINT_PROBE(syscalls, sys_enter_setuid) {
+    struct data_t data = {};
+
+    // Check /sys/kernel/debug/tracing/events/syscalls/sys_enter_setuid/format
+    // for the args format
+    data.uid = args->uid;
+    data.ts = bpf_ktime_get_ns();
+    data.pid = bpf_get_current_pid_tgid();
+    bpf_get_current_comm(&data.comm, sizeof(data.comm));
+
+    events.perf_submit(args, &data, sizeof(data));
+
+    return 0;
+}
+""")
+
+# header
+print("%-14s %-12s %-6s %s" % ("TIME(s)", "COMMAND", "PID", "UID"))
+
+def print_event(cpu, data, size):
+    event = b["events"].event(data)
+    printb(b"%-14.3f %-12s %-6d %d" % ((event.ts/1000000000), 
+           event.comm, event.pid, event.uid))
+
+# loop with callback to print_event
+b["events"].open_perf_buffer(print_event)
+while 1:
+    try:
+        b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        exit()

--- a/examples/tracing/setuid_monitor_example.txt
+++ b/examples/tracing/setuid_monitor_example.txt
@@ -1,0 +1,28 @@
+Examples of setuid_monitor.py, the Linux eBPF/bcc version.
+
+
+To demonstrate this, run following or other commands in which setuid are
+involved:
+
+# su
+# sudo
+# passwd
+
+While setuid_monitor.py was tracing in another session:
+
+# ./setuid_monitor.py
+TIME(s)            COMM             PID    UID
+7615.997           su               2989   0
+7616.005           su               2990   0
+7616.008           su               2991   0
+7621.446           passwd           3008   0
+7624.655           passwd           3009   0
+7624.664           passwd           3010   0
+7629.624           master           1262   0
+7640.942           sudo             3012   0
+
+The UID here is the target User ID that setuid trys to elevate the
+executable's privilege to.
+
+This program was written as a simplified demonstration of tracing a
+tracepoint.

--- a/examples/tracing/urandomread.py
+++ b/examples/tracing/urandomread.py
@@ -4,6 +4,7 @@
 #              For Linux, uses BCC, BPF. Embedded C.
 #
 # REQUIRES: Linux 4.7+ (BPF_PROG_TYPE_TRACEPOINT support).
+#               < 5.18 (urandom_read tracepoint removed).
 #
 # Test by running this, then in another shell, run:
 #     dd if=/dev/urandom of=/dev/null bs=1k count=5


### PR DESCRIPTION
Fix issue #5211 

Add new examples/tracing/setuid_monitor.py as a demonstration of the usage of `TRACEPOINT_PROBE`, for examples/tracing/urandomread.py does not work since kernel 5.18 in which `tracepoint/random/urandom_read` [has been removed](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=99dea2c664d7bc7e4f6f6947182d0d365165a998).

The tutorial and document are modified accordingly.

Note: examples/tracing/urandomread.py is kept because some long-term kernel versions are still in maintenance, so the code still works.