### PR TITLE
libbpf-tools: Fix ringbuf leaks that leak prior events to userspace

### DIFF
--- a/libbpf-tools/compat.bpf.h
+++ b/libbpf-tools/compat.bpf.h
@@ -42,4 +42,16 @@ static __always_inline long submit_buf(void *ctx, void *buf, __u64 size)
 	return bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, buf, size);
 }
 
+/* Zero a buffer returned by reserve_buf so callers don't have to write every
+ * field of the event struct, and so cross-record stack/ringbuf residue is
+ * not emitted to userspace.  __noinline lands as a single BPF-to-BPF
+ * subprogram shared across call sites; volatile defeats LLVM's loop-idiom
+ * recognition, which would otherwise re-lower this back to __builtin_memset
+ * (which the BPF backend cannot inline for buffers larger than ~256 bytes). */
+static __noinline void zero_buf(void *p, __u64 sz)
+{
+	for (__u64 i = 0; i < sz; i++)
+		*(volatile char *)((char *)p + i) = 0;
+}
+
 #endif /* __COMPAT_BPF_H */

--- a/libbpf-tools/filelife.bpf.c
+++ b/libbpf-tools/filelife.bpf.c
@@ -164,6 +164,7 @@ int BPF_KRETPROBE(vfs_unlink_ret)
 	eventp = reserve_buf(sizeof(*eventp));
 	if (!eventp)
 		return 0;
+	zero_buf(eventp, sizeof(*eventp));
 
 	eventp->tgid = unlink_event->tgid;
 	eventp->delta_ns = unlink_event->delta_ns;

--- a/libbpf-tools/mountsnoop.bpf.c
+++ b/libbpf-tools/mountsnoop.bpf.c
@@ -66,6 +66,7 @@ static int probe_exit(void *ctx, int ret)
 	eventp = reserve_buf(sizeof(*eventp));
 	if (!eventp)
 		goto cleanup;
+	zero_buf(eventp, sizeof(*eventp));
 
 	task = (struct task_struct *)bpf_get_current_task();
 	eventp->delta = bpf_ktime_get_ns() - argp->ts;

--- a/libbpf-tools/oomkill.bpf.c
+++ b/libbpf-tools/oomkill.bpf.c
@@ -16,6 +16,7 @@ int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 	data = reserve_buf(sizeof(*data));
 	if (!data)
 		return 0;
+	zero_buf(data, sizeof(*data));
 
 	data->fpid = bpf_get_current_pid_tgid() >> 32;
 	data->tpid = BPF_CORE_READ(oc, chosen, tgid);

--- a/libbpf-tools/opensnoop.bpf.c
+++ b/libbpf-tools/opensnoop.bpf.c
@@ -130,6 +130,7 @@ int trace_exit(struct syscall_trace_exit* ctx)
 	eventp = reserve_buf(sizeof(*eventp));
 	if (!eventp)
 		goto cleanup;
+	zero_buf(eventp, sizeof(*eventp));
 
 	/* event data */
 	eventp->pid = bpf_get_current_pid_tgid() >> 32;

--- a/libbpf-tools/tcppktlat.bpf.c
+++ b/libbpf-tools/tcppktlat.bpf.c
@@ -73,6 +73,7 @@ static int handle_tcp_rcv_space_adjust(void *ctx, struct sock *sk)
 	eventp = reserve_buf(sizeof(*eventp));
 	if (!eventp)
 		goto cleanup;
+	zero_buf(eventp, sizeof(*eventp));
 
 	eventp->pid = pid;
 	eventp->tid = tid;


### PR DESCRIPTION
Five libbpf-tools (`mountsnoop`, `opensnoop`, `filelife`, `oomkill`, and `tcppktlat`) call `reserve_buf()` to obtain an event buffer, populate a subset of the event's fields, and emit the full `sizeof(*eventp)` bytes via `submit_buf()`. Neither path of `reserve_buf()` (`bpf_ringbuf_reserve()` or the per-CPU array `heap` fallback) zero-initializes the returned memory. Any bytes the source-level path leaves unwritten retain whatever the slot held previously. This can leak previously emitted record content back to userspace on subsequent events.

The `mountsnoop` leak was tested on Linux 6.8. Since `struct event` contains a tagged union with one active arm per syscall operation, and only the arm matching `argp->op` is written, the inactive union bytes contained prior `MOUNT` records' `src`, `dest`, `fs`, and `data` paths.

A natural approach to zero the memory would be to use `__builtin_memset(eventp, 0, sizeof(*eventp))`. This does not seem to work reliably for larger BPF event structs: once the size exceeds LLVM's inline-store budget, LLVM may lower the memset into a libcall. BPF programs cannot link against libc, so the BPF backend has no `memset` symbol to resolve and compilation fails. The added `zero_buf()` helper avoids this by writing the byte loop explicitly in a `__noinline` subprogram, so it lands as a single BPF-to-BPF call shared across sites, and by using `volatile` writes so LLVM's loop-idiom recognition does not re-lower it back into `__builtin_memset`.
