### PR TITLE
fix: fix symbolize error when the VMA-offset of ELF section  was different

### DIFF
--- a/src/cc/bcc_elf.h
+++ b/src/cc/bcc_elf.h
@@ -73,8 +73,8 @@ int bcc_elf_foreach_sym_lazy(const char *path, bcc_elf_symcb_lazy callback,
 // Returns -1 on error, and 0 on success or stopped by callback
 int bcc_elf_foreach_vdso_sym(bcc_elf_symcb callback, void *payload);
 
-int bcc_elf_get_text_scn_info(const char *path, uint64_t *addr,
-                              uint64_t *offset);
+int bcc_elf_get_scn_info(const char *path, uint64_t segment_offset,
+                              uint64_t *addr, uint64_t *offset);
 
 int bcc_elf_get_type(const char *path);
 int bcc_elf_is_pie(const char *path);

--- a/src/cc/syms.h
+++ b/src/cc/syms.h
@@ -154,8 +154,10 @@ class ProcSyms : SymbolCache {
       uint64_t start;
       uint64_t end;
       uint64_t file_offset;
-      Range(uint64_t s, uint64_t e, uint64_t f)
-          : start(s), end(e), file_offset(f) {}
+      uint64_t elf_so_addr;
+      uint64_t elf_so_offset;
+      Range(uint64_t s, uint64_t e, uint64_t f, uint64_t elf_so_addr, uint64_t elf_so_offset)
+          : start(s), end(e), file_offset(f), elf_so_addr(elf_so_addr), elf_so_offset(elf_so_offset) {}
     };
 
     Module(const char *name, std::shared_ptr<ModulePath> path,
@@ -167,10 +169,6 @@ class ProcSyms : SymbolCache {
     bool loaded_;
     bcc_symbol_option *symbol_option_;
     ModuleType type_;
-
-    // The file offset within the ELF of the SO's first text section.
-    uint64_t elf_so_offset_;
-    uint64_t elf_so_addr_;
 
     std::unordered_set<std::string> symnames_;
     std::vector<Symbol> syms_;


### PR DESCRIPTION
When we do symbolize, we use the following formula: 
global_addr - (mod_start_addr - mod_file_offset) + (elf_sec_start_addr - elf_sec_file_offset).
However, in some case, a process has multiple code segment mappings for the same ELF file, such as .bolt.org.text and .text segments. Athough the result of (mod_start_addr - mod_file_offset) is correct, but if the VMA-offsets of these two code segments are inconsistent, we only use the info of .text segment, so if the .bolt.org.text has different delta of mod_start_addr and mod_start_offset, we will get a wrong symbol or 'unknown' symbol. Therefore, we attempted to fix this logic. 
During resolution, we look for the corresponding code segment through the program header. Since the VMA-offsets in this batch of code segments are always consistent, we don't need to consider whether the content retrieved is from .text or other segment.