### PR TITLE
tools/trace: fix -M/--max-events exceeding the specified limit

### DIFF
--- a/tools/trace.py
+++ b/tools/trace.py
@@ -592,6 +592,8 @@ BPF_PERF_OUTPUT(%s);
                     print("%s-->COUNT %d\n\n" % (k, v), end="")
 
         def print_event(self, bpf, cpu, data, size):
+                if Probe.done:
+                       return
                 event = bpf[self.events_name].event(data)
                 if self.name not in event.comm:
                     return


### PR DESCRIPTION
## Description

When the event count reaches the -M limit, Probe.done is set to True, but remaining events in the current poll continue to be processed because the callback never checks the flag at entry.

This causes -M to be unpredictable and occasionally print many more events than max_events

ex:
```
# sudo /usr/share/bcc/tools/trace -M 50 'c:malloc "size = %d", arg1' | wc -l
491
```
Add an early return at the top of print_event when Probe.done is already set, so events beyond the limit are not printed.

## Why this approach

AFAICT this is the only point to interrupt inbetween individual events and stopping the entirety of the returned events from being printed
---

## Checklist

- [ x] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [x ] Commit body explains **why** this change is needed

**For new tools only**
- [ ] Explains why this tool is needed and what existing tools cannot cover this use case
- [ ] Includes at least one real production use case
- [ ] Man page (`man/man8/`) with an OVERHEAD section
- [ ] Example output file (`*_example.txt`)
- [ ] README.md entry added
- [ ] Smoke test added to `tests/python/test_tools_smoke.py`

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
