### PR TITLE
tools/kvmexit: implement AMD support and parallel post processing

### DIFF
--- a/tools/kvmexit.py
+++ b/tools/kvmexit.py
@@ -26,6 +26,7 @@
 # 31-Aug-2021  Fei Li <lifei.shirley@bytedance.com>  Initial implementation.
 # 28-Jul-2025  Matt Pelland <mpelland@akamai.com>    Implement support for AMD.
 # 28-Jul-2025  Matt Pelland <mpelland@akamai.com>    Parallelize postprocessing.
+# 28-Jul-2025  Matt Pelland <mpelland@akamai.com>    Silence compiler warnings.
 
 from __future__ import print_function
 from time import sleep
@@ -72,6 +73,7 @@ exgroup.add_argument("-T", "--tids", type=valid_args_list, help="trace a comma s
 exgroup.add_argument("-v", "--vcpu", type=int, help="trace this vcpu only")
 exgroup.add_argument("-a", "--alltids", action="store_true", help="trace all tids for this pid")
 parser.add_argument("-m", "--max-parallelism", type=int, help="limit post processing parallelism to the given thread count", default=64)
+parser.add_argument("-d", "--debug", action="store_true", help="enable debug facilities")
 args = parser.parse_args()
 duration = int(args.duration)
 
@@ -405,7 +407,12 @@ else:
     header_format = "PID      TID      "
 bpf_text = bpf_text.replace('THREAD_FILTER', thread_filter)
 bpf_text = bpf_text.replace('REASON_NUM', str(max(exit_reasons.keys()) + 1))
-b = BPF(text=bpf_text)
+cflags = []
+
+if not args.debug:
+    cflags.append("-w")
+
+b = BPF(text=bpf_text, cflags=cflags)
 
 
 # header

--- a/tools/kvmexit_example.txt
+++ b/tools/kvmexit_example.txt
@@ -240,6 +240,7 @@ optional arguments:
   -a, --alltids         trace all tids for this pid
   -m MAX_PARALLELISM, --max-parallelism MAX_PARALLELISM
                         limit post processing parallelism to the given thread count
+  -d, --debug           enable debug facilities
 
 examples:
     ./kvmexit                              # Display kvm_exit_reason and its statistics in real-time until Ctrl-C


### PR DESCRIPTION
This PR implements a few enhancements for the kvmexit tool.

First, it adds support for AMD's virtualization extensions (SVM) so the tool now works for both AMD and Intel based VMs.

Second, it parallelizes post processing of the VM exit counts in order to reduce the amount of time needed for this step on high core count machines. I included this data in the commit message for the relevant commit but on a 640 core machine this feature reduces the time taken to post process the results from ~37 minutes to ~5 minutes.

Finally, it adds a new `--debug` argument and disables BPF compilation warnings if this argument is not specified. I have been running this tool within a few different environments and having a variable set of warnings emitted in those different contexts makes automated data collection challenging. Disabling BPF compilations warnings makes this more straightforward and reduces visual noise when running this tool manually.