### PR TITLE
libbpf-tools: introduce path helpers and filelife support full-path

### DIFF
--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -113,6 +113,7 @@ COMMON_OBJ = \
 	$(OUTPUT)/uprobe_helpers.o \
 	$(OUTPUT)/btf_helpers.o \
 	$(OUTPUT)/compat.o \
+	$(OUTPUT)/path_helpers.o \
 	$(if $(ENABLE_MIN_CORE_BTFS),$(OUTPUT)/min_core_btf_tar.o) \
 	#
 

--- a/libbpf-tools/filelife.h
+++ b/libbpf-tools/filelife.h
@@ -2,16 +2,15 @@
 #ifndef __FILELIFE_H
 #define __FILELIFE_H
 
-#define DNAME_INLINE_LEN	32
+#include "path_helpers.h"
+
 #define TASK_COMM_LEN		16
 
 struct event {
-	char file[DNAME_INLINE_LEN];
+	struct full_path fname;
 	char task[TASK_COMM_LEN];
 	__u64 delta_ns;
 	pid_t tgid;
-	/* private */
-	void *dentry;
 };
 
 #endif /* __FILELIFE_H */

--- a/libbpf-tools/opensnoop.bpf.c
+++ b/libbpf-tools/opensnoop.bpf.c
@@ -6,6 +6,7 @@
 #include <bpf/bpf_helpers.h>
 #include "compat.bpf.h"
 #include "opensnoop.h"
+#include "path_helpers.bpf.h"
 
 #ifndef O_CREAT
 #define O_CREAT		00000100
@@ -134,9 +135,9 @@ int trace_exit(struct syscall_trace_exit* ctx)
 	eventp->pid = bpf_get_current_pid_tgid() >> 32;
 	eventp->uid = bpf_get_current_uid_gid();
 	bpf_get_current_comm(&eventp->comm, sizeof(eventp->comm));
-	bpf_probe_read_user_str(&eventp->fname, sizeof(eventp->fname),
+	bpf_probe_read_user_str(&eventp->fname.pathes, sizeof(eventp->fname.pathes),
 			  ap->fname);
-	eventp->path_depth = 0;
+	eventp->fname.depth = 0;
 	eventp->flags = ap->flags;
 
 	if (ap->flags & O_CREAT || (ap->flags & O_TMPFILE) == O_TMPFILE)
@@ -152,64 +153,10 @@ int trace_exit(struct syscall_trace_exit* ctx)
 	eventp->callers[0] = stack[1];
 	eventp->callers[1] = stack[2];
 
-	if (full_path && eventp->fname[0] != '/') {
-		int depth;
-		struct task_struct *task;
-		struct dentry *dentry, *parent_dentry, *mnt_root;
-		struct vfsmount *vfsmnt;
-		struct mount *mnt;
-		size_t filepart_length;
-		char *payload = eventp->fname;
-
-
-		task = (struct task_struct *)bpf_get_current_task_btf();
-		dentry = BPF_CORE_READ(task, fs, pwd.dentry);
-		vfsmnt = BPF_CORE_READ(task, fs, pwd.mnt);
-		mnt = container_of(vfsmnt, struct mount, mnt);
-		mnt_root = BPF_CORE_READ(vfsmnt, mnt_root);
-
-		for (depth = 1, payload += NAME_MAX; depth < MAX_PATH_DEPTH; depth++) {
-			filepart_length =
-				bpf_probe_read_kernel_str(payload, NAME_MAX,
-						BPF_CORE_READ(dentry, d_name.name));
-
-			if (filepart_length < 0) {
-				eventp->get_path_failed = 1;
-				break;
-			}
-
-			if (filepart_length > NAME_MAX)
-				break;
-
-			parent_dentry = BPF_CORE_READ(dentry, d_parent);
-
-			if (dentry == parent_dentry || dentry == mnt_root) {
-				struct mount *mnt_parent;
-				mnt_parent = BPF_CORE_READ(mnt, mnt_parent);
-
-				if (mnt != mnt_parent) {
-					dentry = BPF_CORE_READ(mnt, mnt_mountpoint);
-
-					mnt = mnt_parent;
-					vfsmnt = &mnt->mnt;
-
-					mnt_root = BPF_CORE_READ(vfsmnt, mnt_root);
-
-					eventp->path_depth++;
-					payload += NAME_MAX;
-					continue;
-				} else {
-					/* Real root directory */
-					break;
-				}
-			}
-
-			payload += NAME_MAX;
-
-			dentry = parent_dentry;
-			eventp->path_depth++;
-		}
-	}
+	if (full_path && eventp->fname.pathes[0] != '/')
+		bpf_getcwd(eventp->fname.pathes + NAME_MAX, NAME_MAX,
+			   MAX_PATH_DEPTH - 1,
+			   &eventp->fname.failed, &eventp->fname.depth);
 
 	/* emit event */
 	submit_buf(ctx, eventp, sizeof(*eventp));

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -26,6 +26,7 @@
 #ifdef USE_BLAZESYM
 #include "blazesym.h"
 #endif
+#include "path_helpers.h"
 
 #define NSEC_PER_SEC		1000000000ULL
 
@@ -268,33 +269,10 @@ int handle_event(void *ctx, void *data, size_t data_sz)
 		sps_cnt += 9;
 	}
 	if (env.full_path) {
-		for (int depth = e.path_depth; depth >= 0; depth--) {
-			char *fname = (char *)&e.fname[NAME_MAX * depth];
-
-			/**
-			 * If it is a mount point, there will be a '/', because
-			 * the '/' will be added below, so just skip this '/'.
-			 */
-			if (fname[0] == '/' && fname[1] == '\0')
-				continue;
-
-			/**
-			 * 1. If the file/path name starts with '/', do not
-			 *    print the '/' prefix.
-			 * 2. If bpf_probe_read_kernel_str() fails, or the
-			 *    directory depth reaches the upper limit
-			 *    MAX_PATH_DEPTH, the top-level directory
-			 *    is printed without the prefix '/'.
-			 */
-			printf("%s%s",
-				"/\0" + (e.fname[NAME_MAX * depth] == '/' ||
-					 ((e.get_path_failed || e.path_depth == MAX_PATH_DEPTH - 1) &&
-					  depth == e.path_depth)),
-				fname);
-		}
+		print_full_path(&e.fname);
 		printf("\n");
 	} else
