### PR TITLE
Delete the element from the `starts` map after it has been used.

### DIFF
--- a/libbpf-tools/funclatency.bpf.c
+++ b/libbpf-tools/funclatency.bpf.c
@@ -88,6 +88,8 @@ static void exit(void)
 	if (slot >= MAX_SLOTS)
 		slot = MAX_SLOTS - 1;
 	__sync_fetch_and_add(&hist[slot], 1);
+
+	bpf_map_delete_elem(&starts, &pid);
 }
 
 SEC("fexit/dummy_fexit")


### PR DESCRIPTION
I think it has been an omission, as opposed to an optimization, in the original change that introduced this. The python version of the `funclatency` has the delete after the lookup.

Before the change:
./funclatency nvme_setup_cmd
Tracing nvme_setup_cmd.  Hit Ctrl-C to exit
^C
     nsec                : count    distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 0        |                                        |
       512 -> 1023       : 243      |****************************************|
      1024 -> 2047       : 43       |*******                                 |
      2048 -> 4095       : 59       |*********                               |
      4096 -> 8191       : 26       |****                                    |

After the change:
./funclatency nvme_setup_cmd
Tracing nvme_setup_cmd.  Hit Ctrl-C to exit
^C
     nsec                : count    distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 0        |                                        |
         4 -> 7          : 0        |                                        |
         8 -> 15         : 0        |                                        |
        16 -> 31         : 0        |                                        |
        32 -> 63         : 0        |                                        |
        64 -> 127        : 0        |                                        |
       128 -> 255        : 0        |                                        |
       256 -> 511        : 4        |                                        |
       512 -> 1023       : 624      |****************************************|
      1024 -> 2047       : 39       |**                                      |
      2048 -> 4095       : 98       |******                                  |
      4096 -> 8191       : 71       |****                                    |
      8192 -> 16383      : 1        |                                        |