### PR TITLE
libbpf-tools: opensnoop: add full-path argument -F

### DIFF
--- a/libbpf-tools/opensnoop.h
+++ b/libbpf-tools/opensnoop.h
@@ -5,6 +5,7 @@
 #define TASK_COMM_LEN 16
 #define NAME_MAX 255
 #define INVALID_UID ((uid_t)-1)
+#define MAX_PATH_DEPTH 32
 
 struct args_t {
 	const char *fname;
@@ -22,7 +23,15 @@ struct event {
 	__u32 mode;
 	__u64 callers[2];
 	char comm[TASK_COMM_LEN];
-	char fname[NAME_MAX];
+
+	/**
+	 * Example: "/a/b/c/d"
+	 * fname[]: "|d\0     |c\0     |b\0     |a\0     |       |..."
+	 *           |NAME_MAX|
+	 */
+	char fname[NAME_MAX * MAX_PATH_DEPTH];
+	__u32 path_depth;
+	int get_path_failed;
 };
 
 #endif /* __OPENSNOOP_H */


### PR DESCRIPTION
Like commit [1], support display fullpath, for example:

    $ cd /var/tmp/
    $ touch a.out

    $ sudo ./opensnoop -F
    PID    COMM              FD ERR PATH
    106779 touch              3   0 /var/tmp/a.out
                                    ^^^^^^^^^^^^^^

Link: https://github.com/iovisor/bcc/commit/c110a4dd0c8f