### PR TITLE
INSTALL.md: add clang for install build dependence

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -410,6 +410,9 @@ sudo apt-get -y install zip bison build-essential cmake flex git libedit-dev \
 
 # For Lua support
 sudo apt-get -y install luajit luajit-5.1-dev
+
+# Additional dependencies for libbpf-tools
+sudo apt-get -y install llvm clang
 ```
 
 ### Install and compile BCC


### PR DESCRIPTION
clang is not default package of Ubuntu 24.04. So, add clang for install build dependence on INSTALL.md file.

You will get following error during compiling libbpf-tools on Ubuntu 24.04 without this patch.

```
  MKDIR    .output                                                                          
  BPF      memleak.bpf.o                                                                                                                                                             
/bin/sh: 1: clang: not found
make: *** [Makefile:209: /home/bojun/bcc/libbpf-tools/.output/memleak.bpf.o] Error 127
```

I guess other Ubuntu versions also need clang for install dependence. But I didn't test it on other versions.