### PR TITLE
ci: Upgrade ubuntu 20.04 to 24.04

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -6,15 +6,15 @@ inputs:
     description: "OS Disctribution. Ex: ubuntu"
     required: true
   os_version:
-    description: "Version of the OS. Ex: 20.04"
+    description: "Version of the OS. Ex: 24.04"
     required: true
   os_nick:
-    description: "Nickname of the OS. Ex: focal"
+    description: "Nickname of the OS. Ex: noble"
     required: true
   llvm_versions:
     description: "Space separated list of llvm versions to install in the container. Only supported for Ubuntu containers."
     type: string
-    default: "12"
+    default: "15"
   registry:
     description: "Registry where to push images"
     default: ghcr.io

--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -18,11 +18,11 @@ permissions:
 
 jobs:
   test_bcc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        os: [{distro: "ubuntu", version: "20.04", nick: focal}]
-        llvm_version: [12, 15, 17]
+        os: [{distro: "ubuntu", version: "24.04", nick: noble}]
+        llvm_version: [15, 17, 19]
         env:
         - TYPE: Debug
           PYTHON_TEST_LOGFILE: critical.log
@@ -127,7 +127,7 @@ jobs:
         overwrite: true
 
   test_bcc_fedora:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         os: [{distro: "fedora", version: "38", nick: "f38"}]

--- a/.github/workflows/publish-build-containers.yml
+++ b/.github/workflows/publish-build-containers.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [
-          {distro: "ubuntu", version: "20.04", nick: focal, installed_llvm_versions: "12 15 17"},
+          {distro: "ubuntu", version: "24.04", nick: noble, installed_llvm_versions: "15 17 19"},
           {distro: "fedora", version: "38", nick: "f38", installed_llvm_versions: "this is not used"},
         ]
 

--- a/docker/build/Dockerfile.fedora
+++ b/docker/build/Dockerfile.fedora
@@ -30,8 +30,6 @@ RUN dnf -y install \
 	elfutils-debuginfod-client-devel \
 #	elfutils-libelf-devel-static \
 	elfutils-libelf-devel \
-	luajit \
-	luajit-devel \
 	python3-devel \
 	libstdc++ \
 	libstdc++-devel \
@@ -59,6 +57,8 @@ RUN dnf -y install \
 	iperf \
 	netperf
 
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1 pyelftools==0.30
 
 RUN wget -O ruby-install-${RUBY_INSTALL_VERSION}.tar.gz \

--- a/docker/build/Dockerfile.ubuntu
+++ b/docker/build/Dockerfile.ubuntu
@@ -1,10 +1,10 @@
-ARG VERSION="20.04"
+ARG VERSION="24.04"
 FROM ubuntu:${VERSION}
 
-ARG LLVM_VERSION="12"
+ARG LLVM_VERSION="15"
 ENV LLVM_VERSION=$LLVM_VERSION
 
-ARG SHORTNAME="focal"
+ARG SHORTNAME="noble"
 
 ARG RUBY_INSTALL_VERSION="0.8.4"
 ENV RUBY_INSTALL_VERSION=$RUBY_INSTALL_VERSION
@@ -29,7 +29,7 @@ deb-src http://apt.llvm.org/${SHORTNAME}/ llvm-toolchain-${SHORTNAME}-${version}
 ARG DEBIAN_FRONTEND="noninteractive"
 ENV TZ="Etc/UTC"
 
-RUN /bin/bash -c 'apt-get update && apt-get install -y \
+RUN /bin/bash -c 'apt-get install -y \
       util-linux \
       bison \
       binutils-dev \
@@ -56,7 +56,7 @@ RUN /bin/bash -c 'apt-get update && apt-get install -y \
       iperf \
       iputils-ping \
       bridge-utils \
-      libtinfo5 \
+      libtinfo6 \
       libtinfo-dev \
       libzstd-dev \
       xz-utils \
@@ -81,6 +81,9 @@ done \
 && \
       apt-get -y clean'
 
+RUN apt-get install -y python3-venv
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1 pyelftools==0.30
 
 # FIXME this is faster than building from source, but it seems there is a bug


### PR DESCRIPTION
Currently CI does not work since ubuntu 20.04 is end-of-service.
This patch upgraded ubuntu 20.04 to 24.04.