### PR TITLE
tools/execsnoop: fix -l matching comm instead of arguments

### DIFF
--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -226,6 +226,25 @@ static void print_args(const struct event *e, bool quote)
 	}
 }
 
+/* Match the joined argument line, mirroring the Python tool's behavior
+ * (b' '.join(argv)): arguments are NUL-separated in the event, so replace
+ * the separators with spaces to allow strstr() to match across argument
+ * boundaries (e.g. -l "a b" matching "echo a b").
+ */
+static bool args_contains_line(const struct event *e, const char *line)
+{
+	char buf[FULL_MAX_ARGS_ARR];
+	int i, n = 0;
+
+	for (i = 0; i < e->args_size && n < (int)sizeof(buf) - 1; i++) {
+		char c = e->args[i];
+		buf[n++] = (c == '\0') ? ' ' : c;
+	}
+	buf[n] = '\0';
+
+	return strstr(buf, line) != NULL;
+}
+
 static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 {
 	const struct event *e = data;
@@ -238,7 +257,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 		return;
 
 	/* TODO: use pcre lib */
-	if (env.line && strstr(e->comm, env.line) == NULL)
+	if (env.line && !args_contains_line(e, env.line))
 		return;
 
 	time(&t);


### PR DESCRIPTION
## What

Fix `execsnoop -l/--line` filtering to match command-line arguments instead of the process name (`comm`).

## Why

The `--help` text documents `-l` as "only print commands where arg contains this line", but the implementation compared against `e->comm` — identical to `-n/--name`. The Python tool (`tools/execsnoop.py`) filters on the joined argument line (`b' '.join(argv)`), so the C/libbpf-tools version is out of sync.

## How

Added `args_contains_line()` in `handle_event`'s filter path: it walks the NUL-separated `args` buffer in the event, replaces separators with spaces (mirroring the Python tool's join behavior), and runs `strstr()`. This allows matching across argument boundaries (e.g. `-l "a b"` matches `echo a b`).

## Test

- `execsnoop -l secret123` while running `bash -c 'echo secret123'` → event shown (comm `bash` does not contain the filter, args do)
- same filter while running `echo no_match_here` → filtered out

Fixes #5486