### PR TITLE
bcc: Fix for test bpf_stack_id when running on custom image in yocto

### DIFF
--- a/tests/cc/test_bpf_table.cc
+++ b/tests/cc/test_bpf_table.cc
@@ -260,6 +260,7 @@ TEST_CASE("test bpf stack_id table", "[bpf_stack_table]") {
   /* libc locations on different distributions are added below*/
   bpf.add_module("/lib/x86_64-linux-gnu/libc.so.6"); //Location of libc in ubuntu
   bpf.add_module("/lib64/libc.so.6"); //Location of libc fedora machine
+  bpf.add_module("/lib/libc.so.6");//location of libc in custom image
 
   int stack_id = id[0];
   REQUIRE(stack_id >= 0);


### PR DESCRIPTION
The test for `bpf_stack_id` was failing due to the system being unable to locate `libc.so.6`. Upon investigation using `strace`, the following error was observed:
  newfstatat(AT_FDCWD, "/lib/x86_64-linux-gnu/libc.so.6", 0x7ffdcd475420, 0) = -1 ENOENT (No such file or directory)
  newfstatat(AT_FDCWD, "/lib64/libc.so.6", 0x7ffdcd475420, 0) = -1 ENOENT (No such file or directory)

This issue occurs because `libc.so.6` was not found in the expected locations. To resolve this, the location of `libc.so.6` has been added to the custom Yocto images. It is now accessible at: /lib/libc.so.6

This change ensures proper linking and access to `libc.so.6` during runtime in the Yocto custom image.