### PR TITLE
libbpf-tools: signoop: Support real-time signals

### DIFF
--- a/libbpf-tools/sigsnoop.c
+++ b/libbpf-tools/sigsnoop.c
@@ -63,6 +63,39 @@ static const char *sig_name[] = {
 	[29] = "SIGIO",
 	[30] = "SIGPWR",
 	[31] = "SIGSYS",
+	[32] = "SIGNAL-32", /* SIGRTMIN in kernel */
+	[33] = "SIGNAL-33",
+	[34] = "SIGNAL-34",
+	[35] = "SIGNAL-35",
+	[36] = "SIGNAL-36",
+	[37] = "SIGNAL-37",
+	[38] = "SIGNAL-38",
+	[39] = "SIGNAL-39",
+	[40] = "SIGNAL-40",
+	[41] = "SIGNAL-41",
+	[42] = "SIGNAL-42",
+	[43] = "SIGNAL-43",
+	[44] = "SIGNAL-44",
+	[45] = "SIGNAL-45",
+	[46] = "SIGNAL-46",
+	[47] = "SIGNAL-47",
+	[48] = "SIGNAL-48",
+	[49] = "SIGNAL-49",
+	[50] = "SIGNAL-50",
+	[51] = "SIGNAL-51",
+	[52] = "SIGNAL-52",
+	[53] = "SIGNAL-53",
+	[54] = "SIGNAL-54",
+	[55] = "SIGNAL-55",
+	[56] = "SIGNAL-56",
+	[57] = "SIGNAL-57",
+	[58] = "SIGNAL-58",
+	[59] = "SIGNAL-59",
+	[60] = "SIGNAL-60",
+	[61] = "SIGNAL-61",
+	[62] = "SIGNAL-62",
+	[63] = "SIGNAL-63",
+	[64] = "SIGNAL-64", /* SIGRTMAX */
 };
 
 const char *argp_program_version = "sigsnoop 0.1";
@@ -172,10 +205,10 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	tm = localtime(&t);
 	strftime(ts, sizeof(ts), "%H:%M:%S", tm);
 	if (signal_name && e->sig < ARRAY_SIZE(sig_name))
-		printf("%-8s %-7d %-16s %-9s %-7d %-6d\n",
+		printf("%-8s %-7d %-16s %-12s %-7d %-6d\n",
 		       ts, e->pid, e->comm, sig_name[e->sig], e->tpid, e->ret);
 	else
-		printf("%-8s %-7d %-16s %-9d %-7d %-6d\n",
+		printf("%-8s %-7d %-16s %-12d %-7d %-6d\n",
 		       ts, e->pid, e->comm, e->sig, e->tpid, e->ret);
 }
 
@@ -248,7 +281,7 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	printf("%-8s %-7s %-16s %-9s %-7s %-6s\n",
+	printf("%-8s %-7s %-16s %-12s %-7s %-6s\n",
 	       "TIME", "PID", "COMM", "SIG", "TPID", "RESULT");
 
 	while (!exiting) {


### PR DESCRIPTION
For example:

    $ sudo ./sigsnoop --name
    TIME     PID     COMM             SIG          TPID    RESULT
    10:09:34 431623  SIGRTMAX         SIGRTMIN+15  431623  0
    10:09:36 0       swapper/6        SIGRTMIN     2610    0
    10:13:46 0       swapper/11       SIGRTMIN     2610    0
    10:13:47 432111  SIGRTMAX         SIGRTMAX-10  432111  0

The test program:

```c
#include <stdio.h>
#include <signal.h>
#include <unistd.h>
#include <errno.h>

#define LIBC_SIGRTMIN		(__libc_current_sigrtmin())
#define LIBC_SIGRTMAX		(__libc_current_sigrtmax())

void handler(int sig, siginfo_t *si, void *context)
{
	printf("Received signal %d with value %d\n", sig, si->si_value.sival_int);
}

int main(int argc, char *argv[])
{
	struct sigaction sa;
	sigset_t mask;
	int rtoff = 20;

	printf("SIGRTMIN = %d, LIBC_SIGRTMIN = %d\n", SIGRTMIN, LIBC_SIGRTMIN);
	printf("SIGRTMAX = %d, LIBC_SIGRTMAX = %d\n", SIGRTMAX, LIBC_SIGRTMAX);

	/* Set up signal handler */
	sa.sa_flags = SA_SIGINFO;
	sa.sa_sigaction = handler;
	sigemptyset(&sa.sa_mask);
	sigaction(SIGRTMIN + rtoff, &sa, NULL);

	/* Block the signal temporarily */
	sigemptyset(&mask);
	sigaddset(&mask, SIGRTMIN + rtoff);
	sigprocmask(SIG_SETMASK, &mask, NULL);

	/* Send a real-time signal with additional data */
	union sigval sv;
	sv.sival_int = 520;
	sigqueue(getpid(), SIGRTMIN + rtoff, sv);

	/* Unblock the signal */
	sigprocmask(SIG_UNBLOCK, &mask, NULL);

	/* Wait for signal to be handled */
	printf("Press ctrl-C to end.\n");
	pause();

	return 0;
}
```