### PR TITLE
Fix building with LLVM 23

### DIFF
--- a/src/cc/bcc_debug.cc
+++ b/src/cc/bcc_debug.cc
@@ -148,7 +148,11 @@ void SourceDebugger::dump() {
       T->createMCSubtargetInfo(TripleArg, "", ""));
   MCObjectFileInfo MOFI;
 #if LLVM_VERSION_MAJOR >= 13
+#if LLVM_VERSION_MAJOR >= 23
+  MCContext Ctx(TheTriple, *MAI, *MRI, *STI, nullptr);
+#else
   MCContext Ctx(TheTriple, MAI.get(), MRI.get(), STI.get(), nullptr);
+#endif
   Ctx.setObjectFileInfo(&MOFI);
   MOFI.initMCObjectFileInfo(Ctx, false, false);
 #else


### PR DESCRIPTION
## Description

As usually, new LLVM introduced breaking API changes.

This time, it's just a single breakage for BCC - the `MCContext` constructor now accepts `MCAsmInfo`, `MCRegisterInfo`, and `MCSubtargetInfo` by a reference rather than by a pointer.

## Checklist

- [x] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [x] Commit body explains **why** this change is needed