### PR TITLE
libbpf-tools:Fix biosnoop dependency on kernel version

### DIFF
--- a/libbpf-tools/biosnoop.bpf.c
+++ b/libbpf-tools/biosnoop.bpf.c
@@ -126,11 +126,14 @@ int BPF_PROG(block_rq_insert)
 		return 0;
 
 	/**
-	 * commit a54895fa (v5.11-rc1) changed tracepoint argument list
+	 * commit a54895fa (block: remove the request_queue to argument
+	 * request based tracepoints) changed tracepoint argument list
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
+	 * see:
+	 *     https://github.com/torvalds/linux/commit/a54895fa
 	 */
-	if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 11, 0))
+	if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 10, 137))
 		return trace_rq_start((void *)ctx[0], true);
 	else
 		return trace_rq_start((void *)ctx[1], true);
@@ -143,11 +146,14 @@ int BPF_PROG(block_rq_issue)
 		return 0;
 
 	/**
-	 * commit a54895fa (v5.11-rc1) changed tracepoint argument list
+	 * commit a54895fa (block: remove the request_queue to argument
+	 * request based tracepoints) changed tracepoint argument list
 	 * from TP_PROTO(struct request_queue *q, struct request *rq)
 	 * to TP_PROTO(struct request *rq)
+	 * see:
+	 *     https://github.com/torvalds/linux/commit/a54895fa
 	 */
-	if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 11, 0))
+	if (LINUX_KERNEL_VERSION >= KERNEL_VERSION(5, 10, 137))
 		return trace_rq_start((void *)ctx[0], false);
 	else
 		return trace_rq_start((void *)ctx[1], false);


### PR DESCRIPTION
tracepoint block_rq_insert and block_rq_issue changed from 5.10.137, not 5.11

same as merged pr: [libbpf-tools:Fix bitesize dependency on kernel versio](https://github.com/iovisor/bcc/pull/5234)

[v5.10.137 include/trace/events/block.h](https://elixir.bootlin.com/linux/v5.10.137/source/include/trace/events/block.h)
[v5.10.136 include/trace/events/block.h](https://elixir.bootlin.com/linux/v5.10.136/source/include/trace/events/block.h)

from:
```
DEFINE_EVENT(block_rq, block_rq_insert,

	TP_PROTO(struct request_queue *q, struct request *rq),

	TP_ARGS(q, rq)
);

DEFINE_EVENT(block_rq, block_rq_issue,

	TP_PROTO(struct request_queue *q, struct request *rq),

	TP_ARGS(q, rq)
);
```

to:
```
DEFINE_EVENT(block_rq, block_rq_insert,

	TP_PROTO(struct request *rq),

	TP_ARGS(rq)
);

DEFINE_EVENT(block_rq, block_rq_issue,

	TP_PROTO(struct request *rq),

	TP_ARGS(rq)
);
```

The contents of the parentheses refer to this change to a commit message with a link.
```
libbpf-tools/core_fixes.bpf.h: 84

/**
 * commit d152c682f03c ("block: add an explicit ->disk backpointer to the
 * request_queue") and commit f3fa33acca9f ("block: remove the ->rq_disk
 * field in struct request") make some changes to `struct request` and
 * `struct request_queue`. Now, to get the `struct gendisk *` field in a CO-RE
 * way, we need both `struct request` and `struct request_queue`.
 * see:
 *     https://github.com/torvalds/linux/commit/d152c682f03c
 *     https://github.com/torvalds/linux/commit/f3fa33acca9f
 */
```