### PR TITLE
WIP: Remove dependency on kallsyms with eBPF

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -8,7 +8,7 @@ BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
 LIBBPF_SRC := $(abspath ../src/cc/libbpf/src)
 LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
 LIBBLAZESYM_SRC := $(abspath blazesym/target/release/libblazesym.a)
-INCLUDES := -I$(OUTPUT) -I../src/cc/libbpf/include/uapi
+INCLUDES := -I$(OUTPUT) -I../src/cc/libbpf/include/uapi -I/usr/include/x86_64-linux-gnu/
 CFLAGS := -g -O2 -Wall -Wmissing-field-initializers -Werror -Werror=undef
 BPFCFLAGS := -g -O2 -Wall -Werror=undef
 BPFCFLAGS_softirqs := $(BPFCFLAGS) -mcpu=v3
@@ -138,6 +138,8 @@ all: $(APPS) $(APP_ALIASES)
 ifeq ($(V),1)
 Q =
 msg =
+CFLAGS += -v
+BPFCFLAGS += -v
 else
 Q = @
 msg = @printf '  %-8s %s%s\n' "$(1)" "$(notdir $(2))" "$(if $(3), $(3))";

--- a/libbpf-tools/profile.c
+++ b/libbpf-tools/profile.c
@@ -18,6 +18,7 @@
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
 #include <sys/stat.h>
+#include <sys/sdt.h>
 #include "profile.h"
 #include "profile.skel.h"
 #include "trace_helpers.h"
@@ -99,7 +100,6 @@ const char argp_program_doc[] =
 "EXAMPLES:\n"
 "    profile             # profile stack traces at 49 Hertz until Ctrl-C\n"
 "    profile -F 99       # profile stack traces at 99 Hertz\n"
-"    profile -c 1000000  # profile stack traces every 1 in a million events\n"
 "    profile 5           # profile at 49 Hertz for 5 seconds only\n"
 "    profile -f          # output in folded format for flame graphs\n"
 "    profile -p 185      # only profile process with PID 185\n"
@@ -128,7 +128,6 @@ static const struct argp_option opts[] = {
 	{},
 };
 
-struct ksyms *ksyms;
 struct syms_cache *syms_cache;
 struct syms *syms;
 static char syminfo[SYM_INFO_LEN];
@@ -324,16 +323,16 @@ static int read_counts_map(int fd, struct key_ext_t *items, __u32 *count)
 	return 0;
 }
 
