### PR TITLE
libbpf-tools/biostacks: Fix incorrect sizeof in bpf_get_current_comm

### DIFF
--- a/libbpf-tools/biostacks.bpf.c
+++ b/libbpf-tools/biostacks.bpf.c
@@ -59,7 +59,7 @@ int trace_start(void *ctx, struct request *rq, bool merge_bio)
 		bpf_get_stack(ctx, i_rqinfop->rqinfo.kern_stack,
 			sizeof(i_rqinfop->rqinfo.kern_stack), 0);
 	bpf_get_current_comm(&i_rqinfop->rqinfo.comm,
-			sizeof(&i_rqinfop->rqinfo.comm));
+			sizeof(i_rqinfop->rqinfo.comm));
 	i_rqinfop->rqinfo.dev = dev;
 
 	if (i_rqinfop == &i_rqinfo)


### PR DESCRIPTION
## Description

Fix the `comm` buffer size passed to `bpf_get_current_comm` in `biostacks.bpf.c`. The size argument ran `sizeof` on the address of the `comm` array, returning the size of a pointer (8 bytes on 64-bit) instead of `TASK_COMM_LEN` (16). This truncated the recorded process name to 7 characters, so the output showed clipped command names (e.g. `kworker` instead of `kworker/u16:3`). Removing the address-of operator passes the real buffer size. This is similar to the sizeof isue fixed in da296a9.

## Why this approach

The fix mirrors the correct pattern already used two lines above for `kern_stack` (`sizeof(i_rqinfop->rqinfo.kern_stack)`, no `&`). Dropping the `&` is the minimal, correct change.

---

## Checklist

- [x] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [x] Commit body explains **why** this change is needed

**For new tools only**
- [ ] Explains why this tool is needed and what existing tools cannot cover this use case
- [ ] Includes at least one real production use case
- [ ] Man page (`man/man8/`) with an OVERHEAD section
- [ ] Example output file (`*_example.txt`)
- [ ] README.md entry added
- [ ] Smoke test added to `tests/python/test_tools_smoke.py`

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
