### PR TITLE
cc: Synchronize so flags for sw_64 architecture from glibc

### DIFF
--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -447,6 +447,8 @@ static int load_ld_cache(const char *cache_path) {
 #define ABI_S390_LIB64 0x0400
 #define ABI_POWERPC_LIB64 0x0500
 #define ABI_AARCH64_LIB64 0x0a00
+#define ABI_LARCH_FLOAT_ABI_SOFT 0x1100
+#define ABI_LARCH_FLOAT_ABI_DOUBLE 0x1200
 
 static bool match_so_flags(int flags) {
   if ((flags & FLAG_TYPE_MASK) != TYPE_ELF_LIBC6)
@@ -459,6 +461,8 @@ static bool match_so_flags(int flags) {
   case ABI_S390_LIB64:
   case ABI_POWERPC_LIB64:
   case ABI_AARCH64_LIB64:
+  case ABI_LARCH_FLOAT_ABI_SOFT:
+  case ABI_LARCH_FLOAT_ABI_DOUBLE:
     return (sizeof(void *) == 8);
   }
 

--- a/src/cc/bcc_proc.c
+++ b/src/cc/bcc_proc.c
@@ -449,6 +449,7 @@ static int load_ld_cache(const char *cache_path) {
 #define ABI_AARCH64_LIB64 0x0a00
 #define ABI_LARCH_FLOAT_ABI_SOFT 0x1100
 #define ABI_LARCH_FLOAT_ABI_DOUBLE 0x1200
+#define ABI_SW64_LIB64 0x1300
 
 static bool match_so_flags(int flags) {
   if ((flags & FLAG_TYPE_MASK) != TYPE_ELF_LIBC6)
@@ -463,6 +464,7 @@ static bool match_so_flags(int flags) {
   case ABI_AARCH64_LIB64:
   case ABI_LARCH_FLOAT_ABI_SOFT:
   case ABI_LARCH_FLOAT_ABI_DOUBLE:
+  case ABI_SW64_LIB64:
     return (sizeof(void *) == 8);
   }
 


### PR DESCRIPTION
Synchronize the shared library flag bits for sw_64 from glibc to resolve errors in some bcc tools caused by their inability to recognize the libc library.

glibc reference path: sysdeps/generic/ldconfig.h

Signed-off-by: zhangzikang01  zhangzikang@kylinos.cn