### PR TITLE
Fix `gethostlatency` and `slabratetop` string overread

### DIFF
--- a/libbpf-tools/gethostlatency.bpf.c
+++ b/libbpf-tools/gethostlatency.bpf.c
@@ -39,7 +39,7 @@ static int probe_entry(struct pt_regs *ctx)
 	event.time = bpf_ktime_get_ns();
 	event.pid = pid;
 	bpf_get_current_comm(&event.comm, sizeof(event.comm));
-	bpf_probe_read_user(&event.host, sizeof(event.host), (void *)PT_REGS_PARM1(ctx));
+	bpf_probe_read_user_str(&event.host, sizeof(event.host), (void *)PT_REGS_PARM1(ctx));
 	bpf_map_update_elem(&starts, &tid, &event, BPF_ANY);
 	return 0;
 }

--- a/libbpf-tools/slabratetop.bpf.c
+++ b/libbpf-tools/slabratetop.bpf.c
@@ -35,7 +35,7 @@ static int probe_entry(struct kmem_cache *cachep)
 		valuep = bpf_map_lookup_elem(&slab_entries, &name);
 		if (!valuep)
 			return 0;
-		bpf_probe_read_kernel(&valuep->name, sizeof(valuep->name), name);
+		bpf_probe_read_kernel_str(&valuep->name, sizeof(valuep->name), name);
 	}
 
 	valuep->count++;

--- a/tools/gethostlatency.py
+++ b/tools/gethostlatency.py
@@ -66,7 +66,7 @@ int do_entry(struct pt_regs *ctx) {
     u32 tid = (u32)pid_tgid;
 
     if (bpf_get_current_comm(&val.comm, sizeof(val.comm)) == 0) {
-        bpf_probe_read_user(&val.host, sizeof(val.host),
+        bpf_probe_read_user_str(&val.host, sizeof(val.host),
                        (void *)PT_REGS_PARM1(ctx));
         val.pid = pid;
         val.ts = bpf_ktime_get_ns();

--- a/tools/slabratetop.py
+++ b/tools/slabratetop.py
@@ -186,7 +186,7 @@ int kprobe__kmem_cache_alloc(struct pt_regs *ctx, struct kmem_cache *cachep)
 {
     struct info_t info = {};
     const char *name = cachep->name;
-    bpf_probe_read_kernel(&info.name, sizeof(info.name), name);
+    bpf_probe_read_kernel_str(&info.name, sizeof(info.name), name);
 
     struct val_t *valp, zero = {};
     valp = counts.lookup_or_try_init(&info, &zero);


### PR DESCRIPTION
## Description

`gethostlatency` and `slabratetop` each read a NUL-terminated string with a fixed-size, non-string probe-read helper:

- `gethostlatency` reads the resolved host argument with `bpf_probe_read_user(&event.host, sizeof(event.host), ...)` (80 bytes).
- `slabratetop` reads the slab cache name with `bpf_probe_read_kernel(&valuep->name, sizeof(valuep->name), name)` (32 bytes).

These helpers copy the full destination length regardless of the source string's NUL terminator. For a short string, the bytes after the terminator are filled with adjacent memory and exported to user space through the map value and the perf/output ring. That adjacent memory is user memory of the traced process in `gethostlatency`, and read-only kernel string data in `slabratetop`.

We ran both tools with loaders that read back the emitted map/perf values and observed the leaked trailing bytes past the terminator in each. After switching to the `_str` helpers the trailing bytes are zero.

This PR replaces the raw reads with the NUL-stopping `bpf_probe_read_user_str` / `bpf_probe_read_kernel_str` variants, which copy only the string into the already zero-initialized destination. The fix is applied to both the libbpf-tools sources and the BCC Python tools.

Commits:
- `libbpf-tools/gethostlatency,slabratetop: read strings with bpf_probe_read_*_str`
- `tools/gethostlatency,slabratetop: read strings with bpf_probe_read_*_str`

## Why this approach

The `_str` helpers are the intended API for copying C strings: they stop at the NUL and never read past it, so no adjacent memory can leak into the output. The destination structs are already zero-initialized, so the unwritten tail stays zero and the emitted string is unchanged for normal-length inputs. The only behavioral difference is that trailing bytes past the string are no longer copied. This matches the existing convention in the tree (e.g. `filetop` already uses `bpf_probe_read_kernel_str` for exactly this reason) and is a one-line change per site with no map or ABI changes. Manually bounding the copy with the source length (e.g. tracking `dname.len`) would be more invasive and only re-implements what the `_str` helper already provides.

---

## Checklist

- [x] Commit prefix matches changed area (`libbpf-tools/gethostlatency,slabratetop:` and `tools/gethostlatency,slabratetop:`)
- [x] Commit body explains **why** this change is needed

**For new tools only** (N/A, fixes existing tools, no new tool added)
- [ ] Explains why this tool is needed and what existing tools cannot cover this use case
- [ ] Includes at least one real production use case
- [ ] Man page (`man/man8/`) with an OVERHEAD section
- [ ] Example output file (`*_example.txt`)
- [ ] README.md entry added
- [ ] Smoke test added to `tests/python/test_tools_smoke.py`

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review. If a Copilot review is added, treat its feedback as you would any reviewer comment — you can agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