-		printf("%s\n", e.fname);
+		printf("%s\n", e.fname.pathes);
 
 #ifdef USE_BLAZESYM
 	for (i = 0; result && i < result->size; i++) {

--- a/libbpf-tools/opensnoop.h
+++ b/libbpf-tools/opensnoop.h
@@ -2,10 +2,10 @@
 #ifndef __OPENSNOOP_H
 #define __OPENSNOOP_H
 
+#include "path_helpers.h"
+
 #define TASK_COMM_LEN 16
-#define NAME_MAX 255
 #define INVALID_UID ((uid_t)-1)
-#define MAX_PATH_DEPTH 32
 
 struct args_t {
 	const char *fname;
@@ -23,15 +23,7 @@ struct event {
 	__u32 mode;
 	__u64 callers[2];
 	char comm[TASK_COMM_LEN];
-
-	/**
-	 * Example: "/a/b/c/d"
-	 * fname[]: "|d\0     |c\0     |b\0     |a\0     |       |..."
-	 *           |NAME_MAX|
-	 */
-	char fname[NAME_MAX * MAX_PATH_DEPTH];
-	__u32 path_depth;
-	int get_path_failed;
+	struct full_path fname;
 };
 
 #endif /* __OPENSNOOP_H */

--- a/libbpf-tools/path_helpers.bpf.h
+++ b/libbpf-tools/path_helpers.bpf.h
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2025 Rong Tao */
+#ifndef __PATH_HELPERS_BPF_H
+#define __PATH_HELPERS_BPF_H 1
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include "path_helpers.h"
+
+
+static __always_inline
+int bpf_dentry_full_path(char *pathes, int name_len, int max_depth,
+			 struct dentry *dentry, struct vfsmount *vfsmnt,
+			 int *failed, __u32 *path_depth)
+{
+	int depth;
+	struct dentry *parent_dentry, *mnt_root;
+	struct mount *mnt;
+	size_t filepart_length;
+	char *payload = pathes;
+
+	mnt = container_of(vfsmnt, struct mount, mnt);
+	mnt_root = BPF_CORE_READ(vfsmnt, mnt_root);
+
+	for (depth = 0; depth < max_depth; depth++) {
+		filepart_length =
+			bpf_probe_read_kernel_str(payload, name_len,
+					BPF_CORE_READ(dentry, d_name.name));
+
+		if (filepart_length < 0) {
+			*failed = 1;
+			break;
+		}
+
+		if (filepart_length > name_len)
+			break;
+
+		parent_dentry = BPF_CORE_READ(dentry, d_parent);
+
+		if (dentry == parent_dentry || dentry == mnt_root) {
+			struct mount *mnt_parent;
+			mnt_parent = BPF_CORE_READ(mnt, mnt_parent);
+
+			if (mnt != mnt_parent) {
+				dentry = BPF_CORE_READ(mnt, mnt_mountpoint);
+
+				mnt = mnt_parent;
+				vfsmnt = &mnt->mnt;
+
+				mnt_root = BPF_CORE_READ(vfsmnt, mnt_root);
+
+				(*path_depth)++;
+				payload += name_len;
+				continue;
+			} else {
+				/* Real root directory */
+				break;
+			}
+		}
+
+		payload += name_len;
+
+		dentry = parent_dentry;
+		(*path_depth)++;
+	}
+
+	return 0;
+}
+
+static __always_inline
+int bpf_getcwd(char *pathes, int name_len, int max_depth, int *failed,
+	       __u32 *path_depth)
+{
+	struct task_struct *task;
+	struct dentry *dentry;
+	struct vfsmount *vfsmnt;
+
+	task = (struct task_struct *)bpf_get_current_task_btf();
+	dentry = BPF_CORE_READ(task, fs, pwd.dentry);
+	vfsmnt = BPF_CORE_READ(task, fs, pwd.mnt);
+
+	return bpf_dentry_full_path(pathes, name_len, max_depth, dentry, vfsmnt,
+			     failed, path_depth);
+}
+#endif

--- a/libbpf-tools/path_helpers.c
+++ b/libbpf-tools/path_helpers.c
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2025 Rong Tao */
+#include <stdio.h>
+#include "path_helpers.h"
+
+
+int print_full_path(struct full_path *path)
+{
+	int n = 0, depth;
+
+	for (depth = path->depth; depth >= 0; depth--) {
+		char *fname = (char *)&path->pathes[NAME_MAX * depth];
+
+		/**
+		 * If it is a mount point, there will be a '/', because
+		 * the '/' will be added below, so just skip this '/'.
+		 */
+		if (fname[0] == '/' && fname[1] == '\0')
+			continue;
+
+		/**
+		 * 1. If the file/path name starts with '/', do not
+		 *    print the '/' prefix.
+		 * 2. If bpf_probe_read_kernel_str() fails, or the
+		 *    directory depth reaches the upper limit
+		 *    MAX_PATH_DEPTH, the top-level directory
+		 *    is printed without the prefix '/'.
+		 */
+		n = printf("%s%s",
+			"/\0" + (fname[0] == '/' ||
+				 ((path->failed || path->depth == MAX_PATH_DEPTH - 1) &&
+				  depth == path->depth)),
+			fname);
+	}
+	return n;
+}

--- a/libbpf-tools/path_helpers.h
+++ b/libbpf-tools/path_helpers.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (c) 2025 Rong Tao */
+#ifndef __PATH_HELPERS_H
+#define __PATH_HELPERS_H 1
+
+#define NAME_MAX	255
+#define MAX_PATH_DEPTH	32
+
+struct full_path {
+	/**
+	 * Example: "/a/b/c/d"
+	 * pathes[]: "|d\0     |c\0     |b\0     |a\0     |       |..."
+	 *            |NAME_MAX|
+	 */
+	char pathes[NAME_MAX * MAX_PATH_DEPTH];
+	unsigned int depth;
+	int failed;
+};
+
+int print_full_path(struct full_path *path);
+#endif


### PR DESCRIPTION
## 1st patch: libbpf-tools: Introduce path helpers

There will be many programs that need to get the current working directory
or full-path of file, such as opensnoop, which is already supported.
and other tools like filelife/filetop need it too.

Therefore, it will be helpful to separate the bpf_getcwd function from
opensnoop.bpf.c as a public helper function.

Add functions:
  1. bpf_dentry_full_path(): Get the full-path based on the dentry and
                             vfsmount.
  2. bpf_getcwd(): Get the full-path of the current working directory.
  3. print_full_path(): Assembling full-path in user space.

Add structures:
  1. struct full_path {}: Record the absolute path.


## 2nd patch: libbpf-tools/filelife: support full-path

To support full-path, the following operations are performed:

1. First, to support the transmission of larger data, perf-buffer is
   replaced with ring-buff.
2. Then, before this patch, events are constructed in kprobe/unlink,
   and events of successful unlink are submitted in kretprobe/unlink.
   However, the reservation and submission of ring-buff cannot be
   separated, so the struct unlink_event small structure is introduced
   for transfer, and the reservation and submission of events are in
   kretprobe/unlink.
3. In order to record the dentry and vfsmount structures of cwd when the
   file is created, the structure struct create_arg{} is introduced.
   Note: cannot obtain the dentry and vfsmount structures of cwd in
   kretprobe/unlink.

Example:

    # Test commands
    $ cd /home/sda/git-repos/
    $ touch a.out && sleep 0.2 && rm a.out

    # before
    $ sudo ./filelife
    Tracing the lifespan of short-lived files ... Hit Ctrl-C to end.
    TIME     PID    COMM             AGE(s)  FILE
    17:27:05 458702 rm               0.21    a.out

    # after
    $ sudo ./filelife -F
    Tracing the lifespan of short-lived files ... Hit Ctrl-C to end.
    TIME     PID    COMM             AGE(s)  FILE
    17:26:58 458692 rm               0.21    /home/sda/git-repos/a.out
                                             ^^^^^^^^^^^^^^^^^^^^ full-path