### PR TITLE
Fix recv throughput calculation in old tcptop and libbpf-tools tcptop…

### DIFF
--- a/libbpf-tools/tcptop.bpf.c
+++ b/libbpf-tools/tcptop.bpf.c
@@ -38,6 +38,30 @@ struct {
 } sockets SEC(".maps");
 
 
+
+static __always_inline bool filter_socket(struct sock *sk)
+{
+	u16 family;
+	u32 pid;
+
+	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
+		return false;
+
+	pid = bpf_get_current_pid_tgid() >> 32;
+	if (target_pid != -1 && target_pid != pid)
+		return false;
+
+	family = BPF_CORE_READ(sk, __sk_common.skc_family);
+	if (target_family != -1 && target_family != family)
+		return false;
+
+	/* drop */
+	if (family != AF_INET && family != AF_INET6)
+		return false;
+
+	return true;
+}
+
 static int probe_ip(bool receiving, struct sock *sk, size_t size)
 {
 	struct ip_key_t ip_key = {};
@@ -45,22 +69,11 @@ static int probe_ip(bool receiving, struct sock *sk, size_t size)
 	u16 family;
 	u32 pid;
 
-	if (filter_cg && !bpf_current_task_under_cgroup(&cgroup_map, 0))
-		return 0;
-
 	pid = bpf_get_current_pid_tgid() >> 32;
-	if (target_pid != -1 && target_pid != pid)
-		return 0;
-
 	family = BPF_CORE_READ(sk, __sk_common.skc_family);
-	if (target_family != -1 && target_family != family)
-		return 0;
-
-	/* drop */
-	if (family != AF_INET && family != AF_INET6)
-		return 0;
 
 	ip_key.pid = pid;
+
 	bpf_get_current_comm(&ip_key.name, sizeof(ip_key.name));
 	ip_key.lport = BPF_CORE_READ(sk, __sk_common.skc_num);
 	ip_key.dport = bpf_ntohs(BPF_CORE_READ(sk, __sk_common.skc_dport));
@@ -114,6 +127,8 @@ static int probe_ip(bool receiving, struct sock *sk, size_t size)
 SEC("kprobe/tcp_sendmsg")
 int BPF_KPROBE(tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size)
 {
+	if (!filter_socket(sk))
+		return 0;
 	return probe_ip(false, sk, size);
 }
 
@@ -121,6 +136,8 @@ int BPF_KPROBE(tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size)
 SEC("kprobe/tcp_recvmsg")
 int BPF_KPROBE(tcp_recvmsg, struct sock *sk, struct msghdr *msg, size_t len)
 {
+	if (!filter_socket(sk))
+		return 0;
 	u32 tid = bpf_get_current_pid_tgid();
 	bpf_map_update_elem(&sockets, &tid, &sk, BPF_ANY);
 	return 0;
@@ -143,5 +160,33 @@ int BPF_KRETPROBE(tcp_recvmsg_ret, int ret)
 	return 0;
 }
 
+
+
+SEC("kprobe/tcp_read_sock")
+int BPF_KPROBE(tcp_read_sock, struct sock *sk)
+{
+	if (!filter_socket(sk))
+		return 0;
+	u32 tid = bpf_get_current_pid_tgid();
+	bpf_map_update_elem(&sockets, &tid, &sk, BPF_ANY);
+	return 0;
+}
+
+SEC("kretprobe/tcp_read_sock")
+int BPF_KRETPROBE(tcp_read_sock_ret, int ret)
+{
+	u32 tid = bpf_get_current_pid_tgid();
+	struct sock **skp;
+
+	skp = bpf_map_lookup_elem(&sockets, &tid);
+	if (!skp)
+		return 0;
+
+	if (ret > 0)
+		probe_ip(true, *skp, ret);
+
+	bpf_map_delete_elem(&sockets, &tid);
+	return 0;
+}
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/tcptop.bpf.c
+++ b/libbpf-tools/tcptop.bpf.c
@@ -30,6 +30,14 @@ struct {
 	__type(value, struct traffic_t);
 } ip_map SEC(".maps");
 
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, u32);
+	__type(value, struct sock *);
+} sockets SEC(".maps");
+
+
 static int probe_ip(bool receiving, struct sock *sk, size_t size)
 {
 	struct ip_key_t ip_key = {};
@@ -109,19 +117,31 @@ int BPF_KPROBE(tcp_sendmsg, struct sock *sk, struct msghdr *msg, size_t size)
 	return probe_ip(false, sk, size);
 }
 
