### PR TITLE
Fix the issue where xfsslower cannot track write operations on files opened with the O_SYNC flag

### DIFF
--- a/tools/xfsslower.py
+++ b/tools/xfsslower.py
@@ -69,7 +69,7 @@ bpf_text = """
 #define TRACE_FSYNC     3
 
 struct key_t {
-    u64 ptid; //pid and tid
+    u64 id;
     u32 type;
 };
 
@@ -108,7 +108,7 @@ static int trace_rw_entry(struct pt_regs *ctx, struct kiocb *iocb, int type)
         return 0;
 
     struct key_t key = {};
-    key.ptid = id;
+    key.id = id;
     key.type = type;
 
     // store filep and timestamp by id
@@ -143,7 +143,7 @@ int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
         return 0;
     
     struct key_t key = {};
-    key.ptid = id;
+    key.id = id;
     key.type = TRACE_OPEN;
 
     // store filep and timestamp by id
@@ -167,7 +167,7 @@ int trace_fsync_entry(struct pt_regs *ctx, struct file *file)
         return 0;
 
     struct key_t key = {};
-    key.ptid = id;
+    key.id = id;
     key.type = TRACE_FSYNC;
 
     // store filep and timestamp by id
@@ -191,7 +191,7 @@ static int trace_return(struct pt_regs *ctx, int type)
     u64 id = bpf_get_current_pid_tgid();
     u32 pid = id >> 32; // PID is higher part
     struct key_t key = {};
-    key.ptid = id;
+    key.id = id;
     key.type = type;
 
     valp = entryinfo.lookup(&key);

--- a/tools/xfsslower.py
+++ b/tools/xfsslower.py
@@ -68,6 +68,11 @@ bpf_text = """
 #define TRACE_OPEN      2
 #define TRACE_FSYNC     3
 
+struct key_t {
+    u64 ptid; //pid and tid
+    u32 type;
+};
+
 struct val_t {
     u64 ts;
     u64 offset;
@@ -86,7 +91,7 @@ struct data_t {
     char file[DNAME_INLINE_LEN];
 };
 
-BPF_HASH(entryinfo, u64, struct val_t);
+BPF_HASH(entryinfo, struct key_t, struct val_t);
 BPF_PERF_OUTPUT(events);
 
 //
@@ -94,7 +99,7 @@ BPF_PERF_OUTPUT(events);
 //
 
 // xfs_file_read_iter(), xfs_file_write_iter():
-int trace_rw_entry(struct pt_regs *ctx, struct kiocb *iocb)
+static int trace_rw_entry(struct pt_regs *ctx, struct kiocb *iocb, int type)
 {
     u64 id = bpf_get_current_pid_tgid();
     u32 pid = id >> 32; // PID is higher part
@@ -102,15 +107,29 @@ int trace_rw_entry(struct pt_regs *ctx, struct kiocb *iocb)
     if (FILTER_PID)
         return 0;
 
+    struct key_t key = {};
+    key.ptid = id;
+    key.type = type;
+
     // store filep and timestamp by id
     struct val_t val = {};
     val.ts = bpf_ktime_get_ns();
     val.fp = iocb->ki_filp;
     val.offset = iocb->ki_pos;
     if (val.fp)
-        entryinfo.update(&id, &val);
+        entryinfo.update(&key, &val);
 
     return 0;
+}
+
+int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
+{
+    return trace_rw_entry(ctx, iocb, TRACE_READ);
+}
+
+int trace_write_entry(struct pt_regs *ctx, struct kiocb *iocb)
+{
+    return trace_rw_entry(ctx, iocb, TRACE_WRITE);
 }
 
 // xfs_file_open():
@@ -122,6 +141,10 @@ int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
 
     if (FILTER_PID)
         return 0;
+    
+    struct key_t key = {};
+    key.ptid = id;
+    key.type = TRACE_OPEN;
 
     // store filep and timestamp by id
     struct val_t val = {};
@@ -129,7 +152,7 @@ int trace_open_entry(struct pt_regs *ctx, struct inode *inode,
     val.fp = file;
     val.offset = 0;
     if (val.fp)
-        entryinfo.update(&id, &val);
+        entryinfo.update(&key, &val);
 
     return 0;
 }
@@ -143,13 +166,17 @@ int trace_fsync_entry(struct pt_regs *ctx, struct file *file)
     if (FILTER_PID)
         return 0;
 
+    struct key_t key = {};
+    key.ptid = id;
+    key.type = TRACE_FSYNC;
+
     // store filep and timestamp by id
     struct val_t val = {};
     val.ts = bpf_ktime_get_ns();
     val.fp = file;
     val.offset = 0;
     if (val.fp)
-        entryinfo.update(&id, &val);
+        entryinfo.update(&key, &val);
 
     return 0;
 }
