### PR TITLE
libbpf-tools/biotop: Use dump_hash for map processing

### DIFF
--- a/libbpf-tools/map_helpers.h
+++ b/libbpf-tools/map_helpers.h
@@ -6,6 +6,7 @@
 #include <bpf/bpf.h>
 
 int dump_hash(int map_fd, void *keys, __u32 key_size,
-	      void *values, __u32 value_size, __u32 *count, void *invalid_key);
+	      void *values, __u32 value_size, __u32 *count, void *invalid_key,
+	      bool lookup_and_delete);
 
 #endif /* __MAP_HELPERS_H */

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -217,7 +217,7 @@ static void print_count_ipv4(int map_fd)
 	struct in_addr src;
 	struct in_addr dst;
 
-	if (dump_hash(map_fd, keys, key_size, counts, value_size, &n, &zero)) {
+	if (dump_hash(map_fd, keys, key_size, counts, value_size, &n, &zero, false)) {
 		warn("dump_hash: %s", strerror(errno));
 		return;
 	}
@@ -250,7 +250,7 @@ static void print_count_ipv6(int map_fd)
 	struct in6_addr src;
 	struct in6_addr dst;
 
-	if (dump_hash(map_fd, keys, key_size, counts, value_size, &n, &zero)) {
+	if (dump_hash(map_fd, keys, key_size, counts, value_size, &n, &zero, false)) {
 		warn("dump_hash: %s", strerror(errno));
 		return;
 	}


### PR DESCRIPTION
Replace biotop's two-loop map lookup and deletion with a single dump_hash
call, using bpf_map_lookup_and_delete_batch for atomic processing to
prevent potential concurrency issues. Simplify code using dump_hash.
