### PR TITLE
clang: Fix pointer dereference on big-endian machines

### DIFF
--- a/src/cc/frontends/clang/b_frontend_action.h
+++ b/src/cc/frontends/clang/b_frontend_action.h
@@ -91,6 +91,7 @@ class BTypeVisitor : public clang::RecursiveASTVisitor<BTypeVisitor> {
   std::set<clang::Expr *> visited_;
   std::string current_fn_;
   bool cannot_fall_back_safely;
+  std::string probe_read_func;
 };
 
 // Do a depth-first search to rewrite all pointers that need to be probed
@@ -131,6 +132,7 @@ class ProbeVisitor : public clang::RecursiveASTVisitor<ProbeVisitor> {
   const clang::Stmt *addrof_stmt_;
   bool is_addrof_;
   bool cannot_fall_back_safely;
+  std::string probe_read_func;
 };
 
 // A helper class to the frontend action, walks the decls


### PR DESCRIPTION
When pointer is dereferenced, it ends up with bpf_probe_read_kernel(). However, the data type of source and destination might differ in size for genParamIndirectAssign() and this can cause endianness issue.

Fix the pointer dereference by adjusting offsets of source and destination, when there is a size disparity. Also, as a small optimization, perform memset() only on the required destination part, considering the endianness.

* This is specifically needed for the genParamIndirectAssign(), where size disparity could happen. With the patch, the code generated is shown below:

__attribute__((section(".bpf.fn.syscall__kill")))
int syscall__kill(struct pt_regs *ctx)
{
 struct pt_regs * __ctx = (void *)ctx->gprs[2];
 int tpid; BCC_PROBE_READ(&tpid, &__ctx->orig_gpr2, bpf_probe_read_kernel);
 int sig; BCC_PROBE_READ(&sig, &__ctx->gprs[3], bpf_probe_read_kernel);
...

Here ctx->gprs[3] is 64 bit and sig is 32 bit and there is a size disparity.

* However, in other usecases like VisitMemberExpr() etc, The code generated is as below:
if (flags & O_CREAT || (flags & O_TMPFILE) == O_TMPFILE) mode = ({
    typeof(__u64) _val; __builtin_memset(&_val, 0, sizeof(_val));
    bpf_probe_read_kernel(&_val, sizeof(_val), (void *)&how->mode);
_val; });

The code uses typeof(__u64) to create a temporary variable (_val) that matches the size of the data being read. This prevents mismatch between the source and destination sizes and hence changes are not necessary in these usecases.

The fix is based on linux commit:
2e2c6d3fb383 ("selftests/bpf: Fix test_core_reloc_mods on big-endian machines")