### PR TITLE
tools/filetop: fix DNAME_INLINE_LEN by folding to integer constant

### DIFF
--- a/tools/filetop.py
+++ b/tools/filetop.py
@@ -70,6 +70,10 @@ bpf_text = """
 #include <uapi/linux/ptrace.h>
 #include <linux/blkdev.h>
 
+enum { __BCC_DNAME_INLINE_LEN = DNAME_INLINE_LEN };
+#undef DNAME_INLINE_LEN
+#define DNAME_INLINE_LEN __BCC_DNAME_INLINE_LEN
+
 // the key for the output summary
 struct info_t {
     unsigned long inode;


### PR DESCRIPTION
Since Linux v6.14 (commit 61bc24ac974a), DNAME_INLINE_LEN is defined as an expression instead of a constant integer:

	#define DNAME_INLINE_LEN (DNAME_INLINE_WORDS * sizeof(unsigned long))

This causes the name array in struct info_t to be shown in map metadata as `["name", "char""unsigned long", [40]]`
instead of the correct `["name", "char", [40]]`, breaking dumping of the counts map.

Rather than modifying AST handling, fix by storing DNAME_INLINE_LEN in an enum constant after including kernel headers. Enum values are compile-time integer constants, so the expression is folded to a literal and no longer carries the sizeof() expression into the AST.

Closes: iovisor/bcc#5337