### PR TITLE
Improved the implementation of bpf.attach_uprobe

### DIFF
--- a/src/cc/api/BPF.h
+++ b/src/cc/api/BPF.h
@@ -389,7 +389,7 @@ class BPF {
   StatusTuple check_binary_symbol(const std::string& binary_path,
                                   const std::string& symbol,
                                   uint64_t symbol_addr, std::string& module_res,
-                                  uint64_t& offset_res,
+                                  uint64_t& offset_res,pid_t pid,
                                   uint64_t symbol_offset = 0);
 
   void init_fail_reset();


### PR DESCRIPTION
Improved the implementation of bpf.attach_uprobe
﻿
Related issue: [#2147](https://github.com/iovisor/bcc/issues/5282)
﻿﻿
What this PR does:
﻿
This PR resolved the issue where bcc failed to operate as anticipated when utilizing the uprobe method via the c-API.
﻿
Why we need it:
﻿
This issue was blocked when I used BCC through C-API, so I suggest fixing it.

 This might not be the best way to resolve the issue.😉
﻿
﻿