### PR TITLE
libbpf-tools: Fix list_syscalls() prototype return type

### DIFF
--- a/libbpf-tools/syscall_helpers.h
+++ b/libbpf-tools/syscall_helpers.h
@@ -6,7 +6,7 @@
 
 void init_syscall_names(void);
 void free_syscall_names(void);
-void list_syscalls(void);
+int list_syscalls(void);
 int syscall_name(unsigned n, char *buf, size_t size);
 
 #endif /* __SYSCALL_HELPERS_H */


### PR DESCRIPTION
The function list_syscalls() in syscall_helpers.c returns an integer value, but its prototype in syscall_helpers.h declared a void return type.

This commit corrects the function prototype in syscall_helpers.h to match its implementation, changing the return type from void to int.

Fixes: f3fbeb46cb52 ("libbpf-tools: convert BCC syscount to BPF CO-RE version")