### PR TITLE
ext4dist: only measure latency for direct writes

### DIFF
--- a/man/man8/ext4dist.8
+++ b/man/man8/ext4dist.8
@@ -12,6 +12,10 @@ Since this works by tracing the ext4_file_operations interface functions, it
 will need updating to match any changes to these functions.
 
 Since this uses BPF, only the root user can use this tool.
+
+Write latency is only measured for synchronous O_DIRECT requests. Buffered
+and asynchronous writes complete after this tool's return probe fires, so
+their true completion latency isn't captured and they are excluded.
 .SH REQUIREMENTS
 CONFIG_BPF and bcc.
 .SH OPTIONS

--- a/tools/ext4dist.py
+++ b/tools/ext4dist.py
@@ -121,6 +121,23 @@ int trace_read_return(struct pt_regs *ctx)
     return trace_return(ctx, op);
 }
 
+// only time synchronous O_DIRECT requests: buffered/async writes complete
+// later than this return, so entry-to-return here isn't real latency (#3719)
+int trace_write_entry(struct pt_regs *ctx, struct kiocb *iocb)
+{
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u32 pid = pid_tgid >> 32;
+    u32 tid = (u32)pid_tgid;
+
+    if (FILTER_PID)
+        return 0;
+    if (!(iocb->ki_flags & IOCB_DIRECT) || iocb->ki_complete)
+        return 0;
+    u64 ts = bpf_ktime_get_ns();
+    start.update(&tid, &ts);
+    return 0;
+}
+
 int trace_write_return(struct pt_regs *ctx)
 {
     char *op = "write";
@@ -202,7 +219,7 @@ if debug or args.ebpf:
 b = BPF(text=bpf_text)
 
 b.attach_kprobe(event=ext4_read_fn, fn_name=ext4_trace_read_fn)
-b.attach_kprobe(event="ext4_file_write_iter", fn_name="trace_entry")
+b.attach_kprobe(event="ext4_file_write_iter", fn_name="trace_write_entry")
 b.attach_kprobe(event="ext4_file_open", fn_name="trace_entry")
 b.attach_kprobe(event="ext4_sync_file", fn_name="trace_entry")
 b.attach_kretprobe(event=ext4_read_fn, fn_name='trace_read_return')

--- a/tools/ext4dist_example.txt
+++ b/tools/ext4dist_example.txt
@@ -4,6 +4,11 @@ Demonstrations of ext4dist, the Linux eBPF/bcc version.
 ext4dist traces ext4 reads, writes, opens, and fsyncs, and summarizes their
 latency as a power-of-2 histogram. For example:
 
+Note: only synchronous O_DIRECT writes are measured. Buffered/asynchronous
+writes (eg, via libaio) complete after this tool's return probe fires, so
+their real completion time isn't captured; including them would show
+misleadingly low latency.
+
 # ./ext4dist
 Tracing ext4 operation latency... Hit Ctrl-C to end.
 ^C
@@ -52,7 +57,8 @@ interface to the file system, to when it completed. This spans everything:
 block device I/O (disk I/O), file system CPU cycles, file system locks, run
 queue latency, etc. This is a better measure of the latency suffered by
 applications reading from the file system than measuring this down at the
-block device interface.
+block device interface. For writes, this only holds for synchronous O_DIRECT
+requests, per the note above.
 
 Note that this only traces the common file system operations previously
 listed: other file system operations (eg, inode operations including


### PR DESCRIPTION
## Description

ext4dist reports fake write latency for async/buffered I/O (the syscall returns before the write actually completes). Fixes #3719.

## Why this approach

Only start the timer for direct writes (`IOCB_DIRECT`); buffered writes have no real completion time to measure. Tested with `dd oflag=direct` vs buffered `dd`, confirmed only direct writes get counted.

## Checklist

- [ ] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [x] Commit body explains **why** this change is needed

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
