### PR TITLE
ci: add "Run libbpf-tools build with blazesym" to test_bcc_fedora

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -192,6 +192,28 @@ jobs:
                    /bin/bash -c \
                    'cd /bcc/libbpf-tools && make -j9'"
 
+    - name: Run libbpf-tools build with blazesym
+      env: ${{ matrix.env }}
+      run: |
+        /bin/bash -c \
+                   "docker run --privileged \
+                   --pid=host \
+                   -v $(pwd):/bcc \
+                   -v /sys/kernel/debug:/sys/kernel/debug:rw \
+                   -v /lib/modules:/lib/modules:ro \
+                   -v /usr/src:/usr/src:ro \
+                   -v /usr/include/linux:/usr/include/linux:ro \
+                   bcc-docker \
+                   /bin/bash -c \
+                   'curl --proto \"=https\" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+                    source \$HOME/.cargo/env && \
+                    cd /bcc/libbpf-tools && make clean && \
+                    echo \"=== Checking blazesym build configuration ===\" && \
+                    cargo --version && \
+                    echo \"USE_BLAZESYM=1 (cargo detected by Makefile)\" && \
+                    echo \"=== Blazesym enabled, proceeding with build ===\" && \
+                    make -j9'"
+
     - name: Run bcc's cc tests
       env: ${{ matrix.env }}
       # tests are wrapped with `script` as a hack to get a TTY as github actions doesn't provide this


### PR DESCRIPTION
Add a new CI step to test building libbpf-tools with blazesym enabled. This ensures compatibility in environments where cargo is available.