### PR TITLE
Ensure headers are flushed to stdout in offcputime

### DIFF
--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -319,10 +319,10 @@ static void print_headers()
 	if (!print_header_threads())
 		printf(" all threads");
 
-	if (env.duration < 99999999)
-		printf(" for %d secs.\n", env.duration);
-	else
-		printf("... Hit Ctrl-C to end.\n");
+	if (env.duration < 99999999) printf(" for %d secs.\n", env.duration);
+	else printf("... Hit Ctrl-C to end.\n");
+
+  fflush(stdout);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This PR adds an explicit `fflush(stdout)` after printing the headers in the libbpf-tools offcputime example.

I am using this example as a dependency in another tool, where I monitor its standard output to determine when the tracer has successfully attached to a target process. Without an explicit flush, the header output appears to remain buffered and is never observed by the parent process, even after attachment.

By flushing stdout immediately after printing the headers, we ensure that the output is actually written once the tool has attached, making the behavior more reliable when stdout is being monitored or redirected. This change does not affect normal interactive usage but improves correctness in non-interactive and programmatic use cases.