### PR TITLE
Fix running cmake outside of the source subtree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if(NOT CMAKE_USE_LIBBPF_PACKAGE)
     endif()
   else()
     execute_process(COMMAND git diff --shortstat ${CMAKE_CURRENT_SOURCE_DIR}/src/cc/libbpf/
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     OUTPUT_VARIABLE DIFF_STATUS)
     if("${DIFF_STATUS}" STREQUAL "")
       execute_process(COMMAND git submodule update --init --recursive


### PR DESCRIPTION
Configuring bcc in a build directory that is not in the source subtree causes the following warning:

    warning: Not a git repository. Use --no-index to compare two paths outside a working tree

This is caused by a subcommand running in the current working directory. Run it in the source directory instead.

Fixes: 3df26a542f80 ("cmake: sync submodule libbpf when do cmake.")