### PR TITLE
libbpf-tools/filetop,offcputime: Fix stack leaks including KASLR break

### DIFF
--- a/libbpf-tools/filetop.bpf.c
+++ b/libbpf-tools/filetop.bpf.c
@@ -25,7 +25,7 @@ static void get_file_path(struct file *file, char *buf, size_t size)
 	struct qstr dname;
 
 	dname = BPF_CORE_READ(file, f_path.dentry, d_name);
-	bpf_probe_read_kernel(buf, size, dname.name);
+	bpf_probe_read_kernel_str(buf, size, dname.name);
 }
 
 static int probe_entry(struct pt_regs *ctx, struct file *file, size_t count, enum op op)

--- a/libbpf-tools/offcputime.bpf.c
+++ b/libbpf-tools/offcputime.bpf.c
@@ -77,7 +77,7 @@ static bool allow_record(struct task_struct *t)
 static int handle_sched_switch(void *ctx, bool preempt, struct task_struct *prev, struct task_struct *next)
 {
 	struct internal_key *i_keyp, i_key;
-	struct val_t *valp, val;
+	struct val_t *valp, val = {};
 	s64 delta;
 	u32 pid;
 


### PR DESCRIPTION
## Description

**libbpf-tools/filetop:** `get_file_path()` copies the dentry name with `bpf_probe_read_kernel(buf, size, dname.name)` where `size = PATH_MAX` (4096). The non-`_str` probe read helper copies the full size with no NUL stop, so a short name over-reads ~4 KB of adjacent kernel memory into the `file_stat.filename` map value. I confirmed this leaks kernel `.text` and module pointers (e.g. `kernfs_dops`, `ext4_file_operations`) into the `entries` map, and I was able to recover the KASLR slide. Fix: use `bpf_probe_read_kernel_str()`, which stops at the NUL.

**libbpf-tools/offcputime:** `handle_sched_switch()` leaves `struct val_t val` uninitialized, then `bpf_probe_read_kernel_str(&val.comm, ...)` writes only `strlen+1` bytes before the whole `val` is inserted into the `info` map. For short comms the `val.comm` tail keeps stale BPF-stack bytes (the adjacent `start_ts` timestamp), now persisted in the map. Same uninitialized-stack class as the `bashreadline` fix (c2d8f9b4). Fix: zero-initialize the struct (`struct val_t *valp, val = {};`).

## Why this approach

Minimal and consistent with the tree: `bpf_probe_read_kernel_str()` is the idiomatic kernel-string read (e.g. `hardirqs`), and zeroing the struct follows the `bashreadline` precedent. Neither changes behaviour for well-formed inputs.

---

## Checklist

- [x] Commit prefix matches changed area (`libbpf-tools/filetop:`, `libbpf-tools/offcputime:`)
- [x] Commit body explains **why** this change is needed

**For new tools only** — N/A (bug fixes to existing tools, no new tool)
- [ ] Explains why this tool is needed and what existing tools cannot cover this use case
- [ ] Includes at least one real production use case
- [ ] Man page (`man/man8/`) with an OVERHEAD section
- [ ] Example output file (`*_example.txt`)
- [ ] README.md entry added
- [ ] Smoke test added to `tests/python/test_tools_smoke.py`
