### PR TITLE
libbpf-tools/softirqslower: Add libbpf CO-RE port of softirqslower

### DIFF
--- a/libbpf-tools/.gitignore
+++ b/libbpf-tools/.gitignore
@@ -55,6 +55,7 @@
 /sigsnoop
 /slabratetop
 /softirqs
+/softirqslower
 /solisten
 /statsnoop
 /syncsnoop

--- a/libbpf-tools/Makefile
+++ b/libbpf-tools/Makefile
@@ -81,6 +81,7 @@ APPS = \
 	sigsnoop \
 	slabratetop \
 	softirqs \
+	softirqslower \
 	solisten \
 	statsnoop \
 	syncsnoop \

--- a/libbpf-tools/softirqslower.bpf.c
+++ b/libbpf-tools/softirqslower.bpf.c
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2025 Chenyue Zhou  (original BCC Python version)
+// Copyright (c) 2026 Ism Hong      (libbpf/CO-RE port)
+//
+// Based on softirqslower(8) from BCC by Chenyue Zhou.
+// libbpf/CO-RE version.
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "softirqslower.h"
+
+/* Configurable from userspace via rodata */
+const volatile __u64 min_us    = 10000;
+const volatile int   targ_cpu  = -1;
+
+/*
+ * Per-CPU arrays indexed by softirq vector number.
+ * raise[vec] stores the timestamp when the softirq was raised.
+ * entry[vec] stores the timestamp when the softirq handler started.
+ *
+ * We use PERCPU_ARRAY so we don't need locks; each CPU has its own slot.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, NR_SOFTIRQS);
+	__type(key, u32);
+	__type(value, u64);
+} raise_ts SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, NR_SOFTIRQS);
+	__type(key, u32);
+	__type(value, u64);
+} entry_ts SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(u32));
+} events SEC(".maps");
+
+static __always_inline bool cpu_allowed(u32 cpu)
+{
+	if (targ_cpu < 0)
+		return true;
+	return (int)cpu == targ_cpu;
+}
+
+static __always_inline void submit_event(void *ctx, u32 stage, u32 vec,
+					 u32 cpu, u64 delta_us)
+{
+	struct event e = {};
+
+	e.stage    = stage;
+	e.vec      = vec;
+	e.cpu      = cpu;
+	e.delta_us = delta_us;
+	bpf_get_current_comm(&e.task, sizeof(e.task));
+	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,
+			      &e, sizeof(e));
+}
+
+/*
+ * softirq_raise  –  record the moment raise_softirq() fires.
+ * Only record if the slot is empty (ts == 0); if it is already occupied the
+ * previous raise hasn't been consumed yet, which means we'd overwrite a
+ * pending timestamp.  We intentionally skip it so we don't lose the older
+ * measurement.
+ */
+static int handle_raise(void *ctx, unsigned int vec_nr)
+{
+	u64 ts, *tsp;
+	u32 cpu, vec = vec_nr;
+
+	cpu = bpf_get_smp_processor_id();
+	if (!cpu_allowed(cpu) || vec >= NR_SOFTIRQS)
+		return 0;
+
+	tsp = bpf_map_lookup_elem(&raise_ts, &vec);
+	if (!tsp)
+		return 0;
+
+	/*
+	 * Only store if not already pending (equivalent to the Python version's
+	 * "not_first" check: skip if a prior raise timestamp wasn't consumed).
+	 */
+	if (*tsp == 0) {
+		ts = bpf_ktime_get_ns();
+		*tsp = ts;
+	}
+	return 0;
+}
+
+/*
+ * softirq_entry  –  measure raise→entry latency, then start entry timer.
+ */
+static int handle_entry(void *ctx, unsigned int vec_nr)
+{
+	u64 now, delta_us, *tsp;
+	u32 cpu, vec = vec_nr;
+
+	cpu = bpf_get_smp_processor_id();
+	if (!cpu_allowed(cpu) || vec >= NR_SOFTIRQS)
+		return 0;
+
+	now = bpf_ktime_get_ns();
+
+	/* Raise → entry latency */
+	tsp = bpf_map_lookup_elem(&raise_ts, &vec);
+	if (tsp && *tsp) {
+		delta_us = (now - *tsp) / 1000;
+		if (delta_us >= min_us)
+			submit_event(ctx, SOFTIRQ_RAISE, vec, cpu, delta_us);
+		*tsp = 0;
+	}
+
+	/* Start entry timer (always, even if we missed the raise event) */
+	tsp = bpf_map_lookup_elem(&entry_ts, &vec);
+	if (tsp)
+		*tsp = now;
+
+	return 0;
+}
+
+/*
+ * softirq_exit  –  measure entry→exit (handler runtime) latency.
+ */
+static int handle_exit(void *ctx, unsigned int vec_nr)
+{
+	u64 now, delta_us, *tsp;
+	u32 cpu, vec = vec_nr;
+
+	cpu = bpf_get_smp_processor_id();
+	if (!cpu_allowed(cpu) || vec >= NR_SOFTIRQS)
+		return 0;
+
+	now = bpf_ktime_get_ns();
+
+	tsp = bpf_map_lookup_elem(&entry_ts, &vec);
+	if (!tsp || !*tsp)
+		return 0;
+
+	delta_us = (now - *tsp) / 1000;
+	*tsp = 0;
+
+	if (delta_us >= min_us)
+		submit_event(ctx, SOFTIRQ_ENTRY, vec, cpu, delta_us);
+
+	return 0;
+}
+
+/* ── tp_btf variants (preferred when kernel BTF is available) ── */
+
+SEC("tp_btf/softirq_raise")
+int BPF_PROG(softirq_raise_btf, unsigned int vec_nr)
+{
+	return handle_raise(ctx, vec_nr);
+}
+
+SEC("tp_btf/softirq_entry")
+int BPF_PROG(softirq_entry_btf, unsigned int vec_nr)
+{
+	return handle_entry(ctx, vec_nr);
+}
+
+SEC("tp_btf/softirq_exit")
+int BPF_PROG(softirq_exit_btf, unsigned int vec_nr)
+{
+	return handle_exit(ctx, vec_nr);
+}
+
+/* ── raw_tp fallback variants ── */
+
+SEC("raw_tp/softirq_raise")
+int BPF_PROG(softirq_raise_raw, unsigned int vec_nr)
+{
+	return handle_raise(ctx, vec_nr);
+}
+
+SEC("raw_tp/softirq_entry")
+int BPF_PROG(softirq_entry_raw, unsigned int vec_nr)
+{
+	return handle_entry(ctx, vec_nr);
+}
+
+SEC("raw_tp/softirq_exit")
+int BPF_PROG(softirq_exit_raw, unsigned int vec_nr)
+{
+	return handle_exit(ctx, vec_nr);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/softirqslower.bpf.c
+++ b/libbpf-tools/softirqslower.bpf.c
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2025 Chenyue Zhou  (original BCC Python version)
+// Copyright (c) 2026 Ism Hong      (libbpf/CO-RE port)
+//
+// Based on softirqslower(8) from BCC by Chenyue Zhou.
+// libbpf/CO-RE version.
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "softirqslower.h"
+
+/* Configurable from userspace via rodata */
+const volatile __u64 min_us    = 0;
+const volatile int   targ_cpu  = -1;
+
+/*
+ * Per-CPU arrays indexed by softirq vector number.
+ * raise[vec] stores the timestamp when the softirq was raised.
+ * entry[vec] stores the timestamp when the softirq handler started.
+ *
+ * We use PERCPU_ARRAY so we don't need locks; each CPU has its own slot.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, NR_SOFTIRQS);
+	__type(key, u32);
+	__type(value, u64);
+} raise_ts SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, NR_SOFTIRQS);
+	__type(key, u32);
+	__type(value, u64);
+} entry_ts SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+} events SEC(".maps");
+
+static __always_inline bool cpu_allowed(u32 cpu)
+{
+	if (targ_cpu < 0)
+		return true;
+	return (int)cpu == targ_cpu;
+}
+
+static __always_inline void submit_event(void *ctx, u32 stage, u32 vec,
+					 u32 cpu, u64 delta_us)
+{
+	struct event e = {};
+
+	e.stage    = stage;
+	e.vec      = vec;
+	e.cpu      = cpu;
+	e.delta_us = delta_us;
+	bpf_get_current_comm(&e.task, sizeof(e.task));
+	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,
+			      &e, sizeof(e));
+}
+
+/*
+ * softirq_raise  –  record the moment raise_softirq() fires.
+ * Only record if the slot is empty (ts == 0); if it is already occupied the
+ * previous raise hasn't been consumed yet, which means we'd overwrite a
+ * pending timestamp.  We intentionally skip it so we don't lose the older
+ * measurement.
+ */
+static int handle_raise(void *ctx, unsigned int vec_nr)
+{
+	u64 ts, *tsp;
+	u32 cpu, vec = vec_nr;
+
+	cpu = bpf_get_smp_processor_id();
+	if (!cpu_allowed(cpu) || vec >= NR_SOFTIRQS)
+		return 0;
+
+	tsp = bpf_map_lookup_elem(&raise_ts, &vec);
+	if (!tsp)
+		return 0;
+
+	/*
+	 * Only store if not already pending (equivalent to the Python version's
+	 * "not_first" check: skip if a prior raise timestamp wasn't consumed).
+	 */
+	if (*tsp == 0) {
+		ts = bpf_ktime_get_ns();
+		*tsp = ts;
+	}
+	return 0;
+}
+
+/*
+ * softirq_entry  –  measure raise→entry latency, then start entry timer.
+ */
+static int handle_entry(void *ctx, unsigned int vec_nr)
+{
+	u64 now, delta_us, *tsp;
+	u32 cpu, vec = vec_nr;
+
+	cpu = bpf_get_smp_processor_id();
+	if (!cpu_allowed(cpu) || vec >= NR_SOFTIRQS)
+		return 0;
+
+	now = bpf_ktime_get_ns();
+
+	/* Raise → entry latency */
+	tsp = bpf_map_lookup_elem(&raise_ts, &vec);
+	if (tsp && *tsp) {
+		delta_us = (now - *tsp) / 1000;
+		if (delta_us >= min_us)
+			submit_event(ctx, STAGE_RAISE_TO_ENTRY, vec, cpu, delta_us);
+		*tsp = 0;
+	}
+
+	/* Start entry timer (always, even if we missed the raise event) */
+	tsp = bpf_map_lookup_elem(&entry_ts, &vec);
+	if (tsp)
+		*tsp = now;
+
+	return 0;
+}
+
+/*
+ * softirq_exit  –  measure entry→exit (handler runtime) latency.
+ */
+static int handle_exit(void *ctx, unsigned int vec_nr)
+{
+	u64 now, delta_us, *tsp;
+	u32 cpu, vec = vec_nr;
+
+	cpu = bpf_get_smp_processor_id();
+	if (!cpu_allowed(cpu) || vec >= NR_SOFTIRQS)
+		return 0;
+
+	now = bpf_ktime_get_ns();
+
+	tsp = bpf_map_lookup_elem(&entry_ts, &vec);
+	if (!tsp || !*tsp)
+		return 0;
+
+	delta_us = (now - *tsp) / 1000;
+	*tsp = 0;
+
+	if (delta_us >= min_us)
+		submit_event(ctx, STAGE_ENTRY_TO_EXIT, vec, cpu, delta_us);
+
+	return 0;
+}
+
+/* ── tp_btf variants (preferred when kernel BTF is available) ── */
+
+SEC("tp_btf/softirq_raise")
+int BPF_PROG(softirq_raise_btf, unsigned int vec_nr)
+{
+	return handle_raise(ctx, vec_nr);
+}
+
+SEC("tp_btf/softirq_entry")
+int BPF_PROG(softirq_entry_btf, unsigned int vec_nr)
+{
+	return handle_entry(ctx, vec_nr);
+}
+
+SEC("tp_btf/softirq_exit")
+int BPF_PROG(softirq_exit_btf, unsigned int vec_nr)
+{
+	return handle_exit(ctx, vec_nr);
+}
+
+/* ── raw_tp fallback variants ── */
+
+SEC("raw_tp/softirq_raise")
+int BPF_PROG(softirq_raise_raw, unsigned int vec_nr)
+{
+	return handle_raise(ctx, vec_nr);
+}
+
+SEC("raw_tp/softirq_entry")
+int BPF_PROG(softirq_entry_raw, unsigned int vec_nr)
+{
+	return handle_entry(ctx, vec_nr);
+}
+
+SEC("raw_tp/softirq_exit")
+int BPF_PROG(softirq_exit_raw, unsigned int vec_nr)
+{
+	return handle_exit(ctx, vec_nr);
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/softirqslower.c
+++ b/libbpf-tools/softirqslower.c
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2026 Ism Hong
+//
+// Based on softirqslower(8) from BCC by Chenyue Zhou.
+// libbpf/CO-RE version.
+// 27-May-2026   Ported to libbpf.
+#include <argp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "softirqslower.h"
+#include "softirqslower.skel.h"
+#include "trace_helpers.h"
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
+
+static volatile sig_atomic_t exiting = 0;
+
+struct env {
+	__u64 min_us;
+	int   targ_cpu;
+	bool  verbose;
+} env = {
+	.min_us   = 10000,
+	.targ_cpu = -1,
+};
+
+const char *argp_program_version = "softirqslower 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] =
+"Trace slow soft IRQ (interrupt).\n"
+"\n"
+"USAGE: softirqslower [--help] [-c CPU] [min_us]\n"
+"\n"
+"EXAMPLES:\n"
+"    softirqslower        # trace softirq latency higher than 10000 us (default)\n"
+"    softirqslower 100000 # trace softirq latency higher than 100000 us\n"
+"    softirqslower -c 1   # trace softirq latency on CPU 1 only\n";
+
+static const struct argp_option opts[] = {
+	{ "cpu",     'c', "CPU",  0, "Trace this CPU only", 0 },
+	{ "verbose", 'v', NULL,   0, "Verbose debug output", 0 },
+	{ NULL,      'h', NULL,   OPTION_HIDDEN, "Show the full help", 0 },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	static int pos_args;
+	long long val;
+
+	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'c':
+		errno = 0;
+		val = strtol(arg, NULL, 10);
+		if (errno || val < 0) {
+			fprintf(stderr, "invalid cpu: %s\n", arg);
+			argp_usage(state);
+		}
+		env.targ_cpu = (int)val;
+		break;
+	case ARGP_KEY_ARG:
+		if (pos_args++) {
+			fprintf(stderr,
+				"Unrecognized positional argument: %s\n", arg);
+			argp_usage(state);
+		}
+		errno = 0;
+		val = strtoll(arg, NULL, 10);
+		if (errno || val <= 0) {
+			fprintf(stderr,
+				"Invalid min latency (in us): %s\n", arg);
+			argp_usage(state);
+		}
+		env.min_us = (__u64)val;
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level,
+		const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+/* Softirq vector names – same order as the kernel enum */
+static const char *vec_names[] = {
+	[0] = "hi",
+	[1] = "timer",
+	[2] = "net_tx",
+	[3] = "net_rx",
+	[4] = "block",
+	[5] = "irq_poll",
+	[6] = "tasklet",
+	[7] = "sched",
+	[8] = "hrtimer",
+	[9] = "rcu",
+};
+
+static const char *stage_names[] = {
+	[SOFTIRQ_RAISE] = "irq(hard) to softirq",
+	[SOFTIRQ_ENTRY] = "softirq runtime",
+};
+
+static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+{
+	struct event e;
+	char ts[32];
+
+	if (data_sz < sizeof(e)) {
+		printf("Error: packet too small\n");
+		return;
+	}
+	memcpy(&e, data, sizeof(e));
+
+	str_timestamp("%H:%M:%S", ts, sizeof(ts));
+
+	printf("%-8s %-20s %-8s %-14llu %-6u %-16s\n",
+			ts,
+			e.stage < ARRAY_SIZE(stage_names) ? stage_names[e.stage] : "unknown",
+			e.vec  < NR_SOFTIRQS ? vec_names[e.vec] : "unknown",
+			e.delta_us,
+			e.cpu,
+			e.task);
+}
+
+static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	printf("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser  = parse_arg,
+		.doc     = argp_program_doc,
+	};
+	struct perf_buffer       *pb  = NULL;
+	struct softirqslower_bpf *obj;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	obj = softirqslower_bpf__open();
+	if (!obj) {
+		fprintf(stderr, "failed to open BPF object\n");
+		return 1;
+	}
+
+	/* Configure rodata constants before loading */
+	obj->rodata->min_us   = env.min_us;
+	obj->rodata->targ_cpu = env.targ_cpu;
+
+	/* Choose between tp_btf (preferred) and raw_tp (fallback) */
+	if (probe_tp_btf("softirq_raise")) {
+		/* Kernel supports BTF tracepoints – disable raw_tp variants */
+		bpf_program__set_autoload(obj->progs.softirq_raise_raw, false);
+		bpf_program__set_autoload(obj->progs.softirq_entry_raw, false);
+		bpf_program__set_autoload(obj->progs.softirq_exit_raw,  false);
+	} else {
+		/* Fall back to raw tracepoints – disable tp_btf variants */
+		bpf_program__set_autoload(obj->progs.softirq_raise_btf, false);
+		bpf_program__set_autoload(obj->progs.softirq_entry_btf, false);
+		bpf_program__set_autoload(obj->progs.softirq_exit_btf,  false);
+	}
+
+	err = softirqslower_bpf__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF object: %d\n", err);
+		goto cleanup;
+	}
+
+	err = softirqslower_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+
+	printf("Tracing softirq latency higher than %llu us... "
+			"Hit Ctrl-C to end.\n", env.min_us);
+	printf("%-8s %-20s %-8s %-14s %-6s %-16s\n",
+			"TIME", "STAGE", "SOFTIRQ", "LAT(us)", "CPU", "COMM");
+
+	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), 64,
+			handle_event, handle_lost_events, NULL, NULL);
+	if (!pb) {
+		err = -errno;
+		fprintf(stderr, "failed to open perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		fprintf(stderr, "can't set signal handler: %s\n",
+			strerror(errno));
+		err = 1;
+		goto cleanup;
+	}
+
+	while (!exiting) {
+		err = perf_buffer__poll(pb, 100);
+		if (err < 0 && err != -EINTR) {
+			fprintf(stderr, "error polling perf buffer: %s\n",
+				strerror(-err));
+			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
+	}
+
+cleanup:
+	perf_buffer__free(pb);
+	softirqslower_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/libbpf-tools/softirqslower.c
+++ b/libbpf-tools/softirqslower.c
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+// Copyright (c) 2026 Ism Hong
+//
+// Based on softirqslower(8) from BCC by Chenyue Zhou.
+// libbpf/CO-RE version.
+// 27-May-2026   Ported to libbpf.
+#include <argp.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "softirqslower.h"
+#include "softirqslower.skel.h"
+#include "trace_helpers.h"
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(*(x)))
+#endif
+
+static volatile sig_atomic_t exiting = 0;
+
+struct env {
+	__u64 min_us;
+	int   targ_cpu;
+	bool  verbose;
+} env = {
+	.min_us   = 10000,
+	.targ_cpu = -1,
+};
+
+const char *argp_program_version = "softirqslower 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] =
+"Trace slow soft IRQ (interrupt).\n"
+"\n"
+"USAGE: softirqslower [--help] [-c CPU] [min_us]\n"
+"\n"
+"EXAMPLES:\n"
+"    softirqslower        # trace softirq latency higher than 10000 us (default)\n"
+"    softirqslower 100000 # trace softirq latency higher than 100000 us\n"
+"    softirqslower -c 1   # trace softirq latency on CPU 1 only\n";
+
+static const struct argp_option opts[] = {
+	{ "cpu",     'c', "CPU",  0, "Trace this CPU only", 0 },
+	{ "verbose", 'v', NULL,   0, "Verbose debug output", 0 },
+	{ NULL,      'h', NULL,   OPTION_HIDDEN, "Show the full help", 0 },
+	{},
+};
+
+/* Softirq vector names – same order as the kernel enum */
+static const char *vec_names[] = {
+	[0] = "hi",
+	[1] = "timer",
+	[2] = "net_tx",
+	[3] = "net_rx",
+	[4] = "block",
+	[5] = "irq_poll",
+	[6] = "tasklet",
+	[7] = "sched",
+	[8] = "hrtimer",
+	[9] = "rcu",
+};
+
+static const char *stage_names[] = {
+	[STAGE_RAISE_TO_ENTRY] = "irq(hard) to softirq",
+	[STAGE_ENTRY_TO_EXIT]  = "softirq runtime",
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	static int pos_args;
+	long long val;
+
+	switch (key) {
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
+	case 'v':
+		env.verbose = true;
+		break;
+	case 'c': {
+		int nr_cpus;
+
+		errno = 0;
+		val = strtol(arg, NULL, 10);
+		if (errno || val < 0) {
+			fprintf(stderr, "invalid cpu: %s\n", arg);
+			argp_usage(state);
+		}
+		nr_cpus = libbpf_num_possible_cpus();
+		if (nr_cpus > 0 && val >= nr_cpus) {
+			fprintf(stderr, "cpu %lld out of range, system has %d CPUs (0-%d)\n",
+				val, nr_cpus, nr_cpus - 1);
+			argp_usage(state);
+		}
+		env.targ_cpu = (int)val;
+		break;
+	}
+	case ARGP_KEY_ARG:
+		if (pos_args++) {
+			fprintf(stderr,
+				"Unrecognized positional argument: %s\n", arg);
+			argp_usage(state);
+		}
+		errno = 0;
+		val = strtoll(arg, NULL, 10);
+		if (errno || val <= 0) {
+			fprintf(stderr,
+				"Invalid min latency (in us): %s\n", arg);
+			argp_usage(state);
+		}
+		env.min_us = (__u64)val;
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level,
+		const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !env.verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+{
+	struct event e;
+	char ts[32];
+
+	if (data_sz < sizeof(e)) {
+		printf("Error: packet too small\n");
+		return;
+	}
+	memcpy(&e, data, sizeof(e));
+
+	str_timestamp("%H:%M:%S", ts, sizeof(ts));
+
+	printf("%-8s %-20s %-8s %-14llu %-6u %-16s\n",
+			ts,
+			e.stage < ARRAY_SIZE(stage_names) ? stage_names[e.stage] : "unknown",
+			e.vec  < NR_SOFTIRQS ? vec_names[e.vec] : "unknown",
+			e.delta_us,
+			e.cpu,
+			e.task);
+}
+
+static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	printf("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser  = parse_arg,
+		.doc     = argp_program_doc,
+	};
+	struct perf_buffer       *pb  = NULL;
+	struct softirqslower_bpf *obj;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	obj = softirqslower_bpf__open();
+	if (!obj) {
+		fprintf(stderr, "failed to open BPF object\n");
+		return 1;
+	}
+
+	/* Configure rodata constants before loading */
+	obj->rodata->min_us   = env.min_us;
+	obj->rodata->targ_cpu = env.targ_cpu;
+
+	/* Choose between tp_btf (preferred) and raw_tp (fallback) */
+	if (probe_tp_btf("softirq_raise")) {
+		/* Kernel supports BTF tracepoints – disable raw_tp variants */
+		bpf_program__set_autoload(obj->progs.softirq_raise_raw, false);
+		bpf_program__set_autoload(obj->progs.softirq_entry_raw, false);
+		bpf_program__set_autoload(obj->progs.softirq_exit_raw,  false);
+	} else {
+		/* Fall back to raw tracepoints – disable tp_btf variants */
+		bpf_program__set_autoload(obj->progs.softirq_raise_btf, false);
+		bpf_program__set_autoload(obj->progs.softirq_entry_btf, false);
+		bpf_program__set_autoload(obj->progs.softirq_exit_btf,  false);
+	}
+
+	err = softirqslower_bpf__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF object: %d\n", err);
+		goto cleanup;
+	}
+
+	err = softirqslower_bpf__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+
+	printf("Tracing softirq latency higher than %llu us... "
+			"Hit Ctrl-C to end.\n", env.min_us);
+	printf("%-8s %-20s %-8s %-14s %-6s %-16s\n",
+			"TIME", "STAGE", "SOFTIRQ", "LAT(us)", "CPU", "COMM");
+
+	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), 64,
+			handle_event, handle_lost_events, NULL, NULL);
+	if (!pb) {
+		err = -errno;
+		fprintf(stderr, "failed to open perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		fprintf(stderr, "can't set signal handler: %s\n",
+			strerror(errno));
+		err = 1;
+		goto cleanup;
+	}
+
+	while (!exiting) {
+		err = perf_buffer__poll(pb, 100);
+		if (err < 0 && err != -EINTR) {
+			fprintf(stderr, "error polling perf buffer: %s\n",
+				strerror(-err));
+			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
+	}
+
+cleanup:
+	perf_buffer__free(pb);
+	softirqslower_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/libbpf-tools/softirqslower.h
+++ b/libbpf-tools/softirqslower.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __SOFTIRQSLOWER_H
+#define __SOFTIRQSLOWER_H
+
+#define TASK_COMM_LEN	16
+/* Matches NR_SOFTIRQS in linux/interrupt.h
+ * Update if kernel adds new vectors */
+#define NR_SOFTIRQS	10
+
+enum softirq_stage {
+	SOFTIRQ_RAISE = 0,  /* raise_softirq -> softirq handler entry */
+	SOFTIRQ_ENTRY = 1,  /* softirq handler entry -> exit (runtime) */
+};
+
+struct event {
+	__u64 delta_us;
+	__u32 stage;
+	__u32 vec;
+	__u32 cpu;
+	char  task[TASK_COMM_LEN];
+};
+
+#endif /* __SOFTIRQSLOWER_H */

--- a/libbpf-tools/softirqslower.h
+++ b/libbpf-tools/softirqslower.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __SOFTIRQSLOWER_H
+#define __SOFTIRQSLOWER_H
+
+#define TASK_COMM_LEN	16
+/* Matches NR_SOFTIRQS in linux/interrupt.h
+ * Update if kernel adds new vectors */
+#define NR_SOFTIRQS	10
+
+enum softirq_stage {
+	STAGE_RAISE_TO_ENTRY = 0, /* raise_softirq -> softirq handler entry */
+	STAGE_ENTRY_TO_EXIT  = 1, /* softirq handler entry -> exit (runtime) */
+};
+
+struct event {
+	__u64 delta_us;
+	__u32 stage;
+	__u32 vec;
+	__u32 cpu;
+	char  task[TASK_COMM_LEN];
+};
+
+#endif /* __SOFTIRQSLOWER_H */

--- a/man/man8/softirqslower.8
+++ b/man/man8/softirqslower.8
@@ -2,10 +2,10 @@
 .SH NAME
 softirqslower \- Trace softirq handlers with latency exceeding a threshold
 .SH SYNOPSIS
-.B softirqslower.py
+.B softirqslower
 .RI [min_us]
 .br
-.B softirqslower.py
+.B softirqslower
 .RB [ \-c
 .IR CPU ]
 .RI [min_us]


### PR DESCRIPTION
## Description
Convert from legacy Python/bcc to modern libbpf-based C implementation. This tool traces slow softirq events by measuring two critical latency dimensions of softirq handling.

Features:
- Trace irq(hard)-to-softirq latency: delay from raise_softirq() until the softirq handler starts executing
- Trace softirq runtime: actual handler execution duration (entry to exit)
- Filter by minimum latency threshold (default 10000 us)
- Filter by CPU with -c/--cpu option
- Output columns: TIME, STAGE, SOFTIRQ, LAT(us), CPU, COMM
- Supports both tp_btf (preferred) and raw_tp fallback tracepoints
- Uses PERCPU_ARRAY maps indexed by softirq vector for lock-free tracking

Test on x86_64/Manjaro/5.15.60
```
❯ sudo ./softirqslower 100
Tracing softirq latency higher than 100 us... Hit Ctrl-C to end.
TIME     STAGE                SOFTIRQ  LAT(us)        CPU    COMM
18:43:53 irq(hard) to softirq rcu      116            0      ksoftirqd/0
18:43:53 irq(hard) to softirq net_rx   100            3      ksoftirqd/3
18:43:53 softirq runtime      net_rx   143            3      ksoftirqd/3
18:43:53 irq(hard) to softirq sched    387            3      ksoftirqd/3

❯ uname -a
Linux ism-manjaro 5.15.60-1-MANJARO #1 SMP PREEMPT Thu Aug 11 13:14:05 UTC 2022 x86_64 GNU/Linux
```

Test on arm64/Android/6.12.38
```
RTKRTD1325GTV_36:/ # /data/softirqslower 100
Tracing softirq latency higher than 100 us... Hit Ctrl-C to end.
TIME     STAGE                SOFTIRQ  LAT(us)        CPU    COMM
10:37:09 softirq runtime      net_rx   113            0      swapper/0
10:37:09 irq(hard) to softirq sched    104            3      swapper/3
10:37:09 softirq runtime      net_rx   101            0      swapper/0

RTKRTD1325GTV_36:/ # uname -a
Linux localhost 6.12.38-android16-5-gb9e1e77593f9-ab14266828-4k #1 SMP PREEMPT Tue Oct 14 10:02:12 UTC 2025 armv8l Toybox
```

## Why this approach

Just port softirqslower from BCC to libbpf

---

## Checklist

- [x] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [x] Commit body explains **why** this change is needed

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.