### PR TITLE
libbpf-tools/statsnoop: Display syscall name

### DIFF
--- a/libbpf-tools/statsnoop.h
+++ b/libbpf-tools/statsnoop.h
@@ -5,9 +5,18 @@
 #define TASK_COMM_LEN	16
 #define NAME_MAX	255
 
+enum sys_type {
+	SYS_STATFS = 1,
+	SYS_NEWSTAT,
+	SYS_STATX,
+	SYS_NEWFSTATAT,
+	SYS_NEWLSTAT,
+};
+
 struct event {
 	__u64 ts_ns;
 	__u32 pid;
+	enum sys_type type;
 	int ret;
 	char comm[TASK_COMM_LEN];
 	char pathname[NAME_MAX];


### PR DESCRIPTION
Display the system call name is more helpful for analysis, like:

    $ sudo ./statsnoop
    PID     COMM                 RET  ERR  SYSCALL    PATH
    83459   code                 -1   2    statx      /home/rongtao/.config/Code/User/tasks.json
    2807    terminator           0    0    newfstatat /usr/share/icons
    2807    terminator           -1   2    newfstatat /home/rongtao/.local/share/flatpak/exports/share/pixmaps
    2807    terminator           -1   2    newfstatat /usr/local/share/pixmaps
    2807    terminator           0    0    newfstatat /usr/share/pixmaps
    83445   code                 -1   2    statx      /home/sdb/Git/5.10.13/.vscode/c_cpp_properties.json
    2525    pool                 0    0    newfstatat /etc/krb5.conf
    88285   ls                   0    0    statfs     /sys/fs/selinux
    88285   ls                   0    0    statx      listdir.c