### PR TITLE
libbpf-tools: statsnoop: Support fstat(2) and parse fd/dirfd in userspace

### DIFF
--- a/libbpf-tools/statsnoop.h
+++ b/libbpf-tools/statsnoop.h
@@ -9,6 +9,7 @@ enum sys_type {
 	SYS_STATFS = 1,
 	SYS_NEWSTAT,
 	SYS_STATX,
+	SYS_NEWFSTAT,
 	SYS_NEWFSTATAT,
 	SYS_NEWLSTAT,
 };
@@ -19,6 +20,14 @@ struct event {
 	enum sys_type type;
 	int ret;
 	char comm[TASK_COMM_LEN];
+
+	/**
+	 * fd: fstat(2)
+	 * dirfd: statx(2), fstatat(2)
+	 */
+#define INVALID_FD	(-1)
+	int fd;
+	int dirfd;
 	char pathname[NAME_MAX];
 };
 


### PR DESCRIPTION
Added support for fstat system calls, and resolve file names and paths from fd and dirfd in user mode.

Userspace test code:

    # fstatat.c
    dirfd = openat(AT_FDCWD, "./", O_RDONLY | O_CLOEXEC);
    fstatat(dirfd, argv[0], &buf, AT_SYMLINK_NOFOLLOW);
    fstatat(dirfd, "/etc/os-release", &buf, AT_SYMLINK_NOFOLLOW);

    # fstat.c
    fd = open("/etc/os-release", O_RDONLY);
    fstat(fd, &buf);
    fstat(AT_FDCWD, &buf);

Tracing:

  Before:

    $ sudo ./statsnoop -s
    PID     COMM                 RET  ERR  SYSCALL    PATH
    25719   fstatat              0    0    newfstatat ./fstatat        <no cwd>
    25719   fstatat              0    0    newfstatat /etc/os-release
    < couldn't tracing fstat(2) >

  This patch:

    $ sudo ./statsnoop -s
    PID     COMM                 RET  ERR  SYSCALL    PATH
    26794   fstatat              0    0    newfstatat /home/sdb/Git/tst-linux/syscall/samples/stat/./fstatat
    26794   fstatat              0    0    newfstatat /etc/os-release
    26797   fstat                0    0    newfstat   /usr/lib/os-release
    26800   fstat                -1   9    newfstat   /home/sdb/Git/tst-linux/syscall/samples/stat

Maybe this isn't a good approach, as it's possible that both the process and the fd don't exist during parsing the fd and dirfd. Of course, this is problematic for processes and fds that survive for a short period of time, however, for long-running daemons, there is no problem.