### PR TITLE
cc: Synchronize so flags for loongarch64 architecture from glibc

### DIFF
--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -447,6 +447,8 @@ static int load_ld_cache(const char *cache_path) {
 #define ABI_S390_LIB64 0x0400
 #define ABI_POWERPC_LIB64 0x0500
 #define ABI_AARCH64_LIB64 0x0a00
+#define ABI_LARCH_FLOAT_ABI_SOFT 0x1100
+#define ABI_LARCH_FLOAT_ABI_DOUBLE 0x1200
 
 static bool match_so_flags(int flags) {
   if ((flags & FLAG_TYPE_MASK) != TYPE_ELF_LIBC6)
@@ -459,6 +461,8 @@ static bool match_so_flags(int flags) {
   case ABI_S390_LIB64:
   case ABI_POWERPC_LIB64:
   case ABI_AARCH64_LIB64:
+  case ABI_LARCH_FLOAT_ABI_SOFT:
+  case ABI_LARCH_FLOAT_ABI_DOUBLE:
     return (sizeof(void *) == 8);
   }
 


### PR DESCRIPTION
Synchronize the shared library flag bits for LoongArch64 from glibc to resolve errors in some bcc tools caused by their inability to recognize the libc library.

glibc reference path:  sysdeps/generic/ldconfig.h

Error message:
# /usr/share/bcc/tools/gethostlatency
Traceback (most recent call last):
  File "/usr/share/bcc/tools/gethostlatency", line 106, in <module>
    b.attach_uprobe(name="c", sym="getaddrinfo", fn_name="do_entry", pid=args.pid)
  File "/usr/lib/python3.11/site-packages/bpfcc/__init__.py", line 1410, in attach_uprobe
    (path, addr) = BPF._check_path_symbol(name, sym, addr, pid, sym_off)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/bpfcc/__init__.py", line 1008, in _check_path_symbolic_address
    raise Exception("could not determine address of symbol %s in %s"
Exception: could not determine address of symbol getaddrinfo in c


Signed-off-by: zhangzikang01 <zhangzikang@kylinos.cn>