### PR TITLE
docs: Add descriptions for using pid in attach_uprobe and attach_uretprobe

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1709,7 +1709,7 @@ Examples in situ:
 
 ### 4. attach_uprobe()
 
-Syntax: ```BPF.attach_uprobe(name="location", sym="symbol", fn_name="name" [, sym_off=int])```, ```BPF.attach_uprobe(name="location", sym_re="regex", fn_name="name")```, ```BPF.attach_uprobe(name="location", addr=int, fn_name="name")```
+Syntax: ```BPF.attach_uprobe(name="location", sym="symbol", fn_name="name" [, sym_off=int])```, ```BPF.attach_uprobe(name="location", sym_re="regex", fn_name="name")```, ```BPF.attach_uprobe(name="location", addr=int, fn_name="name"), BPF.attach_uprobe(name="location", sym="symbol", fn_name="name", [, pid=int])```
 
 
 Instruments the user-level function ```symbol()``` from either the library or binary named by ```location``` using user-level dynamic tracing of the function entry, and attach our C defined function ```name()``` to be called whenever the user-level function is called. If ```sym_off``` is given, the function is attached to the offset within the symbol.
@@ -1717,6 +1717,11 @@ Instruments the user-level function ```symbol()``` from either the library or bi
 The real address ```addr``` may be supplied in place of ```sym```, in which case ```sym``` must be set to its default value. If the file is a non-PIE executable, ```addr``` must be a virtual address, otherwise it must be an offset relative to the file load address.
 
 Instead of a symbol name, a regular expression can be provided in ```sym_re```. The uprobe will then attach to symbols that match the provided regular expression.
+
+Uprobes can be attached to a specific process by passing `pid` to `attach_uprobe`.
+By default `pid` is set to -1, indicating the `uprobe` will be attached to all processes.
+For libraries, the uprobe will attach to the version of the library used by the process if `pid` was given.
+For how `pid` is used, see examples in [funcinterval](https://github.com/iovisor/bcc/blob/78423e1667db202012bbb032c567589175a2796c/tools/funcinterval.py#L155-L156).
 
 Libraries can be given in the name argument without the lib prefix, or with the full path (/usr/lib/...). Binaries can be given only with the full path (/bin/sh).
 
@@ -1765,6 +1770,7 @@ b.attach_uretprobe(name="/usr/bin/python", sym="main", fn_name="do_main")
 ```
 
 You can call attach_uretprobe() more than once, and attach your BPF function to multiple user-level functions.
+`BPF.attach_uretprobe` can also be used for a specific process.
 
 See the previous uretprobes section for how to instrument the return value from BPF.
 


### PR DESCRIPTION
## Summary

Add descriptions in `docs/reference_guide.md` for using `pid` in `attach_uprobe` and `attach_uretprobe` functions that allows uprobes to be attached to a specific process. The introduced contents were mainly referred by the comments of `attach_probe` function in [bcc/src/python/bcc/\_\_init\_\_.py](https://github.com/iovisor/bcc/blob/78423e1667db202012bbb032c567589175a2796c/src/python/bcc/__init__.py#L1413-L1440). 

## Motivation

I was trying to attach `uprobe` to a specific process but did not find enough useful information in `docs/reference_guide.md`, which blocked me for sometime. I then moved to the source code of `attach_uprobe` ad `attach_uretprobe` in `bcc/src/python/bcc/__init__.py` and found the missing descriptions for `pid` parameter. 

Making this PR to make it clear of how to attach uprobes to process.