### PR TITLE
Bump CMake minimum version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,7 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
-cmake_minimum_required(VERSION 2.8.12)
-
-if(${CMAKE_VERSION} VERSION_EQUAL 3.12.0 OR ${CMAKE_VERSION} VERSION_GREATER 3.12.0)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
-if(${CMAKE_VERSION} VERSION_EQUAL 3.3.0 OR ${CMAKE_VERSION} VERSION_GREATER 3.3.0)
-  cmake_policy(SET CMP0057 NEW)
-endif()
+cmake_minimum_required(VERSION 3.12)
+cmake_policy(SET CMP0074 NEW)
 
 project(bcc)
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
With CMake 4 the minimum support version is 3.5, and since the current minimum version we set is 2.8.12, it will fail with the following message:

```
CMake Error at CMakeLists.txt:3 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

However, instead of bumping the minimum version requirement to 3.5, bump to a slightly higher 3.12 instead to be consistent with `examples/usdt_sample/`.

Also update `cmake_policy()` calls due to this change, dropping CMP0057 since the OLD behavior is no longer supported anyway.