### PR TITLE
libbpf-tools/opensnoop: hint on unused variable

### DIFF
--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -289,6 +289,8 @@ int handle_event(void *ctx, void *data, size_t data_sz)
 
 	blaze_syms_free(syms);
 #endif
+	/* avoid compiler warnings on sps_cnt not being used */
+	(void) sps_cnt;
 	return 0;
 }
 


### PR DESCRIPTION
GCC-16 changed the default of the unused-but-set-variable warnings, which now throws an error when -Wall or -Wextra is enabled.

sps_cnt is only used when USE_BLAZESYM is defined. This patch does a void cast to hint the compiler to ignore sps_cnt being unused in those cases.

* https://gcc.gnu.org/gcc-16/porting_to.html#changes-to-wunused