### PR TITLE
fix(check-links): fix deprecated multiline output syntax for GitHub Actions

### DIFF
--- a/.github/scripts/check_links.py
+++ b/.github/scripts/check_links.py
@@ -39,10 +39,9 @@ if broken_links:
     for text, url, error in broken_links:
         report += f"| {text} | {url} | {error} |\n"
         
-    with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-        delimiter = "_REPORT_DELIMITER_"
-        f.write(f"broken_links=true\n")
-        f.write(f"report<<{delimiter}\n{report}\n{delimiter}\n")
+    print("broken_links=true")
+    escaped_report = report.replace("\n", "%0A").replace("\r", "%0D")
+    print(f"report={escaped_report}")
 else:
-    with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-        f.write("broken_links=false\n")
+    print("broken_links=false")
+    print("report=No broken links found.")


### PR DESCRIPTION
- Replace old heredoc delimiter method with modern %0A-escaped print output
  - Ensures the full report (including Markdown table) is correctly passed to workflow outputs
  - Prevents empty or malformed 'report' value when creating issues

This PR will resolve following issues.
https://github.com/iovisor/bcc/issues/5441
https://github.com/iovisor/bcc/issues/5417
https://github.com/iovisor/bcc/issues/5397

Tested on my forked repo.
The current script detects broken links (though it's actually a script error, not a real detection) and creates an issue for it, but considers the test successful. Since my repository does not allow issue creation, I can confirm that running this script in my repo fails, as shown in the link below. However, I can also confirm that the modified version succeeds, which proves that the patch in this PR does not cause broken links issues.
https://github.com/Bojun-Seo/bcc/actions/workflows/check_links.yml



