### PR TITLE
Adapt to gcc 7.3.0 std::string.replace()

### DIFF
--- a/src/cc/common.cc
+++ b/src/cc/common.cc
@@ -175,7 +175,7 @@ static inline field_kind_t _get_field_kind(std::string const& line,
       auto v = get_enum_val_from_btf(dim.c_str());
       if (v)
         dim = std::to_string(*v);
-      field_name.replace(pos1 + 1, pos2 - pos1 - 1, dim, 0);
+      field_name.replace(pos1 + 1, pos2 - pos1 - 1, dim);
     }
     return field_kind_t::regular;
   }


### PR DESCRIPTION
    $ make
    ...
    [  1%] Building CXX object src/cc/CMakeFiles/bpf-static.dir/common.cc.o
    /home/rongtao/Git/bcc/src/cc/common.cc: In function ‘ebpf::field_kind_t ebpf::_get_field_kind(const string&, std::__cxx11::string&, std::__cxx11::string&, int*)’:
    /home/rongtao/Git/bcc/src/cc/common.cc:178:59: error: no matching function for call to ‘std::__cxx11::basic_string<char>::replace(long unsigned int, long unsigned int, std::__cxx11::basic_string<char>&, int)’
           field_name.replace(pos1 + 1, pos2 - pos1 - 1, dim, 0);
                                                               ^
    In file included from /usr/include/c++/7.3.0/string:52:0,
                     from /usr/include/c++/7.3.0/bits/locale_classes.h:40,
                     from /usr/include/c++/7.3.0/bits/ios_base.h:41,
                     from /usr/include/c++/7.3.0/ios:42,
                     from /usr/include/c++/7.3.0/istream:38,
                     from /usr/include/c++/7.3.0/fstream:38,
                     from /home/rongtao/Git/bcc/src/cc/common.cc:16:
    /usr/include/c++/7.3.0/bits/basic_string.h:1861:7: note: candidate: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>& std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::replace(std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type, const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]
           replace(size_type __pos, size_type __n, const basic_string& __str)
           ^~~~~~~