### PR TITLE
Harden libbpf-tools path handling

### DIFF
--- a/libbpf-tools/gethostlatency.c
+++ b/libbpf-tools/gethostlatency.c
@@ -122,12 +122,14 @@ static int get_libc_path(char *path)
 {
 	char proc_path[PATH_MAX + 32] = {};
 	char buf[PATH_MAX] = {};
+	char *map_path;
 	char *filename;
 	float version;
 	FILE *f;
 
 	if (libc_path) {
-		memcpy(path, libc_path, strlen(libc_path));
+		if (snprintf(path, PATH_MAX, "%s", libc_path) >= PATH_MAX)
+			return -ENAMETOOLONG;
 		return 0;
 	}
 
@@ -140,17 +142,30 @@ static int get_libc_path(char *path)
 	if (!f)
 		return -errno;
 
-	while (fscanf(f, "%*x-%*x %*s %*s %*s %*s %[^\n]\n", buf) != EOF) {
-		if (strchr(buf, '/') != buf)
+	while (fgets(buf, sizeof(buf), f)) {
+		map_path = strchr(buf, '/');
+		if (!map_path)
 			continue;
-		filename = strrchr(buf, '/') + 1;
+		map_path[strcspn(map_path, "\n")] = '\0';
+		filename = strrchr(map_path, '/') + 1;
 		if (sscanf(filename, "libc-%f.so", &version) == 1 ||
 		    sscanf(filename, "libc.so.%f", &version) == 1) {
 			if (target_pid == 0) {
-				memcpy(path, buf, strlen(buf));
+				if (snprintf(path, PATH_MAX, "%s", map_path) >= PATH_MAX) {
+					fclose(f);
+					return -ENAMETOOLONG;
+				}
 			} else {
-				snprintf(proc_path, sizeof(proc_path), "/proc/%d/root%s", target_pid, buf);
-				memcpy(path, proc_path, strlen(proc_path));
+				if (snprintf(proc_path, sizeof(proc_path),
+					     "/proc/%d/root%s", target_pid,
+					     map_path) >= sizeof(proc_path)) {
+					fclose(f);
+					return -ENAMETOOLONG;
+				}
+				if (snprintf(path, PATH_MAX, "%s", proc_path) >= PATH_MAX) {
+					fclose(f);
+					return -ENAMETOOLONG;
+				}
 			}
 			fclose(f);
 			return 0;

--- a/libbpf-tools/ksnoop.c
+++ b/libbpf-tools/ksnoop.c
@@ -436,14 +436,22 @@ static char *type_id_to_str(struct btf *btf, __s32 type_id, char *str)
 	return str;
 }
 
+static void append_str(char *str, size_t str_sz, const char *suffix)
+{
+	size_t len = strnlen(str, str_sz);
+
+	if (len < str_sz)
+		snprintf(str + len, str_sz - len, "%s", suffix);
+}
+
 static char *value_to_str(struct btf *btf, struct value *val, char *str)
 {
 	str = type_id_to_str(btf, val->type_id, str);
 	if (val->flags & KSNOOP_F_PTR)
-		strncat(str, "*", MAX_STR);
+		append_str(str, MAX_STR, "*");
 	if (strlen(val->name) > 0 &&
 	    strcmp(val->name, KSNOOP_RETURN_NAME) != 0)
-		strncat(str, val->name, MAX_STR);
+		append_str(str, MAX_STR, val->name);
 
 	return str;
 }
@@ -464,7 +472,7 @@ static int get_func_ip_mod(struct func *func)
 	}
 
 	while (true) {
-		ret = fscanf(f, "%llx %c %128s%[^\n]\n",
+		ret = fscanf(f, "%llx %c %128s%255[^\n]\n",
 			     &sym_addr, &sym_type, sym_name, mod_info);
 		if (ret == EOF && feof(f))
 			break;
@@ -479,7 +487,7 @@ static int get_func_ip_mod(struct func *func)
 		func->mod[0] = '\0';
 		/* get module name from [modname] */
 		if (ret == 4) {
-			if (sscanf(mod_info, "%*[\t ][%[^]]", func->mod) < 1) {
+			if (sscanf(mod_info, "%*[\t ][%95[^]]", func->mod) < 1) {
 				p_err("failed to read module name");
 				err = -EINVAL;
 				goto out;

--- a/libbpf-tools/uprobe_helpers.c
+++ b/libbpf-tools/uprobe_helpers.c
@@ -70,7 +70,7 @@ int get_pid_lib_path(pid_t pid, const char *lib, char *path, size_t path_sz)
 		return -1;
 	}
 	while (fgets(line_buf, sizeof(line_buf), maps)) {
-		if (sscanf(line_buf, "%*x-%*x %*s %*x %*s %*u %1023s",
+		if (sscanf(line_buf, "%*llx-%*llx %*s %*llx %*s %*u %1023s",
 			   path_buf) != 1)
 			continue;
 		/* e.g. /usr/lib/x86_64-linux-gnu/libc-2.31.so */
@@ -109,12 +109,10 @@ static int which_program(const char *prog, char *path, size_t path_sz)
 {
 	char candidate[PATH_MAX];
 	const char *path_env, *dir, *next;
-	size_t prog_len;
 
 	if (!prog || !prog[0])
 		return -1;
 
-	prog_len = strlen(prog);
 	if (strchr(prog, '/')) {
 		if (access(prog, X_OK))
 			return -1;
@@ -131,16 +129,17 @@ static int which_program(const char *prog, char *path, size_t path_sz)
 
 	for (dir = path_env; dir; dir = next ? next + 1 : NULL) {
 		size_t dir_len;
+		int ret;
 
 		next = strchr(dir, ':');
 		dir_len = next ? (size_t)(next - dir) : strlen(dir);
-		if (dir_len + 1 + prog_len >= sizeof(candidate))
-			continue;
 		if (dir_len)
-			snprintf(candidate, sizeof(candidate), "%.*s/%s",
-				 (int)dir_len, dir, prog);
+			ret = snprintf(candidate, sizeof(candidate), "%.*s/%s",
+				       (int)dir_len, dir, prog);
 		else
-			snprintf(candidate, sizeof(candidate), "./%s", prog);
+			ret = snprintf(candidate, sizeof(candidate), "./%s", prog);
+		if (ret < 0 || (size_t)ret >= sizeof(candidate))
+			continue;
 		if (access(candidate, X_OK))
 			continue;
 		if (snprintf(path, path_sz, "%s", candidate) >= path_sz) {

--- a/libbpf-tools/uprobe_helpers.c
+++ b/libbpf-tools/uprobe_helpers.c
@@ -70,7 +70,8 @@ int get_pid_lib_path(pid_t pid, const char *lib, char *path, size_t path_sz)
 		return -1;
 	}
 	while (fgets(line_buf, sizeof(line_buf), maps)) {
-		if (sscanf(line_buf, "%*x-%*x %*s %*x %*s %*u %s", path_buf) != 1)
+		if (sscanf(line_buf, "%*x-%*x %*s %*x %*s %*u %1023s",
+			   path_buf) != 1)
 			continue;
 		/* e.g. /usr/lib/x86_64-linux-gnu/libc-2.31.so */
 		p = strrchr(path_buf, '/');
@@ -85,7 +86,7 @@ int get_pid_lib_path(pid_t pid, const char *lib, char *path, size_t path_sz)
 		/* libraries can have - or . after the name */
 		if (*p != '.' && *p != '-')
 			continue;
-		if (strnlen(path_buf, 1024) >= path_sz) {
+		if (strnlen(path_buf, sizeof(path_buf)) >= path_sz) {
 			warn("path size too small\n");
 			goto cleanup;
 		}
@@ -106,27 +107,50 @@ cleanup:
  */
 static int which_program(const char *prog, char *path, size_t path_sz)
 {
-	FILE *which;
-	char cmd[100];
+	char candidate[PATH_MAX];
+	const char *path_env, *dir, *next;
+	size_t prog_len;
 
-	if (snprintf(cmd, sizeof(cmd), "which %s", prog) >= sizeof(cmd)) {
-		warn("snprintf which prog failed");
+	if (!prog || !prog[0])
 		return -1;
+
+	prog_len = strlen(prog);
+	if (strchr(prog, '/')) {
+		if (access(prog, X_OK))
+			return -1;
+		if (snprintf(path, path_sz, "%s", prog) >= path_sz) {
+			warn("path size too small\n");
+			return -1;
+		}
+		return 0;
 	}
-	which = popen(cmd, "r");
-	if (!which) {
-		warn("which failed");
+
+	path_env = getenv("PATH");
+	if (!path_env)
 		return -1;
+
+	for (dir = path_env; dir; dir = next ? next + 1 : NULL) {
+		size_t dir_len;
+
+		next = strchr(dir, ':');
+		dir_len = next ? (size_t)(next - dir) : strlen(dir);
+		if (dir_len + 1 + prog_len >= sizeof(candidate))
+			continue;
+		if (dir_len)
+			snprintf(candidate, sizeof(candidate), "%.*s/%s",
+				 (int)dir_len, dir, prog);
+		else
+			snprintf(candidate, sizeof(candidate), "./%s", prog);
+		if (access(candidate, X_OK))
+			continue;
+		if (snprintf(path, path_sz, "%s", candidate) >= path_sz) {
+			warn("path size too small\n");
+			return -1;
+		}
+		return 0;
 	}
-	if (!fgets(path, path_sz, which)) {
-		warn("fgets which failed");
-		pclose(which);
-		return -1;
-	}
-	/* which has a \n at the end of the string */
-	path[strlen(path) - 1] = '\0';
-	pclose(which);
-	return 0;
+
+	return -1;
 }
 
 /*


### PR DESCRIPTION
## Summary
- remove shell-based `which` lookup from libbpf-tools uprobe path resolution
- add bounded parsing/copying for `/proc/*/maps`, `/proc/kallsyms`, and libc path handling
- avoid appending to fixed-size ksnoop strings with the full buffer size as the remaining capacity

## Root cause
`resolve_binary_path()` could pass the user-supplied binary name to `which_program()`, which built `which %s` and executed it through `popen()`. For tools such as `funclatency`, the binary component comes from the `PROGRAM:FUNCTION` argument, so shell metacharacters could be interpreted while resolving a binary name.

The same pass also tightens nearby fixed-buffer handling in libbpf-tools:
- `get_pid_lib_path()` now bounds `%s` parsing to the destination buffer.
- `ksnoop` now appends using remaining buffer space and bounds kallsyms/module-name scans.
- `gethostlatency` now uses bounded `snprintf()` copies and line-based `/proc/maps` parsing.

## Validation
- `git diff --check`
- Searched touched files for the removed risky patterns: `popen(cmd)`, `which %s`, `strncat(`, `memcpy(path, ...)`, and unbounded `%[^\n]` scansets.

I could not run a local libbpf-tools build in the available WSL environment because the required development headers are missing (`gelf.h` / libelf and `bpf/libbpf.h`).