### PR TITLE
Python-BCC: support fmod_ret attaching method, and add a useful tool for mptcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[tcptop](tools/tcptop.py): Summarize TCP send/recv throughput by host. Top for TCP. [Examples](tools/tcptop_example.txt).
 - tools/[tcptracer](tools/tcptracer.py): Trace TCP established connections (connect(), accept(), close()). [Examples](tools/tcptracer_example.txt).
 - tools/[tcpcong](tools/tcpcong.py): Trace TCP socket congestion control status duration. [Examples](tools/tcpcong_example.txt).
+- tools/[mptcpify](tools/mptcpify.py): Force applications to use MPTCP instead of TCP. [Examples](tools/mptcpify_example.txt).
 
 ##### Storage and Filesystems Tools
 

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -461,6 +461,7 @@ class BPF(object):
         self.raw_tracepoint_fds = {}
         self.kfunc_entry_fds = {}
         self.kfunc_exit_fds = {}
+        self.fmod_ret_fds = {}
         self.lsm_fds = {}
         self.perf_buffers = {}
         self.open_perf_events = {}
@@ -1157,6 +1158,12 @@ class BPF(object):
             return True
         return False
 
+    @staticmethod
+    def support_fmod_ret():
+        # Checking the existence of enum BPF_MODIFY_RETURN as the
+        # condition of support_fmod_ret.
+        return BPF.kernel_enum_has_val("bpf_attach_type", "BPF_MODIFY_RETURN") == 1
+
     def detach_kfunc(self, fn_name=b""):
         fn_name = _assert_is_bytes(fn_name)
         fn_name = BPF.add_prefix(b"kfunc__", fn_name)
@@ -1165,6 +1172,15 @@ class BPF(object):
             raise Exception("Kernel entry func %s is not attached" % fn_name)
         os.close(self.kfunc_entry_fds[fn_name])
         del self.kfunc_entry_fds[fn_name]
+
+    def detach_fmod_ret(self, fn_name=b""):
+        fn_name = _assert_is_bytes(fn_name)
+        fn_name = BPF.add_prefix(b"kmod_ret__", fn_name)
+
+        if fn_name not in self.fmod_ret_fds:
+            raise Exception("Fmod_ret func %s is not attached" % fn_name)
+        os.close(self.fmod_ret_fds[fn_name])
+        del self.fmod_ret_fds[fn_name]
 
     def detach_kretfunc(self, fn_name=b""):
         fn_name = _assert_is_bytes(fn_name)
@@ -1187,6 +1203,22 @@ class BPF(object):
         if fd < 0:
             raise Exception("Failed to attach BPF to entry kernel func")
         self.kfunc_entry_fds[fn_name] = fd
+        return self
+
+    def attach_fmod_ret(self, fn_name=b""):
+        fn_name = _assert_is_bytes(fn_name)
+        fn_name = BPF.add_prefix(b"kmod_ret__", fn_name)
+
+        if fn_name in self.fmod_ret_fds:
+            raise Exception("Fmod_ret func %s has been attached" % fn_name)
+
+        fn = self.load_func(fn_name, BPF.TRACING)
+        fd = lib.bpf_attach_kfunc(fn.fd)
+
+        if fd < 0:
+            raise Exception("Failed to attach BPF to fmod_ret kernel func")
+        self.fmod_ret_fds[fn_name] = fd
+
         return self
 
     def attach_kretfunc(self, fn_name=b""):
@@ -1830,6 +1862,8 @@ class BPF(object):
             self.detach_kretfunc(k)
         for k, v in list(self.lsm_fds.items()):
             self.detach_lsm(k)
+        for k, v in list(self.fmod_ret_fds.items()):
+            self.detach_fmod_ret(k)
 
         # Clean up opened perf ring buffer and perf events
         table_keys = list(self.tables.keys())

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1252,6 +1252,12 @@ class BPF(object):
         field_name = _assert_is_bytes(field_name)
         return lib.kernel_struct_has_field(struct_name, field_name)
 
