### PR TITLE
python: Access available_filter_functions via TRACEFS

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -726,7 +726,7 @@ class BPF(object):
                 raise e
             blacklist = set([])
 
-        avail_filter_file = "%s/tracing/available_filter_functions" % DEBUGFS
+        avail_filter_file = "%s/available_filter_functions" % TRACEFS
         try:
             with open(avail_filter_file, "rb") as avail_filter_f:
                 avail_filter = set([line.rstrip().split()[0] for line in avail_filter_f])


### PR DESCRIPTION
The /sys/kernel/debug/tracing mountpoint is considered deprecated and
is only enabled when the CONFIG_TRACEFS_AUTOMOUNT_DEPRECATED kernel
option is set. Some distributions, such as ArchLinux, no longer set
this, which breaks the use of `get_kprobe_functions`:

    Traceback (most recent call last):
      File "biosnoop.py", line 349, in <module>
        if BPF.get_kprobe_functions(b'blk_start_request'):
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.13/site-packages/bcc/__init__.py", line 735, in get_kprobe_functions
        raise e
      File "/usr/lib/python3.13/site-packages/bcc/__init__.py", line 731, in get_kprobe_functions
        with open(avail_filter_file, "rb") as avail_filter_f:
             ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
    FileNotFoundError: [Errno 2] No such file or directory: '/sys/kernel/debug/tracing/available_filter_functions'

Fix this by using the TRACEFS constant (which is set to the correct
tracefs mountpoint) instead.
