### PR TITLE
Update debian changelog for release v0.37.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,37 @@
+bcc (0.37.0-1) unstable; urgency=low
+
+  * Support for kernel up to 7.1
+
+  * Bug Fixes
+    libbpf-tools/trace_helpers.c: Fixed double-free in cleanup path (7b671951)
+    libbpf-tools/biostacks: Fixed sizeof pointer issue in bpf_get_current_comm() (45348eea)
+    libbpf-tools/biosnoop: Fixed incorrect sizeof in bpf_get_current_comm() (da296a9a)
+    libbpf-tools/filetop, offcputime: Fixed kernel memory disclosure (d3b8def9)
+    libbpf-tools/bashreadline: Fixed uninitialized stack data leak of kernel pointers (c2d8f9b4)
+    libbpf-tools/mountsnoop: Fixed compile error in probe_exit() (3fc265d6)
+    libbpf-tools/path_helpers: Fixed -Wstring-plus-int build error (3696ea0e)
+    libbpf-tools/runqlen: Fixed compile error on ppc64el (b11c1bdf)
+    syscall.py, syscall_helpers.c: Updated syscall tables (74572288)
+    tools/mptcpify: Masked socket type before matching SOCK_STREAM (25ca8b4d)
+    tools/ppchcalls: Updated hcall list for newer kernels (a14e204d)
+    tools/bindsnoop: Fixed PROT field showing UNKN (22aeb77b)
+    tools/execsnoop: Fixed typo in check_cpu_field function name (a3dcb9a5)
+    tools: Fixed available_filter_functions path handling (2cc6d1ad)
+    bcc-lua: Restored LuaJIT determinism (825de98f)
+
+  * Build & Test Fixes
+    doc/build: Added clang and llvm to libbpf-tools build dependencies (e1446ea4)
+    Build: Fixed deprecation warnings for LLVM PointerType::get/getUnqual (e75ce68d)
+    Build: Fixed build with LLVM 22 (4c7be1ec)
+    Build: Fixed C23 constness warnings (246c549e)
+    cc: Added ARM64 and riscv syscall prefix detection in C++ API (e48a177f, 88c4e546)
+    cc: Synced loongarch64 handling with glibc flags (#5500, ecb5e5d2)
+    clang: Added Microsoft extensions build flags (c3f35ecc)
+    tests/python: Added ARM and AArch64 support to static tracepoints (c8af3e7f)
+    tests/python: Removed x86-specific naming from tracing header (1afbe3cd)
+
+  * Doc update, other bug fixes and tools improvement
+
 bcc (0.36.1-1) unstable; urgency=low
 
   * Bug Fixes


### PR DESCRIPTION
* Support for kernel up to 7.1

* Bug Fixes
    libbpf-tools/trace_helpers.c: Fixed double-free in cleanup path (https://github.com/iovisor/bcc/commit/7b6719518919e7b73d1334f6c9225681274b0ec7)
    libbpf-tools/biostacks: Fixed sizeof pointer issue in bpf_get_current_comm() (https://github.com/iovisor/bcc/commit/45348eea40fb78449b5c838dc11c7b8f9bdcc69a)
    libbpf-tools/biosnoop: Fixed incorrect sizeof in bpf_get_current_comm() (https://github.com/iovisor/bcc/commit/da296a9a2bad64fb24fcf5fb923b082eb51cc796)
    libbpf-tools/filetop, offcputime: Fixed kernel memory disclosure (https://github.com/iovisor/bcc/commit/d3b8def95dbf61b6f71fe9b2937fed4b72ba8e03)
    libbpf-tools/bashreadline: Fixed uninitialized stack data leak of kernel pointers (https://github.com/iovisor/bcc/commit/c2d8f9b4f782b1e65abace478e249ffd80cdb7b0)
    libbpf-tools/mountsnoop: Fixed compile error in probe_exit() (https://github.com/iovisor/bcc/commit/3fc265d6c847dd7b3b7c532e9323af17b2e7600a)
    libbpf-tools/path_helpers: Fixed -Wstring-plus-int build error (https://github.com/iovisor/bcc/commit/3696ea0e434cc164c1baaa045187785ea5cda118)
    libbpf-tools/runqlen: Fixed compile error on ppc64el (https://github.com/iovisor/bcc/commit/b11c1bdfba4c3450d65b9f0b604e43370c9e6908)
    syscall.py, syscall_helpers.c: Updated syscall tables (https://github.com/iovisor/bcc/commit/745722884120343a9d960795c24d9ea55cc51fbb)
    tools/mptcpify: Masked socket type before matching SOCK_STREAM (https://github.com/iovisor/bcc/commit/25ca8b4d10fba1435e92223d0f8b0a13094b31c1)
    tools/ppchcalls: Updated hcall list for newer kernels (https://github.com/iovisor/bcc/commit/a14e204d4f1a8b8738da1f2e43de898222b487a9)
    tools/bindsnoop: Fixed PROT field showing UNKN (https://github.com/iovisor/bcc/commit/22aeb77be761c4c228a1dfd3f2823ac215dcf2a3)
    tools/execsnoop: Fixed typo in check_cpu_field function name (https://github.com/iovisor/bcc/commit/a3dcb9a53f289a1cabc8f6d9e33acc84e810f1c4)
    tools: Fixed available_filter_functions path handling (https://github.com/iovisor/bcc/commit/2cc6d1ade647db5bf1dab91be3b18569868779ce)
    bcc-lua: Restored LuaJIT determinism (https://github.com/iovisor/bcc/commit/825de98f53243f022c6b762b1e77eb31849284c0)

* Build & Test Fixes
    doc/build: Added clang and llvm to libbpf-tools build dependencies (https://github.com/iovisor/bcc/commit/e1446ea4139495a029fcacb22ae02c0e00e5914e)
    Build: Fixed deprecation warnings for LLVM PointerType::get/getUnqual (https://github.com/iovisor/bcc/commit/e75ce68d72791f9d4a44d53331b863a83af8c177)
    Build: Fixed build with LLVM 22 (https://github.com/iovisor/bcc/commit/4c7be1ec6ab74e973f8d18a9011fa349c3d9dd58)
    Build: Fixed C23 constness warnings (https://github.com/iovisor/bcc/commit/246c549ed7bd0a7d52116207dfd016f01d66e2b3)
    cc: Added ARM64 and riscv syscall prefix detection in C++ API (https://github.com/iovisor/bcc/commit/e48a177f467018eaacd7691aea92d909e2700607, https://github.com/iovisor/bcc/commit/88c4e546041d7f9988b9caef6b001fbfbbc7b5d7)
    cc: Synced loongarch64 handling with glibc flags (https://github.com/iovisor/bcc/pull/5500, https://github.com/iovisor/bcc/commit/ecb5e5d262dad3f1a613f0c3ebf045bc797f3d6b)
    clang: Added Microsoft extensions build flags (https://github.com/iovisor/bcc/commit/c3f35ecca18b1ce926bd272f60f6d4465656a80b)
    tests/python: Added ARM and AArch64 support to static tracepoints (https://github.com/iovisor/bcc/commit/c8af3e7fb1348bf65c1074ea523380dd59da23f5)
    tests/python: Removed x86-specific naming from tracing header (https://github.com/iovisor/bcc/commit/1afbe3cdbd07a47ad5f5ce6f8bd86397ee7cda07)

* Doc update, other bug fixes and tools improvement