-static const char *ksymname(unsigned long addr)
+static const char *ksymname(unsigned long addr, int ksym_map)
 {
-	const struct ksym *ksym = ksyms__map_addr(ksyms, addr);
+	static char name[MAX_SYM_LEN];
+	int err = bpf_map_lookup_elem(ksym_map, &addr, name);
 
 	if (!env.verbose)
-		return ksym ? ksym->name : "[unknown]";
+		return !err ? name : "[unknown]";
 
-	if (ksym)
-		snprintf(syminfo, SYM_INFO_LEN, "0x%lx %s+0x%lx", addr,
-			 ksym->name, addr - ksym->addr);
+	if (!err)
+		snprintf(syminfo, SYM_INFO_LEN, "0x%lx %s", addr, name);
 	else
 		snprintf(syminfo, SYM_INFO_LEN, "0x%lx [unknown]", addr);
 
@@ -381,7 +380,6 @@ static void print_stacktrace(unsigned long *ip, symname_fn_t symname, struct fmt
 	if (!f->folded) {
 		for (i = 0; ip[i] && i < env.perf_max_stack_depth; i++)
 			pr_format(symname(ip[i]), f);
-		return;
 	} else {
 		for (i = env.perf_max_stack_depth - 1; i >= 0; i--) {
 			if (!ip[i])
@@ -414,7 +412,7 @@ static bool print_user_stacktrace(struct key_t *event, int stack_map,
 	return true;
 }
 
-static bool print_kern_stacktrace(struct key_t *event, int stack_map,
+static bool print_kern_stacktrace(struct key_t *event, int stack_map, int ksym_map,
 				  unsigned long *ip, struct fmt_t *f, bool delim)
 {
 	if (env.user_stacks_only || STACK_ID_EFAULT(event->kern_stack_id))
@@ -425,13 +423,26 @@ static bool print_kern_stacktrace(struct key_t *event, int stack_map,
 
 	if (bpf_map_lookup_elem(stack_map, &event->kern_stack_id, ip) != 0)
 		pr_format("[Missed Kernel Stack]", f);
-	else
-		print_stacktrace(ip, ksymname, f);
+	else {
+		int i;
+
+		if (!f->folded) {
+			for (i = 0; ip[i] && i < env.perf_max_stack_depth; i++)
+				pr_format(ksymname(ip[i], ksym_map), f);
+		} else {
+			for (i = env.perf_max_stack_depth - 1; i >= 0; i--) {
+				if (!ip[i])
+					continue;
+
+				pr_format(ksymname(ip[i], ksym_map), f);
+			}
+		}
+	}
 
 	return true;
 }
 
-static int print_count(struct key_t *event, __u64 count, int stack_map, bool folded)
+static int print_count(struct key_t *event, __u64 count, int stack_map, int ksym_map, bool folded)
 {
 	unsigned long *ip;
 	int ret;
@@ -445,7 +456,7 @@ static int print_count(struct key_t *event, __u64 count, int stack_map, bool fol
 
 	if (!folded) {
 		/* multi-line stack output */
-		ret = print_kern_stacktrace(event, stack_map, ip, fmt, false);
+		ret = print_kern_stacktrace(event, stack_map, ksym_map, ip, fmt, false);
 		print_user_stacktrace(event, stack_map, ip, fmt, ret && env.delimiter);
 		printf("    %-16s %s (%d)\n", "-", event->name, event->pid);
 		printf("        %lld\n\n", count);
@@ -453,7 +464,7 @@ static int print_count(struct key_t *event, __u64 count, int stack_map, bool fol
 		/* folded stack output */
 		printf("%s", event->name);
 		ret = print_user_stacktrace(event, stack_map, ip, fmt, false);
-		print_kern_stacktrace(event, stack_map, ip, fmt, ret && env.delimiter);
+		print_kern_stacktrace(event, stack_map, ksym_map, ip, fmt, ret && env.delimiter);
 		printf(" %lld\n", count);
 	}
 
@@ -462,7 +473,7 @@ static int print_count(struct key_t *event, __u64 count, int stack_map, bool fol
 	return 0;
 }
 
-static int print_counts(int counts_map, int stack_map)
+static int print_counts(int counts_map, int stack_map, int kaddr_map)
 {
 	struct key_ext_t *counts;
 	struct key_t *event;
@@ -473,14 +484,43 @@ static int print_counts(int counts_map, int stack_map)
 	int i, ret = 0;
 
 	counts = calloc(MAX_ENTRIES, sizeof(struct key_ext_t));
-	if (!counts) {
-		fprintf(stderr, "Out of memory\n");
-		return -ENOMEM;
-	}
+	if (!counts)
+		goto out_of_mem;
 
 	ret = read_counts_map(counts_map, counts, &nr_count);
 	if (ret)
 		goto cleanup;
+
+	if (!env.user_stacks_only) {
+		char empty_str[MAX_SYM_LEN] = {0};
+		unsigned long *ip = calloc(env.perf_max_stack_depth, sizeof(ip[0]));
+		if (!ip)
+			goto out_of_mem;
+		for (i = 0; i < nr_count; i++) {
+			event = &counts[i].k;
+
+			if (STACK_ID_EFAULT(event->kern_stack_id))
+				continue;
+
+			if (bpf_map_lookup_elem(stack_map, &event->kern_stack_id, ip)) {
+				static bool has_run = false;
+				if (!has_run) {
+				fprintf(stderr, "Error searchin for kernel stack.\n"
+						"Consider incresing stack-storage-size.\n"
+						"Continuing anyway\n");
+				has_run = true;
+				}
+				continue;
+			}
+			for (int j=0; ip[j] && j < env.perf_max_stack_depth; j++) {
+				bpf_map_update_elem (kaddr_map, ip+j, empty_str, BPF_NOEXIST);
+			}
+			memset(ip, 0, env.perf_max_stack_depth);
+		}
+		free(ip);
+
+		DTRACE_PROBE(USDT_PROVIDER, USDT_READY_TO_CONVERT);
+	}
 
 	qsort(counts, nr_count, sizeof(struct key_ext_t), cmp_counts);
 
@@ -488,7 +528,7 @@ static int print_counts(int counts_map, int stack_map)
 		event = &counts[i].k;
 		count = counts[i].v;
 
-		print_count(event, count, stack_map, env.folded);
+		print_count(event, count, stack_map, kaddr_map, env.folded);
 
 		/* handle stack id errors */
 		nr_missing_stacks += MISSING_STACKS(event->user_stack_id, event->kern_stack_id);
@@ -501,8 +541,13 @@ static int print_counts(int counts_map, int stack_map)
 			" Consider increasing --stack-storage-size.":"");
 	}
 
+	goto cleanup;
+out_of_mem:
+	fprintf(stderr, "Out of memory\n");
+	ret = -ENOMEM;
 cleanup:
-	free(counts);
+	if (counts)
+		free(counts);
 
 	return ret;
 }
@@ -642,12 +687,6 @@ int main(int argc, char **argv)
 		}
 	}
 
-	ksyms = ksyms__load();
-	if (!ksyms) {
-		fprintf(stderr, "failed to load kallsyms\n");
-		goto cleanup;
-	}
-
 	syms_cache = syms_cache__new(0);
 	if (!syms_cache) {
 		fprintf(stderr, "failed to create syms_cache\n");
@@ -669,8 +708,16 @@ int main(int argc, char **argv)
 	 */
 	sleep(env.duration);
 
+	profile_bpf__attach(obj);
+	if (!obj->links.convert) {
+		err = errno;
+		fprintf(stderr, "attaching failed: %s\n", strerror(err));
+		goto cleanup;
+	}
+
 	print_counts(bpf_map__fd(obj->maps.counts),
-		     bpf_map__fd(obj->maps.stackmap));
+		     bpf_map__fd(obj->maps.stackmap),
+		     bpf_map__fd(obj->maps.kaddr_to_sym));
 
 cleanup:
 	if (env.cpu != -1)
@@ -681,8 +728,6 @@ cleanup:
 	}
 	if (syms_cache)
 		syms_cache__free(syms_cache);
-	if (ksyms)
-		ksyms__free(ksyms);
 	profile_bpf__destroy(obj);
 
 	return err != 0;

--- a/libbpf-tools/profile.h
+++ b/libbpf-tools/profile.h
@@ -7,6 +7,15 @@
 #define MAX_ENTRIES		10240
 #define MAX_PID_NR		30
 #define MAX_TID_NR		30
+// maximum kernel symbol name length including trailing 0
+#define MAX_SYM_LEN		128
+#define USDT_PROVIDER		bpfprofiler
+#define USDT_READY_TO_CONVERT	ready_to_launch_converter
+
+
+#define STRINGIFY(x) #x
+// Useful to convert usdt tokens to strings
+#define TOSTRING(x) STRINGIFY(x)
 
 struct key_t {
 	__u32 pid;


### PR DESCRIPTION
I've been trying to improve perf tools' startup time to make working on fixing broken tests/features of perf bearable on NixOs. I've learned that processing /proc/kallsyms is a costly operation; on my ryzen5 system around 100ms just to read through it.

Aside from decreasing how many times kallsyms are read, I started to look into how to remove dependency on kallsyms.
From kernel source code kernel/kallsyms.c and printk() documentation https://docs.kernel.org/core-api/printk-formats.html#symbols-function-pointers I learned about special pointer formatting flags in kernel.

Writing a custom kernel module just for the purpose of extracting symbol names didn't feel right to me, so I've tried to use eBPF for that purpose. eBPF programs have these helpers available that are promising:
- bpf_snprintf
- bpf_trace_printk

I've looked into how these two are implemented and found that both of them use bstr_printf underneath. But before any printing is done, the format string must first go through bpf_bprintf_prepare, which disallows certain flags.

Fortunately for us, thanks to Florent Revest
https://lore.kernel.org/bpf/20210427174313.860948-1-revest@chromium.org/ %pB is accepted. We might consider adding that info to bpf-helpers man page?

Overview of the new approach:
1. eBPF profiler does low-latency recording of stack frames as it used to;
2. Go through all kernel ips recorded in stack traces and save them in bpf_hashmap(K=u64, V=char[MAX_SYM_LEN]) with an empty value for now;
3. Call eBPF converter program, which will populate values in the hashmap with bpf_snprintf(%pB);
4. Report recorded callstacks using the now-populated hashmap for ksyms.

In order to reliably trigger the converter program, I decided to use USDT.

Running `time ./profile -F 2344 1` on a mostly idle system I got Before:
real    0m1,215s
user    0m0,058s
sys     0m0,157s

After:
real    0m1,045s
user    0m0,009s
sys     0m0,026s

I ask the community here for your opinion, help and guidance to make this mergeable.

Using %pB slightly changes the format of a symbol name. Example: kmem_cache_alloc_noprof+0x2cf/0x300
It would be trivial to remove the suffix if it's necessary. Generating flamegraphs with Brendan Gregg's perl script still works.

For now, max_entries of the hashmap is hardcoded. Would you make it dynamic, like stack-storage-size or compute it by collecting all ips into a set and take this set's size as value for max_entries?

In Makefile:
When adding bpf/usdt.bpf.h clang errored it couldn't find asm/errno.h so I added -v to cflags when V is set.
As a quick fix, I hardcoded include path to x86_64 host header files. In contrast to clang, gcc corretly has this in it's default include path. Do you have any idea how to set this path, preferably so it doesn't only work on ubuntu?

Experimentally I added BPF_F_FAST_STACK_CMP | BPF_F_REUSE_STACKID to bpf_get_stackid. It doesn't seem to break the program and should make recording faster. If somebody knows why adding them is a bad idea please do tell.

If this gets a positive reaction, I will look into converting other tools here to use eBPF instead of /proc/kallsyms when possible.

Best,
Krzysztof