-/*
- * tcp_recvmsg() would be obvious to trace, but is less suitable because:
- * - we'd need to trace both entry and return, to have both sock and size
- * - misses tcp_read_sock() traffic
- * we'd much prefer tracepoints once they are available.
- */
-SEC("kprobe/tcp_cleanup_rbuf")
-int BPF_KPROBE(tcp_cleanup_rbuf, struct sock *sk, int copied)
+
+SEC("kprobe/tcp_recvmsg")
+int BPF_KPROBE(tcp_recvmsg, struct sock *sk, struct msghdr *msg, size_t len)
 {
-	if (copied <= 0)
+	u32 tid = bpf_get_current_pid_tgid();
+	bpf_map_update_elem(&sockets, &tid, &sk, BPF_ANY);
+	return 0;
+}
+
+SEC("kretprobe/tcp_recvmsg")
+int BPF_KRETPROBE(tcp_recvmsg_ret, int ret)
+{
+	u32 tid = bpf_get_current_pid_tgid();
+	struct sock **skp;
+
+	skp = bpf_map_lookup_elem(&sockets, &tid);
+	if (!skp)
 		return 0;
 
-	return probe_ip(true, sk, copied);
+	if (ret > 0)
+		probe_ip(true, *skp, ret);
+
+	bpf_map_delete_elem(&sockets, &tid);
+	return 0;
 }
+
 
 char LICENSE[] SEC("license") = "GPL";

--- a/libbpf-tools/tcptop.c
+++ b/libbpf-tools/tcptop.c
@@ -361,6 +361,11 @@ int main(int argc, char **argv)
 	obj->rodata->target_family = family;
 	obj->rodata->filter_cg = cgroup_filtering;
 
