### PR TITLE
tools/javaobjnew: Use MIN macro instead of min function

### DIFF
--- a/tools/lib/uobjnew.py
+++ b/tools/lib/uobjnew.py
@@ -92,6 +92,9 @@ int alloc_entry(struct pt_regs *ctx, size_t size) {
 #
 elif language == "java":
     program += """
+#ifndef MIN
+    #define MIN(x, y) ((x) < (y) ? (x) : (y))
+#endif
 int alloc_entry(struct pt_regs *ctx) {
     struct key_t key = {};
     struct val_t *valp, zero = {};
@@ -100,7 +103,7 @@ int alloc_entry(struct pt_regs *ctx) {
     bpf_usdt_readarg(2, ctx, &classptr);
     bpf_usdt_readarg(3, ctx, &length);
     bpf_usdt_readarg(4, ctx, &size);
-    bpf_probe_read_user(&key.name, min(sizeof(key.name), (size_t)length), (void *)classptr);
+    bpf_probe_read_user(&key.name, MIN(sizeof(key.name), (size_t)length), (void *)classptr);
     valp = allocs.lookup_or_try_init(&key, &zero);
     if (valp) {
         valp->total_size += size;


### PR DESCRIPTION
The function min() is called among the arguments of bpf_probe_read_user(). Depending on kernel version, the expansion of the macro may emmit a fake function that prevent the compilation of the BPF code.

Replace the min() function by the MIN() macro to solve the issue. This is safe since both members of the comparison are unsigned integer.

Solves the following error:
/virtual/main.c:48:36: error: cannot call non-static helper function
   48 |     bpf_probe_read_user(&key.name, min(sizeof(key.name), (size_t)length), (void *)classptr);
      |                                    ^
include/linux/minmax.h:129:19: note: expanded from macro 'min'
  129 | #define min(x, y)       __careful_cmp(min, x, y)
      |                         ^
include/linux/minmax.h:105:2: note: expanded from macro '__careful_cmp'
  105 |         __careful_cmp_once(op, x, y, __UNIQUE_ID(x_), __UNIQUE_ID(y_))
      |         ^
include/linux/minmax.h:100:2: note: expanded from macro '__careful_cmp_once'
  100 |         BUILD_BUG_ON_MSG(!__types_ok(x,y,ux,uy),        \
      |         ^
note: (skipping 2 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
include/linux/compiler_types.h:418:2: note: expanded from macro '_compiletime_assert'
  418 |         __compiletime_assert(condition, msg, prefix, suffix)
      |         ^
include/linux/compiler_types.h:411:4: note: expanded from macro '__compiletime_assert'
  411 |                         prefix ## suffix();                             \
      |                         ^
<scratch space>:91:1: note: expanded from here
   91 | __compiletime_assert_317
      | ^
1 error generated.
Traceback (most recent call last):
  File "/usr/share/bcc/tools/lib/uobjnew", line 178, in <module>
    bpf = BPF(text=program, usdt_contexts=[usdt])
  File "/usr/lib/python3.9/site-packages/bcc/__init__.py", line 507, in __init__
    raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
Exception: Failed to compile BPF module <text>