### PR TITLE
libbpf-tools: statsnoop: Missing dirfd check

### DIFF
--- a/libbpf-tools/statsnoop.bpf.c
+++ b/libbpf-tools/statsnoop.bpf.c
@@ -38,7 +38,7 @@ static int probe_entry(void *ctx, enum sys_type type, int fd, int dirfd,
 	__u32 tid = (__u32)id;
 	struct value value = {};
 
-	if (!pathname && fd == INVALID_FD)
+	if (!pathname && fd == INVALID_FD && dirfd == INVALID_FD)
 		return 0;
 
 	if (target_pid && target_pid != pid)


### PR DESCRIPTION
Forgot check dirfd in [1].

Link: https://github.com/iovisor/bcc/commit/55f5bd3ac43fe47f51b0b98ea0dbcb142e3b788e [1]