### PR TITLE
Fix llvm compilation failure

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -114,7 +114,11 @@ void SourceDebugger::getDebugSections(
 
 void SourceDebugger::dump() {
   string Error;
+#if LLVM_VERSION_MAJOR >= 21
+  string TripleStr(mod_->getTargetTriple().str());
+#else
   string TripleStr(mod_->getTargetTriple());
+#endif
   Triple TheTriple(TripleStr);
   const Target *T = TargetRegistry::lookupTarget(TripleStr, Error);
   if (!T) {

--- a/src/cc/bpf_module.cc
+++ b/src/cc/bpf_module.cc
@@ -543,7 +543,11 @@ int BPFModule::finalize() {
   sec_map_def tmp_sections,
       *sections_p;
 
+#if LLVM_VERSION_MAJOR >= 21
+  mod->setTargetTriple(Triple("bpf-pc-linux"));
+#else
   mod->setTargetTriple("bpf-pc-linux");
+#endif
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   mod->setDataLayout("e-m:e-p:64:64-i64:64-i128:128-n32:64-S128");
 #else


### PR DESCRIPTION
Upstream patch [1] caused bcc build failure:
```
  ...
  /home/yhs/work/bcc/src/cc/bcc_debug.cc: In member function ‘void ebpf::SourceDebugger::dump()’:
  /home/yhs/work/bcc/src/cc/bcc_debug.cc:117:43: error: no matching function for call to
      ‘std::__cxx11::basic_string<char>::basic_str’
    117 |   string TripleStr(mod_->getTargetTriple());
        |                                           ^
  ...
  /home/yhs/work/bcc/src/cc/bpf_module.cc: In member function ‘int ebpf::BPFModule::finalize()’:
  /home/yhs/work/bcc/src/cc/bpf_module.cc:546:24: error: cannot convert ‘const char [13]’ to ‘llvm::Triple’
    546 |   mod->setTargetTriple("bpf-pc-linux");
        |                        ^~~~~~~~~~~~~~
        |                        |
        |                        const char [13]
  ...
```
This patch fixed the above compilation failure.

  [1] https://github.com/llvm/llvm-project/pull/129868