+	if (!kprobe_exists("tcp_read_sock")) {
+		bpf_program__set_autoload(obj->progs.tcp_read_sock, false);
+		bpf_program__set_autoload(obj->progs.tcp_read_sock_ret, false);
+	}
+
 	err = tcptop_bpf__load(obj);
 	if (err) {
 		warn("failed to load BPF object: %d\n", err);

--- a/tools/old/tcptop.py
+++ b/tools/old/tcptop.py
@@ -111,6 +111,7 @@ struct ipv6_key_t {
 BPF_HASH(ipv6_send_bytes, struct ipv6_key_t);
 BPF_HASH(ipv6_recv_bytes, struct ipv6_key_t);
 BPF_HASH(sock_store, u32, struct sock *);
+BPF_HASH(sock_recv, u32, struct sock *);
 
 static int tcp_sendstat(int size)
 {
@@ -189,13 +190,8 @@ int tcp_send_entry(struct pt_regs *ctx, struct sock *sk)
     return 0;
 }
 
-/*
- * tcp_recvmsg() would be obvious to trace, but is less suitable because:
- * - we'd need to trace both entry and return, to have both sock and size
- * - misses tcp_read_sock() traffic
- * we'd much prefer tracepoints once they are available.
- */
-int kprobe__tcp_cleanup_rbuf(struct pt_regs *ctx, struct sock *sk, int copied)
+
+static int tcp_recvstat(int size)
 {
     if (container_should_be_filtered()) {
         return 0;
@@ -203,24 +199,31 @@ int kprobe__tcp_cleanup_rbuf(struct pt_regs *ctx, struct sock *sk, int copied)
 
     u32 pid = bpf_get_current_pid_tgid() >> 32;
     FILTER_PID
-
-    u16 dport = 0, family = sk->__sk_common.skc_family;
-    u64 *val, zero = 0;
-
-    if (copied <= 0)
-        return 0;
-
+    u32 tid = bpf_get_current_pid_tgid();
+    struct sock **sockpp;
+    sockpp = sock_recv.lookup(&tid);
+    if (sockpp == 0) {
+        return 0; //miss the entry
+    }
+    struct sock *sk = *sockpp;
+    u16 dport = 0, family;
+    bpf_probe_read_kernel(&family, sizeof(family),
+        &sk->__sk_common.skc_family);
     FILTER_FAMILY
 
     if (family == AF_INET) {
         struct ipv4_key_t ipv4_key = {.pid = pid};
         bpf_get_current_comm(&ipv4_key.name, sizeof(ipv4_key.name));
-        ipv4_key.saddr = sk->__sk_common.skc_rcv_saddr;
-        ipv4_key.daddr = sk->__sk_common.skc_daddr;
-        ipv4_key.lport = sk->__sk_common.skc_num;
-        dport = sk->__sk_common.skc_dport;
+        bpf_probe_read_kernel(&ipv4_key.saddr, sizeof(ipv4_key.saddr),
+            &sk->__sk_common.skc_rcv_saddr);
+        bpf_probe_read_kernel(&ipv4_key.daddr, sizeof(ipv4_key.daddr),
+            &sk->__sk_common.skc_daddr);
+        bpf_probe_read_kernel(&ipv4_key.lport, sizeof(ipv4_key.lport),
+            &sk->__sk_common.skc_num);
+        bpf_probe_read_kernel(&dport, sizeof(dport),
+            &sk->__sk_common.skc_dport);
         ipv4_key.dport = ntohs(dport);
-        ipv4_recv_bytes.increment(ipv4_key, copied);
+        ipv4_recv_bytes.increment(ipv4_key, size);
 
     } else if (family == AF_INET6) {
         struct ipv6_key_t ipv6_key = {.pid = pid};
@@ -229,15 +232,42 @@ int kprobe__tcp_cleanup_rbuf(struct pt_regs *ctx, struct sock *sk, int copied)
             &sk->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
         bpf_probe_read_kernel(&ipv6_key.daddr, sizeof(ipv6_key.daddr),
             &sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
-        ipv6_key.lport = sk->__sk_common.skc_num;
-        dport = sk->__sk_common.skc_dport;
+        bpf_probe_read_kernel(&ipv6_key.lport, sizeof(ipv6_key.lport),
+            &sk->__sk_common.skc_num);
+        bpf_probe_read_kernel(&dport, sizeof(dport),
+            &sk->__sk_common.skc_dport);
         ipv6_key.dport = ntohs(dport);
-        ipv6_recv_bytes.increment(ipv6_key, copied);
+        ipv6_recv_bytes.increment(ipv6_key, size);
     }
+    sock_recv.delete(&tid);
     // else drop
 
     return 0;
 }
+
+int tcp_recv_ret(struct pt_regs *ctx)
+{
+    int size = PT_REGS_RC(ctx);
+    if (size > 0)
+        return tcp_recvstat(size);
+    else
+        return 0;
+}
+
+int tcp_recv_entry(struct pt_regs *ctx, struct sock *sk)
+{
+    if (container_should_be_filtered()) {
+        return 0;
+    }
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+    FILTER_PID
+    u32 tid = bpf_get_current_pid_tgid();
+    u16 family = sk->__sk_common.skc_family;
+    FILTER_FAMILY
+    sock_recv.update(&tid, &sk);
+    return 0;
+}
+
 """
 
 # code substitutions
@@ -286,6 +316,9 @@ htab_batch_ops = True if BPF.kernel_struct_has_field(b'bpf_map_ops',
 
 b.attach_kprobe(event='tcp_sendmsg', fn_name='tcp_send_entry')
 b.attach_kretprobe(event='tcp_sendmsg', fn_name='tcp_send_ret')
+b.attach_kprobe(event='tcp_recvmsg', fn_name='tcp_recv_entry')
+b.attach_kretprobe(event='tcp_recvmsg', fn_name='tcp_recv_ret')
+
 if BPF.get_kprobe_functions(b'tcp_sendpage'):
     b.attach_kprobe(event='tcp_sendpage', fn_name='tcp_send_entry')
     b.attach_kretprobe(event='tcp_sendpage', fn_name='tcp_send_ret')

--- a/tools/old/tcptop.py
+++ b/tools/old/tcptop.py
@@ -115,12 +115,7 @@ BPF_HASH(sock_recv, u32, struct sock *);
 
 static int tcp_sendstat(int size)
 {
-    if (container_should_be_filtered()) {
-        return 0;
-    }
-
     u32 pid = bpf_get_current_pid_tgid() >> 32;
-    FILTER_PID
     u32 tid = bpf_get_current_pid_tgid();
     struct sock **sockpp;
     sockpp = sock_store.lookup(&tid);
@@ -131,7 +126,6 @@ static int tcp_sendstat(int size)
     u16 dport = 0, family;
     bpf_probe_read_kernel(&family, sizeof(family),
         &sk->__sk_common.skc_family);
-    FILTER_FAMILY
 
     if (family == AF_INET) {
         struct ipv4_key_t ipv4_key = {.pid = pid};
@@ -193,12 +187,7 @@ int tcp_send_entry(struct pt_regs *ctx, struct sock *sk)
 
 static int tcp_recvstat(int size)
 {
-    if (container_should_be_filtered()) {
-        return 0;
-    }
-
     u32 pid = bpf_get_current_pid_tgid() >> 32;
-    FILTER_PID
     u32 tid = bpf_get_current_pid_tgid();
     struct sock **sockpp;
     sockpp = sock_recv.lookup(&tid);
@@ -209,7 +198,6 @@ static int tcp_recvstat(int size)
     u16 dport = 0, family;
     bpf_probe_read_kernel(&family, sizeof(family),
         &sk->__sk_common.skc_family);
-    FILTER_FAMILY
 
     if (family == AF_INET) {
         struct ipv4_key_t ipv4_key = {.pid = pid};
@@ -318,6 +306,9 @@ b.attach_kprobe(event='tcp_sendmsg', fn_name='tcp_send_entry')
 b.attach_kretprobe(event='tcp_sendmsg', fn_name='tcp_send_ret')
 b.attach_kprobe(event='tcp_recvmsg', fn_name='tcp_recv_entry')
 b.attach_kretprobe(event='tcp_recvmsg', fn_name='tcp_recv_ret')
+if BPF.get_kprobe_functions(b'tcp_read_sock'):
+    b.attach_kprobe(event='tcp_read_sock', fn_name='tcp_recv_entry')
+    b.attach_kretprobe(event='tcp_read_sock', fn_name='tcp_recv_ret')
 
 if BPF.get_kprobe_functions(b'tcp_sendpage'):
     b.attach_kprobe(event='tcp_sendpage', fn_name='tcp_send_entry')

--- a/tools/old/tcptop.py
+++ b/tools/old/tcptop.py
@@ -164,10 +164,13 @@ static int tcp_sendstat(int size)
 int tcp_send_ret(struct pt_regs *ctx)
 {
     int size = PT_REGS_RC(ctx);
-    if (size > 0)
+    if (size > 0) {
         return tcp_sendstat(size);
-    else
+    } else {
+        u32 tid = bpf_get_current_pid_tgid();
+        sock_store.delete(&tid);
         return 0;
+    }
 }
 
 int tcp_send_entry(struct pt_regs *ctx, struct sock *sk)
@@ -236,10 +239,13 @@ static int tcp_recvstat(int size)
 int tcp_recv_ret(struct pt_regs *ctx)
 {
     int size = PT_REGS_RC(ctx);
-    if (size > 0)
+    if (size > 0) {
         return tcp_recvstat(size);
-    else
+    } else {
+        u32 tid = bpf_get_current_pid_tgid();
+        sock_recv.delete(&tid);
         return 0;
+    }
 }
 
 int tcp_recv_entry(struct pt_regs *ctx, struct sock *sk)


### PR DESCRIPTION
Fixes #5352

## Description

tcp_cleanup_rbuf is called in a loop inside tcp_recvmsg, which means tracing it and accumulating the 'copied' parameter causes the same data to be counted multiple times, drastically inflating the reported recv throughput. Just clarifying for reviewers: While PR #5375 fixed the tcp_cleanup_rbuf loop bug for the modern Python tool using fentry/fexit, it left the CO-RE C tool (libbpf-tools/tcptop.bpf.c) and the legacy kernel fallback(tools/old/tcptop.py) broken. This PR implements the tcp_recvmsg boundary fix using standard kprobes to resolve the double-counting issue for the C tool and older kernels.

## Why this approach

This commit replaces the kprobes on tcp_cleanup_rbuf with kprobes on tcp_recvmsg entry and return. This mirrors the fix applied to the modern tools/tcptop.py in commit da3a474, preventing the loop amplification and correctly reporting received bytes.

---

## Checklist

- [x] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [x] Commit body explains **why** this change is needed

**For new tools only**
- [ ] Explains why this tool is needed and what existing tools cannot cover this use case
- [ ] Includes at least one real production use case
- [ ] Man page (`man/man8/`) with an OVERHEAD section
- [ ] Example output file (`*_example.txt`)
- [ ] README.md entry added
- [ ] Smoke test added to `tests/python/test_tools_smoke.py`

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
