### PR TITLE
libbpf-tools/klockstat: Disable *_nested kprobes in the fentry code

### DIFF
--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -804,6 +804,22 @@ static void enable_fentry(struct klockstat_bpf *obj)
 	bpf_program__set_autoload(obj->progs.kprobe_down_write_killable_exit, false);
 	bpf_program__set_autoload(obj->progs.kprobe_up_write, false);
 
+	bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_exit_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_interruptible_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_interruptible_exit_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_killable_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_mutex_lock_killable_exit_nested, false);
+
+	bpf_program__set_autoload(obj->progs.kprobe_down_read_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_down_read_exit_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_down_read_killable_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_down_read_killable_exit_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_down_write_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_down_write_exit_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_down_write_killable_nested, false);
+	bpf_program__set_autoload(obj->progs.kprobe_down_write_killable_exit_nested, false);
+
 	bpf_program__set_autoload(obj->progs.kprobe_rtnetlink_rcv_msg, false);
 	bpf_program__set_autoload(obj->progs.kprobe_rtnetlink_rcv_msg_exit, false);
 	bpf_program__set_autoload(obj->progs.kprobe_netlink_dump, false);


### PR DESCRIPTION
Commit 789e923f ("libbpf-tools/klockstat: Allows kprobe fallback to work with lock debugging (#5359)") add new kprobes to be enabled on debug kernel and disabled on normal kernel. But it forgot to disable them in the fentry code, along with other kprobes.

Disable *_nested kprobes in the fentry code.

Fixes: 789e923f ("libbpf-tools/klockstat: Allows kprobe fallback to work with lock debugging (#5359)")