### PR TITLE
libbpf-tools: llcstat: Fix error: redefinition of 'key_info' on aarch64

### DIFF
--- a/libbpf-tools/llcstat.bpf.c
+++ b/libbpf-tools/llcstat.bpf.c
@@ -13,15 +13,15 @@ const volatile bool targ_per_thread = false;
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, MAX_ENTRIES);
-	__type(key, struct key_info);
-	__type(value, struct value_info);
+	__type(key, struct llcstat_key_info);
+	__type(value, struct llcstat_value_info);
 } infos SEC(".maps");
 
 static __always_inline
 int trace_event(__u64 sample_period, bool miss)
 {
-	struct key_info key = {};
-	struct value_info *infop, zero = {};
+	struct llcstat_key_info key = {};
+	struct llcstat_value_info *infop, zero = {};
 
 	u64 pid_tgid = bpf_get_current_pid_tgid();
 	key.cpu = bpf_get_smp_processor_id();

--- a/libbpf-tools/llcstat.c
+++ b/libbpf-tools/llcstat.c
@@ -139,9 +139,9 @@ static void print_map(struct bpf_map *map)
 {
 	__u64 total_ref = 0, total_miss = 0, total_hit, hit;
 	__u32 pid, cpu, tid;
-	struct key_info lookup_key = { .cpu = -1 }, next_key;
+	struct llcstat_key_info lookup_key = { .cpu = -1 }, next_key;
 	int err, fd = bpf_map__fd(map);
-	struct value_info info;
+	struct llcstat_value_info info;
 
 	while (!bpf_map_get_next_key(fd, &lookup_key, &next_key)) {
 		err = bpf_map_lookup_elem(fd, &next_key, &info);

--- a/libbpf-tools/llcstat.h
+++ b/libbpf-tools/llcstat.h
@@ -4,13 +4,13 @@
 
 #define TASK_COMM_LEN	16
 
-struct value_info {
+struct llcstat_value_info {
 	__u64 ref;
 	__u64 miss;
 	char comm[TASK_COMM_LEN];
 };
 
-struct key_info {
+struct llcstat_key_info {
 	__u32 cpu;
 	__u32 pid;
 	__u32 tid;


### PR DESCRIPTION
Rename key_info to llcsta_key_info, at the same time, in order to ensure the consistency of key-value naming, rename value_info to llvstat_value_info.

    $ make
    ...
      BPF      llcstat.bpf.o
    In file included from llcstat.bpf.c:7:
    ./llcstat.h:13:8: error: redefinition of 'key_info'
       13 | struct key_info {
          |        ^
    arm64/vmlinux.h:140310:8: note: previous definition is here
     140310 | struct key_info {
            |        ^
    llcstat.bpf.c:27:6: error: no member named 'cpu' in 'struct key_info'
       27 |         key.cpu = bpf_get_smp_processor_id();
          |         ~~~ ^
    llcstat.bpf.c:28:6: error: no member named 'pid' in 'struct key_info'
       28 |         key.pid = pid_tgid >> 32;
          |         ~~~ ^
    llcstat.bpf.c:30:7: error: no member named 'tid' in 'struct key_info'
       30 |                 key.tid = (u32)pid_tgid;
          |                 ~~~ ^
    llcstat.bpf.c:32:7: error: no member named 'tid' in 'struct key_info'
       32 |                 key.tid = key.pid;
          |                 ~~~ ^
    llcstat.bpf.c:32:17: error: no member named 'pid' in 'struct key_info'
       32 |                 key.tid = key.pid;
          |                           ~~~ ^
    6 errors generated.
    make: *** [Makefile:207: /home/rongtao/Git/bcc/libbpf-tools/.output/llcstat.bpf.o] Error 1