### PR TITLE
Bcc: mptcpify: add the NULL check for variable 'mode'

### DIFF
--- a/tools/mptcpify.py
+++ b/tools/mptcpify.py
@@ -65,7 +65,7 @@ KMOD_RET(update_socket_protocol, int family, int type, int protocol, int ret)
     if ((family == AF_INET || family == AF_INET6) &&
         type == SOCK_STREAM &&
         (!protocol || protocol == IPPROTO_TCP) &&
-        (*mode == 0 || support_apps.lookup(&target)))
+        (mode && *mode == 0 || support_apps.lookup(&target)))
         return IPPROTO_MPTCP;
 
     return protocol;


### PR DESCRIPTION
Recently, the mptcpify meets an error in some OS, the error is caused by the EBPF code of mptcpify. The error message is attached below:

'''
...
; (*mode == 0 || bpf_map_lookup_elem((void *)bpf_pseudo_fd(1, -2), &target))
30: (61) r1 = *(u32 *)(r6 +0)
...
HINT: The 'map_value_or_null' error can happen if you deference a pointer value from a map lookup without first checking if that pointer is NULL.
...
Exception: Failed to load BPF program
b'kmod_ret__updatesocket_protocol': Permission denied '''

The error is caused by variable 'mode' is used without check, so this patch can fix the problem.