### PR TITLE
ci: Install python3-setuptools for ubuntu 24.04

### DIFF
--- a/docker/build/Dockerfile.fedora
+++ b/docker/build/Dockerfile.fedora
@@ -55,11 +55,12 @@ RUN dnf -y install \
 	iproute \
 	bpftool \
 	iperf \
-	netperf
-
-RUN python3 -m venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1 pyelftools==0.30
+	netperf \
+	python3-pyroute2 \
+	python3-netaddr \
+	python3-dnslib \
+	python3-cachetools \
+	python3-pyelftools
 
 RUN wget -O ruby-install-${RUBY_INSTALL_VERSION}.tar.gz \
          https://github.com/postmodern/ruby-install/archive/v${RUBY_INSTALL_VERSION}.tar.gz && \

--- a/docker/build/Dockerfile.ubuntu
+++ b/docker/build/Dockerfile.ubuntu
@@ -9,7 +9,7 @@ ARG SHORTNAME="noble"
 ARG RUBY_INSTALL_VERSION="0.8.4"
 ENV RUBY_INSTALL_VERSION=$RUBY_INSTALL_VERSION
 
-ARG RUBY_VERSION="3.1.2"
+ARG RUBY_VERSION="3.3.6"
 ENV RUBY_VERSION=$RUBY_VERSION
 
 RUN /bin/bash -c 'apt-get update && apt-get install -y curl gnupg &&\
@@ -81,10 +81,12 @@ done \
 && \
       apt-get -y clean'
 
-RUN apt-get install -y python3-venv
-RUN python3 -m venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-RUN pip3 install pyroute2==0.5.18 netaddr==0.8.0 dnslib==0.9.14 cachetools==3.1.1 pyelftools==0.30
+RUN apt-get install -y python3-setuptools \
+      python3-pyroute2 \
+      python3-netaddr \
+      python3-dnslib \
+      python3-cachetools \
+      python3-pyelftools
 
 # FIXME this is faster than building from source, but it seems there is a bug
 # in probing libruby.so rather than ruby binary


### PR DESCRIPTION
For ubuntu 24.04, setuptools is not installed by default. So let us install it during Dockerfile.ubuntu preparation. Also, pip3 installation is replaced with package installation so we do not need venv any more.