### PR TITLE
libbpf-tools/mountsnoop: Fix a compiler error in probe_exit()

### DIFF
--- a/libbpf-tools/mountsnoop.bpf.c
+++ b/libbpf-tools/mountsnoop.bpf.c
@@ -130,6 +130,8 @@ static int probe_exit(void *ctx, int ret)
 					sizeof(eventp->move_mount.to_pathname),
 					argp->sys.move_mount.to_pathname);
 		break;
+	default:
+		break;
 	}
 
 	submit_buf(ctx, eventp, sizeof(*eventp));


### PR DESCRIPTION
## Description

This PR is to fix the following build error
```
  libbpf-tools/mountsnoop.bpf.c:79:10: error: enumeration value 'OP_MIN' not handled in switch [-Werror,-Wswitch]
     79 |         switch (argp->op) {
        |                 ^~~~~~~~
  1 error generated.
```

## Why this approach

It'd be simpler to add `default` label rather than handle missing cases.

---

## Checklist

- [X] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [X] Commit body explains **why** this change is needed

**For new tools only**
- [ ] Explains why this tool is needed and what existing tools cannot cover this use case
- [ ] Includes at least one real production use case
- [ ] Man page (`man/man8/`) with an OVERHEAD section
- [ ] Example output file (`*_example.txt`)
- [ ] README.md entry added
- [ ] Smoke test added to `tests/python/test_tools_smoke.py`

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
