### PR TITLE
cc: restore _UAPI__LINUX_BPF_H__ guard in virtual_bpf.h after libbpf …

### DIFF
--- a/src/cc/compat/linux/virtual_bpf.h
+++ b/src/cc/compat/linux/virtual_bpf.h
@@ -6,8 +6,8 @@ R"********(
  * modify it under the terms of version 2 of the GNU General Public
  * License as published by the Free Software Foundation.
  */
-#ifndef __LINUX_BPF_H__
-#define __LINUX_BPF_H__
+#ifndef _UAPI__LINUX_BPF_H__
+#define _UAPI__LINUX_BPF_H__
 
 #include <linux/types.h>
 #include <linux/bpf_common.h>


### PR DESCRIPTION
…sync

The libbpf update uses __LINUX_BPF_H__ guard, causing duplicate inclusions in BCC's pipeline. Revert to _UAPI__ prefix for now to restore test stability.