### PR TITLE
bcc_zip: Convert zip header fields from little endian to host order

### DIFF
--- a/src/cc/bcc_zip.c
+++ b/src/cc/bcc_zip.c
@@ -16,6 +16,7 @@
 
 #include "bcc_zip.h"
 
+#include <endian.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <stdint.h>
@@ -42,7 +43,7 @@ typedef struct {
 static uint16_t unaligned_uint16_read(unaligned_uint16_t value) {
   uint16_t return_value;
   memcpy(&return_value, value.raw, sizeof(return_value));
-  return return_value;
+  return le16toh(return_value);
 }
 
 typedef struct {
@@ -52,7 +53,7 @@ typedef struct {
 static uint32_t unaligned_uint32_read(unaligned_uint32_t value) {
   uint32_t return_value;
   memcpy(&return_value, value.raw, sizeof(return_value));
-  return return_value;
+  return le32toh(return_value);
 }
 
 #define END_OF_CD_RECORD_MAGIC 0x06054b50


### PR DESCRIPTION
The following bpftrace zip test fails on s390:
bpftrace -e 'uprobe:"./testprogs/archive.zip!/true":main {} begin { exit() }'

This test sets a uprobe on the main function of the true program that is stored in the archive.

The zip file format specs mentions that all multibyte fields (uint16_t and uint32_t) are stored in little endian format. However, the original code in bcc_zip.c was reading these values directly without converting them to the host systems byte order [1] (see sections 4.3.3 and 4.4.1.1)

[1] https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT

Use le16toh() and le32toh() when reading unaligned zip header fields in bcc_zip.c to ensure correct parsing on big endian systems.

Reviewed-by: Ilya Leoshkevich <iii@linux.ibm.com>
Signed-off-by: Sumanth Korikkar <sumanthk@linux.ibm.com>
