### PR TITLE
python: Replace deprecated setup.py with pypa/build+pip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ if(CMAKE_USE_LIBBPF_PACKAGE)
   find_package(LibBpf)
 endif()
 
+if(NOT PYTHON_CMD)
+  set(PYTHON_CMD "python3")
+endif()
+
 if(NOT PYTHON_ONLY)
   find_package(LLVM REQUIRED CONFIG)
   message(STATUS "Found LLVM: ${LLVM_INCLUDE_DIRS} ${LLVM_PACKAGE_VERSION} (Use LLVM_ROOT envronment variable for another version of LLVM)")
@@ -234,5 +238,8 @@ if(NOT TARGET uninstall)
     IMMEDIATE @ONLY)
 
   add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/CmakeUninstall.cmake)
+    COMMAND ${CMAKE_COMMAND} -DPYTHON_CMD=\"${PYTHON_CMD}\"
+                             -DREVISION=${REVISION}
+                             -P ${CMAKE_CURRENT_BINARY_DIR}/CmakeUninstall.cmake
+  )
 endif()

--- a/cmake/CmakeUninstall.cmake.in
+++ b/cmake/CmakeUninstall.cmake.in
@@ -26,4 +26,11 @@ endforeach()
 endfunction()
 
 UninstallManifest("@CMAKE_BINARY_DIR@/install_manifest.txt")
-UninstallManifest("@CMAKE_BINARY_DIR@/install_manifest_python_bcc.txt")
+
+if(EXISTS "/etc/debian_version")
+  set(PY_PIP_ARGS "--break-system-packages")
+endif()
+foreach(PY_CMD ${PYTHON_CMD})
+  message(STATUS "Uninstall python-bcc for ${PY_CMD}.")
+  execute_process(COMMAND ${PY_CMD} -m pip uninstall -y ${PY_PIP_ARGS} bcc==${REVISION})
+endforeach()

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,14 +1,6 @@
 # Copyright (c) PLUMgrid, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License")
 
-if(NOT PYTHON_CMD)
-  set(PYTHON_CMD "python3")
-endif()
-
-if(EXISTS "/etc/debian_version" AND NOT PY_SKIP_DEB_LAYOUT)
-  set(PYTHON_FLAGS "${PYTHON_FLAGS} --install-layout deb")
-endif()
-
 file(GLOB_RECURSE PYTHON_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/*.py)
 file(GLOB_RECURSE PYTHON_INCLUDES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
@@ -27,13 +19,13 @@ foreach(PY_CMD ${PYTHON_CMD})
     configure_file(${PY_INC} ${PY_DIRECTORY}/${PY_INC_REPLACED} @ONLY)
   endforeach()
 
-  set(PIP_INSTALLABLE "${PY_DIRECTORY}/dist/bcc-${REVISION}.tar.gz")
+  set(PIP_INSTALLABLE "${PY_DIRECTORY}/dist/bcc-${REVISION}-py3-none-any.whl")
   add_custom_command(
     OUTPUT ${PIP_INSTALLABLE}
-    COMMAND ${PY_CMD} setup.py sdist
+    COMMAND ${PY_CMD} -m build --wheel ${PY_DIRECTORY}
     WORKING_DIRECTORY ${PY_DIRECTORY}
     DEPENDS ${PYTHON_SOURCES} ${PYTHON_INCLUDES}
-    COMMENT "Building sdist for ${PY_CMD}"
+    COMMENT "Building ${PIP_INSTALLABLE} for ${PY_CMD}"
   )
   add_custom_target(bcc_py_${PY_CMD_ESCAPED} ALL DEPENDS ${PIP_INSTALLABLE})
 
@@ -41,10 +33,11 @@ foreach(PY_CMD ${PYTHON_CMD})
      set(PYTHON_PREFIX ${CMAKE_INSTALL_PREFIX})
   endif()
 
+  message(STATUS "Install ${PIP_INSTALLABLE} for ${PY_CMD}.")
   install(
     CODE "
       execute_process(
-        COMMAND ${PY_CMD} setup.py install -f ${PYTHON_FLAGS} --prefix=${PYTHON_PREFIX} --record ${CMAKE_BINARY_DIR}/install_manifest_python_bcc.txt
-        WORKING_DIRECTORY ${PY_DIRECTORY})"
+        COMMAND ${PY_CMD} -m pip install --force-reinstall --prefix=${PYTHON_PREFIX} ${PIP_INSTALLABLE}
+	WORKING_DIRECTORY ${PY_DIRECTORY})"
     COMPONENT python)
 endforeach()


### PR DESCRIPTION
When setuptools>58.2.0 setup.py installation is a deprecated method, a warning message will be prompted [1]:

    $ sudo make install
    ....
    running install
    /usr/lib/python3.13/site-packages/setuptools/_distutils/cmd.py:66:
    SetuptoolsDeprecationWarning: setup.py install is deprecated.
    !!

            ********************************************************************************
            Please avoid running ``setup.py`` directly.
            Instead, use pypa/build, pypa/installer or other
            standards-based tools.

            See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
            ********************************************************************************

    !!
      self.initialize_options()
    /usr/lib/python3.13/site-packages/setuptools/_distutils/cmd.py:66:
    EasyInstallDeprecationWarning: easy_install command is deprecated.
    !!

            ********************************************************************************
            Please avoid running ``setup.py`` and ``easy_install``.
            Instead, use pypa/build, pypa/installer or other
            standards-based tools.

            See https://github.com/pypa/setuptools/issues/917 for details.
            ********************************************************************************

    !!
      self.initialize_options()

Use the recommended solution [2] to replace setup.py with pypa/build and pip-install to completely solve the problem. It is worth noting that under Debian, you need to add the --break-system-packages parameter to pip-uninstall, as shown in the following prompt:

    Debian12:~$ sudo pip3 uninstall bcc
    error: externally-managed-environment

    × This environment is externally managed
    ╰─> To install Python packages system-wide, try apt install
        python3-xyz, where xyz is the package you are trying to
        install.

        If you wish to install a non-Debian-packaged Python package,
        create a virtual environment using python3 -m venv path/to/venv.
        Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
        sure you have python3-full installed.

        If you wish to install a non-Debian packaged Python application,
        it may be easiest to use pipx install xyz, which will manage a
        virtual environment for you. Make sure you have pipx installed.

        See /usr/share/doc/python3.11/README.venv for more information.

    note: If you believe this is a mistake, please contact your Python
    installation or OS distribution provider. You can override this, at the
    risk of breaking your Python installation or OS, by passing
    --break-system-packages.
    hint: See PEP 668 for the detailed specification.

    # Successfully uninstalled
    Debian12:~$ sudo pip3 uninstall bcc --break-system-packages

Fix: https://github.com/iovisor/bcc/issues/4586 [1]
Link: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html [2]