### PR TITLE
Enable CI testing with ubuntu 24.04 and fedora 41

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "OS Disctribution. Ex: ubuntu"
     required: true
   os_version:
-    description: "Version of the OS. Ex: 20.04"
+    description: "Version of the OS. Ex: 24.04"
     required: true
   os_nick:
     description: "Nickname of the OS. Ex: focal"

--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -18,10 +18,10 @@ permissions:
 
 jobs:
   test_bcc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        os: [{distro: "ubuntu", version: "20.04", nick: focal}]
+        os: [{distro: "ubuntu", version: "24.04", nick: noble}]
         llvm_version: [12, 15, 17]
         env:
         - TYPE: Debug
@@ -127,10 +127,10 @@ jobs:
         overwrite: true
 
   test_bcc_fedora:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        os: [{distro: "fedora", version: "38", nick: "f38"}]
+        os: [{distro: "fedora", version: "41", nick: "f41"}]
         env:
         - TYPE: Debug
           PYTHON_TEST_LOGFILE: critical.log


### PR DESCRIPTION
The ubuntu 20.04 and fedora 38 are not supported any more. So let us upgrade to new releases for CI testing.