### PR TITLE
bcc-lua: Restore LuaJIT determinism.

### DIFF
--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -15,7 +15,7 @@ if (LUAJIT_LIBRARIES AND LUAJIT)
 
 	ADD_CUSTOM_COMMAND(
 		OUTPUT bcc.o
-		COMMAND ${LUAJIT} -b bcc.lua bcc.o
+		COMMAND ${LUAJIT} -bgd bcc.lua bcc.o || ${LUAJIT} -b bcc.lua bcc.o
 		DEPENDS bcc.lua
 	)
 


### PR DESCRIPTION
This reverts commit 26eaf13bbcf89f0d73b5b0043f5905cac08039d4.

## Description
The aforementioned commit introduced a regression, breaking reproducible builds for bcc-lua.
These flags were added to LuaJIT in early 2024.

Timeline:

- 2023-06-07: LuaJIT: deterministic bytecode generation requested [1]
- 2024-01-22: LuaJIT: deterministic bytecode merged [2]
- 2025-02-13: bcc: PR opened to enable LuaJIT determinism [3]
- 2025-06-08: bcc: PR opened to disable LuaJIT determinism [4]

[1]: https://github.com/LuaJIT/LuaJIT/issues/1008
[2]: https://github.com/LuaJIT/LuaJIT/commit/4b90f6c4d7420139c135435e1580acb52ea18436
[3]: https://github.com/iovisor/bcc/pull/5213
[4]: https://github.com/iovisor/bcc/pull/5326