### PR TITLE
libbpf-tools/syncsnoop: Add support for sync_file_range2

### DIFF
--- a/libbpf-tools/syncsnoop.bpf.c
+++ b/libbpf-tools/syncsnoop.bpf.c
@@ -52,6 +52,18 @@ void tracepoint__syscalls__sys_enter_sync_file_range(struct trace_event_raw_sys_
 	__syscall(ctx, SYS_SYNC_FILE_RANGE);
 }
 
+SEC("tracepoint/syscalls/sys_enter_sync_file_range2")
+void tracepoint__syscalls__sys_enter_sync_file_range2(struct trace_event_raw_sys_enter *ctx)
+{
+	__syscall(ctx, SYS_SYNC_FILE_RANGE2);
+}
+
+SEC("tracepoint/syscalls/sys_enter_arm_sync_file_range")
+void tracepoint__syscalls__sys_enter_arm_sync_file_range(struct trace_event_raw_sys_enter *ctx)
+{
+	__syscall(ctx, SYS_ARM_SYNC_FILE_RANGE);
+}
+
 SEC("tracepoint/syscalls/sys_enter_syncfs")
 void tracepoint__syscalls__sys_enter_syncfs(struct trace_event_raw_sys_enter *ctx)
 {

--- a/libbpf-tools/syncsnoop.h
+++ b/libbpf-tools/syncsnoop.h
@@ -11,6 +11,8 @@ enum sync_syscalls {
 	SYS_FDATASYNC,
 	SYS_MSYNC,
 	SYS_SYNC_FILE_RANGE,
+	SYS_SYNC_FILE_RANGE2,
+	SYS_ARM_SYNC_FILE_RANGE,
 	SYS_SYNCFS,
 	SYS_T_MAX,
 };
@@ -28,6 +30,8 @@ static const char *sys_names[] = {
 	"fdatasync",
 	"msync",
 	"sync_file_range",
+	"sync_file_range2",
+	"arm_sync_file_range",
 	"syncfs",
 	"N/A",
 };


### PR DESCRIPTION
Some architectures like ppc64 don't use the sync_file_range syscall, but sync_file_range2 instead and that makes syncsnoop fails on those arches. Add support for it.

Fixes the following error:
libbpf: failed to determine tracepoint 'syscalls/sys_enter_sync_file_range' perf event ID: No such file or directory libbpf: prog 'tracepoint__syscalls__sys_enter_sync_file_range': failed to create tracepoint 'syscalls/sys_enter_sync_file_range' perf event: No such file or directory libbpf: prog 'tracepoint__syscalls__sys_enter_sync_file_range': failed to auto-attach: -2 failed to attach BPF object