### PR TITLE
libbpf-tools: fix build error on ppc64el (#5330)

### DIFF
--- a/libbpf-tools/bashreadline.c
+++ b/libbpf-tools/bashreadline.c
@@ -7,6 +7,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
@@ -87,7 +88,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_size)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 static char *find_readline_function_name(const char *bash_path)

--- a/libbpf-tools/bindsnoop.c
+++ b/libbpf-tools/bindsnoop.c
@@ -9,6 +9,7 @@
 #include <argp.h>
 #include <arpa/inet.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -178,7 +179,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/biosnoop.c
+++ b/libbpf-tools/biosnoop.c
@@ -4,6 +4,7 @@
 // Based on biosnoop(8) from BCC by Brendan Gregg.
 // 29-Jun-2020   Wenbo Zhang   Created this.
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -216,7 +217,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 static void blk_account_io_set_attach_target(struct biosnoop_bpf *obj)

--- a/libbpf-tools/capable.c
+++ b/libbpf-tools/capable.c
@@ -4,6 +4,7 @@
 // Copyright 2022 Sony Group Corporation
 
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -300,7 +301,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/drsnoop.c
+++ b/libbpf-tools/drsnoop.c
@@ -4,6 +4,7 @@
 // Based on drsnoop(8) from BCC by Wenbo Zhang.
 // 28-Feb-2020   Wenbo Zhang   Created this.
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -143,7 +144,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -1,6 +1,7 @@
 // Based on execsnoop(8) from BCC by Brendan Gregg and others.
 //
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -262,7 +263,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	fprintf(stderr, "Lost %" PRIu64" events on CPU #%d!\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/exitsnoop.c
+++ b/libbpf-tools/exitsnoop.c
@@ -10,6 +10,7 @@
  */
 #include <argp.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <string.h>
 #include <time.h>
@@ -163,7 +164,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -7,6 +7,7 @@
 // 23-Aug-2023   Rong Tao      Add vfs_* 'struct mnt_idmap' support.(CO-RE)
 // 08-Nov-2023   Rong Tao      Support unlink failed
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -111,7 +112,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/fsslower.c
+++ b/libbpf-tools/fsslower.c
@@ -12,6 +12,7 @@
  * 27-Oct-2023  Pcheng Cui   Add support for F2FS.
  */
 #include <argp.h>
+#include <inttypes.h>
 #include <libgen.h>
 #include <signal.h>
 #include <stdio.h>
@@ -386,7 +387,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/gethostlatency.c
+++ b/libbpf-tools/gethostlatency.c
@@ -10,6 +10,7 @@
  */
 #include <argp.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <time.h>
 #include <unistd.h>
@@ -119,7 +120,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 static int get_libc_path(char *path)

--- a/libbpf-tools/ksnoop.c
+++ b/libbpf-tools/ksnoop.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -772,7 +773,7 @@ static void trace_handler(void *ctx, int cpu, void *data, __u32 size)
 
 static void lost_handler(void *ctx, int cpu, __u64 cnt)
 {
-	p_err("\t/* lost %llu events */", cnt);
+	p_err("\t/* lost %" PRIu64" events */", cnt);
 }
 
 static void sig_int(int signo)

--- a/libbpf-tools/mdflush.c
+++ b/libbpf-tools/mdflush.c
@@ -10,6 +10,7 @@
  */
 #include <argp.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <string.h>
 #include <time.h>
@@ -84,7 +85,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/mountsnoop.c
+++ b/libbpf-tools/mountsnoop.c
@@ -15,6 +15,7 @@
 #include <argp.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <string.h>
 #include <time.h>
@@ -454,7 +455,7 @@ static int handle_event(void *ctx, void *data, size_t len)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/oomkill.c
+++ b/libbpf-tools/oomkill.c
@@ -7,6 +7,7 @@
 // 17-Oct-2022   Krisztian Fekete Edited this.
 #include <argp.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -90,7 +91,7 @@ static int handle_event(void *ctx, void *data, size_t len)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	printf("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	printf("Lost %" PRIu64" events on CPU #%d!\n", (uint64_t)lost_cnt, cpu);
 }
 
 static void sig_int(int signo)

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -8,6 +8,7 @@
 #define _GNU_SOURCE
 #endif
 #include <argp.h>
