### PR TITLE
uprobe: Fix failed to attach BPF to uprobe error

### DIFF
--- a/src/cc/bcc_usdt.h
+++ b/src/cc/bcc_usdt.h
@@ -87,7 +87,7 @@ const char *bcc_usdt_get_fully_specified_probe_argctype(
   void *ctx, const char* provider_name, const char* probe_name, const int arg_index
 );
 
-typedef void (*bcc_usdt_uprobe_cb)(const char *, const char *, uint64_t, int);
+typedef void (*bcc_usdt_uprobe_cb)(const char *, const char *, uint64_t, int, uint64_t);
 void bcc_usdt_foreach_uprobe(void *usdt, bcc_usdt_uprobe_cb callback);
 
 #ifdef __cplusplus

--- a/src/cc/usdt.h
+++ b/src/cc/usdt.h
@@ -343,7 +343,7 @@ public:
   typedef void (*each_cb)(struct bcc_usdt *);
   void each(each_cb callback);
 
-  typedef void (*each_uprobe_cb)(const char *, const char *, uint64_t, int);
+  typedef void (*each_uprobe_cb)(const char *, const char *, uint64_t, int, uint64_t);
   void each_uprobe(each_uprobe_cb callback);
 
   friend class ::ebpf::BPF;

--- a/src/cc/usdt/usdt.cc
+++ b/src/cc/usdt/usdt.cc
@@ -398,7 +398,7 @@ void Context::each_uprobe(each_uprobe_cb callback) {
 
     for (Location &loc : p->locations_) {
       callback(loc.bin_path_.c_str(), p->attached_to_->c_str(), loc.address_,
-               pid_.value_or(-1));
+               pid_.value_or(-1), p->semaphore_offset_);
     }
   }
 }

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -112,7 +112,7 @@ lib.bpf_detach_kprobe.restype = ct.c_int
 lib.bpf_detach_kprobe.argtypes = [ct.c_char_p]
 lib.bpf_attach_uprobe.restype = ct.c_int
 lib.bpf_attach_uprobe.argtypes = [ct.c_int, ct.c_int, ct.c_char_p, ct.c_char_p,
-        ct.c_ulonglong, ct.c_int]
+        ct.c_ulonglong, ct.c_int, ct.c_ulonglong]
 lib.bpf_detach_uprobe.restype = ct.c_int
 lib.bpf_detach_uprobe.argtypes = [ct.c_char_p]
 lib.bpf_attach_tracepoint.restype = ct.c_int
@@ -360,7 +360,7 @@ lib.bcc_usdt_get_argument.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_char_p, ct.
                                       ct.c_int, ct.POINTER(bcc_usdt_argument)]
 
 _USDT_PROBE_CB = ct.CFUNCTYPE(None, ct.c_char_p, ct.c_char_p,
-                              ct.c_ulonglong, ct.c_int)
+                              ct.c_ulonglong, ct.c_int, ct.c_ulonglong)
 
 lib.bcc_usdt_foreach_uprobe.restype = None
 lib.bcc_usdt_foreach_uprobe.argtypes = [ct.c_void_p, _USDT_PROBE_CB]

--- a/src/python/bcc/usdt.py
+++ b/src/python/bcc/usdt.py
@@ -203,16 +203,16 @@ To check which probes are present in the process, use the tplist tool.
     # is a USDT context and probes need to be attached.
     def attach_uprobes(self, bpf, attach_usdt_ignore_pid):
         probes = self.enumerate_active_probes()
-        for (binpath, fn_name, addr, pid) in probes:
+        for (binpath, fn_name, addr, pid, semaphore_offset) in probes:
             if attach_usdt_ignore_pid:
                 pid = -1
             bpf.attach_uprobe(name=binpath, fn_name=fn_name,
-                              addr=addr, pid=pid)
+                              addr=addr, pid=pid, semaphore_offset=semaphore_offset)
 
     def enumerate_active_probes(self):
         probes = []
-        def _add_probe(binpath, fn_name, addr, pid):
-            probes.append((binpath, fn_name, addr, pid))
+        def _add_probe(binpath, fn_name, addr, pid, semaphore_offset):
+            probes.append((binpath, fn_name, addr, pid, semaphore_offset))
 
         lib.bcc_usdt_foreach_uprobe(self.context, _USDT_PROBE_CB(_add_probe))
         return probes


### PR DESCRIPTION
./ugc <pid>
Sometimes errors may occur:
Traceback (most recent call last):
  File "/usr/share/bcc/tools/lib/./ugc", line 216, in <module>
    bpf = BPF(text=program, usdt_contexts=[usdt])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/bpfcc/__init__.py", line 512, in __init__
    usdt_context.attach_uprobes(self, attach_usdt_ignore_pid)
  File "/usr/lib/python3.11/site-packages/bpfcc/usdt.py", line 209, in attach_uprobes
    bpf.attach_uprobe(name=binpath, fn_name=fn_name,
  File "/usr/lib/python3.11/site-packages/bpfcc/__init__.py", line 1417, in attach_uprobe
    raise Exception("Failed to attach BPF to uprobe")
Exception: Failed to attach BPF to uprobe

The error location is at IS_LIGHNED(ref_ctr_offset, sizeof(short)) of function __uprobe_register. This is because the input of the bpf_attach_uprobe function in libbpf.c has increased, but lib.bpf_attach_uprobe has not been modified,
resulting in ref_ctr_offset being a random number and potentially causing an error.

Fixes: 50f2009c7521 ("uprobe: Add ref_cnt_offset arg to bpf_attach_uprobe")