### PR TITLE
libbpf: Fix event name too long error

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1365,11 +1365,11 @@ class BPF(object):
 
     def _get_uprobe_evname(self, prefix, path, addr, pid):
         if pid == -1:
-            return b"%s_%s_0x%x" % (prefix, self._probe_repl.sub(b"_", path), addr)
+            return b"%s_%s_0x%x" % (prefix, self._probe_repl.sub(b"_", os.path.basename(path)), addr)
         else:
             # if pid is valid, put pid in the name, so different pid
             # can have different event names
-            return b"%s_%s_0x%x_%d" % (prefix, self._probe_repl.sub(b"_", path), addr, pid)
+            return b"%s_%s_0x%x_%d" % (prefix, self._probe_repl.sub(b"_", os.path.basename(path)), addr, pid)
 
     def attach_uprobe(self, name=b"", sym=b"", sym_re=b"", addr=None,
             fn_name=b"", pid=-1, sym_off=0):


### PR DESCRIPTION
When the event name is too long, such as p:uprobes/p__proc_124566_root_usr_lib64_libruby_so_3_2_2_0xda3ac_124566_bcc_131967, an error will occur when executing the write function of function create_probe_event.

The kernel error path is
probes_write
  trace_parse_run_command
    create_or_delete_trace_uprobe
      trace_uprobe_create
        trace_probe_create
          __trace_uprobe_create
            traceprobe_parse_event_name
		else if (len >= MAX_EVENT_NAME_LEN)
Requires less than 64 bytes.