+#include <inttypes.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
@@ -307,7 +308,7 @@ int handle_event(void *ctx, void *data, size_t data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	fprintf(stderr, "Lost %" PRIu64" events on CPU #%d!\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/runqslower.c
+++ b/libbpf-tools/runqslower.c
@@ -4,6 +4,7 @@
 // Based on runqslower(8) from BCC by Ivan Babrou.
 // 11-Feb-2020   Andrii Nakryiko   Created this.
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -142,7 +143,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	printf("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	printf("Lost %" PRIu64" events on CPU #%d!\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/sigsnoop.c
+++ b/libbpf-tools/sigsnoop.c
@@ -8,6 +8,7 @@
  * 08-Aug-2021   Hengqi Chen   Created this.
  */
 #include <argp.h>
+#include <inttypes.h>
 #include <libgen.h>
 #include <signal.h>
 #include <time.h>
@@ -232,7 +233,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/solisten.c
+++ b/libbpf-tools/solisten.c
@@ -11,6 +11,7 @@
 #include <argp.h>
 #include <arpa/inet.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <sys/socket.h>
 #include <time.h>
@@ -129,7 +130,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/statsnoop.c
+++ b/libbpf-tools/statsnoop.c
@@ -7,6 +7,7 @@
 #include <argp.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <time.h>
 #include <unistd.h>
@@ -183,7 +184,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/syncsnoop.c
+++ b/libbpf-tools/syncsnoop.c
@@ -5,6 +5,7 @@
 // 08-Feb-2024   Tiago Ilieve   Created this.
 // 19-Jul-2024   Rong Tao       Support more sync syscalls
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <bpf/libbpf.h>
@@ -76,7 +77,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	printf("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	printf("Lost %" PRIu64" events on CPU #%d!\n", (uint64_t)lost_cnt, cpu);
 }
 
 static void sig_int(int signo)

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -5,6 +5,7 @@
 #include <sys/resource.h>
 #include <arpa/inet.h>
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <limits.h>
 #include <unistd.h>
@@ -357,7 +358,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	warn("Lost %" PRIu64" events on CPU #%d!\n", (uint64_t)lost_cnt, cpu);
 }
 
 static void print_events(int perf_map_fd)

--- a/libbpf-tools/tcpconnlat.c
+++ b/libbpf-tools/tcpconnlat.c
@@ -5,6 +5,7 @@
 // 11-Jul-2020   Wenbo Zhang   Created this.
 #include <argp.h>
 #include <arpa/inet.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -151,7 +152,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/tcplife.c
+++ b/libbpf-tools/tcplife.c
@@ -9,6 +9,7 @@
  * 02-Jun-2022   Hengqi Chen   Created this.
  */
 #include <argp.h>
+#include <inttypes.h>
 #include <errno.h>
 #include <signal.h>
 #include <time.h>
@@ -144,7 +145,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/tcppktlat.c
+++ b/libbpf-tools/tcppktlat.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 // Copyright (c) 2023 Wenbo Zhang
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -172,7 +173,7 @@ static int handle_event(void *ctx, void *data, size_t data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/tcpstates.c
+++ b/libbpf-tools/tcpstates.c
@@ -8,6 +8,7 @@
  * 18-Dec-2021   Hengqi Chen   Created this.
  */
 #include <argp.h>
+#include <inttypes.h>
 #include <arpa/inet.h>
 #include <errno.h>
 #include <signal.h>
@@ -189,7 +190,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %" PRIu64" events on CPU #%d\n", (uint64_t)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/tcptracer.c
+++ b/libbpf-tools/tcptracer.c
@@ -6,6 +6,7 @@
 #include <sys/resource.h>
 #include <arpa/inet.h>
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <limits.h>
 #include <unistd.h>
@@ -226,7 +227,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	warn("Lost %" PRIu64" events on CPU #%d!\n", (uint64_t)lost_cnt, cpu);
 }
 
 static void print_events(int perf_map_fd)


### PR DESCRIPTION
bashreadline.c: In function ‘handle_lost_events’:
bashreadline.c:90:14: error: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘__u64’ {aka ‘long unsigned int’} [-Werror=format=]
   90 |         warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~
      |                                               |
      |                                               __u64 {aka long unsigned int}