### PR TITLE
libbpf-tools/javagc: Include usdt.bpf.h header

### DIFF
--- a/libbpf-tools/javagc.bpf.c
+++ b/libbpf-tools/javagc.bpf.c
@@ -3,6 +3,7 @@
 #include <vmlinux.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
+#include <bpf/usdt.bpf.h>
 #include "javagc.h"
 
 struct {


### PR DESCRIPTION
Include usdt.bpf.h header to javagc.bpf.c.

Fixes the following error:
libbpf: usdt: failed to find USDT support BPF maps, did you forget to include bpf/usdt.bpf.h? attach usdt mem__pool__gc__begin failed: No such process