### PR TITLE
libbpf-tools/klockstat: Allows kprobe fallback to work with lock debugging

### DIFF
--- a/libbpf-tools/klockstat.bpf.c
+++ b/libbpf-tools/klockstat.bpf.c
@@ -832,6 +832,201 @@ int BPF_KPROBE(kprobe_up_write, struct rw_semaphore *lock)
 	return 0;
 }
 
+/* CONFIG_DEBUG_LOCK_ALLOC is enabled */
+
+SEC("kprobe/mutex_lock_nested")
+int BPF_KPROBE(kprobe_mutex_lock_nested, struct mutex *lock)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+
+	bpf_map_update_elem(&locks, &tid, &lock, BPF_ANY);
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("kretprobe/mutex_lock_nested")
+int BPF_KRETPROBE(kprobe_mutex_lock_exit_nested, long ret)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	void **lock;
+
+	lock = bpf_map_lookup_elem(&locks, &tid);
+	if (!lock)
+		return 0;
+
+	bpf_map_delete_elem(&locks, &tid);
+	lock_acquired(*lock);
+	return 0;
+}
+
+SEC("kprobe/mutex_lock_interruptible_nested")
+int BPF_KPROBE(kprobe_mutex_lock_interruptible_nested, struct mutex *lock)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+
+	bpf_map_update_elem(&locks, &tid, &lock, BPF_ANY);
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("kretprobe/mutex_lock_interruptible_nested")
+int BPF_KRETPROBE(kprobe_mutex_lock_interruptible_exit_nested, long ret)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	void **lock;
+
+	lock = bpf_map_lookup_elem(&locks, &tid);
+	if (!lock)
+		return 0;
+
+	bpf_map_delete_elem(&locks, &tid);
+
+	if (ret)
+		lock_aborted(*lock);
+	else
+		lock_acquired(*lock);
+	return 0;
+}
+
+SEC("kprobe/mutex_lock_killable_nested")
+int BPF_KPROBE(kprobe_mutex_lock_killable_nested, struct mutex *lock)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+
+	bpf_map_update_elem(&locks, &tid, &lock, BPF_ANY);
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("kretprobe/mutex_lock_killable_nested")
+int BPF_KRETPROBE(kprobe_mutex_lock_killable_exit_nested, long ret)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	void **lock;
+
+	lock = bpf_map_lookup_elem(&locks, &tid);
+	if (!lock)
+		return 0;
+
+	bpf_map_delete_elem(&locks, &tid);
+
+	if (ret)
+		lock_aborted(*lock);
+	else
+		lock_acquired(*lock);
+	return 0;
+}
+
+SEC("kprobe/down_read_nested")
+int BPF_KPROBE(kprobe_down_read_nested, struct rw_semaphore *lock)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+
+	bpf_map_update_elem(&locks, &tid, &lock, BPF_ANY);
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("kretprobe/down_read_nested")
+int BPF_KRETPROBE(kprobe_down_read_exit_nested, long ret)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	void **lock;
+
+	lock = bpf_map_lookup_elem(&locks, &tid);
+	if (!lock)
+		return 0;
+
+	bpf_map_delete_elem(&locks, &tid);
+
+	lock_acquired(*lock);
+	return 0;
+}
+
+SEC("kprobe/down_read_killable_nested")
+int BPF_KPROBE(kprobe_down_read_killable_nested, struct rw_semaphore *lock)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+
+	bpf_map_update_elem(&locks, &tid, &lock, BPF_ANY);
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("kretprobe/down_read_killable_nested")
+int BPF_KRETPROBE(kprobe_down_read_killable_exit_nested, long ret)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	void **lock;
+
+	lock = bpf_map_lookup_elem(&locks, &tid);
+	if (!lock)
+		return 0;
+
+	bpf_map_delete_elem(&locks, &tid);
+
+	if (ret)
+		lock_aborted(*lock);
+	else
+		lock_acquired(*lock);
+	return 0;
+}
+
+SEC("kprobe/down_write_nested")
+int BPF_KPROBE(kprobe_down_write_nested, struct rw_semaphore *lock)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+
+	bpf_map_update_elem(&locks, &tid, &lock, BPF_ANY);
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("kretprobe/down_write_nested")
+int BPF_KRETPROBE(kprobe_down_write_exit_nested, long ret)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	void **lock;
+
+	lock = bpf_map_lookup_elem(&locks, &tid);
+	if (!lock)
+		return 0;
+
+	bpf_map_delete_elem(&locks, &tid);
+
+	lock_acquired(*lock);
+	return 0;
+}
+
+SEC("kprobe/down_write_killable_nested")
+int BPF_KPROBE(kprobe_down_write_killable_nested, struct rw_semaphore *lock)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+
+	bpf_map_update_elem(&locks, &tid, &lock, BPF_ANY);
+	lock_contended(ctx, lock);
+	return 0;
+}
+
+SEC("kretprobe/down_write_killable_nested")
+int BPF_KRETPROBE(kprobe_down_write_killable_exit_nested, long ret)
+{
+	u32 tid = (u32)bpf_get_current_pid_tgid();
+	void **lock;
+
+	lock = bpf_map_lookup_elem(&locks, &tid);
+	if (!lock)
+		return 0;
+
+	bpf_map_delete_elem(&locks, &tid);
+
+	if (ret)
+		lock_aborted(*lock);
+	else
+		lock_acquired(*lock);
+	return 0;
+}
+
 SEC("kprobe/rtnetlink_rcv_msg")
 int BPF_KPROBE(kprobe_rtnetlink_rcv_msg, struct sk_buff *skb, struct nlmsghdr *nlh,
 	       struct netlink_ext_ack *ext)

--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -879,6 +879,41 @@ static void enable_kprobes(struct klockstat_bpf *obj)
 	bpf_program__set_autoload(obj->progs.netlink_dump_exit, false);
 	bpf_program__set_autoload(obj->progs.sock_do_ioctl, false);
 	bpf_program__set_autoload(obj->progs.sock_do_ioctl_exit, false);
+
+        /* CONFIG_DEBUG_LOCK_ALLOC is on */
+	if (kprobe_exists("mutex_lock_nested")) {
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock, false);
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_exit, false);
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_interruptible, false);
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_interruptible_exit, false);
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_killable, false);
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_killable_exit, false);
+
+		bpf_program__set_autoload(obj->progs.kprobe_down_read, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_read_exit, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_read_killable, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_read_killable_exit, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_write, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_write_exit, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_write_killable, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_write_killable_exit, false);
+	} else {
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_exit_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_interruptible_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_interruptible_exit_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_killable_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_killable_exit_nested, false);
+
+		bpf_program__set_autoload(obj->progs.kprobe_down_read_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_read_exit_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_read_killable_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_read_killable_exit_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_write_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_write_exit_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_write_killable_nested, false);
+		bpf_program__set_autoload(obj->progs.kprobe_down_write_killable_exit_nested, false);
+	}
 }
 
 static void disable_nldump_ioctl_probes(struct klockstat_bpf *obj)


### PR DESCRIPTION
The klockstat tool fallback on kprobes when fentries are not available, but the fallback doesn't work on debug kernel (CONFIG_DEBUG_LOCK_ALLOC enabled).

Attach kprobes to the debug locking functions (*_nested) when they exists as is done with the fentry code.