### PR TITLE
removing luajit options to remove cmake error

### DIFF
--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -15,7 +15,7 @@ if (LUAJIT_LIBRARIES AND LUAJIT)
 
 	ADD_CUSTOM_COMMAND(
 		OUTPUT bcc.o
-		COMMAND ${LUAJIT} -bgd bcc.lua bcc.o
+		COMMAND ${LUAJIT} -b bcc.lua bcc.o
 		DEPENDS bcc.lua
 	)
 


### PR DESCRIPTION
Tested using ubuntu `noble`, with all dependencies installed.

When running the command in `INSTALL.md` > source > Ubuntu

```
cmake ..
make
```

Errors are caused by non-existent luajit options
```
[  1%] Built target clang_frontend-objects
[  1%] Built target clang_frontend
[ 11%] Built target bpf-static
[ 12%] Built target api-static
[ 13%] Built target usdt-static
[ 18%] Built target bcc-shared
[ 20%] Built target bcc-loader-static
[ 21%] Built target api-objects
[ 27%] Built target bcc-static
[ 37%] Built target bpf-shared
[ 37%] Built target bcc_py_python3
[ 37%] Generating bcc.o
Save LuaJIT bytecode: luajit -b[options] input output
  -l        Only list bytecode.
  -s        Strip debug info (default).
  -g        Keep debug info.
  -n name   Set module name (default: auto-detect from input name).
  -t type   Set output file type (default: auto-detect from output name).
  -a arch   Override architecture for object files (default: native).
  -o os     Override OS for object files (default: native).
  -F name   Override filename (default: input filename).
  -e chunk  Use chunk string as input.
  --        Stop handling options.
  -         Use stdin as input and/or stdout as output.

File types: c cc h obj o raw (default)
make[2]: *** [src/lua/CMakeFiles/bcc-lua.dir/build.make:74: src/lua/bcc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1072: src/lua/CMakeFiles/bcc-lua.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```