### PR TITLE
Use ubuntu 24.04 and fedora 41 for CI testing

### DIFF
--- a/.github/workflows/publish-build-containers.yml
+++ b/.github/workflows/publish-build-containers.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       matrix:
         os: [
-          {distro: "ubuntu", version: "20.04", nick: focal, installed_llvm_versions: "12 15 17"},
-          {distro: "fedora", version: "38", nick: "f38", installed_llvm_versions: "this is not used"},
+          {distro: "ubuntu", version: "24.04", nick: focal, installed_llvm_versions: "12 15 17 19"},
+          {distro: "fedora", version: "41", nick: "f41", installed_llvm_versions: "this is not used"},
         ]
 
     steps:


### PR DESCRIPTION
The ubuntu 20.04 and fedora 38 are not supported any more. So let us upgrade to new releases for CI testing.