### PR TITLE
tools/criticalstat: Update error message with kernel version-specific…

### DIFF
--- a/man/man8/criticalstat.8
+++ b/man/man8/criticalstat.8
@@ -17,10 +17,21 @@ Since this uses BPF, only the root user can use this tool. Further, the kernel
 has to be built with certain CONFIG options enabled. See below.
 
 .SH REQUIREMENTS
-Enable CONFIG_PREEMPT_TRACER, CONFIG_PREEMPTIRQ_EVENTS
-(CONFIG_PREEMPTIRQ_TRACEPOINTS in kernel 4.19 and later)
-and CONFIG_DEBUG_PREEMPT. Additionally, the following options
-should be DISABLED on older kernels: CONFIG_PROVE_LOCKING, CONFIG_LOCKDEP.
+Enable following kernel configurations based on which kernel version you use.
+    - CONFIG_DEBUG_PREEMPT
+    - CONFIG_PREEMPT_TRACER
+    
+    For kernel 4.19 and later:
+    - CONFIG_PREEMPTIRQ_TRACEPOINTS
+    - CONFIG_TRACE_IRQFLAGS
+    - CONFIG_TRACE_PREEMPT_TOGGLE
+    
+    For kernel 4.15 to 4.18:
+    - CONFIG_PREEMPTIRQ_EVENTS
+    - CONFIG_PROVE_LOCKING
+    - CONFIG_DEBUG_PREEMPT
+Additionally, the following options should be turned off on older kernels:
+    - CONFIG_LOCKDEP
 .SH OPTIONS
 .TP
 \-h

--- a/tools/criticalstat.py
+++ b/tools/criticalstat.py
@@ -62,12 +62,26 @@ if (not os.path.exists(trace_path + b"irq_disable") or
    not os.path.exists(trace_path + b"irq_enable") or
    not os.path.exists(trace_path + b"preempt_disable") or
    not os.path.exists(trace_path + b"preempt_enable")):
-    print("ERROR: required tracing events are not available\n" +
-        "Make sure the kernel is built with CONFIG_DEBUG_PREEMPT " +
-        "CONFIG_PREEMPT_TRACER " +
-        "and CONFIG_PREEMPTIRQ_EVENTS (CONFIG_PREEMPTIRQ_TRACEPOINTS in "
-        "kernel 4.19 and later) enabled. Also please disable " +
-        "CONFIG_PROVE_LOCKING and CONFIG_LOCKDEP on older kernels.")
+    error_message = """
+    ERROR: required tracing events are not available
+
+    Make sure the kernel is built with the following configurations enabled:
+    - CONFIG_DEBUG_PREEMPT
+    - CONFIG_PREEMPT_TRACER
+
+    For kernel 4.19 and later:
+    - CONFIG_PREEMPTIRQ_TRACEPOINTS
+    - CONFIG_TRACE_IRQFLAGS
+    - CONFIG_TRACE_PREEMPT_TOGGLE
+
+    For kernel 4.15 to 4.18:
+    - CONFIG_PREEMPTIRQ_EVENTS
+    - CONFIG_PROVE_LOCKING
+    - CONFIG_DEBUG_PREEMPT
+
+    Also, please disable CONFIG_LOCKDEP on older kernels.
+    """
+    print(error_message)
     sys.exit(0)
 
 bpf_text = """

--- a/tools/criticalstat_example.txt
+++ b/tools/criticalstat_example.txt
@@ -10,13 +10,20 @@ sections are a source of long latency/responsive issues for real-time systems.
 This works by probing the preempt/irq and cpuidle tracepoints in the kernel.
 Since this uses BPF, only the root user can use this tool. Further, the kernel
 has to be built with certain CONFIG options enabled inorder for it to work:
-CONFIG_PREEMPTIRQ_EVENTS before kernel 4.19
-CONFIG_PREEMPTIRQ_TRACEPOINTS in kernel 4.19 and later
-CONFIG_DEBUG_PREEMPT
-CONFIG_PREEMPT_TRACER
+    - CONFIG_DEBUG_PREEMPT
+    - CONFIG_PREEMPT_TRACER
+    
+    For kernel 4.19 and later:
+    - CONFIG_PREEMPTIRQ_TRACEPOINTS
+    - CONFIG_TRACE_IRQFLAGS
+    - CONFIG_TRACE_PREEMPT_TOGGLE
+    
+    For kernel 4.15 to 4.18:
+    - CONFIG_PREEMPTIRQ_EVENTS
+    - CONFIG_PROVE_LOCKING
+    - CONFIG_DEBUG_PREEMPT
 Additionally, the following options should be turned off on older kernels:
-CONFIG_PROVE_LOCKING
-CONFIG_LOCKDEP
+    - CONFIG_LOCKDEP
 
 USAGE:
 # ./criticalstat -h


### PR DESCRIPTION
… config requirements

The kernel configurations required for preempt/irq tracepoints changed in Linux 4.19 due to commit c3bc8fd637a9 ("tracing: Centralize preemptirq tracepoints and unify their usage"). This patch updates the error messages and documentation to clearly specify which kernel configurations should be enabled based on kernel version:

- For kernel 4.19 and later: CONFIG_PREEMPTIRQ_TRACEPOINTS, CONFIG_TRACE_IRQFLAGS, CONFIG_TRACE_PREEMPT_TOGGLE

- For kernel 4.15 to 4.18: CONFIG_PREEMPTIRQ_EVENTS, CONFIG_PROVE_LOCKING

Common requirements for all versions:
- CONFIG_DEBUG_PREEMPT
- CONFIG_PREEMPT_TRACER

Additionally, CONFIG_LOCKDEP should be disabled on older kernels.

These changes make it easier for users to identify and enable the correct configuration options for their specific kernel version.

Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c3bc8fd637a9