### PR TITLE
tools/biolatency: Restore tracepoint-first probe logic

### DIFF
--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -267,28 +267,28 @@ kprobe_done = None
 tp_done = None
 
 if args.queued:
-    if BPF.get_kprobe_functions(b'__blk_account_io_start'):
-        kprobe_start.add("__blk_account_io_start")
-    elif BPF.get_kprobe_functions(b'blk_account_io_start'):
-        kprobe_start.add("blk_account_io_start")
-    elif BPF.tracepoint_exists("block", "block_io_start"):
+    if BPF.tracepoint_exists("block", "block_io_start"):
         tp_start = "block_io_start"
     elif BPF.tracepoint_exists("block", "block_bio_queue"):
         tp_start = "block_bio_queue"
+    elif BPF.get_kprobe_functions(b'__blk_account_io_start'):
+        kprobe_start.add("__blk_account_io_start")
+    elif BPF.get_kprobe_functions(b'blk_account_io_start'):
+        kprobe_start.add("blk_account_io_start")
 
 else:
     if BPF.get_kprobe_functions(b'blk_start_request'):
         kprobe_start.add("blk_start_request")
     kprobe_start.add("blk_mq_start_request")
 
-if BPF.get_kprobe_functions(b'__blk_account_io_done'):
-    kprobe_done = "__blk_account_io_done"
-elif BPF.get_kprobe_functions(b'blk_account_io_done'):
-    kprobe_done = "blk_account_io_done"
-elif BPF.tracepoint_exists("block", "block_io_done"):
+if BPF.tracepoint_exists("block", "block_io_done"):
     tp_done = "block_io_done"
 elif BPF.tracepoint_exists("block", "block_rq_complete"):
     tp_done = "block_rq_complete"
+elif BPF.get_kprobe_functions(b'__blk_account_io_done'):
+    kprobe_done = "__blk_account_io_done"
+elif BPF.get_kprobe_functions(b'blk_account_io_done'):
+    kprobe_done = "blk_account_io_done"
 
 if args.flags and (tp_start or tp_done):
             # Some flags are accessible in the rwbs field (RAHEAD, SYNC and META)


### PR DESCRIPTION
On Linux kernels v5.16 and newer, kprobe attachment for biolatency can fail. The `blk_account_io_done` function became an inline function in v5.16 and was later removed in v6.4. This causes biolatency to fail with an "attach to kprobe failed" error on recent kernels like v6.6.

Commit 947bd74 ("tools/{biolatency,biosnoop,biotop}: Use tracepoint first") originally established the intended behavior to prefer tracepoints.  However, commit 3630581
("tools/{biolatency,biosnoop,biotop}: use TRACEPOINT_PROBE() for tracepoints") inadvertently changed the probe attachment logic, causing it to prioritize kprobes over tracepoints. When the necessary kprobes are not found, the tool fails instead of falling back to available tracepoints.

This patch fixes the issue by restoring the original logic, ensuring that the tool checks for available tracepoints before attempting to attach kprobes. This resolves the failure on modern kernels and aligns with the tool's intended design.

Fixes: 3630581 ("tools/{biolatency,biosnoop,biotop}: use TRACEPOINT_PROBE() for tracepoints")

Change-Id: I7ed3e61d629c033e0f87dc736d18949c81c25d58