### PR TITLE
Fix 'SOCK_STREAM' bug in mptcpify

### DIFF
--- a/tools/mptcpify.py
+++ b/tools/mptcpify.py
@@ -48,6 +48,10 @@ prog = """
 #include <uapi/linux/in.h>
 #include <linux/string.h>
 
+#ifndef SOCK_TYPE_MASK
+#define SOCK_TYPE_MASK 0xf
+#endif
+
 struct app_name {
     char name[TASK_COMM_LEN];
 };
@@ -63,7 +67,7 @@ KMOD_RET(update_socket_protocol, int family, int type, int protocol, int ret)
     bpf_get_current_comm(&target.name, TASK_COMM_LEN);
 
     if ((family == AF_INET || family == AF_INET6) &&
-        type == SOCK_STREAM &&
+        (type & SOCK_TYPE_MASK) == SOCK_STREAM &&
         (!protocol || protocol == IPPROTO_TCP) &&
         (mode && *mode == 0 || support_apps.lookup(&target)))
         return IPPROTO_MPTCP;


### PR DESCRIPTION
## Description

The hook receives the raw type with SOCK_NONBLOCK/SOCK_CLOEXEC still ORed in, so callers like curl that pass SOCK_STREAM|SOCK_NONBLOCK never match "type == SOCK_STREAM" and aren't converted to MPTCP. 

## Why this approach
Use (type & SOCK_TYPE_MASK) == SOCK_STREAM instead.

---

## Checklist

- [x] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)

- [x] Commit body explains **why** this change is needed

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
