### PR TITLE
bcc: import subprocess in __init__.py

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -22,6 +22,7 @@ import re
 import errno
 import sys
 import platform
+import subprocess
 
 from .libbcc import lib, bcc_symbol, bcc_symbol_option, bcc_stacktrace_build_id, _SYM_CB_TYPE
 from .table import Table, PerfEventArray, RingBuf, BPF_MAP_TYPE_QUEUE, BPF_MAP_TYPE_STACK


### PR DESCRIPTION
When executing the bcc script, there exists the following fatal error on LoongArch:

$ sudo /usr/share/bcc/tools/filetop

In file included from <built-in>:4:
In file included from /virtual/include/bcc/helpers.h:54: In file included from arch/loongarch/include/asm/page.h:9: In file included from arch/loongarch/include/asm/addrspace.h:16: arch/loongarch/include/asm/loongarch.h:13:10: fatal error: 'larchintrin.h' file not found
   13 | #include <larchintrin.h>
      |          ^~~~~~~~~~~~~~~
1 error generated.

git log shows that it has been fixed in the commit 8aa9f7072d53 ("Fix larchintrin.h not found error for loongarch64"), but the same error still exists in the latest mainline bcc.

This is because both clang_include_path_str and gcc_include_path_str are False due to subprocess.check_output() failed, import subprocess in __init__.py to fix it.

How to reproduce:

git clone https://github.com/iovisor/bcc.git
mkdir bcc/build; cd bcc/build
cmake ..
make
sudo make install

Fixes: 8aa9f7072d53 ("Fix larchintrin.h not found error for loongarch64")