### PR TITLE
clang: Define DCONFIG_CC_IS_CLANG in KBuildHelper::get_flags() (#5172)

### DIFF
--- a/src/cc/frontends/clang/kbuild_helper.cc
+++ b/src/cc/frontends/clang/kbuild_helper.cc
@@ -137,6 +137,13 @@ int KBuildHelper::get_flags(const char *uname_machine, vector<string> *cflags) {
   cflags->push_back("-Wno-pointer-sign");
   cflags->push_back("-fno-stack-protector");
 
+  /*
+   * kernel is usually build with gcc and the kernel devel header
+   * reflects that fact. However we build with clang and this must be
+   * set to avoid some compilation errors
+   */
+  cflags->push_back("-DCONFIG_CC_IS_CLANG");
+
   return 0;
 }
 


### PR DESCRIPTION
On powerpc, many tools fail with an "invalid output constraint '=YZ<>' in asm" error. This come from the following code in arch/powerpc/include/asm/asm-compat.h:

Because CONFIG_CC_IS_CLANG is not defined in the headers, we end up using a constraint that is not understoog by clang.

Defining CONFIG_CC_IS_CLANG in KBuildHelper::get_flags() fixes this error and possibly other similar error.

Suggested-by: Shung-Hsi Yu <shung-hsi.yu@suse.com>