### PR TITLE
ci: Update workflow settings to fix CI test failure issue

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -35,6 +35,9 @@ jobs:
           RW_ENGINE_ENABLED: ON
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
     - uses: dorny/paths-filter@v3
       id: changes
       with:
@@ -138,6 +141,9 @@ jobs:
           PYTHON_TEST_LOGFILE: critical.log
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
     - uses: dorny/paths-filter@v3
       id: changes
       with:


### PR DESCRIPTION
Testing to see if it works.

**Test Results:**
The "Run bcc build" succeeded, including on Ubuntu 24.04.
The "NOTFOUND" issue did not occur on either Ubuntu or Fedora.
Issues in subsequent steps seem to require separate handling.

Thank you.
