### PR TITLE
Add missing install dependencies to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -349,7 +349,8 @@ sudo apt-get install arping bison clang-format cmake dh-python \
   dpkg-dev pkg-kde-tools ethtool flex inetutils-ping iperf \
   libbpf-dev libclang-dev libclang-cpp-dev libedit-dev libelf-dev \
   libfl-dev libzip-dev linux-libc-dev llvm-dev libluajit-5.1-dev \
-  luajit python3-netaddr python3-pyroute2 python3-setuptools python3
+  luajit python3-netaddr python3-pyroute2 python3-setuptools python3 \
+  zip libpolly-19-dev
 ```
 
 #### Install and compile BCC


### PR DESCRIPTION
Just tried to build bcc on a today's debian-sid-nocloud-amd64-daily.raw, and it first failed with:

```
[...]
[ 18%] Building CXX object src/cc/CMakeFiles/bcc-shared.dir/common.cc.o                                                                                                                                              
make[2]: *** No rule to make target '/usr/lib/llvm-19/lib/libPolly.a', needed by 'src/cc/libbcc.so.0.34.0'.  Stop.                                                                                                   
make[1]: *** [CMakeFiles/Makefile2:1043: src/cc/CMakeFiles/bcc-shared.dir/all] Error 2                                                                                                                               
make: *** [Makefile:146: all] Error 2 
```

That got fixed with `apt install libpolly-19-dev`, but the build failed with

```
[ 92%] Built target debuginfo_test_lib
[ 93%] Generating archive.zip
/bin/sh: 1: zip: not found
make[2]: *** [tests/cc/CMakeFiles/zip_archive.dir/build.make:75: tests/cc/archive.zip] Error 127
make[1]: *** [CMakeFiles/Makefile2:2166: tests/cc/CMakeFiles/zip_archive.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

That got fixed with `apt install zip`.