### PR TITLE
Fix exit codes in BCC python tools for reliable error handling

### DIFF
--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -65,7 +65,7 @@ debug = 0
 
 if args.flags and args.disks:
     print("ERROR: can only use -D or -F. Exiting.")
-    exit()
+    exit(1)
 
 # define BPF program
 bpf_text = """

--- a/tools/biolatency.py
+++ b/tools/biolatency.py
@@ -294,7 +294,7 @@ if args.flags and (tp_start or tp_done):
             # Some flags are accessible in the rwbs field (RAHEAD, SYNC and META)
             # but other aren't. Disable the -F option for tracepoint for now.
             print("ERROR: blk_account_io_start/done probes not available. Can't use -F.")
-            exit()
+            exit(1)
 
 if tp_start:
     bpf_text += tp_start_text.replace("START_TP", tp_start)

--- a/tools/biosnoop.py
+++ b/tools/biosnoop.py
@@ -344,7 +344,7 @@ if not tp_start:
         b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
     else:
         print("ERROR: No found any block io start probe/tp.")
-        exit()
+        exit(1)
 
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
@@ -357,7 +357,7 @@ if not tp_done:
         b.attach_kprobe(event="blk_account_io_done", fn_name="trace_req_completion")
     else:
         print("ERROR: No found any block io done probe/tp.")
-        exit()
+        exit(1)
 
 
 # header

--- a/tools/biotop.py
+++ b/tools/biotop.py
@@ -285,7 +285,7 @@ if not tp_start:
         b.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
     else:
         print("ERROR: No found any block io start probe/tp.")
-        exit()
+        exit(1)
 
 if BPF.get_kprobe_functions(b'blk_start_request'):
     b.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
@@ -298,7 +298,7 @@ if not tp_done:
         b.attach_kprobe(event="blk_account_io_done", fn_name="trace_req_completion")
     else:
         print("ERROR: No found any block io done probe/tp.")
-        exit()
+        exit(1)
 
 # check whether hash table batch ops is supported
 htab_batch_ops = True if BPF.kernel_struct_has_field(b'bpf_map_ops',

--- a/tools/btrfsdist.py
+++ b/tools/btrfsdist.py
@@ -53,7 +53,7 @@ else:
     label = "usecs"
 if args.interval and int(args.interval) == 0:
     print("ERROR: interval 0. Exiting.")
-    exit()
+    exit(1)
 debug = 0
 
 # define BPF program

--- a/tools/btrfsdist.py
+++ b/tools/btrfsdist.py
@@ -188,7 +188,7 @@ with open(kallsyms) as syms:
     if ops == '':
         print("ERROR: no btrfs_file_operations in /proc/kallsyms. Exiting.")
         print("HINT: the kernel should be built with CONFIG_KALLSYMS_ALL.")
-        exit()
+        exit(1)
     bpf_text = bpf_text.replace('BTRFS_FILE_OPERATIONS', ops)
 bpf_text = bpf_text.replace('FACTOR', str(factor))
 if args.pid:

--- a/tools/btrfsslower.py
+++ b/tools/btrfsslower.py
@@ -278,7 +278,7 @@ with open(kallsyms) as syms:
     if ops == '':
         print("ERROR: no btrfs_file_operations in /proc/kallsyms. Exiting.")
         print("HINT: the kernel should be built with CONFIG_KALLSYMS_ALL.")
-        exit()
+        exit(1)
     bpf_text = bpf_text.replace('BTRFS_FILE_OPERATIONS', ops)
 if min_ms == 0:
     bpf_text = bpf_text.replace('FILTER_US', '0')

--- a/tools/cpuunclaimed.py
+++ b/tools/cpuunclaimed.py
@@ -164,7 +164,7 @@ if args.csv:
     interval = 0.2
 if args.interval != -1 and (args.fullcsv or args.csv):
     print("ERROR: cannot use interval with either -j or -J. Exiting.")
-    exit()
+    exit(1)
 if args.interval == -1:
     args.interval = "1"
 interval = float(args.interval)

--- a/tools/criticalstat.py
+++ b/tools/criticalstat.py
@@ -54,7 +54,7 @@ debugfs_path = subprocess.Popen ("cat /proc/mounts | grep -w debugfs" +
 
 if debugfs_path == "":
     print("ERROR: Unable to find debugfs mount point");
-    sys.exit(0);
+    sys.exit(1);
 
 trace_path = debugfs_path + b"/tracing/events/preemptirq/";
 

--- a/tools/drsnoop.py
+++ b/tools/drsnoop.py
@@ -80,7 +80,7 @@ with open(kallsyms) as syms:
     if vm_stat_addr == '':
         print("ERROR: no vm_stat or vm_zone_stat in /proc/kallsyms. Exiting.")
         print("HINT: the kernel should be built with CONFIG_KALLSYMS_ALL.")
-        exit()
+        exit(1)
 
 NR_FREE_PAGES = 0
 

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -53,7 +53,7 @@ else:
     label = "usecs"
 if args.interval and int(args.interval) == 0:
     print("ERROR: interval 0. Exiting.")
-    exit()
+    exit(1)
 debug = 0
 
 # define BPF program

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -165,7 +165,7 @@ else:
         if ext4_file_ops_addr == '':
             print("ERROR: no ext4_file_operations in /proc/kallsyms. Exiting.")
             print("HINT: the kernel should be built with CONFIG_KALLSYMS_ALL.")
-            exit()
+            exit(1)
     ext4_trace_read_code = """
 int trace_read_entry(struct pt_regs *ctx, struct kiocb *iocb)
 {

--- a/tools/ext4slower.py
+++ b/tools/ext4slower.py
@@ -270,7 +270,7 @@ with open(kallsyms) as syms:
     if ops == '':
         print("ERROR: no ext4_file_operations in /proc/kallsyms. Exiting.")
         print("HINT: the kernel should be built with CONFIG_KALLSYMS_ALL.")
-        exit()
+        exit(1)
     bpf_text = bpf_text.replace('EXT4_FILE_OPERATIONS', ops)
 if min_ms == 0:
     bpf_text = bpf_text.replace('FILTER_US', '0')

--- a/tools/f2fsslower.py
+++ b/tools/f2fsslower.py
@@ -240,7 +240,7 @@ with open(kallsyms) as syms:
     if ops == '':
         print("ERROR: no f2fs_file_operations in /proc/kallsyms. Exiting.")
         print("HINT: the kernel should be built with CONFIG_KALLSYMS_ALL.")
-        exit()
+        exit(1)
     bpf_text = bpf_text.replace('F2FS_FILE_OPERATIONS', ops)
 if min_ms == 0:
     bpf_text = bpf_text.replace('FILTER_US', '0')

--- a/tools/funclatency.py
+++ b/tools/funclatency.py
@@ -358,7 +358,7 @@ else:
 
 if matched == 0:
     print("0 functions matched by \"%s\". Exiting." % args.pattern)
-    exit()
+    exit(1)
 
 # header
 print("Tracing %d functions for \"%s\"... Hit Ctrl-C to end." %

--- a/tools/nfsdist.py
+++ b/tools/nfsdist.py
@@ -47,7 +47,7 @@ else:
     label = "usecs"
     if args.interval and int(args.interval) == 0:
         print("ERROR: interval 0. Exiting.")
-        exit()
+        exit(1)
 debug = 0
 
 # define BPF program

--- a/tools/offcputime.py
+++ b/tools/offcputime.py
@@ -122,7 +122,7 @@ debug = 0
 
 if args.folded and args.offset:
     print("ERROR: can only use -f or -s. Exiting.")
-    exit()
+    exit(1)
 
 # signal handler
 def signal_ignore(signal, frame):

--- a/tools/offwaketime.py
+++ b/tools/offwaketime.py
@@ -299,7 +299,7 @@ b.attach_kprobe(event="try_to_wake_up", fn_name="waker")
 matched = b.num_open_kprobes()
 if matched == 0:
     print("0 functions traced. Exiting.")
-    exit()
+    exit(1)
 
 # header
 if not folded:

--- a/tools/old/offcputime.py
+++ b/tools/old/offcputime.py
@@ -163,7 +163,7 @@ b.attach_kprobe(event="finish_task_switch", fn_name="oncpu")
 matched = b.num_open_kprobes()
 if matched == 0:
     print("0 functions traced. Exiting.")
-    exit()
+    exit(1)
 
 # header
 if not folded:

--- a/tools/old/offcputime.py
+++ b/tools/old/offcputime.py
@@ -51,7 +51,7 @@ debug = 0
 maxdepth = 20    # and MAXDEPTH
 if args.pid and args.useronly:
     print("ERROR: use either -p or -u.")
-    exit()
+    exit(1)
 
 # signal handler
 def signal_ignore(signal, frame):

--- a/tools/old/offwaketime.py
+++ b/tools/old/offwaketime.py
@@ -55,7 +55,7 @@ maxwdepth = 10    # and MAXWDEPTH
 maxtdepth = 20    # and MAXTDEPTH
 if args.pid and args.useronly:
     print("ERROR: use either -p or -u.")
-    exit()
+    exit(1)
 
 # signal handler
 def signal_ignore(signal, frame):

--- a/tools/old/offwaketime.py
+++ b/tools/old/offwaketime.py
@@ -212,7 +212,7 @@ b.attach_kprobe(event="try_to_wake_up", fn_name="waker")
 matched = b.num_open_kprobes()
 if matched == 0:
     print("0 functions traced. Exiting.")
-    exit()
+    exit(1)
 
 # header
 if not folded:

--- a/tools/old/stackcount.py
+++ b/tools/old/stackcount.py
@@ -137,7 +137,7 @@ b.attach_kprobe(event_re=pattern, fn_name="trace_count")
 matched = b.num_open_kprobes()
 if matched == 0:
     print("0 functions matched by \"%s\". Exiting." % args.pattern)
-    exit()
+    exit(1)
 
 # header
 print("Tracing %d functions for \"%s\"... Hit Ctrl-C to end." %

--- a/tools/old/wakeuptime.py
+++ b/tools/old/wakeuptime.py
@@ -51,7 +51,7 @@ debug = 0
 maxdepth = 20    # and MAXDEPTH
 if args.pid and args.useronly:
     print("ERROR: use either -p or -u.")
-    exit()
+    exit(1)
 
 # signal handler
 def signal_ignore(signal, frame):

--- a/tools/old/wakeuptime.py
+++ b/tools/old/wakeuptime.py
@@ -177,7 +177,7 @@ b.attach_kprobe(event="try_to_wake_up", fn_name="waker")
 matched = b.num_open_kprobes()
 if matched == 0:
     print("0 functions traced. Exiting.")
-    exit()
+    exit(1)
 
 # header
 if not folded:

--- a/tools/opensnoop.py
+++ b/tools/opensnoop.py
@@ -92,11 +92,11 @@ debug = 0
 
 if args.pid and args.exec:
     print("ERROR: can only use -p or --exec. Exiting.")
-    exit()
+    exit(1)
 
 if args.exec is not None and len(args.exec) == 0:
     print("ERROR: --exec without command. Exiting.")
-    exit()
+    exit(1)
 
 if args.duration:
     args.duration = timedelta(seconds=int(args.duration))

--- a/tools/readahead.py
+++ b/tools/readahead.py
@@ -185,7 +185,7 @@ if BPF.support_kfunc():
         ra_func = "page_cache_ra_order"
     else:
         print("Not found any kfunc for page cache readahead.")
-        exit()
+        exit(1)
     bpf_text += bpf_text_kfunc_cache_readahead.replace("RA_FUNC", ra_func)
     if BPF.get_kprobe_functions(b"__page_cache_alloc"):
         bpf_text += bpf_text_kfunc_cache_alloc_ret_page
@@ -196,7 +196,7 @@ if BPF.support_kfunc():
             bpf_text += bpf_text_kfunc_cache_alloc_ret_folio_noprof
         else:
             print("ERROR: No cache alloc function found. Exiting.")
-            exit()
+            exit(1)
         bpf_text += bpf_text_kfunc_cache_alloc_ret_folio_func_body
     if BPF.get_kprobe_functions(b"folio_mark_accessed"):
         ma_func_name = "folio_mark_accessed"
@@ -216,7 +216,7 @@ if BPF.support_kfunc():
             .replace("GET_PAGE_PTR_FROM_ARG0", get_page_ptr_code)
     else:
         print("Not found any kfunc for page cache mark accessed.")
-        exit()
+        exit(1)
     bpf_text += bpf_text_kfunc_mark_accessed
     b = BPF(text=bpf_text)
 else:
@@ -229,7 +229,7 @@ else:
         ra_event = "page_cache_ra_order"
     else:
         print("Not found any kprobe for page cache readahead.")
-        exit()
+        exit(1)
     if BPF.get_kprobe_functions(b"__page_cache_alloc"):
         cache_func = "__page_cache_alloc"
         bpf_text = bpf_text.replace('GET_RETVAL_PAGE', 'PT_REGS_RC(ctx)')
@@ -240,7 +240,7 @@ else:
             cache_func = "filemap_alloc_folio_noprof"
         else:
             print("ERROR: No cache alloc function found. Exiting.")
-            exit()
+            exit(1)
         bpf_text = bpf_text.replace('GET_RETVAL_PAGE', 'folio_page((struct folio *)PT_REGS_RC(ctx), 0)')
     if BPF.get_kprobe_functions(b"folio_mark_accessed"):
         ma_event = "folio_mark_accessed"
@@ -250,7 +250,7 @@ else:
         bpf_text = bpf_text.replace('GET_ARG1_PAGE', '(struct page *)PT_REGS_PARM1(ctx)')
     else:
         print("Not found any kprobe for page cache mark accessed.")
-        exit()
+        exit(1)
 
     b = BPF(text=bpf_text)
     b.attach_kprobe(event=ra_event, fn_name="entry__do_page_cache_readahead")

--- a/tools/stackcount.py
+++ b/tools/stackcount.py
@@ -267,7 +267,7 @@ class Tool(object):
         if self.args.kernel_stacks_only and self.args.user_stacks_only:
             print("ERROR: -K and -U are mutually exclusive. If you want " +
                 "both stacks, that is the default.")
-            exit()
+            exit(1)
         if not self.args.kernel_stacks_only and not self.args.user_stacks_only:
             self.kernel_stack = True
             self.user_stack = True

--- a/tools/swapin.py
+++ b/tools/swapin.py
@@ -75,7 +75,7 @@ else:
     print("ERROR: swap_readpage() and swap_read_folio() kernel function"
           " not found or traceable. "
           "The kernel might be too old or the the function has been inlined.")
-    exit()
+    exit(1)
 
 print("Counting swap ins. Ctrl-C to end.");
 

--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -87,11 +87,11 @@ if not args.interval:
 
 if args.pid and args.exec:
     print("ERROR: can only use -p or --exec. Exiting.")
-    exit()
+    exit(1)
 
 if args.exec is not None and len(args.exec) == 0:
     print("ERROR: --exec without command. Exiting.")
-    exit()
+    exit(1)
 
 syscall_nr = -1
 if args.syscall is not None:

--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -209,7 +209,7 @@ else:
 if args.pid_netns != 0:
     if args.netns_id != 0:
         print("ERROR: --pid_netns and --netns-id not allowed together")
-        exit()
+        exit(1)
     args.netns_id = os.stat('/proc/{}/ns/net'.format(args.pid_netns)).st_ino
 
 if args.netns_id != 0:

--- a/tools/tcpdrop.py
+++ b/tools/tcpdrop.py
@@ -386,7 +386,7 @@ else:
     print("ERROR: tcp_drop() kernel function and tracepoint:skb:kfree_skb"
           " not found or traceable. "
           "The kernel might be too old or the the function has been inlined.")
-    exit()
+    exit(1)
 stack_traces = b.get_table("stack_traces")
 
 # header

--- a/tools/wakeuptime.py
+++ b/tools/wakeuptime.py
@@ -212,7 +212,7 @@ if not is_supported_raw_tp:
     matched = b.num_open_kprobes()
     if matched == 0:
         print("0 functions traced. Exiting.")
-        exit()
+        exit(1)
 
 # check whether hash table batch ops is supported
 htab_batch_ops = True if BPF.kernel_struct_has_field(b'bpf_map_ops',

--- a/tools/xfsdist.py
+++ b/tools/xfsdist.py
@@ -50,7 +50,7 @@ else:
     label = "usecs"
 if args.interval and int(args.interval) == 0:
     print("ERROR: interval 0. Exiting.")
-    exit()
+    exit(1)
 debug = 0
 
 # define BPF program

--- a/tools/zfsdist.py
+++ b/tools/zfsdist.py
@@ -50,7 +50,7 @@ else:
     label = "usecs"
 if args.interval and int(args.interval) == 0:
     print("ERROR: interval 0. Exiting.")
-    exit()
+    exit(1)
 debug = 0
 
 # define BPF program


### PR DESCRIPTION
Some BCC tools currently exit with status code 0 even when encountering
fatal errors. This makes it impossible to distinguish between success and
failure, which makes smoke tests (and packaging checks) unreliable.

Examples are:
- No kprobe or tracepoint event attached
- Missing required symbols in /proc/kallsyms
- Invalid or conflicting command-line options

This PR updates the BCC python tools to consistently return exit(1) in
these cases. This ensures errors are clearly reported and allows the
tools to be used more effectively in automated workflows such as smoke
testing.