### PR TITLE
Fix a build failure with clang21

### DIFF
--- a/src/cc/frontends/clang/loader.cc
+++ b/src/cc/frontends/clang/loader.cc
@@ -396,11 +396,19 @@ int ClangLoader::do_compile(
                     flags_cstr_rem.end());
 
   // set up the error reporting class
+#if LLVM_VERSION_MAJOR >= 21
+  DiagnosticOptions diag_opts;
+  auto diag_client = new TextDiagnosticPrinter(llvm::errs(), diag_opts);
+
+  IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());
+  DiagnosticsEngine diags(DiagID, diag_opts, diag_client);
+#else
   IntrusiveRefCntPtr<DiagnosticOptions> diag_opts(new DiagnosticOptions());
   auto diag_client = new TextDiagnosticPrinter(llvm::errs(), &*diag_opts);
 
   IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());
   DiagnosticsEngine diags(DiagID, &*diag_opts, diag_client);
+#endif
 
   // set up the command line argument wrapper
 


### PR DESCRIPTION
The build error message:
```
  src/cc/frontends/clang/loader.cc:400:73: error: no matching function for
   call to ‘clang::TextDiagnosticPrinter::TextDiagnosticPrinter(
     llvm::raw_fd_ostream&, clang::DiagnosticOptions*)’
  400 |   auto diag_client = new TextDiagnosticPrinter(llvm::errs(), &*diag_opts);
      |                                                                         ^
```
The llvm commit
  https://github.com/llvm/llvm-project/pull/139584
caused the build failure.

Adjust the code properly and the error is fixed.