@@ -163,8 +190,11 @@ static int trace_return(struct pt_regs *ctx, int type)
     struct val_t *valp;
     u64 id = bpf_get_current_pid_tgid();
     u32 pid = id >> 32; // PID is higher part
+    struct key_t key = {};
+    key.ptid = id;
+    key.type = type;
 
-    valp = entryinfo.lookup(&id);
+    valp = entryinfo.lookup(&key);
     if (valp == 0) {
         // missed tracing issue or filtered
         return 0;
@@ -173,7 +203,7 @@ static int trace_return(struct pt_regs *ctx, int type)
     // calculate delta
     u64 ts = bpf_ktime_get_ns();
     u64 delta_us = ts - valp->ts;
-    entryinfo.delete(&id);
+    entryinfo.delete(&key);
 
     // Skip entries with backwards time: temp workaround for #728
     if ((s64) delta_us < 0)
@@ -267,8 +297,8 @@ def print_event(cpu, data, size):
 b = BPF(text=bpf_text)
 
 # common file functions
-b.attach_kprobe(event="xfs_file_read_iter", fn_name="trace_rw_entry")
-b.attach_kprobe(event="xfs_file_write_iter", fn_name="trace_rw_entry")
+b.attach_kprobe(event="xfs_file_read_iter", fn_name="trace_read_entry")
+b.attach_kprobe(event="xfs_file_write_iter", fn_name="trace_write_entry")
 b.attach_kprobe(event="xfs_file_open", fn_name="trace_open_entry")
 b.attach_kprobe(event="xfs_file_fsync", fn_name="trace_fsync_entry")
 b.attach_kretprobe(event="xfs_file_read_iter", fn_name="trace_read_return")


### PR DESCRIPTION
This patch fixes an issue in xfsslower where write operation traces are overwritten when files are opened with O_SYNC flag. Currently, when a file is opened with O_SYNC, xfsslower fails to track write operations and only shows sync operations.
For example, when testing XFS I/O using this fio command:
[xxx@yyy ~]# fio --name=dsync-write --group_reporting --ioengine=psync --filename=./test --direct=1 --sync=1 --rw=write --bs=32k --size=4G --iodepth=1 --thread=1 --numjobs=1
And tracing with:
[xxx@yyy ~]# /usr/share/bcc/tools/xfsslower 0
The output only shows fsync operations without any write traces:
14:57:16 fio 189921 S 0 0 0.00 test
14:57:16 fio 189921 S 0 0 0.00 test
14:57:16 fio 189921 S 0 0 0.04 test
The root cause is that for O_SYNC files, xfs_file_write_iter calls xfs_file_fsync internally. This causes both trace_rw_entry and trace_fsync_entry to execute sequentially in the same process context.Since xfsslower uses BPF_HASH(entryinfo, u64, struct val_t) where entryinfo only uses pid and tid as keys, the entryinfo entry created by trace_rw_entry gets overwritten by trace_fsync_entry, making it impossible to track xfs_file_write_iter latency.
The solution introduces a new key structure:
struct key_t {
u64 ptid; // pid and tid
u32 type; // operation type
};
All kprobe trace functions in xfsslower have been updated to work with the new key structure. After this change, xfsslower correctly tracks both xfs_file_write_iter and xfs_file_fsync latencies:
15:22:13 fio 190028 S 0 0 0.00 test
15:22:13 fio 190028 W 32768 2293504 0.05 test
15:22:13 fio 190028 S 0 0 0.00 test
15:22:13 fio 190028 W 32768 2293536 0.05 test
See the code changes in this commit for implementation details.