### PR TITLE
libbpf-tools/memleak: Fix output error for invalid stackid when using…

### DIFF
--- a/libbpf-tools/memleak.c
+++ b/libbpf-tools/memleak.c
@@ -82,7 +82,7 @@ struct allocation_node {
 };
 
 struct allocation {
-	uint64_t stack_id;
+	int64_t stack_id;
 	size_t size;
 	size_t count;
 	struct allocation_node* allocations;
@@ -1018,6 +1018,11 @@ int print_outstanding_combined_allocs(int combined_allocs_fd, int stack_traces_f
 			.count = combined_alloc_info.number_of_allocs,
 			.allocations = NULL
 		};
+
+		// filter invalid stacks
+		if (alloc.stack_id < 0) {
+			continue;
+		}
 
 		memcpy(&allocs[nr_allocs], &alloc, sizeof(alloc));
 		nr_allocs++;

--- a/libbpf-tools/memleak.c
+++ b/libbpf-tools/memleak.c
@@ -126,6 +126,17 @@ struct allocation {
 #define ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name) __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, false)
 #define ATTACH_URETPROBE_CHECKED(skel, sym_name, prog_name) __ATTACH_UPROBE_CHECKED(skel, sym_name, prog_name, true)
 
+/*
+ * -EFAULT in get_stackid normally means the stack-trace is not available,
+ * such as getting kernel stack trace in user mode
+ */
+#define STACK_ID_EFAULT(stack_id)	(stack_id == -EFAULT)
+
+#define STACK_ID_ERR(stack_id)		((stack_id < 0) && !STACK_ID_EFAULT(stack_id))
+
+/* hash collision (-EEXIST) suggests that stack map size may be too small */
+#define STACK_ID_COLLISION(stack_id)		(stack_id == -EEXIST)
+
 static void sig_handler(int signo);
 
 static long argp_parse_long(int key, const char *arg, struct argp_state *state);
@@ -861,6 +872,8 @@ int print_outstanding_allocs(int allocs_fd, int stack_traces_fd)
 	struct tm *tm = localtime(&t);
 
 	size_t nr_allocs = 0;
+	size_t nr_missing_stacks = 0;
+	size_t nr_collision_stacks = 0;
 
 	// for each struct alloc_info "alloc_info" in the bpf map "allocs"
 	for (uint64_t prev_key = 0, curr_key = 0;; prev_key = curr_key) {
@@ -893,6 +906,10 @@ int print_outstanding_allocs(int allocs_fd, int stack_traces_fd)
 
 		// filter invalid stacks
 		if (alloc_info.stack_id < 0) {
+			/* handle stack id errors */
+			nr_missing_stacks += STACK_ID_ERR(alloc_info.stack_id);
+			nr_collision_stacks += STACK_ID_COLLISION(alloc_info.stack_id);
+
 			continue;
 		}
 
@@ -977,6 +994,13 @@ int print_outstanding_allocs(int allocs_fd, int stack_traces_fd)
 		}
 	}
 
+	if (nr_missing_stacks > 0) {
+		fprintf(stderr, "WARNING: %zu stack traces could not be displayed"
+			" due to memory shortage, including %zu caused by hash collisions."
+			" Consider increasing --stack-storage-size.\n",
+			nr_missing_stacks, nr_collision_stacks);
+	}
+
 	return 0;
 }
 
@@ -986,6 +1010,8 @@ int print_outstanding_combined_allocs(int combined_allocs_fd, int stack_traces_f
 	struct tm *tm = localtime(&t);
 
 	size_t nr_allocs = 0;
+	size_t nr_missing_stacks = 0;
+	size_t nr_collision_stacks = 0;
 
 	// for each stack_id "curr_key" and union combined_alloc_info "alloc"
 	// in bpf_map "combined_allocs"
@@ -1021,6 +1047,11 @@ int print_outstanding_combined_allocs(int combined_allocs_fd, int stack_traces_f
 
 		// filter invalid stacks
 		if (alloc.stack_id < 0) {
+			/* handle stack id errors */
+			if (STACK_ID_ERR(alloc.stack_id))
+				nr_missing_stacks += alloc.count;
+			if (STACK_ID_COLLISION(alloc.stack_id))
+				nr_collision_stacks += alloc.count;
 			continue;
 		}
 
@@ -1037,6 +1068,13 @@ int print_outstanding_combined_allocs(int combined_allocs_fd, int stack_traces_f
 			tm->tm_hour, tm->tm_min, tm->tm_sec, nr_allocs);
 
 	print_stack_frames(allocs, nr_allocs, stack_traces_fd);
+
+	if (nr_missing_stacks > 0) {
+		fprintf(stderr, "WARNING: %zu stack traces could not be displayed"
+			" due to memory shortage, including %zu caused by hash collisions."
+			" Consider increasing --stack-storage-size.\n",
+			nr_missing_stacks, nr_collision_stacks);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
… combined-only

Issue: In combined-only mode, when obtaining the stack ID in the BPF program,
the returned error values are also counted and included in the outstanding
allocation list in the user program. This can convey inaccurate information
to the user, so fixed.

Before:
```
  $ ./memleak --stack-storage-size 3 -C
    Tracing outstanding memory allocs...  Hit Ctrl-C to end
    [17:10:33] Top 2 stacks with outstanding allocations:
    50456128 bytes in 13270 allocations from stack
    31971040 bytes in 5056 allocations from stack
    ^C[17:10:35] Top 2 stacks with outstanding allocations:
    51514048 bytes in 13538 allocations from stack
    31992664 bytes in 5123 allocations from stack
    done
```
  When adding logs (// indicates logs added for testing):
```
  $ ./memleak --stack-storage-size 3 -C
    Tracing outstanding memory allocs...  Hit Ctrl-C to end
    // alloc.stack_id: -17, alloc.count: 236
    // alloc.stack_id: -12, alloc.count: 5492
    [17:18:15] Top 2 stacks with outstanding allocations:
    22481736 bytes in 5492 allocations from stack // <-- The count of -17 (EEXIST)
    61040 bytes in 236 allocations from stack
```

After:
```
  $ ./memleak --stack-storage-size 3 -C
    Tracing outstanding memory allocs...  Hit Ctrl-C to end
    // [filterout] alloc.stack_id: -12, alloc.count: 5742
    // alloc.stack_id: 3, alloc.count: 5
    [17:22:31] Top 1 stacks with outstanding allocations:
    480 bytes in 5 allocations from stack
      0 [<ffffffffbbc5eb0d>] __kmalloc+0x28d
      1 [<ffffffffbbc5eb0d>] __kmalloc+0x28d
      2 [<ffffffffbbb0b6b7>] bpf_prog_array_copy+0x177
      3 [<ffffffffbbaebee2>] perf_event_attach_bpf_prog+0xf2
      4 [<ffffffffbbba6b8c>] perf_event_set_bpf_prog+0x18c
```