### PR TITLE
libbpf-tools/offcputime: fix min or max_block_ns unit

### DIFF
--- a/libbpf-tools/offcputime.bpf.c
+++ b/libbpf-tools/offcputime.bpf.c
@@ -108,9 +108,9 @@ static int handle_sched_switch(void *ctx, bool preempt, struct task_struct *prev
 	delta = (s64)(bpf_ktime_get_ns() - i_keyp->start_ts);
 	if (delta < 0)
 		goto cleanup;
-	delta /= 1000U;
 	if (delta < min_block_ns || delta > max_block_ns)
 		goto cleanup;
+	delta /= 1000U;
 	valp = bpf_map_lookup_elem(&info, &i_keyp->key);
 	if (!valp)
 		goto cleanup;


### PR DESCRIPTION
This pull request includes a small change to the `handle_sched_switch` function in `libbpf-tools/offcputime.bpf.c`. The change moves the division operation (`delta /= 1000U`) to occur after the range check for `delta`, ensuring the value is only divided if it passes the range validation, so the validation can correctly valid nanoseconds.