### PR TITLE
libbpf-tools/runqlen: Fix compile error on ppc64el

### DIFF
--- a/libbpf-tools/runqlen.c
+++ b/libbpf-tools/runqlen.c
@@ -196,7 +196,7 @@ static void print_runq_occupancy(struct runqlen_bpf__bss *bss)
 				queued += val;
 		}
 		samples = idle + queued;
-		runqocc = queued * 1.0 / max(1ULL, samples);
+		runqocc = queued * 1.0 / max(1ULL, (unsigned long long)samples);
 		if (env.per_cpu)
 			printf("runqocc, CPU %-3d %6.2f%%\n", i,
 				100 * runqocc);


### PR DESCRIPTION
The compile error is caused by a type mismatch between u64 and `unsigned long long`. This patch explicitly casts the `samples` variable to `unsigned long long` to resolve the issue #5332.