### PR TITLE
hardirqs: Optimize output information and increase CPU display

### DIFF
--- a/libbpf-tools/hardirqs.h
+++ b/libbpf-tools/hardirqs.h
@@ -6,10 +6,13 @@
 
 struct irq_key {
 	char name[32];
+	__u32 cpu;
 };
 
 struct info {
 	__u64 count;
+	__u64 total_time;
+	__u64 max_time;
 	__u32 slots[MAX_SLOTS];
 };
 


### PR DESCRIPTION
Combine the previous count and time into one,
and increase CPU independent statistics and maximum interrupt time
```
Before:
    ./hardirqs
    Tracing hard irq event time... Hit Ctrl-C to end.
    ^C
    HARDIRQ                    TOTAL_usecs
    enp0s3                             254
    snd_intel8x0                       368
    
    ./hardirqs -C
    Tracing hard irq events... Hit Ctrl-C to end.
    ^C
    HARDIRQ                    TOTAL_count
    enp0s3                              14
    ata_piix                             2
    
After:
    ./hardirqs
    Tracing hard irq event time... Hit Ctrl-C to end.
    ^C
    HARDIRQ                    TOTAL_count TOTAL_usecs MAX_usecs
    ata_piix                             2          32        21
    enp0s3                              19         318        42
    
    ./hardirqs -C
    Tracing hard irq event time... Hit Ctrl-C to end.
    ^C
    HARDIRQ                    TOTAL_count TOTAL_usecs MAX_usecs CPU
    enp0s3                          111375     1420732       303   2
    enp0s3                            1546       21826        39   9
    ata_piix                             8         162        33   8

```