### PR TITLE
Add workaround for 'bpf_task_work' on Linux 6.18

### DIFF
--- a/src/cc/compat/linux/virtual_bpf.h
+++ b/src/cc/compat/linux/virtual_bpf.h
@@ -7576,5 +7576,9 @@ enum bpf_kfunc_flags {
 	BPF_F_PAD_ZEROS = (1ULL << 0),
 };
 
+struct bpf_task_work {
+	__u64 __opaque;
+} __attribute__((aligned(8)));
+
 #endif /* _UAPI__LINUX_BPF_H__ */
 )********"


### PR DESCRIPTION
Fix compilation errors caused by `bpf_task_work` being forward-declared in Linux 6.18. A placeholder definition is added to `virtual_bpf.h` for compatibility.

Related to libbpf commit f820b824036b0b932157a2b2932d04fd6efa8a5a.