### PR TITLE
tcpdrop: add support for dumping TCP drop reasons

### DIFF
--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -17,6 +17,7 @@
 #
 # 30-May-2018   Brendan Gregg   Created this.
 # 15-Jun-2022   Rong Tao        Add tracepoint:skb:kfree_skb
+# 23-Mar-2025   Lance Yang      Dump drop reason
 
 from __future__ import print_function
 from bcc import BPF
@@ -59,6 +60,7 @@ bpf_text = """
 #include <uapi/linux/ip.h>
 #include <net/sock.h>
 #include <bcc/proto.h>
+#include <linux/skbuff.h>
 
 BPF_STACK_TRACE(stack_traces, 1024);
 
@@ -73,6 +75,7 @@ struct ipv4_data_t {
     u8 state;
     u8 tcpflags;
     u32 stack_id;
+    u32 drop_reason;
 };
 BPF_PERF_OUTPUT(ipv4_events);
 
@@ -86,6 +89,7 @@ struct ipv6_data_t {
     u8 state;
     u8 tcpflags;
     u32 stack_id;
+    u32 drop_reason;
 };
 BPF_PERF_OUTPUT(ipv6_events);
 
@@ -106,7 +110,7 @@ static inline struct iphdr *skb_to_iphdr(const struct sk_buff *skb)
 #define tcp_flag_byte(th) (((u_int8_t *)th)[13])
 #endif
 
-static int __trace_tcp_drop(void *ctx, struct sock *sk, struct sk_buff *skb)
+static int __trace_tcp_drop(void *ctx, struct sock *sk, struct sk_buff *skb, u32 reason)
 {
     if (sk == NULL)
         return 0;
@@ -139,6 +143,7 @@ static int __trace_tcp_drop(void *ctx, struct sock *sk, struct sk_buff *skb)
         data4.state = state;
         data4.tcpflags = tcpflags;
         data4.stack_id = stack_traces.get_stackid(ctx, 0);
+        data4.drop_reason = reason;
         ipv4_events.perf_submit(ctx, &data4, sizeof(data4));
 
     } else if (family == AF_INET6) {
@@ -156,6 +161,7 @@ static int __trace_tcp_drop(void *ctx, struct sock *sk, struct sk_buff *skb)
         data6.state = state;
         data6.tcpflags = tcpflags;
         data6.stack_id = stack_traces.get_stackid(ctx, 0);
+        data6.drop_reason = reason;
         ipv6_events.perf_submit(ctx, &data6, sizeof(data6));
     }
     // else drop
@@ -165,12 +171,12 @@ static int __trace_tcp_drop(void *ctx, struct sock *sk, struct sk_buff *skb)
 
 int trace_tcp_drop(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb)
 {
-    return __trace_tcp_drop(ctx, sk, skb);
+    // tcp_drop() does not supply a drop reason.
+    return __trace_tcp_drop(ctx, sk, skb, SKB_DROP_REASON_NOT_SPECIFIED);
 }
 """
 
 bpf_kfree_skb_text = """
-#include <linux/skbuff.h>
 
 TRACEPOINT_PROBE(skb, kfree_skb) {
     struct sk_buff *skb = args->skbaddr;
@@ -180,7 +186,7 @@ TRACEPOINT_PROBE(skb, kfree_skb) {
     // SKB_NOT_DROPPED_YET,
     // SKB_DROP_REASON_NOT_SPECIFIED,
     if (reason > SKB_DROP_REASON_NOT_SPECIFIED) {
-        return __trace_tcp_drop(args, sk, skb);
+        return __trace_tcp_drop(args, sk, skb, (u32)reason);
     }
 
     return 0;
@@ -213,14 +219,135 @@ if args.netns_id != 0:
 else:
     bpf_text = bpf_text.replace('FILTER_NETNS', '')
 
+# the reasons of skb drop
+drop_reasons = {
+    0: "SKB_NOT_DROPPED_YET",
+    1: "SKB_CONSUMED",
+    2: "NOT_SPECIFIED",
+    3: "NO_SOCKET",
+    4: "SOCKET_CLOSE",
+    5: "SOCKET_FILTER",
+    6: "SOCKET_RCVBUFF",
+    7: "UNIX_DISCONNECT",
+    8: "UNIX_SKIP_OOB",
+    9: "PKT_TOO_SMALL",
+    10: "TCP_CSUM",
+    11: "UDP_CSUM",
+    12: "NETFILTER_DROP",
+    13: "OTHERHOST",
+    14: "IP_CSUM",
+    15: "IP_INHDR",
+    16: "IP_RPFILTER",
+    17: "UNICAST_IN_L2_MULTICAST",
+    18: "XFRM_POLICY",
+    19: "IP_NOPROTO",
+    20: "PROTO_MEM",
+    21: "TCP_AUTH_HDR",
+    22: "TCP_MD5NOTFOUND",
+    23: "TCP_MD5UNEXPECTED",
+    24: "TCP_MD5FAILURE",
+    25: "TCP_AONOTFOUND",
+    26: "TCP_AOUNEXPECTED",
+    27: "TCP_AOKEYNOTFOUND",
+    28: "TCP_AOFAILURE",
+    29: "SOCKET_BACKLOG",
+    30: "TCP_FLAGS",
+    31: "TCP_ABORT_ON_DATA",
+    32: "TCP_ZEROWINDOW",
+    33: "TCP_OLD_DATA",
+    34: "TCP_OVERWINDOW",
+    35: "TCP_OFOMERGE",
+    36: "TCP_RFC7323_PAWS",
+    37: "TCP_RFC7323_PAWS_ACK",
+    38: "TCP_OLD_SEQUENCE",
+    39: "TCP_INVALID_SEQUENCE",
+    40: "TCP_INVALID_ACK_SEQUENCE",
+    41: "TCP_RESET",
+    42: "TCP_INVALID_SYN",
+    43: "TCP_CLOSE",
+    44: "TCP_FASTOPEN",
+    45: "TCP_OLD_ACK",
+    46: "TCP_TOO_OLD_ACK",
+    47: "TCP_ACK_UNSENT_DATA",
+    48: "TCP_OFO_QUEUE_PRUNE",
+    49: "TCP_OFO_DROP",
+    50: "IP_OUTNOROUTES",
+    51: "BPF_CGROUP_EGRESS",
+    52: "IPV6DISABLED",
+    53: "NEIGH_CREATEFAIL",
+    54: "NEIGH_FAILED",
+    55: "NEIGH_QUEUEFULL",
+    56: "NEIGH_DEAD",
+    57: "TC_EGRESS",
+    58: "SECURITY_HOOK",
+    59: "QDISC_DROP",
+    60: "QDISC_OVERLIMIT",
+    61: "QDISC_CONGESTED",
+    62: "CAKE_FLOOD",
+    63: "FQ_BAND_LIMIT",
+    64: "FQ_HORIZON_LIMIT",
+    65: "FQ_FLOW_LIMIT",
+    66: "CPU_BACKLOG",
+    67: "XDP",
+    68: "TC_INGRESS",
+    69: "UNHANDLED_PROTO",
+    70: "SKB_CSUM",
+    71: "SKB_GSO_SEG",
+    72: "SKB_UCOPY_FAULT",
+    73: "DEV_HDR",
+    74: "DEV_READY",
+    75: "FULL_RING",
+    76: "NOMEM",
+    77: "HDR_TRUNC",
+    78: "TAP_FILTER",
+    79: "TAP_TXFILTER",
+    80: "ICMP_CSUM",
+    81: "INVALID_PROTO",
+    82: "IP_INADDRERRORS",
+    83: "IP_INNOROUTES",
+    84: "IP_LOCAL_SOURCE",
+    85: "IP_INVALID_SOURCE",
+    86: "IP_LOCALNET",
+    87: "IP_INVALID_DEST",
+    88: "PKT_TOO_BIG",
+    89: "DUP_FRAG",
+    90: "FRAG_REASM_TIMEOUT",
+    91: "FRAG_TOO_FAR",
+    92: "TCP_MINTTL",
+    93: "IPV6_BAD_EXTHDR",
+    94: "IPV6_NDISC_FRAG",
+    95: "IPV6_NDISC_HOP_LIMIT",
+    96: "IPV6_NDISC_BAD_CODE",
+    97: "IPV6_NDISC_BAD_OPTIONS",
+    98: "IPV6_NDISC_NS_OTHERHOST",
+    99: "QUEUE_PURGE",
+    100: "TC_COOKIE_ERROR",
+    101: "PACKET_SOCK_ERROR",
+    102: "TC_CHAIN_NOTFOUND",
+    103: "TC_RECLASSIFY_LOOP",
+    104: "VXLAN_INVALID_HDR",
+    105: "VXLAN_VNI_NOT_FOUND",
+    106: "MAC_INVALID_SOURCE",
+    107: "VXLAN_ENTRY_EXISTS",
+    108: "NO_TX_TARGET",
+    109: "IP_TUNNEL_ECN",
+    110: "TUNNEL_TXINFO",
+    111: "LOCAL_MAC",
+    112: "ARP_PVLAN_DISABLE",
+    113: "MAC_IEEE_MAC_CONTROL",
+    114: "BRIDGE_INGRESS_STP_STATE",
+}
+
 # process event
 def print_ipv4_event(cpu, data, size):
     event = b["ipv4_events"].event(data)
-    print("%-8s %-7d %-2d %-20s > %-20s %s (%s)" % (
+    reason_str = drop_reasons.get(event.drop_reason, "UNKNOWN")
+    state_flag_str = "%s (%s)" % (tcp.tcpstate[event.state], tcp.flags2str(event.tcpflags))
+    print("%-8s %-7d %-2d %-20s > %-20s %-20s %s (%d)" % (
         strftime("%H:%M:%S"), event.pid, event.ip,
         "%s:%d" % (inet_ntop(AF_INET, pack('I', event.saddr)), event.sport),
         "%s:%s" % (inet_ntop(AF_INET, pack('I', event.daddr)), event.dport),
-        tcp.tcpstate[event.state], tcp.flags2str(event.tcpflags)))
+        state_flag_str, reason_str, event.drop_reason))
     for addr in stack_traces.walk(event.stack_id):
         sym = b.ksym(addr, show_offset=True)
         print("\t%s" % sym)
@@ -228,11 +355,13 @@ def print_ipv4_event(cpu, data, size):
 
 def print_ipv6_event(cpu, data, size):
     event = b["ipv6_events"].event(data)
-    print("%-8s %-7d %-2d %-20s > %-20s %s (%s)" % (
+    reason_str = drop_reasons.get(event.drop_reason, "UNKNOWN")
+    state_flag_str = "%s (%s)" % (tcp.tcpstate[event.state], tcp.flags2str(event.tcpflags))
+    print("%-8s %-7d %-2d %-20s > %-20s %-20s %s (%d)" % (
         strftime("%H:%M:%S"), event.pid, event.ip,
         "%s:%d" % (inet_ntop(AF_INET6, event.saddr), event.sport),
         "%s:%d" % (inet_ntop(AF_INET6, event.daddr), event.dport),
-        tcp.tcpstate[event.state], tcp.flags2str(event.tcpflags)))
+        state_flag_str, reason_str, event.drop_reason))
     for addr in stack_traces.walk(event.stack_id):
         sym = b.ksym(addr, show_offset=True)
         print("\t%s" % sym)
@@ -261,8 +390,8 @@ else:
 stack_traces = b.get_table("stack_traces")
 
 # header
-print("%-8s %-7s %-2s %-20s > %-20s %s (%s)" % ("TIME", "PID", "IP",
-    "SADDR:SPORT", "DADDR:DPORT", "STATE", "FLAGS"))
+print("%-8s %-7s %-2s %-20s > %-20s %-20s %s" % ("TIME", "PID", "IP",
+    "SADDR:SPORT", "DADDR:DPORT", "STATE (FLAGS)", "REASON (CODE)"))
 
 # read events
 b["ipv4_events"].open_perf_buffer(print_ipv4_event)

--- a/tools/tcpdrop_example.txt
+++ b/tools/tcpdrop_example.txt
@@ -5,54 +5,46 @@ tcpdrop prints details of TCP packets or segments that were dropped by the
 kernel, including the kernel stack trace that led to the drop:
 
 # ./tcpdrop.py
-TIME     PID    IP SADDR:SPORT          > DADDR:DPORT          STATE (FLAGS)
-20:49:06 0      4  10.32.119.56:443     > 10.66.65.252:22912   CLOSE (ACK)
-	tcp_drop+0x1
-	tcp_v4_do_rcv+0x135
-	tcp_v4_rcv+0x9c7
-	ip_local_deliver_finish+0x62
-	ip_local_deliver+0x6f
-	ip_rcv_finish+0x129
-	ip_rcv+0x28f
-	__netif_receive_skb_core+0x432
-	__netif_receive_skb+0x18
-	netif_receive_skb_internal+0x37
-	napi_gro_receive+0xc5
-	ena_clean_rx_irq+0x3c3
-	ena_io_poll+0x33f
-	net_rx_action+0x140
-	__softirqentry_text_start+0xdf
-	irq_exit+0xb6
-	do_IRQ+0x82
-	ret_from_intr+0x0
-	native_safe_halt+0x6
-	default_idle+0x20
-	arch_cpu_idle+0x15
-	default_idle_call+0x23
-	do_idle+0x17f
-	cpu_startup_entry+0x73
-	rest_init+0xae
-	start_kernel+0x4dc
-	x86_64_start_reservations+0x24
-	x86_64_start_kernel+0x74
-	secondary_startup_64+0xa5
-
-20:49:50 12431  4  127.0.0.1:8198       > 127.0.0.1:48280      CLOSE (RST|ACK)
-	tcp_drop+0x1
-	tcp_v4_do_rcv+0x135
-	__release_sock+0x88
-	release_sock+0x30
-	inet_stream_connect+0x47
-	SYSC_connect+0x9e
-	sys_connect+0xe
-	do_syscall_64+0x73
-	entry_SYSCALL_64_after_hwframe+0x3d
+TIME     PID     IP SADDR:SPORT          > DADDR:DPORT          STATE (FLAGS)        REASON (CODE)
+14:46:49 0       4  39.156.66.10:80      > 10.211.55.10:33280   SYN_SENT (SYN|ACK)   NETFILTER_DROP (12)
+	b'__traceiter_kfree_skb+0x90'
+	b'__traceiter_kfree_skb+0x90'
+	b'sk_skb_reason_drop+0x1e4'
+	b'nft_do_chain+0x93c'
+	b'nft_do_chain_ipv4+0x16c'
+	b'nf_hook_slow+0xb0'
+	b'ip_local_deliver+0x244'
+	b'ip_sublist_rcv_finish+0xec'
+	b'ip_sublist_rcv+0x32c'
+	b'ip_list_rcv+0x210'
+	b'__netif_receive_skb_list_core+0x348'
+	b'netif_receive_skb_list_internal+0x498'
+	b'napi_complete_done+0x190'
+	b'virtnet_poll+0x10a8'
+	b'__napi_poll+0xa4'
+	b'net_rx_action+0x460'
+	b'handle_softirqs+0x304'
+	b'__do_softirq+0x20'
+	b'____do_softirq+0x1c'
+	b'call_on_irq_stack+0x3c'
+	b'do_softirq_own_stack+0x28'
+	b'__irq_exit_rcu+0x384'
+	b'irq_exit_rcu+0x1c'
+	b'el1_interrupt+0x4c'
+	b'el1h_64_irq_handler+0x1c'
+	b'el1h_64_irq+0x84'
+	b'do_idle+0x31c'
+	b'cpu_startup_entry+0x6c'
+	b'rest_init+0x170'
+	b'start_kernel+0x314'
+	b'__primary_switched+0x94'
 
 [...]
 
-The last two columns show the state of the TCP session, and the TCP flags.
-These two examples show packets arriving for a session in the closed state,
-that were dropped by the kernel.
+The last four columns show the state of the TCP session, the TCP flags, the
+reason for the packet drop, and the corresponding reason code. In this
+example, a packet arriving for a session in the `SYN_SENT` state with
+`SYN|ACK` flags was dropped by the kernel due to the reason `NETFILTER_DROP`.
 
 This tool is useful for debugging high rates of drops, which can cause the
 remote end to do timer-based retransmits, hurting performance.


### PR DESCRIPTION
This commit adds support for dumping TCP drop reasons. It maps these reasons
to human-readable strings, making it easier to understand why TCP packets
are dropped. In cases where the drop reason is not supported, 'NOT_SPECIFIED'
will be displayed.