### PR TITLE
tcpdrop: tcp_drop() not findable is an error.

### DIFF
--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -248,8 +248,10 @@ b = BPF(text=bpf_text)
 if b.get_kprobe_functions(b"tcp_drop"):
     b.attach_kprobe(event="tcp_drop", fn_name="trace_tcp_drop")
 elif b.tracepoint_exists("skb", "kfree_skb"):
-    print("WARNING: tcp_drop() kernel function not found or traceable. "
-          "Use tracpoint:skb:kfree_skb instead.")
+    print("ERROR: tcp_drop() kernel function not found or traceable. "
+          "(It may have been inlined.) "
+          "Use tracepoint:skb:kfree_skb instead.")
+    exit()
 else:
     print("ERROR: tcp_drop() kernel function and tracpoint:skb:kfree_skb"
           " not found or traceable. "


### PR DESCRIPTION
I was attempting to use `tcpdrop` on a system where this "warning" was being printed. I waited for a while as the program seemed to be doing something. But it actually wasn't. I think this is really an error that should exit the tool. But I might be wrong.