### PR TITLE
libbpf-tools: Fix the license for newly added path* files

### DIFF
--- a/libbpf-tools/path_helpers.bpf.h
+++ b/libbpf-tools/path_helpers.bpf.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2025 Rong Tao */
 #ifndef __PATH_HELPERS_BPF_H
 #define __PATH_HELPERS_BPF_H 1

--- a/libbpf-tools/path_helpers.c
+++ b/libbpf-tools/path_helpers.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2025 Rong Tao */
 #include <stdio.h>
 #include "path_helpers.h"

--- a/libbpf-tools/path_helpers.h
+++ b/libbpf-tools/path_helpers.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2025 Rong Tao */
 #ifndef __PATH_HELPERS_H
 #define __PATH_HELPERS_H 1


### PR DESCRIPTION
Change the license from
  SPDX-License-Identifier: GPL-2.0
to
  SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)

The later is more compatible for userspace tools.