### PR TITLE
tools/statsnoop: Add -s to display syscall name

### DIFF
--- a/tools/statsnoop_example.txt
+++ b/tools/statsnoop_example.txt
@@ -56,18 +56,20 @@ to opensnoop, which shows what files were actually opened.
 USAGE message:
 
 # ./statsnoop -h
-usage: statsnoop [-h] [-t] [-x] [-p PID]
+usage: statsnoop.py [-h] [-t] [-s] [-x] [-p PID]
 
 Trace stat() syscalls
 
-optional arguments:
-  -h, --help         show this help message and exit
-  -t, --timestamp    include timestamp on output
-  -x, --failed       only show failed stats
-  -p PID, --pid PID  trace this PID only
+options:
+  -h, --help       show this help message and exit
+  -t, --timestamp  include timestamp on output
+  -s, --sysname    include syscall name on output
+  -x, --failed     only show failed stats
+  -p, --pid PID    trace this PID only
 
 examples:
     ./statsnoop           # trace all stat() syscalls
     ./statsnoop -t        # include timestamps
+    ./statsnoop -s        # include syscall name
     ./statsnoop -x        # only show failed stats
     ./statsnoop -p 181    # only trace PID 181


### PR DESCRIPTION
Do the same thing that [1] did.

    $ sudo ./statsnoop.py -t -s
    TIME(s)       PID     COMM               FD ERR SYSCALL      PATH
    0.000000000   9761    lstat               0   0 newfstatat   /etc/os-release
    0.000269740   9761    lstat               0   0 newlstat     /etc/os-release
    1.871977757   2555    pool                0   0 newfstatat   /etc/krb5.conf
    3.135518800   2931    terminator         -1   2 newfstatat   /home/rongtao/.local/share/icons/Adwaita
    3.135549915   2931    terminator         -1   2 newfstatat   /home/rongtao/.icons/Adwaita

Link: https://github.com/iovisor/bcc/commit/82f9d1cb633a [1]