### PR TITLE
libbpf-tools/trace_helpers.c: free() called more than once

### DIFF
--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -491,6 +491,16 @@ static void dso__free_fields(struct dso *dso)
 	free(dso->ranges);
 	free(dso->syms);
 	btf__free(dso->btf);
+
+	/* Clear relevant fields in dso to avoid dangling pointers*/
+	dso->name = NULL;
+	dso->ranges = NULL;
+	dso->syms = NULL;
+	dso->btf = NULL;
+
+	/* zero out size and capacity to prevent dso__add_sym from reallocating */
+	dso->syms_sz = 0;
+	dso->syms_cap = 0;
 }
 
 static int dso__load_sym_table_from_elf(struct dso *dso, int fd)

--- a/libbpf-tools/trace_helpers.c
+++ b/libbpf-tools/trace_helpers.c
@@ -492,15 +492,19 @@ static void dso__free_fields(struct dso *dso)
 	free(dso->syms);
 	btf__free(dso->btf);
 
-	/* Clear relevant fields in dso to avoid dangling pointers*/
+	/* Clear relevant fields in dso to avoid dangling pointers. */
 	dso->name = NULL;
 	dso->ranges = NULL;
+	dso->range_sz = 0;
 	dso->syms = NULL;
 	dso->btf = NULL;
 
-	/* zero out size and capacity to prevent dso__add_sym from reallocating */
+	/* Zero out size/capacity to avoid stale bounds/alloc decisions. */
 	dso->syms_sz = 0;
 	dso->syms_cap = 0;
+	dso->type = UNKNOWN;
+	dso->sh_addr = 0;
+	dso->sh_offset = 0;
 }
 
 static int dso__load_sym_table_from_elf(struct dso *dso, int fd)


### PR DESCRIPTION
dso__free_fields could be called by (err_out in trace_helpers.c) and then by the finalizer (cleanup in profile.c).

This will cause the case where a dangling pointer is freed. To fix this issue - the freed pointers are set to NULL.

Furthermore, to prevent lazy reload `if (!dso->syms && dso__load_sym_table(dso))` from populating dso again, size and capacity are also set to 0

---

## Checklist

- [x] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [x] Commit body explains **why** this change is needed

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
