### PR TITLE
Fix tests to support finish_task_switch.isra.* suffix

### DIFF
--- a/tests/python/test_clang.py
+++ b/tests/python/test_clang.py
@@ -399,7 +399,7 @@ struct key_t {
   u32 curr_pid;
 };
 BPF_HASH(stats, struct key_t, u64, 1024);
-int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
+int count_sched(struct pt_regs *ctx, struct task_struct *prev) {
   struct key_t key = {};
   u64 zero = 0, *val;
   key.curr_pid = bpf_get_current_pid_tgid();
@@ -412,6 +412,10 @@ int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
   return 0;
 }
 """)
+        b.attach_kprobe(
+            event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
+            fn_name=b"count_sched"
+        )
 
     def test_probe_simple_assign(self):
         b = BPF(text=b"""

--- a/tests/python/test_histogram.py
+++ b/tests/python/test_histogram.py
@@ -64,7 +64,7 @@ int kprobe__htab_map_delete_elem(struct pt_regs *ctx, struct bpf_map *map, u64 *
 #include <linux/version.h>
 typedef struct { char name[TASK_COMM_LEN]; u64 slot; } Key;
 BPF_HISTOGRAM(hist1, Key, 1024);
-int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
+int count_prev_task_start_time(struct pt_regs *ctx, struct task_struct *prev) {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)
     Key k = {.slot = bpf_log2l(prev->real_start_time)};
 #else
@@ -77,6 +77,10 @@ int kprobe__finish_task_switch(struct pt_regs *ctx, struct task_struct *prev) {
     return 0;
 }
 """)
+        b.attach_kprobe(
+            event_re=r'^finish_task_switch$|^finish_task_switch\.isra\.\d$',
+            fn_name=b"count_prev_task_start_time"
+        )
         for i in range(0, 100): time.sleep(0.01)
         b[b"hist1"].print_log2_hist()
         b.cleanup()


### PR DESCRIPTION
When running on kernels compiled with GCC 11.4, the `py_test_clang` and `py_test_histogram` tests fail because the `finish_task_switch` function changed to `finish_task_switch.isra.0`.
- Output of `cat /proc/kallsyms | grep finish_task_switch`:
```
0000000000000000 t finish_task_switch.isra.0
0000000000000000 t finish_task_switch.isra.0.cold
```
This problem was reported in [PR #3315](https://github.com/iovisor/bcc/pull/3315). This PR applies the same fix to `py_test_clang` and `py_test_histogram`.

<details><summary>Output of `sudo ctest -R "py_test_clang|py_test_histogram" --output-on-failure` before the fix</summary>

```
Test project /opt/bcc/build
    Start 16: py_test_clang
1/2 Test #16: py_test_clang ....................***Failed   64.85 sec
................./virtual/main.c:2:1: error: field has incomplete type 'struct key_t'
BPF_HASH(drops, struct key_t);
^
/virtual/include/bcc/helpers.h:290:48: note: expanded from macro 'BPF_HASH'
BPF_HASHX(__VA_ARGS__, BPF_HASH4, BPF_HASH3, BPF_HASH2, BPF_HASH1)(__VA_ARGS__)
                                            ^
/virtual/main.c:2:24: note: forward declaration of 'struct key_t'
BPF_HASH(drops, struct key_t);
                    ^
/virtual/main.c:2:1: error: field has incomplete type 'struct key_t'
BPF_HASH(drops, struct key_t);
^
/virtual/include/bcc/helpers.h:290:48: note: expanded from macro 'BPF_HASH'
BPF_HASHX(__VA_ARGS__, BPF_HASH4, BPF_HASH3, BPF_HASH2, BPF_HASH1)(__VA_ARGS__)
                                            ^
/virtual/main.c:2:24: note: forward declaration of 'struct key_t'
BPF_HASH(drops, struct key_t);
                    ^
2 errors generated.
../virtual/main.c:6:12: error: cannot call non-static helper function
    return bar();
        ^
1 error generated.
.........................................................../virtual/main.c:1:30: error: expected expression
int failure(void *ctx) { if (); return 0; }
                            ^
1 error generated.
.cannot attach kprobe, probe entry may not exist
E/virtual/main.c:3:73: error: too many arguments, bcc only supports in-register parameters
int many(struct pt_regs *ctx, int a, int b, int c, int d, int e, int f, int g) {
                                                                        ^
1 error generated.
.cannot attach kprobe, probe entry may not exist
...
======================================================================
ERROR: test_task_switch (__main__.TestClang)
----------------------------------------------------------------------
Traceback (most recent call last):
File "/opt/bcc/tests/python/test_clang.py", line 394, in test_task_switch
    b = BPF(text=b"""
File "/opt/bcc/build/src/python/bcc-python3/bcc/__init__.py", line 514, in __init__
    self._trace_autoload()
File "/opt/bcc/build/src/python/bcc-python3/bcc/__init__.py", line 1544, in _trace_autoload
    self.attach_kprobe(
File "/opt/bcc/build/src/python/bcc-python3/bcc/__init__.py", line 882, in attach_kprobe
    raise Exception("Failed to attach BPF program %s to kprobe %s"
Exception: Failed to attach BPF program b'kprobe__finish_task_switch' to kprobe b'finish_task_switch', it's not traceable (either non-existing, inlined, or marked as "notrace")

----------------------------------------------------------------------
Ran 84 tests in 64.238s

FAILED (errors=1)
0
Current kernel does not have __vfs_read, try vfs_read instead
Failed

    Start 17: py_test_histogram
2/2 Test #17: py_test_histogram ................***Failed    2.47 sec
cannot attach kprobe, probe entry may not exist
E
k_1 & k_2 =   0 0
    size                : count     distribution
        32 -> 63         : 2        |******                                  |
        64 -> 127        : 3        |**********                              |
    128 -> 255        : 0        |                                        |
    256 -> 511        : 0        |                                        |
    512 -> 1023       : 6        |********************                    |
    1024 -> 2047       : 5        |****************                        |
    2048 -> 4095       : 0        |                                        |
    4096 -> 8191       : 0        |                                        |
    8192 -> 16383      : 0        |                                        |
    16384 -> 32767      : 0        |                                        |
    32768 -> 65535      : 4        |*************                           |
    65536 -> 131071     : 0        |                                        |
    131072 -> 262143     : 12       |****************************************|

k_1 & k_2 =   0 4
    size                : count     distribution
        4 -> 7          : 2        |****************************************|

k_1 & k_2 =   0 5
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  16 0
    size                : count     distribution
        32 -> 63         : 1        |                                        |
        64 -> 127        : 4        |*                                       |
    128 -> 255        : 0        |                                        |
    256 -> 511        : 0        |                                        |
    512 -> 1023       : 11       |**                                      |
    1024 -> 2047       : 0        |                                        |
    2048 -> 4095       : 0        |                                        |
    4096 -> 8191       : 0        |                                        |
    8192 -> 16383      : 0        |                                        |
    16384 -> 32767      : 0        |                                        |
    32768 -> 65535      : 0        |                                        |
    65536 -> 131071     : 5        |*                                       |
    131072 -> 262143     : 156      |****************************************|
    262144 -> 524287     : 6        |*                                       |

k_1 & k_2 =  16 1
    size                : count     distribution
    65536 -> 131071     : 2        |****************************************|

k_1 & k_2 =  16 2
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  16 4
    size                : count     distribution
        4 -> 7          : 1        |****************************************|

k_1 & k_2 =  16 5
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  16 6
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  16 7
    size                : count     distribution
        0 -> 1          : 2        |****************************************|
        2 -> 3          : 0        |                                        |
        4 -> 7          : 0        |                                        |
        8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
    128 -> 255        : 0        |                                        |
    256 -> 511        : 0        |                                        |
    512 -> 1023       : 0        |                                        |
    1024 -> 2047       : 0        |                                        |
    2048 -> 4095       : 0        |                                        |
    4096 -> 8191       : 0        |                                        |
    8192 -> 16383      : 0        |                                        |
    16384 -> 32767      : 0        |                                        |
    32768 -> 65535      : 0        |                                        |
    65536 -> 131071     : 1        |********************                    |

k_1 & k_2 =  32 0
    size                : count     distribution
        16 -> 31         : 1        |**                                      |
        32 -> 63         : 1        |**                                      |
        64 -> 127        : 1        |**                                      |
    128 -> 255        : 0        |                                        |
    256 -> 511        : 0        |                                        |
    512 -> 1023       : 10       |*************************               |
    1024 -> 2047       : 1        |**                                      |
    2048 -> 4095       : 0        |                                        |
    4096 -> 8191       : 16       |****************************************|
    8192 -> 16383      : 0        |                                        |
    16384 -> 32767      : 0        |                                        |
    32768 -> 65535      : 0        |                                        |
    65536 -> 131071     : 9        |**********************                  |

k_1 & k_2 =  32 1
    size                : count     distribution
    65536 -> 131071     : 2        |****************************************|

k_1 & k_2 =  32 2
    size                : count     distribution
    65536 -> 131071     : 4        |****************************************|

k_1 & k_2 =  32 3
    size                : count     distribution
    65536 -> 131071     : 4        |****************************************|

k_1 & k_2 =  32 4
    size                : count     distribution
    65536 -> 131071     : 3        |****************************************|

k_1 & k_2 =  32 5
    size                : count     distribution
    65536 -> 131071     : 3        |****************************************|

k_1 & k_2 =  32 6
    size                : count     distribution
    65536 -> 131071     : 6        |****************************************|

k_1 & k_2 =  32 7
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  48 0
    size                : count     distribution
        32 -> 63         : 3        |******                                  |
        64 -> 127        : 2        |****                                    |
    128 -> 255        : 0        |                                        |
    256 -> 511        : 0        |                                        |
    512 -> 1023       : 4        |********                                |
    1024 -> 2047       : 20       |****************************************|
    2048 -> 4095       : 0        |                                        |
    4096 -> 8191       : 2        |****                                    |
    8192 -> 16383      : 0        |                                        |
    16384 -> 32767      : 0        |                                        |
    32768 -> 65535      : 0        |                                        |
    65536 -> 131071     : 2        |****                                    |

k_1 & k_2 =  48 1
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  48 2
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  48 6
...
======================================================================
ERROR: test_chars (__main__.TestHistogram)
----------------------------------------------------------------------
Traceback (most recent call last):
File "/opt/bcc/tests/python/test_histogram.py", line 61, in test_chars
    b = BPF(text=b"""
File "/opt/bcc/build/src/python/bcc-python3/bcc/__init__.py", line 514, in __init__
    self._trace_autoload()
File "/opt/bcc/build/src/python/bcc-python3/bcc/__init__.py", line 1544, in _trace_autoload
    self.attach_kprobe(
File "/opt/bcc/build/src/python/bcc-python3/bcc/__init__.py", line 882, in attach_kprobe
    raise Exception("Failed to attach BPF program %s to kprobe %s"
Exception: Failed to attach BPF program b'kprobe__finish_task_switch' to kprobe b'finish_task_switch', it's not traceable (either non-existing, inlined, or marked as "notrace")

----------------------------------------------------------------------
Ran 4 tests in 2.368s

FAILED (errors=1)
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  48 7
    size                : count     distribution
        0 -> 1          : 4        |****************************************|
        2 -> 3          : 0        |                                        |
        4 -> 7          : 0        |                                        |
        8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
    128 -> 255        : 0        |                                        |
    256 -> 511        : 0        |                                        |
    512 -> 1023       : 0        |                                        |
    1024 -> 2047       : 0        |                                        |
    2048 -> 4095       : 0        |                                        |
    4096 -> 8191       : 0        |                                        |
    8192 -> 16383      : 0        |                                        |
    16384 -> 32767      : 0        |                                        |
    32768 -> 65535      : 0        |                                        |
    65536 -> 131071     : 2        |********************                    |

k_1 & k_2 =  64 0
    size                : count     distribution
        64 -> 127        : 1        |*                                       |
    128 -> 255        : 0        |                                        |
    256 -> 511        : 0        |                                        |
    512 -> 1023       : 21       |****************************************|
    1024 -> 2047       : 6        |***********                             |
    2048 -> 4095       : 0        |                                        |
    4096 -> 8191       : 0        |                                        |
    8192 -> 16383      : 1        |*                                       |
    16384 -> 32767      : 0        |                                        |
    32768 -> 65535      : 0        |                                        |
    65536 -> 131071     : 3        |*****                                   |

k_1 & k_2 =  64 1
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  64 2
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  64 3
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  64 4
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  64 5
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  64 6
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  64 7
    size                : count     distribution
        0 -> 1          : 1        |****************************************|

k_1 & k_2 =  80 0
    size                : count     distribution
        32 -> 63         : 3        |************                            |
        64 -> 127        : 1        |****                                    |
    128 -> 255        : 0        |                                        |
    256 -> 511        : 0        |                                        |
    512 -> 1023       : 2        |********                                |
    1024 -> 2047       : 10       |****************************************|

k_1 & k_2 =  80 1
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  80 2
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  80 4
    size                : count     distribution
    65536 -> 131071     : 2        |****************************************|

k_1 & k_2 =  80 5
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  80 6
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  96 0
    size                : count     distribution
        32 -> 63         : 4        |                                        |
        64 -> 127        : 2        |                                        |
    128 -> 255        : 0        |                                        |
    256 -> 511        : 0        |                                        |
    512 -> 1023       : 10       |*                                       |
    1024 -> 2047       : 7        |                                        |
    2048 -> 4095       : 310      |****************************************|
    4096 -> 8191       : 3        |                                        |
    8192 -> 16383      : 14       |*                                       |

k_1 & k_2 =  96 1
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 =  96 6
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 = 112 0
    size                : count     distribution
        32 -> 63         : 1        |*****                                   |
        64 -> 127        : 1        |*****                                   |
    128 -> 255        : 0        |                                        |
    256 -> 511        : 0        |                                        |
    512 -> 1023       : 6        |******************************          |
    1024 -> 2047       : 8        |****************************************|

k_1 & k_2 = 112 1
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|

k_1 & k_2 = 112 4
    size                : count     distribution
    65536 -> 131071     : 1        |****************************************|
Failed


0% tests passed, 2 tests failed out of 2

Total Test time (real) =  67.32 sec

The following tests FAILED:
        16 - py_test_clang (Failed)
        17 - py_test_histogram (Failed)
Errors while running CTest
```

</details>

<details><summary>Output of `sudo ctest -R "py_test_clang|py_test_histogram" --output-on-failure` after the fix</summary>

```
Test project /opt/bcc/build
    Start 16: py_test_clang
1/2 Test #16: py_test_clang ....................   Passed   66.03 sec
    Start 17: py_test_histogram
2/2 Test #17: py_test_histogram ................   Passed    4.06 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  70.09 sec
```    

</details>
