### PR TITLE
libbpf-tools/offcputime: fix PID filters in PID namespaces

### DIFF
--- a/libbpf-tools/offcputime.bpf.c
+++ b/libbpf-tools/offcputime.bpf.c
@@ -17,6 +17,9 @@ const volatile __u64 min_block_us = 1;
 const volatile bool filter_by_tgid = false;
 const volatile bool filter_by_pid = false;
 const volatile long state = -1;
+const volatile bool use_pidns = false;
+const volatile __u64 pidns_dev = 0;
+const volatile __u64 pidns_ino = 0;
 
 struct internal_key {
 	u64 start_ts;
@@ -56,14 +59,27 @@ struct {
 	__uint(max_entries, MAX_TID_NR);
 } pids SEC(".maps");
 
-static bool allow_record(struct task_struct *t)
+static bool allow_record(struct task_struct *t, u32* ns_pid, u32* ns_tgid)
 {
-	u32 tgid = BPF_CORE_READ(t, tgid);
-	u32 pid = BPF_CORE_READ(t, pid);
+	s64 id;
+	struct bpf_pidns_info ns = {};
 
-	if (filter_by_tgid && !bpf_map_lookup_elem(&tgids, &tgid))
+	if (use_pidns && BPF_CORE_READ(t, pid) != 0) {
+		if (!bpf_get_ns_current_pid_tgid(pidns_dev, pidns_ino, &ns, sizeof(ns))) {
+			*ns_pid = ns.pid;
+			*ns_tgid = ns.tgid;
+		} else {
+			return false;
+		}
+	} else {
+		id = bpf_get_current_pid_tgid();
+		*ns_pid = id;
+		*ns_tgid = id >> 32;
+	}
+
+	if (filter_by_tgid && !bpf_map_lookup_elem(&tgids, ns_tgid))
 		return false;
-	if (filter_by_pid && !bpf_map_lookup_elem(&pids, &pid))
+	if (filter_by_pid && !bpf_map_lookup_elem(&pids, ns_pid))
 		return false;
 	if (user_threads_only && (BPF_CORE_READ(t, flags) & PF_KTHREAD))
 		return false;
@@ -79,9 +95,9 @@ static int handle_sched_switch(void *ctx, bool preempt, struct task_struct *prev
 	struct internal_key *i_keyp, i_key;
 	struct val_t *valp, val;
 	s64 delta;
-	u32 pid;
+	u32 pid, ns_pid, ns_tgid;
 
-	if (allow_record(prev)) {
+	if (allow_record(prev, &ns_pid, &ns_tgid)) {
 		pid = BPF_CORE_READ(prev, pid);
 		/* To distinguish idle threads of different cores */
 		if (!pid)
@@ -97,6 +113,8 @@ static int handle_sched_switch(void *ctx, bool preempt, struct task_struct *prev
 		i_key.key.kern_stack_id = bpf_get_stackid(ctx, &stackmap, 0);
 		bpf_map_update_elem(&start, &pid, &i_key, 0);
 		bpf_probe_read_kernel_str(&val.comm, sizeof(prev->comm), BPF_CORE_READ(prev, comm));
+		val.ns_pid = ns_pid;
+		val.ns_tgid = ns_tgid;
 		val.delta = 0;
 		bpf_map_update_elem(&info, &i_key.key, &val, BPF_NOEXIST);
 	}

--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -11,6 +11,7 @@
 #include <time.h>
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
+#include <sys/stat.h>
 #include "offcputime.h"
 #include "offcputime.skel.h"
 #include "trace_helpers.h"
@@ -252,7 +253,7 @@ print_ustack:
 			goto skip_ustack;
 		}
 
-		syms = syms_cache__get_syms(syms_cache, next_key.tgid);
+		syms = syms_cache__get_syms(syms_cache, val.ns_tgid);
 		if (!syms) {
 			if (!env.verbose) {
 				fprintf(stderr, "failed to get syms\n");
@@ -282,7 +283,7 @@ print_ustack:
 		}
 
 skip_ustack:
-		printf("    %-16s %s (%d)\n", "-", val.comm, next_key.pid);
+		printf("    %-16s %s (%d)\n", "-", val.comm, val.ns_pid);
 		printf("        %lld\n\n", val.delta);
 	}
 
@@ -310,6 +311,23 @@ static bool print_header_threads()
 	}
 
 	return printed;
+}
+
+static int set_pidns(const struct offcputime_bpf *obj)
+{
+	struct stat statbuf;
+
+	if (!probe_bpf_ns_current_pid_tgid())
+		return -EPERM;
+
+	if (stat("/proc/self/ns/pid", &statbuf) == -1)
+		return -errno;
+
+	obj->rodata->use_pidns = true;
+	obj->rodata->pidns_dev = statbuf.st_dev;
+	obj->rodata->pidns_ino = statbuf.st_ino;
+
+	return 0;
 }
 
 static void print_headers()
@@ -380,6 +398,10 @@ int main(int argc, char **argv)
 		bpf_program__set_autoload(obj->progs.sched_switch, false);
 	else
 		bpf_program__set_autoload(obj->progs.sched_switch_raw, false);
+
+	err = set_pidns(obj);
+	if (err && env.verbose)
+		fprintf(stderr, "failed to translate pidns: %s\n", strerror(-err));
 
 	err = offcputime_bpf__load(obj);
 	if (err) {

--- a/libbpf-tools/offcputime.h
+++ b/libbpf-tools/offcputime.h
@@ -14,6 +14,8 @@ struct key_t {
 };
 
 struct val_t {
+	__u32 ns_pid;
+	__u32 ns_tgid;
 	__u64 delta;
 	char comm[TASK_COMM_LEN];
 };


### PR DESCRIPTION
## Description

<!-- What does this PR do? Which problem does it solve? -->

In PID namespaces, the TGIDs and PIDs seen by users differ from the IDs seen by the kernel, causing the filters to fail. Fix this by using PID namespace TGIDs and PIDs for filtering and output.

## Why this approach

<!-- Explain why you chose this approach over alternatives. -->

PID namespace TGIDs and PIDs must be stored as value instead of key, because there isn't a helper function that returns PID namespace TGIDs and PIDs of `task_struct *next` in `sched_switch`.

---

## Checklist

- [x] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [x] Commit body explains **why** this change is needed

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
