### PR TITLE
tools/killsnoop: migrate to tracepoints

### DIFF
--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -222,7 +222,7 @@ class SmokeTests(TestCase):
     def test_hardirqs(self):
         self.run_with_duration("hardirqs.py 1 1")
 
-    @skipUnless(kernel_version_ge(4,4), "requires kernel >= 4.4")
+    @skipUnless(kernel_version_ge(4,7), "requires kernel >= 4.7")
     def test_killsnoop(self):
         # Because killsnoop intercepts signals, if we send it a SIGINT we we
         # we likely catch it while it is handling the data packet from the

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -143,8 +143,6 @@ TRACEPOINT_PROBE(syscalls, sys_exit_tgkill)
 {
     return probe_exit(args, args->ret);
 }
-;
-
 
 """
 

--- a/tools/killsnoop.py
+++ b/tools/killsnoop.py
@@ -67,7 +67,8 @@ struct data_t {
 BPF_HASH(infotmp, u32, struct val_t);
 BPF_PERF_OUTPUT(events);
 
-int syscall__kill(struct pt_regs *ctx, int tpid, int sig)
+
+static int probe_entry(u32 tpid, int sig)
 {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
@@ -85,9 +86,24 @@ int syscall__kill(struct pt_regs *ctx, int tpid, int sig)
     }
 
     return 0;
-};
+}
 
-int do_ret_sys_kill(struct pt_regs *ctx)
+TRACEPOINT_PROBE(syscalls, sys_enter_kill)
+{
+    return probe_entry(args->pid, args->sig);
+}
+
+TRACEPOINT_PROBE(syscalls, sys_enter_tkill)
+{
+    return probe_entry(args->pid, args->sig);
+}
+
+TRACEPOINT_PROBE(syscalls, sys_enter_tgkill)
+{
+    return probe_entry(args->pid, args->sig);
+}
+
+static int probe_exit(void *ctx, int ret)
 {
     struct data_t data = {};
     struct val_t *valp;
@@ -104,7 +120,7 @@ int do_ret_sys_kill(struct pt_regs *ctx)
     bpf_probe_read_kernel(&data.comm, sizeof(data.comm), valp->comm);
     data.pid = pid;
     data.tpid = valp->tpid;
-    data.ret = PT_REGS_RC(ctx);
+    data.ret = ret;
     data.sig = valp->sig;
 
     events.perf_submit(ctx, &data, sizeof(data));
@@ -112,6 +128,24 @@ int do_ret_sys_kill(struct pt_regs *ctx)
 
     return 0;
 }
+
+TRACEPOINT_PROBE(syscalls, sys_exit_kill)
+{
+    return probe_exit(args, args->ret);
+}
+
+TRACEPOINT_PROBE(syscalls, sys_exit_tkill)
+{
+    return probe_exit(args, args->ret);
+}
+
+TRACEPOINT_PROBE(syscalls, sys_exit_tgkill)
+{
+    return probe_exit(args, args->ret);
+}
+;
+
+
 """
 
 if args.tpid:
@@ -141,9 +175,6 @@ if debug or args.ebpf:
 
 # initialize BPF
 b = BPF(text=bpf_text)
-kill_fnname = b.get_syscall_fnname("kill")
-b.attach_kprobe(event=kill_fnname, fn_name="syscall__kill")
-b.attach_kretprobe(event=kill_fnname, fn_name="do_ret_sys_kill")
 
 # detect the length of PID column
 pid_bytes = 6


### PR DESCRIPTION
Fixes #3592

This commit updates the python killsnoop tool to use tracepoints for the kill, tkill, and tgkill syscalls. Previously, it used kprobes on sys_kill, which broke on Linux 5.11 due to kernel changes. This brings the python tool in parity with the libbpf-tools C version (sigsnoop), providing a more robust and stable tracing mechanism.

 ## Description
    Fixes #3592.

    This PR migrates the Python `tools/killsnoop.py` script from using `kprobes` to using
  `tracepoints`.

    Previously, the tool relied on kprobing `sys_kill`. Starting with Linux 5.11,
  architectural changes to syscall wrappers caused this kprobe approach to fail. This PR
  removes the fragile kprobe logic and replaces it with robust `TRACEPOINT_PROBE` macros for
  `syscalls:sys_enter_kill`, `tkill`, and `tgkill` (and their respective `sys_exit`
  counterparts).

## Why this approach
    Tracepoints provide a stable, kernel-maintained ABI for tracing syscalls that is immune
  to the underlying function renaming and `pt_regs` mapping changes that break kprobes.

    Additionally, the `libbpf-tools` C equivalent (`sigsnoop`) had already successfully
  migrated to this exact tracepoint approach, but the original Python tool was left behind.
  This PR brings the Python implementation back into parity and restores its functionality on
  all modern kernels.

---

## Checklist

- [x] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [x] Commit body explains **why** this change is needed

**For new tools only**
- [ ] Explains why this tool is needed and what existing tools cannot cover this use case
- [ ] Includes at least one real production use case
- [ ] Man page (`man/man8/`) with an OVERHEAD section
- [ ] Example output file (`*_example.txt`)
- [ ] README.md entry added
- [ ] Smoke test added to `tests/python/test_tools_smoke.py`

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
