### PR TITLE
tools/ppchalls: Update the hcall list with new hcalls introduced

### DIFF
--- a/tools/ppchcalls.py
+++ b/tools/ppchcalls.py
@@ -104,6 +104,7 @@ hcall_table = {
     472: 'H_POLL_PENDING',
     484: 'H_QUERY_INT_STATE',
     580: 'H_ILLAN_ATTRIBUTES',
+    584: 'H_ADD_LOGICAL_LAN_BUFFERS',
     592: 'H_MODIFY_HEA_QP',
     596: 'H_QUERY_HEA_QP',
     600: 'H_QUERY_HEA',
@@ -182,6 +183,7 @@ hcall_table = {
     1100: 'H_SCM_FLUSH',
     1104: 'H_GET_ENERGY_SCALE_INFO',
     1108: 'H_PKS_SIGNED_UPDATE',
+    1112: 'H_HTM',
     1116: 'H_WATCHDOG',
     # Platform specific hcalls used by KVM on PowerVM
     1120: 'H_GUEST_GET_CAPABILITIES',
@@ -193,6 +195,9 @@ hcall_table = {
     1152: 'H_GUEST_RUN_VCPU',
     1156: 'H_GUEST_COPY_MEMORY',
     1160: 'H_GUEST_DELETE',
+    # Key wrapping hcalls
+    1168: 'H_PKS_WRAP_OBJECT',
+    1172: 'H_PKS_UNWRAP_OBJECT',
     # Platform-specific hcalls used by the Ultravisor
     61184: 'H_SVM_PAGE_IN',
     61188: 'H_SVM_PAGE_OUT',


### PR DESCRIPTION
Update the hcall list with new hcalls introduced for PPC [1].

[1]: git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/powerpc/include/asm/hvcall.h

## Description

<!-- What does this PR do? Which problem does it solve? -->
Some new hcalls are introduced in PPC. Add them to the hcall list in ppchcalls.py

---

## Checklist

- [X] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [X] Commit body explains **why** this change is needed

**For new tools only**
- [ ] Explains why this tool is needed and what existing tools cannot cover this use case
- [ ] Includes at least one real production use case
- [ ] Man page (`man/man8/`) with an OVERHEAD section
- [ ] Example output file (`*_example.txt`)
- [ ] README.md entry added
- [ ] Smoke test added to `tests/python/test_tools_smoke.py`

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
