### PR TITLE
libbpf-tools/bashreadline: Fix uninitialized stack data that leaks kernel pointers

### DIFF
--- a/libbpf-tools/bashreadline.bpf.c
+++ b/libbpf-tools/bashreadline.bpf.c
@@ -15,9 +15,10 @@ struct {
 
 SEC("uretprobe/readline")
 int BPF_URETPROBE(printret, const void *ret) {
-	struct str_t data;
+	struct str_t data = {};
 	char comm[TASK_COMM_LEN];
 	u32 pid;
+	int err_ret;
 
 	if (!ret)
 		return 0;
@@ -28,7 +29,9 @@ int BPF_URETPROBE(printret, const void *ret) {
 
 	pid = bpf_get_current_pid_tgid() >> 32;
 	data.pid = pid;
-	bpf_probe_read_user_str(&data.str, sizeof(data.str), ret);
+	err_ret = bpf_probe_read_user_str(&data.str, sizeof(data.str), ret);
+	if (err_ret < 0)
+		return 0;
 
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &data, sizeof(data));
 


### PR DESCRIPTION
`bashreadline` stack-allocates an 84-byte `struct str_t` (4-byte pid + 80-byte command buffer) without zero-initialization, then fills only `data.pid` and the prefix of `data.str` written by `bpf_probe_read_user_str` (which stops at the user string's terminating `\0`), and finally emits the entire struct via `bpf_perf_event_output`. The trailing bytes past the user string are never written by any source-level code path and hold stale kernel stack data. This leaks kernel pointers that are sufficient to break KASLR (tested on Linux 6.8 with clang 21). 

A second related defect is that the `bpf_probe_read_user_str` return value is silently discarded. On helper failure, 0 bytes are written to `data.str` but the event is still emitted with the full 80 bytes of stack residue.

Zero-initializing the struct fixes the leak, and dealing with the unchecked helper return prevents failed reads from sending events to userspace.
