### PR TITLE
libbpf-tools: Always escape tab and newline chars in execsnoop

### DIFF
--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -171,11 +171,15 @@ static void time_since_start()
 	printf("%-8.3f", time_diff);
 }
 
-static void inline quoted_symbol(char c) {
+static void inline escape_symbol(char c, bool quote) {
 	switch(c) {
 		case '"':
-			putchar('\\');
-			putchar('"');
+			if (quote) {
+				putchar('\\');
+				putchar('"');
+			} else {
+				putchar(c);
+			}
 			break;
 		case '\t':
 			putchar('\\');
@@ -210,14 +214,14 @@ static void print_args(const struct event *e, bool quote)
 					putchar('"');
 				}
 			} else {
-				quoted_symbol(c);
+				escape_symbol(c, true);
 			}
 		} else {
 			if (c == '\0') {
 				args_counter++;
 				putchar(' ');
 			} else {
-				putchar(c);
+				escape_symbol(c, false);
 			}
 		}
 	}


### PR DESCRIPTION
5340c21bc94c199cae55e891e6dbff972a6f0df6 made it so that the Python execsnoop always escaped newline characters which is required to avoid breaking tools that parse the execsnoop stdout when command args contain newlines. This applies the same change to the libbpf-tools version as well as additionally escaping tab characters.

Specifically I noticed this difference in behavior when porting system76-scheduler to libbpf execsnoop. It would probably be better to have a json output instead but this at least gets system76-scheduler working without additional changes.