### PR TITLE
tools/biosnoop: Fix biosnoop pattern option

### DIFF
--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -218,7 +218,6 @@ static int __trace_req_completion(void *ctx, struct hash_key key)
     struct start_req_t *startp;
     struct val_t *valp;
     struct data_t data = {};
-    //struct gendisk *rq_disk;
     u64 ts;
 
     // fetch timestamp and calculate delta
@@ -228,7 +227,6 @@ static int __trace_req_completion(void *ctx, struct hash_key key)
         return 0;
     }
     ts = bpf_ktime_get_ns();
-    //rq_disk = req->__RQ_DISK__;
     data.delta = ts - startp->ts;
     data.ts = ts / 1000;
     data.qdelta = 0;
@@ -260,10 +258,10 @@ static int __trace_req_completion(void *ctx, struct hash_key key)
 
     sector = last_sectors.lookup(&sector_key);
     if (sector != 0) {
-        data.pattern = req->__sector == *sector ? SEQUENTIAL : RANDOM;
+        data.pattern = key.sector == *sector ? SEQUENTIAL : RANDOM;
     }
 
-    last_sector = req->__sector + data.len / 512;
+    last_sector = key.sector + data.len / 512;
     last_sectors.update(&sector_key, &last_sector);
 #endif
 


### PR DESCRIPTION
The code to support the block_io tracepoints failed to update some code that is used with the -P option. That code changed the second argument of __trace_req_completion from 'req' to 'key', but in the "#ifdef INCLUDE_PATTERN" block, the use of 'req' remained unchanged. Of course, 'key' should be use here too.

It fixes the following error:
$ biosnoop -P
/virtual/main.c:213:24: error: use of undeclared identifier 'req'
  213 |         data.pattern = req->__sector == *sector ? SEQUENTIAL : RANDOM;
      |                        ^
/virtual/main.c:216:19: error: use of undeclared identifier 'req'
  216 |     last_sector = req->__sector + data.len / 512;
      |                   ^
2 errors generated.
Traceback (most recent call last):
  File "/usr/share/bcc/tools/biosnoop", line 335, in <module>
    b = BPF(text=bpf_text)
  File "/usr/lib/python3.13/site-packages/bcc/__init__.py", line 505, in __init__
    raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
Exception: Failed to compile BPF module <text>