### PR TITLE
tcppktlat: Add histogram mode with per-PID grouping

### DIFF
--- a/libbpf-tools/tcppktlat.h
+++ b/libbpf-tools/tcppktlat.h
@@ -4,6 +4,7 @@
 
 #define TASK_COMM_LEN 16
 #define MAX_SLOTS 26
+#define MAX_ENTRIES 10240
 
 struct event {
 	__u32 saddr[4];

--- a/libbpf-tools/tcppktlat_example.txt
+++ b/libbpf-tools/tcppktlat_example.txt
@@ -42,7 +42,7 @@ PID     COMM             LADDR           LPORT RADDR           RPORT MS
 The -H option can be used to show latency as a histogram, grouped by PID.
 
 # tcppktlat -H
-Tracing TCP packet latency. Hit Ctrl-C to end.
+Summarize TCP packet latency as a histogram. Hit Ctrl-C to end.
 ^C
 
 pid = 2333671 sshd-session
@@ -71,7 +71,7 @@ pid = 1357503 verge-mihomo
 The -H option can also take an interval argument to print histograms periodically.
 
 # tcppktlat -H 5
-Tracing TCP packet latency. Hit Ctrl-C to end.
+Summarize TCP packet latency as a histogram. Hit Ctrl-C to end.
 
 pid = 1357503 verge-mihomo
      usecs               : count    distribution
@@ -100,7 +100,7 @@ pid = 1357503 verge-mihomo
 The -p option can be combined with -H to show histogram for a specific PID only.
 
 # tcppktlat -p 1357503 -H
-Tracing TCP packet latency. Hit Ctrl-C to end.
+Summarize TCP packet latency as a histogram. Hit Ctrl-C to end.
 ^C
 
 pid = 1357503 verge-mihomo


### PR DESCRIPTION
Add -H option to display latency as histograms grouped by PID. Supports periodic printing with interval argument and works with existing filters like -p, -t, -l, -r.