### PR TITLE
libbpf-tools/offcputime: Fix the unit conversion error

### DIFF
--- a/libbpf-tools/offcputime.bpf.c
+++ b/libbpf-tools/offcputime.bpf.c
@@ -12,8 +12,8 @@
 
 const volatile bool kernel_threads_only = false;
 const volatile bool user_threads_only = false;
-const volatile __u64 max_block_ns = -1;
-const volatile __u64 min_block_ns = 1;
+const volatile __u64 max_block_us = -1;
+const volatile __u64 min_block_us = 1;
 const volatile bool filter_by_tgid = false;
 const volatile bool filter_by_pid = false;
 const volatile long state = -1;
@@ -108,9 +108,9 @@ static int handle_sched_switch(void *ctx, bool preempt, struct task_struct *prev
 	delta = (s64)(bpf_ktime_get_ns() - i_keyp->start_ts);
 	if (delta < 0)
 		goto cleanup;
-	if (delta < min_block_ns || delta > max_block_ns)
-		goto cleanup;
 	delta /= 1000U;
+	if (delta < min_block_us || delta > max_block_us)
+		goto cleanup;
 	valp = bpf_map_lookup_elem(&info, &i_keyp->key);
 	if (!valp)
 		goto cleanup;

--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -363,8 +363,8 @@ int main(int argc, char **argv)
 	obj->rodata->user_threads_only = env.user_threads_only;
 	obj->rodata->kernel_threads_only = env.kernel_threads_only;
 	obj->rodata->state = env.state;
-	obj->rodata->min_block_ns = env.min_block_time;
-	obj->rodata->max_block_ns = env.max_block_time;
+	obj->rodata->min_block_us = env.min_block_time;
+	obj->rodata->max_block_us = env.max_block_time;
 
 	/* User space PID and TID correspond to TGID and PID in the kernel, respectively */
 	if (env.pids[0])


### PR DESCRIPTION
The units of min_block_time and max_block_time are microseconds, yet they are directly passed to min_block_ns and max_block_ns (which expect nanoseconds).