+    @staticmethod
+    def kernel_enum_has_val(enum_name, value_name):
+        enum_name = _assert_is_bytes(enum_name)
+        value_name = _assert_is_bytes(value_name)
+        return lib.kernel_enum_has_val(enum_name, value_name)
+
     def detach_tracepoint(self, tp=b""):
         """detach_tracepoint(tp="")
 

--- a/src/python/bcc/libbcc.py
+++ b/src/python/bcc/libbcc.py
@@ -133,6 +133,8 @@ lib.bpf_has_kernel_btf.restype = ct.c_bool
 lib.bpf_has_kernel_btf.argtypes = None
 lib.kernel_struct_has_field.restype = ct.c_int
 lib.kernel_struct_has_field.argtypes = [ct.c_char_p, ct.c_char_p]
+lib.kernel_enum_has_val.restype = ct.c_int
+lib.kernel_enum_has_val.argtypes = [ct.c_char_p, ct.c_char_p]
 lib.bpf_open_perf_buffer.restype = ct.c_void_p
 lib.bpf_open_perf_buffer.argtypes = [_RAW_CB_TYPE, _LOST_CB_TYPE, ct.py_object, ct.c_int, ct.c_int, ct.c_int]
 

--- a/tools/mptcpify.py
+++ b/tools/mptcpify.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+#
+# mptcpify Make the applications to use MPTCP.
+#           For Linux, uses BCC, eBPF. Embedded C.
+#
+# USAGE: ./mptcpify
+#        ./mptcpify -t curl,iperf3
+#
+# Copyright 2025 Kylin Software, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+#
+# 05-Apr-2025   Gang Yan   Created this.
+
+import ctypes as ct
+import argparse
+import signal
+import time
+
+from bcc import BPF
+
+#arguments
+parser = argparse.ArgumentParser(
+         description="mptcpify try to force applications to use MPTCP instead of TCP")
+parser.add_argument("-t", "--targets", type=str,
+                    help="use ',' for multi targets, eg: 'iperf3,rsync'. "
+                         "Without '-t', it can works on all applications by default.")
+
+args_str = parser.parse_args()
+if args_str.targets != None:
+    mode = 1
+    args_list = [t.strip() for t in args_str.targets.split(',')]
+else:
+    mode = 0
+
+if (not BPF.support_fmod_ret()):
+    print("Your kernel version is too old,"
+          " fmod_ret method is only support kernel v5.7 and later.")
+    exit()
+
+TASK_COMM_LEN = 16
+
+class app_name(ct.Structure):
+    _fields_ = [("str", ct.c_char * TASK_COMM_LEN)]
+
+# define BPF program
+prog = """
+#include <linux/net.h>
+#include <uapi/linux/in.h>
+#include <linux/string.h>
+
+struct app_name {
+    char name[TASK_COMM_LEN];
+};
+
+BPF_ARRAY(work_mode, int, 1);
+BPF_HASH(support_apps, struct app_name);
+
+KMOD_RET(update_socket_protocol, int family, int type, int protocol, int ret)
+{
+    struct app_name target = {};
+    int index = 0;
+    int *mode = work_mode.lookup(&index);
+    bpf_get_current_comm(&target.name, TASK_COMM_LEN);
+
+    if ((family == AF_INET || family == AF_INET6) &&
+        type == SOCK_STREAM &&
+        (!protocol || protocol == IPPROTO_TCP) &&
+        (*mode == 0 || support_apps.lookup(&target)))
+        return IPPROTO_MPTCP;
+
+    return protocol;
+
+}
+
+"""
+
+b = BPF(text=prog)
+b.attach_fmod_ret("update_socket_protocol")
+
+work_mode = b["work_mode"]
+support_apps = b.get_table("support_apps")
+if mode:
+    for i in args_list:
+        app = i.encode()
+        name = app_name()
+        name.str = app[:TASK_COMM_LEN-1].ljust(TASK_COMM_LEN, b'\0')
+        support_apps[name] = ct.c_uint32(1)
+
+work_mode[ct.c_int(0)] = ct.c_int(mode)
+
+print("MPTCP is been forced for ", args_list if mode == 1 else "all applications");
+signal.pause()

--- a/tools/mptcpify_example.txt
+++ b/tools/mptcpify_example.txt
@@ -1,0 +1,44 @@
+Demonstrations of mptcpify, the Linux eBPF/bcc version.
+
+
+mptcpify forces the application to use to MPTCP instead of TCP.
+
+mptcpify has been verified with iperf3 and rsync[TCP module]. It can be used
+for incresing the speed of transferring data with rsync.
+
+The MPTCP configuration is decribed in
+https://www.mptcp.dev/pm.html
+
+USAGE message:
+
+usage: sudo python ./mptcpify.py [-h] [-t TARGETS]
+
+mptcpify try to force applications to use MPTCP instead of TCP
+
+options:
+  -h, --help            show this help message and exit
+  -t TARGETS, --targets TARGETS
+                        use ',' for multi targets, eg: 'iperf3,rsync'. Without '-t', it can works on all applications by default.
+
+Here are some example output.
+
+1、curl
+	$ curl https://check.mptcp.dev
+	You are not using MPTCP.
+
+	$ sudo python3 mptcpify.py -t curl &
+	$ curl https://check.mptcp.dev
+	You are using MPTCP.
+
+2、iperf3
+	'iperf.sh' can be obtained through th link below:
+	https://github.com/Dwyane-Yan/bcc_test_iperf/blob/main/iperf.sh
+
+	$ sudo ./iperf.sh
+	[ ID] Interval Transfer Bitrate
+	[ 5] 0.00-1.00 sec 11.4 MBytes 95.3 Mbits/sec
+
+	$ sudo python3 mptcpify.py -t iperf3
+	$ sudo ./iperf.sh
+	[ ID] Interval Transfer Bitrate
+	[ 5] 0.00-1.00 sec 87.0 MBytes 729 Mbits/sec


### PR DESCRIPTION
Multipath TCP (MPTCP) serves as an enhancement to the conventional TCP
protocol, enabling a single transport-layer connection to leverage
multiple network interfaces. This capability makes MPTCP advantageous
for applications requiring bandwidth consolidation, seamless failover
mechanisms, and more robust connectivity solutions.

Linux kernel starts to support MPTCP since v5.6, and it provides a
fmod_ret interface 'update_socket_protocol' to force applications using
MPTCP instead of TCP without modifyiing its code.

So these patches provide a tool named 'mptcpify' which can achieve this.
Using python-BCC is a more easy way for future development, so it is so
important to support 'fmod_ret' in python-BCC.

The first patch is suggested by Yonghong:
‘’‘
On Sun, 2024-08-25 at 21:05 -0700, Yonghong Song wrote:
...
\> Gang Yan, could you explore to add fmod_ret support in bcc? It should
\> be similar to kfunc/kretfunc support. I am happy to review your patches.
’‘’
when I try to make a commit to kernel. (Link attached below)
https://patchwork.kernel.org/project/netdevbpf/patch/tencent_1E619C9E44C8C4B2B713A0D6DD45B92BF70A@qq.com/

@matttbe from the MPTCP kernel team had a look at the new tool.