### PR TITLE
libbpf-tools: tcpstates: Fix CLOSE to SYN_SENT wrong delta

### DIFF
--- a/libbpf-tools/tcpstates.h
+++ b/libbpf-tools/tcpstates.h
@@ -10,7 +10,7 @@ struct event {
 	unsigned __int128 daddr;
 	__u64 skaddr;
 	__u64 ts_us;
-	__u64 delta_us;
+	__u64 delta_ns;
 	__u32 pid;
 	int oldstate;
 	int newstate;


### PR DESCRIPTION
When the TCP socket is initially created, the timestamp of when sk is created is not recorded, so the delay from the CLOSE state to any state is 0, which is obviously wrong.

This patch records the time when sk is created as the start time of the CLOSE state, thereby obtaining the time from CLOSE to LISTEN or SYN_SENT.

At the same time, because some time differences are really too small, nanosecond level time display support is added (-n).

Before:

    bcc/libbpf-tools$ sudo ./tcpstates | grep CLOSE
    ffff8b296bd1af80 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.000
    ffff8b296bd1df00 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.000
    ffff8b29c851a600 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.000
    ffff8b29c4ac4c00 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.000
    ffff8b29c4ac6880 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.000
    ffff8b29c4ac4280 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.000
    ffff8b29c4ac5580 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.000
                                                                                                ^^^^^

After:

    bcc/libbpf-tools$ sudo ./tcpstates | grep CLOSE
    ffff8b29f6c91300 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.020
    ffff8b29f6c94280 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.011
    ffff8b2a1d45cc00 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.022
    ffff8b2a1d45af80 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.027
    ffff8b29c8518980 421523  Chrome_Chi 10.56.52.9  0  10.32.0.200  8080  CLOSE  -> SYN_SENT    0.023