### PR TITLE
add a new tool in libbpf-tools named ext4File

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -20,6 +20,7 @@
 /execsnoop
 /exitsnoop
 /ext4dist
+/ext4file
 /ext4slower
 /f2fsdist
 /f2fsslower

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -55,6 +55,7 @@ APPS = \
 	drsnoop \
 	execsnoop \
 	exitsnoop \
+	ext4file \
 	filelife \
 	filetop \
 	fsdist \

--- a/libbpf-tools/ext4file.bpf.c
+++ b/libbpf-tools/ext4file.bpf.c
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+//  Copyright (c) 2026 Samsung Electronics Co., Ltd.
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_core_read.h>
+
+#include "ext4file.h"
+
+volatile __u64 dev_target = 0;
+volatile __u64 blocks_per_group = 0;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1000000);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, u32);
+	__type(value, struct file_info_key);
+} ino_name_map SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1000000);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, struct file_info_key);
+	__type(value, struct file_info_val);
+} file_info_map SEC(".maps");
+
+static __always_inline bool str_equal(const char *a, const char *b) {
+    for (size_t i = 0; i < MAX_FILE_NAME; i++) {
+        if (a[i] == '\0' && b[i] == '\0')
+            return true;
+        if (a[i] != b[i])
+            return false;
+    }
+    return true;
+}
+
+SEC("fexit/ext4_add_entry")
+int BPF_PROG(my_ext4_add_entry, handle_t *handle,
+    struct dentry *dentry, struct inode *inode)
+{
+    struct inode *pa_inode = dentry->d_parent->d_inode;
+    dev_t dev_cur = pa_inode->i_sb->s_dev;
+    u64 ino_id = inode->i_ino;
+    struct file_info_key fik = {};
+    struct file_info_val fiv = {};
+
+    if (dev_target && dev_target != dev_cur)
+        return 0;
+
+    fik.fk_ino = ino_id;
+    fik.fk_pa_ino = pa_inode->i_ino;
+    bpf_probe_read_str(&fik.fk_name,
+        sizeof(fik.fk_name), dentry->d_name.name);
+
+    if (bpf_map_update_elem(&file_info_map, &fik, &fiv, BPF_ANY))
+        return 0;
+    if (bpf_map_update_elem(&ino_name_map, &ino_id, &fik, BPF_ANY))
+        return 0;
+    return 0;
+}
+
+SEC("tp_btf/ext4_unlink_enter")
+int BPF_PROG(my_ext4_unlink, 
+    struct inode *pa_inode, struct dentry *dentry)
+{
+    struct inode *inode = dentry->d_inode;
+    struct file_info_key fik = {}, *fikp;
+    struct file_info_val *fivp = NULL;
+    u64 ino_id = inode->i_ino;
+    dev_t dev_cur = pa_inode->i_sb->s_dev;
+    if (dev_target && dev_target != dev_cur)
+        return 0;
+    
+    fik.fk_ino = inode->i_ino;
+    fik.fk_pa_ino = pa_inode->i_ino;
+    bpf_probe_read_str(&fik.fk_name,
+        sizeof(fik.fk_name), dentry->d_name.name);
+    fivp = bpf_map_lookup_elem(&file_info_map, &fik);
+    if (!fivp)
+        return 0;
+    fivp->fv_delete = true;
+	fikp = bpf_map_lookup_elem(&ino_name_map, &ino_id);
+    if (!fikp)
+        return 0;
+    if (str_equal(fikp->fk_name, fik.fk_name))
+        bpf_map_delete_elem(&ino_name_map, &ino_id);
+    return 0;
+}
+
+SEC("fentry/ext4_rmdir")
+int BPF_PROG(my_ext4_rmdir,
+    struct inode *dir, struct dentry *dentry) 
+{
+    struct inode *inode = dentry->d_inode;
+    struct file_info_key fik = {}, *fikp;
+    struct file_info_val *fivp = NULL;
+    u64 ino_id = inode->i_ino;
+    dev_t dev_cur = inode->i_sb->s_dev;
+    if (dev_target && dev_target != dev_cur)
+        return 0;
+    
+    fik.fk_ino = inode->i_ino;
+    fik.fk_pa_ino = dir->i_ino;
+    bpf_probe_read_str(&fik.fk_name,
+        sizeof(fik.fk_name), dentry->d_name.name);
+    fivp = bpf_map_lookup_elem(&file_info_map, &fik);
+    if (!fivp)
+        return 0;
+    fivp->fv_delete = true;
+
+    fikp = bpf_map_lookup_elem(&ino_name_map, &ino_id);
+    if (!fikp)
+        return 0;
+    if (str_equal(fikp->fk_name, fik.fk_name))
+        bpf_map_delete_elem(&ino_name_map, &ino_id);
+    return 0;
+}
+
+SEC("fentry/ext4_file_write_iter")
+int BPF_PROG(my_ext4_file_write_iter, 
+    struct kiocb *iocb, struct iov_iter *from)
+{
+    struct inode *inode = iocb->ki_filp->f_inode;
+    dev_t dev_cur = inode->i_sb->s_dev;
+    struct file_info_key *fikp = NULL;
+    struct file_info_val *fivp = NULL;
+    u64 ino_id = inode->i_ino;
+
+    if (dev_target && dev_target != dev_cur)
+        return 0;
+
+    fikp = bpf_map_lookup_elem(&ino_name_map, &ino_id);
+    if (!fikp)
+        return 0;
+    fivp = bpf_map_lookup_elem(&file_info_map, fikp);
+    if (!fivp)
+        return 0;
+
+    fivp->fv_hint = inode->i_write_hint;
+    if(iocb->ki_flags & IOCB_DIRECT)
+        if (fivp->fv_rw_cnt[RW_TYPE_DIRECT_WRITE] < (__u64)-1)
+            __sync_fetch_and_add(&fivp->fv_rw_cnt[RW_TYPE_DIRECT_WRITE], 1);
+    else
+        if (fivp->fv_rw_cnt[RW_TYPE_BUFFER_WRITE] < (__u64)-1)
+            __sync_fetch_and_add(&fivp->fv_rw_cnt[RW_TYPE_BUFFER_WRITE], 1);
+    return 0;
+}
+
+SEC("fentry/ext4_file_read_iter")
+int BPF_PROG(my_ext4_file_read_iter,
+    struct kiocb *iocb, struct iov_iter *to)
+{
+    struct file *file = iocb->ki_filp;
+    struct inode *inode = file->f_inode;
+    dev_t dev_cur = inode->i_sb->s_dev;
+    struct file_info_key *fikp = NULL;
+    struct file_info_val *fivp = NULL;
+    u64 ino_id = inode->i_ino;
+    if (dev_target && dev_target != dev_cur)
+        return 0;
+
+    fikp = bpf_map_lookup_elem(&ino_name_map, &ino_id);
+    if (!fikp)
+        return 0;
+    fivp = bpf_map_lookup_elem(&file_info_map, fikp);
+    if (!fivp)
+        return 0;
+
+    if (iocb->ki_flags & IOCB_DIRECT)
+        if (fivp->fv_rw_cnt[RW_TYPE_DIRECT_READ] < (__u64)-1)
+            __sync_fetch_and_add(&fivp->fv_rw_cnt[RW_TYPE_DIRECT_READ], 1);
+    else
+        if (fivp->fv_rw_cnt[RW_TYPE_BUFFER_READ] < (__u64)-1)
+            __sync_fetch_and_add(&fivp->fv_rw_cnt[RW_TYPE_BUFFER_READ], 1);
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/libbpf-tools/ext4file.c
+++ b/libbpf-tools/ext4file.c
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+//  Copyright (c) 2026 Samsung Electronics Co., Ltd.
+#include <argp.h>
+#include <signal.h>
+#include <time.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <math.h>
+#include <bpf/bpf.h>
+#include "ext4file.skel.h"
+#include "trace_helpers.h"
+#include "ext4file.h"
+
+struct config {
+	char *dir;
+    char *output_file;
+	char *dev;
+	time_t interval;
+	int times;
+}config = {
+	.interval = 100000000,
+	.times = 100000000,
+};
+
+static volatile bool exiting;
+
+void print_usage(FILE *fp, int argc, char **argv) {
+    fprintf(fp,
+        "Show I/O pattern for every file in ext4 filesystem\n"
+        "\n"
+        "Usage: %s [-h] [-d DIR] [-o FILE] [interval] [count]\n"
+        "\n"
+        "Options:\n"
+        "  -h, --help                   Print this help message\n"
+        "  -d DIR, --dir=DIR            Trace the ext4 filesystem mounted on the specified directory\n"
+        "  -o FILE, --output=FILE       Write output to a file (optional; default: stdout)\n"
+        "  interval                     Time interval (in seconds) between reports (default: unlimited)\n"
+        "  count                        Number of reports to generate (default: unlimited)\n"
+        "\n"
+        "Examples:\n"
+        "  %s -d /mnt/ext4                      # Trace I/O patterns of files on the ext4 filesystem mounted at /mnt/ext4\n"
+        "  %s -d /mnt/ext4 1 10                 # Generate 10 reports, one per second\n"
+        "  %s -d /mnt/ext4 -o output 1 10       # Generate 10 reports at 1-second intervals, saving output to ./output\n",
+        argv[0], argv[0], argv[0], argv[0]);
+}
+
+int parse_opt(int argc, char **argv) {
+    int c;
+    int option_index = 0;
+    static struct option long_options[] = {
+        {"dir", required_argument, 0, 'd'},
+        {"output", required_argument, 0, 'o'},
+        {"help", no_argument, 0, 'h'},
+        {0, 0, 0, 0}
+    };
+
+    while ((c = getopt_long(argc, argv, "d:o:h", long_options, &option_index)) != -1) {
+        switch (c) {
+        case 'd':
+            config.dir = optarg;
+            break;
+        case 'h':
+            print_usage(stdout, argc, argv);
+            exit(0);
+        case 'o':
+            if (optarg)
+                config.output_file = optarg;
+            else
+                config.output_file = NULL;
+            break;
+        case '?':
+            print_usage(stderr, argc, argv);
+            exit(1);
+        default:
+            print_usage(stderr, argc, argv);
+            exit(1);
+        }
+    }
+
+    if (optind < argc) {
+        if (optind + 1 > argc) {
+            fprintf(stderr, "Missing value for interval\n");
+            print_usage(stderr, argc, argv);
+            exit(1);
+        }
+        config.interval = atoi(argv[optind++]);
+        if (optind < argc) {
+            config.times = atoi(argv[optind++]);
+        }
+    }
+
+    return 0;
+}
+
+void targeted_printf(int fd_output, const char *format, ...){
+    va_list args;
+    va_start(args, format);
+
+    char buf[1024];
+    int len;
+    len = vsnprintf(buf, sizeof(buf), format, args);
+
+    va_end(args);
+    if (fd_output == FD_STDOUT)
+        fwrite(buf, 1, len, stdout);
+    else if (fd_output == FD_STDERR)
+        fwrite(buf, 1, len, stderr);
+    else if (fd_output >= 0)
+        if (write(fd_output, buf, len) < 0)
+            return;
+}
+
+void sig_handler(int sig) {
+	exiting = true;
+}
+
+int get_mounts_dev_by_dir(const char *dev, char *dir, char *type) {
+    FILE *f = NULL;
+    char mount_dev[256] = { 0 };
+    char mount_dir[256] = { 0 };
+    char mount_type[50] = { 0 };
+    int match;
+
+    if (dir[strlen(dir) - 1] == '/')
+        dir[strlen(dir) - 1] = '\0';
+
+    f = fopen("/proc/mounts", "r");
+    if (!f) {
+        fprintf(stderr, "could not open /proc/mounts\n");
+        return -1;
+    }
+
+    do {
+        match = fscanf(f, "%255s %255s %49s\n",
+            mount_dev, mount_dir, mount_type);
+        if (match == 3 && strcmp(dir, mount_dir) == 0) {
+            memcpy((void*)dev, mount_dev, sizeof(mount_dev));
+            memcpy(type, mount_type, sizeof(mount_type));
+            fclose(f);
+            return 0;
+        }
+        memset(mount_dev, 0, strlen(mount_dev));
+        memset(mount_dir, 0, strlen(mount_dir));
+        memset(mount_type, 0, strlen(mount_type));
+    } while (match != EOF);
+
+    fclose(f);
+    return -1;
+}
+
+void get_device_name_from_path(const char *mount_dev, char *device_name) {
+    int len = strlen(mount_dev);
+    int pos;
+    for (pos = len - 1; pos >= 0; pos--) {
+        if (mount_dev[pos] == '/') break;
+    }
+    pos = pos >= 0 ? pos + 1 : 0;
+    memcpy(device_name, mount_dev + pos, len - pos);
+}
+
+int ext4_info_get(struct ext4_config *ext4_config) {
+    int fd_ext4_dev;
+    int ret = 0;
+
+    fd_ext4_dev = open(config.dev, O_RDONLY);
+    if (fd_ext4_dev < 0) {
+        targeted_printf(FD_STDERR, "failed to open %s\n", config.dev);
+        ret = -1;
+        goto cleanup;
+    }
+    if (pread(fd_ext4_dev, &ext4_config->blocks_per_group, 4, 1056) != 4 ||
+        pread(fd_ext4_dev, &ext4_config->blocks_count, 4, 1028) != 4) {
+        targeted_printf(FD_STDERR, "failed to read ext4 superblock\n");
+        ret = -1;
+        goto cleanup;
+    }
+    ext4_config->bg_cnt = ext4_config->blocks_count / ext4_config->blocks_per_group;
+
+cleanup:
+    if (fd_ext4_dev >= 0)
+        close(fd_ext4_dev);
+    return ret;
+}
+
+void print_file_infos(int fdT, char *time_buffer, int fd_output) {
+    int err;
+    struct file_info_key lookup_key = {}, next_key;
+    struct file_info_val fiv;
+    targeted_printf(fd_output, "%s\n", time_buffer);
+    targeted_printf(fd_output, "%-10s %-20s %-10s %-6s "
+        "%-15s %-15s %-15s %-15s %-8s\n",
+        "file_name", "inode", "pa_inode", "hint", 
+        "buffer_read", "direct_read", "buffer_write", "direct_write", "delete");
+    while (!bpf_map_get_next_key(fdT, &lookup_key, &next_key)) {
+        err = bpf_map_lookup_elem(fdT, &next_key, &fiv);
+        if (err < 0) {
+            targeted_printf(FD_STDERR, 
+                "failed to lookup err: %u\n", err);
+            return;
+        }
+        targeted_printf(fd_output, "%-10u %-20s %-10u %-6u ",
+            next_key.fk_name, next_key.fk_ino, next_key.fk_pa_ino, fiv.fv_hint);
+        targeted_printf(fd_output, "%-15d %-15d %-15d %-15d ",
+            fiv.fv_rw_cnt[RW_TYPE_BUFFER_READ], fiv.fv_rw_cnt[RW_TYPE_DIRECT_READ], 
+            fiv.fv_rw_cnt[RW_TYPE_BUFFER_WRITE], fiv.fv_rw_cnt[RW_TYPE_DIRECT_WRITE]);
+        targeted_printf(fd_output, "%-8s\n",
+            fiv.fv_delete ? "True": "False");
+        lookup_key = next_key;
+    }
+}
+
+int program_configure(int argc, char **argv, int *fd_output,
+    struct partitions **partitions, const struct partition **partition) {
+    const char *fs_type = "ext4";
+    char device_name[20];
+    char mount_type[10];
+    config.dev = malloc(256);
+    memset(config.dev, 0, 256);
+
+    if (parse_opt(argc, argv)) {
+        targeted_printf(FD_STDERR, "error: parse_opt failed!\n");
+        return -1;
+    }
+    if (!config.dir) {
+        targeted_printf(FD_STDERR, "error: the FS mounted dir is needed\n");
+        return -1;
+    }
+
+    //if the dev is mounted or made by ext4
+    if (get_mounts_dev_by_dir(config.dev, config.dir, mount_type)) {
+        targeted_printf(FD_STDERR, 
+            "error: failed to find %s, you can refer to \"df -h\"\n", config.dir);
+        return -1;
+    }
+    if (strcmp(fs_type, mount_type)) {
+        targeted_printf(FD_STDERR, "error: the fs is not ext4\n");
+        return -1;
+    }
+
+    // get the device_name(eg. get 'nvme0n1' from '/dev/nvme0n1')
+    get_device_name_from_path(config.dev, device_name);
+
+    *partitions = partitions__load();
+    if (!*partitions) {
+        targeted_printf(FD_STDERR, "error: failed to load partitions\n");
+        return -1;
+    }
+    *partition = partitions__get_by_name(*partitions, device_name);
+    if (!*partition) {
+        targeted_printf(FD_STDERR, "error: failed to find the %s in partitions\n", device_name);
+        return -1;
+    }
+    if (config.output_file) {
+        *fd_output = open(config.output_file, O_WRONLY | O_CREAT, 0644);
+        if (*fd_output == -1) {
+            targeted_printf(FD_STDERR, "error: failed to open %s\n", config.output_file);
+            return -1;
+        }
+    }
+    /* INT EVENT */
+    signal(SIGINT, sig_handler);
+    return 0;
+}
+
+int bpf_initialize_and_load(struct ext4file_bpf **objp, const struct partition *partition, struct ext4_config *ext4_config) {
+    LIBBPF_OPTS(bpf_object_open_opts, open_opts);
+    *objp = ext4file_bpf__open_opts(&open_opts);
+    if (!*objp) {
+        targeted_printf(FD_STDERR, "failed to open BPF object\n");
+        return -1;
+    }
+
+    if (ext4file_bpf__load(*objp)) {
+        targeted_printf(FD_STDERR, "failed to load BPF object\n");
+        return -1;
+    }
+
+    if (ext4_info_get(ext4_config)) {
+        targeted_printf(FD_STDERR, "failed to get ext4 info\n");
+        ext4file_bpf__destroy(*objp);
+        return -1;
+    }
+    (*objp)->bss->blocks_per_group = ext4_config->blocks_per_group;
+    (*objp)->bss->dev_target = partition->dev;
+
+    if (ext4file_bpf__attach(*objp)) {
+        targeted_printf(FD_STDERR, "failed to attach BPF programs\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    int fd_output = FD_STDOUT;
+    char time_buffer[20];
+    struct ext4_config ext4_config = {};
+    struct partitions *partitions = NULL;
+    const struct partition *partition = NULL;
+    struct ext4file_bpf *obj = NULL;
+    time_t cur_time;
+    struct tm *info;
+    if (program_configure(argc, argv, &fd_output, &partitions, &partition))
+        goto cleanup;
+    if (bpf_initialize_and_load(&obj, partition, &ext4_config))
+        goto cleanup; 
+    
+    int fd_map_ffm = bpf_map__fd(obj->maps.file_info_map);
+
+    targeted_printf(FD_STDOUT, "interval: %u\n", config.interval);
+    targeted_printf(FD_STDOUT, "EXT4 FS Info: blocks_count=%u blocks_per_group=%u bg_cnt=%u\n", ext4_config.blocks_count, ext4_config.blocks_per_group, ext4_config.bg_cnt);
+    targeted_printf(FD_STDOUT, "Tracing Ext4 read/write... Hit Ctrl-C to end.\n");
+    
+	while (!exiting) {
+        sleep(config.interval);
+        time(&cur_time);
+        info = localtime(&cur_time);
+        strftime(time_buffer, 80, "%Y-%m-%d %H:%M:%S", info);
+
+        print_file_infos(fd_map_ffm, time_buffer, fd_output);
+        config.times--;
+        if (config.times <= 0)
+            break;
+    }
+    close(fd_map_ffm);
+cleanup:
+    if(obj)
+        ext4file_bpf__destroy(obj);
+    if(partitions)
+        partitions__free(partitions);
+    if(fd_output > -1)
+        close(fd_output);
+    if(config.dev)
+        free(config.dev);
+    return 0;
+}

--- a/libbpf-tools/ext4file.h
+++ b/libbpf-tools/ext4file.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+//  Copyright (c) 2026 Samsung Electronics Co., Ltd.
+#ifndef __EXT4FILE_H
+#define __EXT4FILE_H
+
+#define IOCB_DIRECT		(1 << 17)
+
+#define FD_STDOUT 1
+#define FD_STDERR 2
+
+#define MAX_FILE_NAME 255
+
+enum rw_type {
+    RW_TYPE_BUFFER_READ,
+    RW_TYPE_DIRECT_READ,
+    RW_TYPE_BUFFER_WRITE,
+    RW_TYPE_DIRECT_WRITE,
+    RW_TYPE_CNT
+};
+
+struct file_info_key{
+    __u32 fk_ino;
+    __u32 fk_pa_ino;
+    char fk_name[MAX_FILE_NAME];
+};
+
+struct file_info_val {
+    __u64 fv_rw_cnt[RW_TYPE_CNT];
+    int fv_hint;
+    bool fv_delete;
+};
+
+struct unique_file {
+    int ino;
+    char filename[MAX_FILE_NAME];
+};
+
+struct ext4_config {
+	uint32_t blocks_per_group;
+	uint32_t blocks_count;
+	uint32_t bg_cnt;
+};
+
+#endif


### PR DESCRIPTION
# ext4file introduction

## Overview
ext4file is used to monitor the I/O patterns (buffer or direct) of each file in the target ext4 filesystem, as well as the hint used by each file.

## Why ext4file
ext4file is a tool used to track file-level buffer or direct I/O. Currently, in the repository, there exist block-layer tools to monitor I/O patterns of whole disk (such as biopattern, biolatency, etc.) and VFS-layer tools to trace file lifecycle and I/O behavior of files throughout the entire VFS (such as filelife and vfsstat, etc.).

Below is a comparative summary:

| Tool Name     | Layer               | Main Function                                                                                                 | Tracks Filename? |  Differences |
|---------------|---------------------|---------------------------------------------------------------------------------------------------------------|------------------|------------------------|
| biopattern    | Block        | Measures the proportion of random vs. sequential I/O on a storage device                                | ❌ No | Can not achieve file-layer tracing(**The other bio tools all have this problem**) |
| fsdist        | VFS           | Tracks latency distribution of operations like read, write, open, and sync                                    | ❌ No | Focus on latency, not I/O pattern |
| fsslower      | VFS           | Traces slow file operations (e.g., long-latency reads/writes), focuses on I/O size                            | ✅ Yes| Trace the I/O size and latency, not I/O pattern |
| filelife      | VFS           | Monitors file lifecycle events (creation and deletion)                                                        | ✅ Yes| Only focus on file creation and deletion |
| filetop       | VFS          | Shows real-time I/O activity of active files (displays only top entries to avoid verbosity)                   | ✅ Yes| There exists no distinction between buffer and direct I/O |
| ext4file      | ext4 Filesystem | Tracks **buffer vs. direct I/O patterns** per file, enables fine-grained file-level monitoring using inode | ✅ Yes|  |

## How to use
Run ext4file before executing your test. You can refer to **./ext4file -h** to get the usage of the tool
```Shell
Show I/O pattern for every file in ext4 filesystem.

Usage: ./ext4file [-h] [-d DIR] [-o FILE] [interval] [count]

Options:
  -h, --help                   Print this help message
  -d DIR, --dir=DIR            Trace the ext4 filesystem mounted on the specified directory
  -o FILE, --output=FILE       Write output to a file (optional; default: stdout)
  interval                     Time interval (in seconds) between reports (default: unlimited)
  count                        Number of reports to generate (default: unlimited)

Examples:
  ./ext4file -d /mnt/ext4                      # Trace I/O patterns of files on the ext4 filesystem mounted at /mnt/ext4
  ./ext4file -d /mnt/ext4 1 10                 # Generate 10 reports, one per second
  ./ext4file -d /mnt/ext4 -o output 1 10       # Generate 10 reports at 1-second intervals, saving output to ./output
```

The output could be:
```Shell
root@server:/home/nbw/OpenSource/biohint/libbpf-tools# ./ext4file -d /mnt/ext4File/
EXT4 Filesystem Info: blocks_count=3750232064 blocks_per_group=32768 bg_cnt=114448
Tracing Ext4 read/write... Hit Ctrl-C to end.
2026-01-14 13:58:21
file_name            inode      pa_inode   hint   buffer_read     direct_read     buffer_write    direct_write    delete
test3                83361794   83361793   0      0               0               0               0               False
test2                34         2          2      8               0               1               0               False
dir1                 83361793   2          0      0               0               0               0               False
dir2                 440467457  2          0      0               0               0               0               True
test3                33         2          3      8               0               1               0               False
test1                33         2          5      8               0               1               0               True
test3                440467458  440467457  0      0               0               0               0               True
```
Below is the detailed explanation of each field in the ext4file output. This tool traces per-file I/O patterns (buffered vs. direct) on ext4 filesystems, providing fine-grained visibility into application behavior.
| Field         | Description   |
|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| file_name | The name of the file (without full path). Note: multiple files may share the same name.                                                                                                                     |
| inode     | The inode number of the file. Inode is the unique identifier for a file within the filesystem, even across renames or hard links. This enables accurate tracking of I/O for specific files.                 |
| pa_inode  | The inode number of the file’s parent directory.|
| hint      | The FDP (Flexible Data Placement) hint value associated with the file. FDP is a new NVMe feature that enables the host to guide data placement on the SSD.                                                 |
| buffer_read | Number of buffered read operations performed on the file. Buffered I/O goes through the kernel page cache.                                                                                             |
| direct_read | Number of direct read operations performed on the file. Direct I/O bypasses the page cache.                                                                                                           |
| direct_write | Number of direct write operations performed on the file. Like direct read, it skips the page cache and writes data directly from user space to storage.                                             |
| buffer_write | Number of buffered write operations performed on the file. Data is first written to the page cache and later flushed to disk asynchronously by the kernel.                                         |
| delete    | Indicates whether the file has been unlinked (deleted). If `True`, the file was removed from the directory but may still be accessible if held open by a process. I/O on such files can indicate resource leaks or long-running file handles. |

## Target Audience
This tool is intended for ext4 filesystem developers and performance engineers who need to analyze I/O behavior at the file level. 
