### PR TITLE
tools/filewatch: add VFS file access tracer with process ancestry

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ pair of .c and .py files, and some are directories of files.
 - tools/[filegone](tools/filegone.py): Trace why file gone (deleted or renamed). [Examples](tools/filegone_example.txt).
 - tools/[fileslower](tools/fileslower.py): Trace slow synchronous file reads and writes. [Examples](tools/fileslower_example.txt).
 - tools/[filetop](tools/filetop.py): File reads and writes by filename and process. Top for files. [Examples](tools/filetop_example.txt).
+- tools/[filewatch](tools/filewatch.py): Watch a file or directory tree for VFS access and dump process ancestry. [Examples](tools/filewatch_example.txt).
 - tools/[mdflush](tools/mdflush.py): Trace md flush events. [Examples](tools/mdflush_example.txt).
 - tools/[mountsnoop](tools/mountsnoop.py): Trace mount and umount syscalls system-wide. [Examples](tools/mountsnoop_example.txt).
 - tools/[virtiostat](tools/virtiostat.py): Show VIRTIO device IO statistics. [Examples](tools/virtiostat_example.txt).

--- a/man/man8/filewatch.8
+++ b/man/man8/filewatch.8
@@ -1,0 +1,142 @@
+.TH filewatch 8 "2026-08-26" "USER COMMANDS"
+.SH NAME
+filewatch \- Watch a file or directory tree for VFS access and dump process
+ancestry. Uses Linux eBPF/bcc.
+.SH SYNOPSIS
+.B filewatch [\-h] [\-r] [\-w] [\-m] [\-c] [\-u] [\-a] [\-k] [\-d SEC] [\-\-ebpf] path
+.SH DESCRIPTION
+filewatch traces VFS reads, writes, metadata changes, file/directory
+creation, and file/directory deletion on a single file or an entire
+directory tree.  For every event it prints the operation type, the
+affected filename with its full path, the triggering user, and the
+complete process ancestry with command lines.
+
+It is filesystem\-agnostic: because it hooks the VFS layer (vfs_read,
+vfs_write, notify_change, security_inode_create, security_inode_unlink,
+security_inode_mkdir, security_inode_rmdir), it works on ext4, btrfs,
+ZFS (OpenZFS), VxFS, XFS, tmpfs, NFS, and any other filesystem that
+goes through VFS.
+
+Target matching uses inode + device number, making it immune to bind
+mounts, hardlinks, and relative\-path tricks.  When pointed at a
+directory, the BPF probe walks the dentry parent chain in\-kernel so
+files at any depth are caught.
+
+The caller's command line is captured inside the BPF probe via
+mm\->arg_start, so even a short\-lived "bash \-c '...'" that exits
+right after the I/O is fully recorded.  Parent process command lines
+are enriched from /proc in userspace (they are long\-lived: sshd,
+systemd, crond, ansible, ...).
+
+If the target is a file and it is unlinked, filewatch prints the
+UNLINK event and exits cleanly.  If the target path does not exist,
+filewatch watches the parent directory for creation of that name.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bcc.  Kernel >= 5.12 recommended (for mnt_idmap
+notify_change signature).
+.SH OPTIONS
+.TP
+\-h
+Print usage message.
+.TP
+\-r, \-\-reads
+Trace reads (vfs_read / vfs_readv).
+.TP
+\-w, \-\-writes
+Trace writes (vfs_write / vfs_writev).  This is the default if no
+mode flags are specified.
+.TP
+\-m, \-\-meta
+Trace metadata changes: touch, chmod, chown, truncate (notify_change).
+.TP
+\-c, \-\-create
+Trace file and directory creation (directory mode only).
+.TP
+\-u, \-\-unlink
+Trace file deletion (unlink) and directory removal (rmdir).
+.TP
+\-a, \-\-all
+Enable all trace modes: reads + writes + metadata + create + unlink.
+.TP
+\-d SEC, \-\-debounce SEC
+Minimum seconds between reports for the same PID + operation type.
+Default is 0 (report every event).  Useful for suppressing bursts
+from programs that write in tight loops.
+.TP
+\-k, \-\-kstack
+Capture and display kernel stack traces for each event.
+.TP
+\-\-ebpf
+Print the BPF C source and exit (for debugging).
+.SH EXAMPLES
+.TP
+Watch a single file for writes (default):
+#
+.B filewatch /etc/fstab
+.TP
+Watch an entire directory tree for reads and writes:
+#
+.B filewatch \-rw /etc/
+.TP
+Watch for metadata changes on a file:
+#
+.B filewatch \-m /etc/passwd
+.TP
+Watch for file creation in a directory:
+#
+.B filewatch \-c /tmp/
+.TP
+Watch for file deletion:
+#
+.B filewatch \-u /etc/hosts
+.TP
+Trace everything with kernel stacks:
+#
+.B filewatch \-ak /etc/
+.TP
+Wait for a non\-existent file to be created:
+#
+.B filewatch \-a /tmp/file_not_yet_created.txt
+.TP
+Debounce writes at 1 second per PID:
+#
+.B filewatch \-w /var/log/messages \-d 1.0
+.SH OUTPUT
+Each event prints a separator line followed by a header showing the
+operation type (READ, WRITE, META, CREATE, UNLINK), a timestamp, the
+filename, and the user.  For reads and writes, the byte count is shown.
+For metadata changes, the changed attributes are decoded (MODE, UID,
+MTIME, etc.).
+
+Below the header, the full path from the filesystem root is displayed,
+followed by the process tree from the caller up to init (PID 1).  The
+caller (first entry, marked with >>>) includes its full command line
+captured in\-kernel.  Parent processes show command lines and executable
+paths read from /proc.
+
+If \-k is given, the kernel stack trace is appended after the process
+tree.
+.SH OVERHEAD
+This traces VFS read/write entry points, notify_change, and LSM hooks.
+On a quiet system the overhead is negligible.  On a system with heavy
+I/O to the watched path, the per\-event perf_submit and userspace
+/proc reads may become measurable.  Use \-d (debounce) to reduce
+output volume in high\-throughput scenarios, or narrow the scope to a
+single file rather than a large directory tree.
+.PP
+This is from bcc.
+.IP
+https://github.com/iovisor/bcc
+.PP
+Also look in the bcc distribution for a companion _examples.txt file
+containing example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable \- in development.
+.SH AUTHOR
+Vincent S. Cojot
+.SH SEE ALSO
+filelife(8), fileslower(8), filetop(8), opensnoop(8)

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -203,6 +203,10 @@ class SmokeTests(TestCase):
     def test_filetop(self):
         self.run_with_duration("filetop.py 1 1")
 
+    @skipUnless(kernel_version_ge(5,12), "requires kernel >= 5.12")
+    def test_filewatch(self):
+        self.run_with_int("filewatch.py /tmp")
+
     def test_funccount(self):
         self.run_with_int("funccount.py __kmalloc_noprof -i 1")
 

--- a/tools/filewatch.py
+++ b/tools/filewatch.py
@@ -1,0 +1,922 @@
+#!/usr/bin/python3
+# @lint-avoid-python-3-compatibility-imports
+#
+# filewatch    Watch a file or directory tree for VFS reads, writes,
+#              metadata changes, creation, and deletion, then dump
+#              the full process ancestry with command lines.
+#              For Linux, uses BCC, eBPF. Embedded C.
+#
+# Filesystem-agnostic: hooks the VFS layer, so it works on ext4,
+# btrfs, ZFS (OpenZFS), VxFS, XFS, tmpfs, NFS, ...
+#
+# Matches by inode+device -- immune to bind mounts, hardlinks, and
+# relative-path tricks.  When pointed at a directory, walks the
+# dentry parent chain in-kernel so files at any depth are caught.
+#
+# The caller's own cmdline is captured inside the BPF probe
+# (via mm->arg_start), so even a short-lived "bash -c '...'" that
+# exits right after the I/O is fully recorded.  Parent processes
+# are enriched from /proc in userspace.
+#
+# USAGE: filewatch [-h] [-r] [-w] [-m] [-c] [-u] [-a] [-k]
+#                  [-d SEC] [--ebpf] path
+#
+# Copyright (c) 2026 Vincent S. Cojot.
+# Licensed under the Apache License, Version 2.0 (the "License")
+#
+# 26-Aug-2026   Vincent S. Cojot   Created this.
+
+from __future__ import print_function
+from bcc import BPF
+import argparse
+import ctypes as ct
+import os
+import pwd
+import re
+import stat
+import sys
+import time
+
+MAX_ANCESTORS = 20
+MAX_DIR_DEPTH = 24
+MAX_PATH_COMP = 8
+PATH_COMP_LEN = 48
+
+# ── BPF C program ───────────────────────────────────────────────────
+bpf_text = r"""
+#include <uapi/linux/ptrace.h>
+#include <linux/build_bug.h>
+
+/* Kernel 7.x has static_assert checks in fs.h that fail under   */
+/* BCC Clang.  Override after build_bug.h sets its include guard. */
+#undef static_assert
+#define static_assert(expr, ...)
+
+#include <linux/fs.h>
+#include <linux/sched.h>
+#include <linux/mm_types.h>
+
+struct iovec;  /* forward-decl avoids -Wvisibility in readv/writev */
+
+#define MAX_ANCESTORS  MAXANC_PLACEHOLDER
+#define MAX_DIR_DEPTH  MAXDIRDEPTH_PLACEHOLDER
+#define MAX_PATH_COMP  8
+#define PATH_COMP_LEN  48
+
+#define OP_READ   1
+#define OP_WRITE  2
+#define OP_META   3
+#define OP_CREATE 4
+#define OP_DELETE 5
+
+struct ancestor_t {
+    u32 tgid;
+    char comm[TASK_COMM_LEN];
+};
+
+struct event_t {
+    u64  ts_ns;
+    u32  pid;
+    u32  tid;
+    u32  uid;
+    u64  bytes;           /* byte count for r/w, ia_valid for meta */
+    u8   op;
+    u32  depth;
+    char fname[64];
+    char dirpath[64];
+    char caller_cmdline[256];
+    struct ancestor_t chain[MAX_ANCESTORS];
+    int kstack_id;
+    u32 npath;
+    char fpath[MAX_PATH_COMP][PATH_COMP_LEN];
+};
+
+BPF_PERF_OUTPUT(events);
+BPF_PERCPU_ARRAY(heap, struct event_t, 1);
+STACK_TABLE_PLACEHOLDER
+
+/* ── match target by inode+dev ─────────────────────────────────── */
+static __always_inline int
+check_match(struct dentry *dentry)
+{
+    MATCH_CHECK_PLACEHOLDER
+}
+
+/* ── fill common event fields ──────────────────────────────────── */
+static __always_inline void
+fill_event(struct event_t *event, struct dentry *de, u8 op)
+{
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    event->pid   = pid_tgid >> 32;
+    event->tid   = (u32)pid_tgid;
+    event->uid   = bpf_get_current_uid_gid() & 0xFFFFFFFF;
+    event->op    = op;
+    event->ts_ns = bpf_ktime_get_ns();
+
+    bpf_probe_read_kernel_str(&event->fname, sizeof(event->fname),
+                              de->d_name.name);
+
+    struct dentry *pde = de->d_parent;
+    if (pde && pde != de)
+        bpf_probe_read_kernel_str(&event->dirpath,
+                                  sizeof(event->dirpath),
+                                  pde->d_name.name);
+
+    /* --- caller cmdline, captured in-kernel (race-free) ---------- */
+    struct task_struct *curr =
+        (struct task_struct *)bpf_get_current_task();
+    struct mm_struct *mm = NULL;
+    bpf_probe_read_kernel(&mm, sizeof(mm), &curr->mm);
+    if (mm) {
+        unsigned long arg_start = 0, arg_end = 0;
+        bpf_probe_read_kernel(&arg_start, sizeof(arg_start),
+                              &mm->arg_start);
+        bpf_probe_read_kernel(&arg_end, sizeof(arg_end),
+                              &mm->arg_end);
+        long len = arg_end - arg_start;
+        if (len > 0) {
+            if (len > (long)sizeof(event->caller_cmdline) - 1)
+                len = sizeof(event->caller_cmdline) - 1;
+            bpf_probe_read_user(event->caller_cmdline, len,
+                                (void *)arg_start);
+        }
+    }
+
+    /* --- walk process ancestry ----------------------------------- */
+    struct task_struct *task = curr;
+    int done = 0;
+    #pragma unroll
+    for (int i = 0; i < MAX_ANCESTORS; i++) {
+        if (!done && task) {
+            event->chain[i].tgid = task->tgid;
+            bpf_probe_read_kernel_str(
+                &event->chain[i].comm,
+                sizeof(event->chain[i].comm),
+                task->comm);
+            event->depth = i + 1;
+            if (task->tgid <= 1) {
+                done = 1;
+            } else {
+                bpf_probe_read_kernel(&task, sizeof(task),
+                                      &task->real_parent);
+            }
+        }
+    }
+
+    /* --- walk dentry chain for full path (child -> root) ---------- */
+    struct dentry *_walk = de;
+    int _wdone = 0;
+    #pragma unroll
+    for (int _i = 0; _i < MAX_PATH_COMP; _i++) {
+        if (!_wdone && _walk) {
+            bpf_probe_read_kernel_str(
+                &event->fpath[_i], PATH_COMP_LEN,
+                _walk->d_name.name);
+            event->npath = _i + 1;
+            struct dentry *_wp = _walk->d_parent;
+            if (_wp == _walk) {
+                _wdone = 1;
+            } else {
+                _walk = _wp;
+            }
+        }
+    }
+}
+
+/* ── data read/write path ────────────────────────────────────────── */
+static __always_inline int
+do_trace(struct pt_regs *ctx, struct file *file, u64 count, u8 op)
+{
+    struct dentry *de = file->f_path.dentry;
+    if (!check_match(de))
+        return 0;
+
+    int zero = 0;
+    struct event_t *event = heap.lookup(&zero);
+    if (!event)
+        return 0;
+    event->fname[0] = '\0';
+    event->dirpath[0] = '\0';
+    event->caller_cmdline[0] = '\0';
+    event->depth = 0;
+    event->npath = 0;
+    event->kstack_id = -1;
+
+    event->bytes = count;
+    fill_event(event, de, op);
+    STACK_CAPTURE_PLACEHOLDER
+    events.perf_submit(ctx, event, sizeof(*event));
+    return 0;
+}
+
+/* ── metadata path (notify_change) ───────────────────────────────── */
+static __always_inline int
+do_trace_meta(struct pt_regs *ctx, struct dentry *dentry,
+              unsigned int ia_valid)
+{
+    if (!check_match(dentry))
+        return 0;
+
+    int zero = 0;
+    struct event_t *event = heap.lookup(&zero);
+    if (!event)
+        return 0;
+    event->fname[0] = '\0';
+    event->dirpath[0] = '\0';
+    event->caller_cmdline[0] = '\0';
+    event->depth = 0;
+    event->npath = 0;
+    event->kstack_id = -1;
+
+    event->bytes = (u64)ia_valid;
+    fill_event(event, dentry, OP_META);
+    STACK_CAPTURE_PLACEHOLDER
+    events.perf_submit(ctx, event, sizeof(*event));
+    return 0;
+}
+
+/* ── read probes ─────────────────────────────────────────────────── */
+
+int trace_vfs_read(struct pt_regs *ctx, struct file *file,
+                   char __user *buf, size_t count)
+{
+    return do_trace(ctx, file, (u64)count, OP_READ);
+}
+
+int trace_vfs_readv(struct pt_regs *ctx, struct file *file,
+                    const struct iovec __user *vec,
+                    unsigned long vlen)
+{
+    return do_trace(ctx, file, (u64)vlen, OP_READ);
+}
+
+/* ── write probes ────────────────────────────────────────────────── */
+
+int trace_vfs_write(struct pt_regs *ctx, struct file *file,
+                    char __user *buf, size_t count)
+{
+    return do_trace(ctx, file, (u64)count, OP_WRITE);
+}
+
+int trace_vfs_writev(struct pt_regs *ctx, struct file *file,
+                     const struct iovec __user *vec,
+                     unsigned long vlen)
+{
+    return do_trace(ctx, file, (u64)vlen, OP_WRITE);
+}
+
+/* ── metadata probe (touch, chmod, chown, truncate) ──────────────── */
+
+int trace_notify_change(struct pt_regs *ctx)
+{
+    struct dentry *dentry =
+        (struct dentry *)NOTIFY_PARM_DENTRY_PLACEHOLDER(ctx);
+    struct iattr *attr =
+        (struct iattr *)NOTIFY_PARM_ATTR_PLACEHOLDER(ctx);
+    unsigned int ia_valid = attr->ia_valid;
+    return do_trace_meta(ctx, dentry, ia_valid);
+}
+
+/* ── lifecycle match (creation: dentry->d_inode is NULL) ─────────── */
+static __always_inline int
+check_match_create(struct dentry *dentry)
+{
+    MATCH_CREATE_CHECK_PLACEHOLDER
+}
+
+/* ── lifecycle path (create / delete) ────────────────────────────── */
+static __always_inline int
+do_trace_lifecycle(struct pt_regs *ctx, struct dentry *dentry, u8 op)
+{
+    if (op == OP_CREATE) {
+        if (!check_match_create(dentry))
+            return 0;
+    } else {
+        if (!check_match(dentry))
+            return 0;
+    }
+
+    int zero = 0;
+    struct event_t *event = heap.lookup(&zero);
+    if (!event)
+        return 0;
+    event->fname[0] = '\0';
+    event->dirpath[0] = '\0';
+    event->caller_cmdline[0] = '\0';
+    event->depth = 0;
+    event->npath = 0;
+    event->kstack_id = -1;
+
+    event->bytes = 0;
+    fill_event(event, dentry, op);
+    STACK_CAPTURE_PLACEHOLDER
+    events.perf_submit(ctx, event, sizeof(*event));
+    return 0;
+}
+
+/* ── create probe (security_inode_create) ─────────────────────────── */
+
+int trace_security_create(struct pt_regs *ctx)
+{
+    struct dentry *dentry =
+        (struct dentry *)PT_REGS_PARM2(ctx);
+    return do_trace_lifecycle(ctx, dentry, OP_CREATE);
+}
+
+/* ── delete probe (security_inode_unlink) ─────────────────────────── */
+
+int trace_security_unlink(struct pt_regs *ctx)
+{
+    struct dentry *dentry =
+        (struct dentry *)PT_REGS_PARM2(ctx);
+    return do_trace_lifecycle(ctx, dentry, OP_DELETE);
+}
+
+/* ── mkdir probe (security_inode_mkdir) ───────────────────────────── */
+
+int trace_security_mkdir(struct pt_regs *ctx)
+{
+    struct dentry *dentry =
+        (struct dentry *)PT_REGS_PARM2(ctx);
+    return do_trace_lifecycle(ctx, dentry, OP_CREATE);
+}
+
+/* ── rmdir probe (security_inode_rmdir) ───────────────────────────── */
+
+int trace_security_rmdir(struct pt_regs *ctx)
+{
+    struct dentry *dentry =
+        (struct dentry *)PT_REGS_PARM2(ctx);
+    return do_trace_lifecycle(ctx, dentry, OP_DELETE);
+}
+"""
+
+# ── match-check C fragments ────────────────────────────────────────
+# Injected into check_match().  Must "return 0" on miss, "return 1"
+# on hit.
+
+MATCH_FILE = r"""
+    u64 _ino = dentry->d_inode->i_ino;
+    dev_t _dev = dentry->d_inode->i_sb->s_dev;
+    if (_ino != TARGET_INO_PLACEHOLDER ||
+        _dev != TARGET_DEV_PLACEHOLDER)
+        return 0;
+    return 1;
+"""
+
+MATCH_DIR = r"""
+    dev_t _dev = dentry->d_inode->i_sb->s_dev;
+    if (_dev != TARGET_DEV_PLACEHOLDER)
+        return 0;
+    struct dentry *_d = dentry;
+    int _matched = 0;
+    #pragma unroll
+    for (int _i = 0; _i < MAX_DIR_DEPTH; _i++) {
+        if (!_matched && _d) {
+            if (_d->d_inode->i_ino == TARGET_INO_PLACEHOLDER) {
+                _matched = 1;
+            } else {
+                struct dentry *_p = _d->d_parent;
+                if (_p == _d)
+                    _matched = -1;
+                _d = _p;
+            }
+        }
+    }
+    return (_matched == 1) ? 1 : 0;
+"""
+
+MATCH_FILE_CREATE = r"""
+    /* Single-file mode: creation events not applicable. */
+    return 0;
+"""
+
+MATCH_DIR_CREATE = r"""
+    /* For creation, dentry->d_inode is NULL -- walk from parent. */
+    struct dentry *_parent = dentry->d_parent;
+    if (!_parent) return 0;
+    dev_t _dev = _parent->d_inode->i_sb->s_dev;
+    if (_dev != TARGET_DEV_PLACEHOLDER)
+        return 0;
+    struct dentry *_d = _parent;
+    int _matched = 0;
+    #pragma unroll
+    for (int _i = 0; _i < MAX_DIR_DEPTH; _i++) {
+        if (!_matched && _d) {
+            if (_d->d_inode->i_ino == TARGET_INO_PLACEHOLDER) {
+                _matched = 1;
+            } else {
+                struct dentry *_p = _d->d_parent;
+                if (_p == _d)
+                    _matched = -1;
+                _d = _p;
+            }
+        }
+    }
+    return (_matched == 1) ? 1 : 0;
+"""
+
+# ── constants ───────────────────────────────────────────────────────
+OP_READ   = 1
+OP_WRITE  = 2
+OP_META   = 3
+OP_CREATE = 4
+OP_DELETE = 5
+OP_LABEL = {
+    OP_READ: "READ", OP_WRITE: "WRITE", OP_META: "META",
+    OP_CREATE: "CREATE", OP_DELETE: "UNLINK",
+}
+
+TASK_COMM_LEN = 16
+
+ATTR_FLAGS = [
+    (0x0001, "MODE"),       # chmod
+    (0x0002, "UID"),        # chown
+    (0x0004, "GID"),        # chgrp
+    (0x0008, "SIZE"),       # truncate
+    (0x0010, "ATIME"),      # access time
+    (0x0020, "MTIME"),      # modification time
+    (0x0040, "CTIME"),      # change time
+    (0x0080, "ATIME_SET"),  # utimes (explicit)
+    (0x0100, "MTIME_SET"),  # utimes (explicit)
+]
+
+
+# Manual ctypes layout -- BCC can't auto-detect struct arrays.
+class AncestorT(ct.Structure):
+    _fields_ = [
+        ("tgid", ct.c_uint32),
+        ("comm", ct.c_char * TASK_COMM_LEN),
+    ]
+
+
+class EventT(ct.Structure):
+    _fields_ = [
+        ("ts_ns",           ct.c_uint64),
+        ("pid",             ct.c_uint32),
+        ("tid",             ct.c_uint32),
+        ("uid",             ct.c_uint32),
+        ("bytes",           ct.c_uint64),
+        ("op",              ct.c_uint8),
+        ("depth",           ct.c_uint32),
+        ("fname",           ct.c_char * 64),
+        ("dirpath",         ct.c_char * 64),
+        ("caller_cmdline",  ct.c_char * 256),
+        ("chain",           AncestorT * MAX_ANCESTORS),
+        ("kstack_id",       ct.c_int32),
+        ("npath",           ct.c_uint32),
+        ("fpath",           (ct.c_char * PATH_COMP_LEN)
+                            * MAX_PATH_COMP),
+    ]
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+def _kernel_version():
+    """Return (major, minor) from uname release string."""
+    m = re.match(r"(\d+)\.(\d+)", os.uname().release)
+    return (int(m.group(1)), int(m.group(2))) if m else (0, 0)
+
+
+def _resolve_sb_dev(path):
+    """Return (major, minor) of the superblock device for *path*.
+
+    Filesystems like btrfs and ZFS override stat()->st_dev to a
+    per-subvolume anonymous device, which differs from the kernel's
+    i_sb->s_dev.  /proc/self/mountinfo always reports s_dev, so we
+    parse that to get the value the BPF probe will see.
+    """
+    abs_path = os.path.realpath(path)
+    best_mount = ""
+    best_major = -1
+    best_minor = -1
+    try:
+        with open("/proc/self/mountinfo") as f:
+            for line in f:
+                parts = line.split()
+                mount_point = parts[4]
+                if mount_point == "/":
+                    matches = abs_path.startswith("/")
+                else:
+                    matches = (abs_path == mount_point or
+                               abs_path.startswith(mount_point + "/"))
+                if matches and len(mount_point) > len(best_mount):
+                    best_mount = mount_point
+                    maj, mn = parts[2].split(":")
+                    best_major, best_minor = int(maj), int(mn)
+    except (OSError, ValueError, IndexError):
+        pass
+    if best_major < 0:
+        st = os.stat(path)
+        best_major = os.major(st.st_dev)
+        best_minor = os.minor(st.st_dev)
+    return best_major, best_minor
+
+
+def decode_ia_valid(val):
+    """Decode an iattr ia_valid bitmask to human-readable labels."""
+    parts = []
+    for mask, name in ATTR_FLAGS:
+        if val & mask:
+            parts.append(name)
+    return "|".join(parts) if parts else "0x%x" % val
+
+
+def read_proc(pid, entry):
+    """Read /proc/PID/{cmdline,exe,cwd}.  Returns None on failure."""
+    try:
+        if entry == "cmdline":
+            with open("/proc/%d/cmdline" % pid, "rb") as f:
+                raw = f.read()
+                if not raw:
+                    return None
+                return (raw.replace(b"\0", b" ")
+                        .decode("utf-8", "replace").strip()) or None
+        else:
+            return os.readlink("/proc/%d/%s" % (pid, entry))
+    except (FileNotFoundError, PermissionError,
+            ProcessLookupError, OSError):
+        return None
+
+
+def uid_to_name(uid):
+    try:
+        return pwd.getpwuid(uid).pw_name
+    except KeyError:
+        return str(uid)
+
+
+def build_bpf(target_ino, target_dev, dir_mode, want_stacks):
+    """Substitute placeholders in the BPF C source."""
+    src = bpf_text
+
+    src = src.replace("MAXANC_PLACEHOLDER", str(MAX_ANCESTORS))
+    src = src.replace("MAXDIRDEPTH_PLACEHOLDER", str(MAX_DIR_DEPTH))
+
+    src = src.replace("TARGET_INO_PLACEHOLDER", str(target_ino))
+    src = src.replace("TARGET_DEV_PLACEHOLDER", str(target_dev))
+
+    match_code = MATCH_DIR if dir_mode else MATCH_FILE
+    match_code = match_code.replace(
+        "TARGET_INO_PLACEHOLDER", str(target_ino))
+    match_code = match_code.replace(
+        "TARGET_DEV_PLACEHOLDER", str(target_dev))
+    src = src.replace("MATCH_CHECK_PLACEHOLDER", match_code)
+
+    match_create = MATCH_DIR_CREATE if dir_mode else MATCH_FILE_CREATE
+    match_create = match_create.replace(
+        "TARGET_INO_PLACEHOLDER", str(target_ino))
+    match_create = match_create.replace(
+        "TARGET_DEV_PLACEHOLDER", str(target_dev))
+    src = src.replace("MATCH_CREATE_CHECK_PLACEHOLDER", match_create)
+
+    kver = _kernel_version()
+    if kver >= (5, 12):
+        src = src.replace("NOTIFY_PARM_DENTRY_PLACEHOLDER",
+                          "PT_REGS_PARM2")
+        src = src.replace("NOTIFY_PARM_ATTR_PLACEHOLDER",
+                          "PT_REGS_PARM3")
+    else:
+        src = src.replace("NOTIFY_PARM_DENTRY_PLACEHOLDER",
+                          "PT_REGS_PARM1")
+        src = src.replace("NOTIFY_PARM_ATTR_PLACEHOLDER",
+                          "PT_REGS_PARM2")
+
+    if want_stacks:
+        src = src.replace(
+            "STACK_TABLE_PLACEHOLDER",
+            "BPF_STACK_TRACE(stack_traces, 1024);")
+        src = src.replace(
+            "STACK_CAPTURE_PLACEHOLDER",
+            "event->kstack_id = stack_traces.get_stackid("
+            "ctx, BPF_F_REUSE_STACKID);")
+    else:
+        src = src.replace("STACK_TABLE_PLACEHOLDER", "")
+        src = src.replace("STACK_CAPTURE_PLACEHOLDER", "")
+
+    return src
+
+
+# ── argument parsing ────────────────────────────────────────────────
+examples = """examples:
+    ./filewatch /etc/fstab            # watch one file (writes)
+    ./filewatch /etc/                 # watch entire /etc/ tree
+    ./filewatch -rw /etc/             # reads + writes, tree
+    ./filewatch -r  /etc/shadow       # reads only, one file
+    ./filewatch -m  /etc/passwd       # metadata (touch/chmod/...)
+    ./filewatch -c  /tmp/             # creation only (dir mode)
+    ./filewatch -u  /etc/hosts        # unlink only
+    ./filewatch -a  /etc/             # all: r+w+m+create+unlink
+    ./filewatch -w  /path -d 1.0      # writes, debounce 1s
+    ./filewatch -rwk /etc/hosts       # include kernel stacks
+"""
+
+parser = argparse.ArgumentParser(
+    description="Watch a file or directory tree for VFS access and "
+    "dump the full process ancestry with command lines.  Works on "
+    "any filesystem (ext4, btrfs, ZFS, VxFS, XFS, NFS, ...).",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=examples)
+parser.add_argument("path",
+    help="file or directory to watch (directories are recursive)")
+parser.add_argument("-r", "--reads", action="store_true",
+    help="trace reads (vfs_read / vfs_readv)")
+parser.add_argument("-w", "--writes", action="store_true",
+    help="trace writes (vfs_write / vfs_writev)")
+parser.add_argument("-m", "--meta", action="store_true",
+    help="trace metadata changes: touch, chmod, chown, truncate")
+parser.add_argument("-c", "--create", action="store_true",
+    help="trace file/directory creation (directory mode only)")
+parser.add_argument("-u", "--unlink", action="store_true",
+    help="trace file/directory deletion (unlink/rmdir)")
+parser.add_argument("-a", "--all", action="store_true",
+    help="trace everything: reads + writes + metadata + create "
+         "+ unlink")
+parser.add_argument("-d", "--debounce", type=float, default=0.0,
+    metavar="SEC",
+    help="minimum seconds between reports for same PID+op "
+         "(default: 0 = every event)")
+parser.add_argument("-k", "--kstack", action="store_true",
+    help="capture and display kernel stack traces")
+parser.add_argument("--ebpf", action="store_true",
+    help=argparse.SUPPRESS)
+args = parser.parse_args()
+
+if args.all:
+    args.reads = args.writes = args.meta = True
+    args.create = args.unlink = True
+if (not args.reads and not args.writes and not args.meta
+        and not args.create and not args.unlink):
+    args.writes = True
+
+if os.geteuid() != 0:
+    print("error: must be run as root (for BPF)", file=sys.stderr)
+    exit(1)
+
+filter_name = None
+try:
+    st = os.stat(args.path)
+except FileNotFoundError:
+    parent = os.path.dirname(os.path.abspath(args.path))
+    basename = os.path.basename(os.path.abspath(args.path))
+    try:
+        st = os.stat(parent)
+    except (FileNotFoundError, PermissionError):
+        print("error: %s: not found and parent dir "
+              "does not exist" % args.path, file=sys.stderr)
+        exit(1)
+    if not stat.S_ISDIR(st.st_mode):
+        print("error: %s: not found" % args.path, file=sys.stderr)
+        exit(1)
+    args.path = parent
+    args.create = True
+    filter_name = basename
+except PermissionError:
+    print("error: %s: permission denied" % args.path,
+          file=sys.stderr)
+    exit(1)
+
+dir_mode = stat.S_ISDIR(st.st_mode)
+
+if args.create and not dir_mode:
+    print("  *** -c/--create ignored for file targets "
+          "(use a directory for creation tracing) ***",
+          file=sys.stderr)
+    args.create = False
+
+target_ino = st.st_ino
+st_major, st_minor = _resolve_sb_dev(args.path)
+target_dev = (st_major << 20) | st_minor
+abs_path = os.path.abspath(args.path)
+
+modes = []
+if args.reads:
+    modes.append("reads")
+if args.writes:
+    modes.append("writes")
+if args.meta:
+    modes.append("metadata")
+if args.create and dir_mode:
+    modes.append("create")
+if args.unlink:
+    modes.append("unlink")
+
+print("filewatch - VFS file access tracer")
+if dir_mode:
+    print("  dir   : %s  (recursive)" % abs_path)
+else:
+    print("  file  : %s" % abs_path)
+print("  inode : %d" % target_ino)
+print("  dev   : major=%d, minor=%d (kernel_dev=%d)" % (
+    st_major, st_minor, target_dev))
+print("  mode  : %s" % " + ".join(modes))
+if dir_mode:
+    print("  depth : up to %d levels" % MAX_DIR_DEPTH)
+if filter_name:
+    print("  filter: %s (waiting for creation)" % filter_name)
+if args.debounce > 0:
+    print("  debounce: %.1fs per PID" % args.debounce)
+print("Hit Ctrl-C to end.\n")
+
+print("Loading probes...")
+src = build_bpf(target_ino, target_dev, dir_mode, args.kstack)
+
+if args.ebpf:
+    print(src)
+    exit()
+
+b = BPF(text=src,
+        cflags=["-Wno-missing-declarations"])
+
+attached = []
+if args.reads:
+    b.attach_kprobe(event="vfs_read", fn_name="trace_vfs_read")
+    attached.append("vfs_read")
+    try:
+        b.attach_kprobe(event="vfs_readv",
+                        fn_name="trace_vfs_readv")
+        attached.append("vfs_readv")
+    except Exception:
+        pass
+if args.writes:
+    b.attach_kprobe(event="vfs_write", fn_name="trace_vfs_write")
+    attached.append("vfs_write")
+    try:
+        b.attach_kprobe(event="vfs_writev",
+                        fn_name="trace_vfs_writev")
+        attached.append("vfs_writev")
+    except Exception:
+        pass
+if args.meta:
+    try:
+        b.attach_kprobe(event="notify_change",
+                        fn_name="trace_notify_change")
+        attached.append("notify_change")
+    except Exception as e:
+        print("warning: could not attach to notify_change: %s" %
+              e, file=sys.stderr)
+        print("  metadata tracing (-m) will not work on this "
+              "kernel", file=sys.stderr)
+if args.create and dir_mode:
+    try:
+        b.attach_kprobe(event="security_inode_create",
+                        fn_name="trace_security_create")
+        attached.append("security_inode_create")
+    except Exception as e:
+        print("warning: could not attach to "
+              "security_inode_create: %s" % e,
+              file=sys.stderr)
+    try:
+        b.attach_kprobe(event="security_inode_mkdir",
+                        fn_name="trace_security_mkdir")
+        attached.append("security_inode_mkdir")
+    except Exception as e:
+        print("warning: could not attach to "
+              "security_inode_mkdir: %s" % e,
+              file=sys.stderr)
+if args.unlink:
+    try:
+        b.attach_kprobe(event="security_inode_unlink",
+                        fn_name="trace_security_unlink")
+        attached.append("security_inode_unlink")
+    except Exception as e:
+        print("warning: could not attach to "
+              "security_inode_unlink: %s" % e,
+              file=sys.stderr)
+    try:
+        b.attach_kprobe(event="security_inode_rmdir",
+                        fn_name="trace_security_rmdir")
+        attached.append("security_inode_rmdir")
+    except Exception as e:
+        print("warning: could not attach to "
+              "security_inode_rmdir: %s" % e,
+              file=sys.stderr)
+
+print("Attached probes: %s" % ", ".join(attached))
+print()
+
+last_seen = {}
+exiting = [False]
+
+
+def print_event(cpu, data, size):
+    ev = ct.cast(data, ct.POINTER(EventT)).contents
+    now = time.time()
+
+    if filter_name:
+        evname = ev.fname.decode("utf-8", "replace")
+        if evname != filter_name:
+            return
+
+    if args.debounce > 0:
+        key = (ev.pid, ev.op)
+        prev = last_seen.get(key, 0)
+        if now - prev < args.debounce:
+            return
+        last_seen[key] = now
+
+    ts = time.strftime("%H:%M:%S")
+    fname = ev.fname.decode("utf-8", "replace")
+    dirpath = ev.dirpath.decode("utf-8", "replace")
+    user = uid_to_name(ev.uid)
+    op = OP_LABEL.get(ev.op, "?")
+
+    if dir_mode and dirpath and dirpath != "/":
+        display_path = "%s/%s" % (dirpath, fname)
+    else:
+        display_path = fname
+
+    full_path = ""
+    if ev.npath > 0:
+        parts = []
+        for i in range(ev.npath):
+            comp = ev.fpath[i].value.decode("utf-8", "replace")
+            if comp and comp != "/":
+                parts.append(comp)
+        parts.reverse()
+        full_path = "/" + "/".join(parts)
+    elif not dir_mode:
+        full_path = abs_path
+
+    raw = ev.caller_cmdline
+    bpf_cmdline = (raw.replace(b"\0", b" ")
+                   .decode("utf-8", "replace").strip()) or None
+
+    print("=" * 72)
+    if ev.op == OP_META:
+        attrs = decode_ia_valid(ev.bytes)
+        print("%-6s %s  file=%s  attrs=%s  user=%s" % (
+            op, ts, display_path, attrs, user))
+    elif ev.op in (OP_CREATE, OP_DELETE):
+        print("%-6s %s  file=%s  user=%s" % (
+            op, ts, display_path, user))
+    else:
+        print("%-6s %s  file=%s  bytes=%d  user=%s" % (
+            op, ts, display_path, ev.bytes, user))
+    if full_path:
+        print("       path: %s" % full_path)
+    target_unlinked = False
+    if ev.op == OP_DELETE:
+        if not dir_mode:
+            if fname == os.path.basename(abs_path):
+                target_unlinked = True
+        elif full_path and full_path == abs_path:
+            target_unlinked = True
+    print("Process tree (caller first):\n")
+
+    for i in range(ev.depth):
+        a = ev.chain[i]
+        pid  = a.tgid
+        comm = a.comm.decode("utf-8", "replace")
+
+        if i == 0 and bpf_cmdline:
+            cmdline = bpf_cmdline
+        else:
+            cmdline = read_proc(pid, "cmdline")
+
+        exe = read_proc(pid, "exe")
+        indent = "  " * i
+        tag = ">>>" if i == 0 else "   "
+
+        line = "%s %s[%d] %s" % (tag, indent, pid, comm)
+        if cmdline and cmdline != comm:
+            line += "\n    %scmdline: %s" % (indent, cmdline)
+        if exe:
+            line += "\n    %sexe:     %s" % (indent, exe)
+        if i == 0:
+            cwd = read_proc(pid, "cwd")
+            if cwd:
+                line += "\n    %scwd:     %s" % (indent, cwd)
+        if pid <= 1:
+            line += "  (init)"
+        if read_proc(pid, "cmdline") is None and i > 0:
+            line += "  [exited]"
+        print(line)
+
+    if args.kstack:
+        try:
+            stack_id = ev.kstack_id
+            if stack_id >= 0:
+                stack = list(b["stack_traces"].walk(stack_id))
+                if stack:
+                    print("\n    Kernel stack:")
+                    for addr in stack:
+                        sym = b.ksym(addr).decode(
+                            "utf-8", "replace")
+                        print("      %s" % sym)
+        except Exception:
+            pass
+
+    print()
+
+    if target_unlinked:
+        print("  *** target was unlinked -- exiting ***")
+        exiting[0] = True
+
+
+b["events"].open_perf_buffer(print_event, page_cnt=64)
+
+while not exiting[0]:
+    try:
+        b.perf_buffer_poll(timeout=100)
+    except KeyboardInterrupt:
+        exit()

--- a/tools/filewatch.py
+++ b/tools/filewatch.py
@@ -549,6 +549,22 @@ def uid_to_name(uid):
         return str(uid)
 
 
+def _resolve_comm(comm, cmdline):
+    """Expand a truncated comm using cmdline when available.
+
+    The kernel's task->comm is limited to TASK_COMM_LEN (16 bytes,
+    15 usable chars).  When it looks truncated, scan the cmdline for
+    the full name.
+    """
+    if len(comm) < 15 or not cmdline:
+        return comm
+    for arg in cmdline.split():
+        name = os.path.basename(arg)
+        if name.startswith(comm):
+            return name
+    return comm
+
+
 def build_bpf(target_ino, target_dev, dir_mode, want_stacks):
     """Substitute placeholders in the BPF C source."""
     src = bpf_text
@@ -885,8 +901,9 @@ def print_event(cpu, data, size):
         indent = "  " * i
         tag = ">>>" if i == 0 else "   "
 
-        line = "%s %s[%d] %s" % (tag, indent, pid, comm)
-        if cmdline and cmdline != comm:
+        display_comm = _resolve_comm(comm, cmdline)
+        line = "%s %s[%d] %s" % (tag, indent, pid, display_comm)
+        if cmdline and cmdline != display_comm:
             line += "\n    %scmdline: %s" % (indent, cmdline)
         if exe:
             line += "\n    %sexe:     %s" % (indent, exe)

--- a/tools/filewatch.py
+++ b/tools/filewatch.py
@@ -478,12 +478,16 @@ def _kernel_version():
 
 
 def _resolve_sb_dev(path):
-    """Return (major, minor) of the superblock device for *path*.
+    """Return (major, minor, mount_point) for the superblock of *path*.
 
     Filesystems like btrfs and ZFS override stat()->st_dev to a
     per-subvolume anonymous device, which differs from the kernel's
     i_sb->s_dev.  /proc/self/mountinfo always reports s_dev, so we
     parse that to get the value the BPF probe will see.
+
+    mount_point is returned so that dentry-based paths (which are
+    relative to the filesystem root) can be prefixed to form the
+    real absolute path.
     """
     abs_path = os.path.realpath(path)
     best_mount = ""
@@ -509,7 +513,7 @@ def _resolve_sb_dev(path):
         st = os.stat(path)
         best_major = os.major(st.st_dev)
         best_minor = os.minor(st.st_dev)
-    return best_major, best_minor
+    return best_major, best_minor, best_mount
 
 
 def decode_ia_valid(val):
@@ -684,7 +688,7 @@ if args.create and not dir_mode:
     args.create = False
 
 target_ino = st.st_ino
-st_major, st_minor = _resolve_sb_dev(args.path)
+st_major, st_minor, mount_point = _resolve_sb_dev(args.path)
 target_dev = (st_major << 20) | st_minor
 abs_path = os.path.abspath(args.path)
 
@@ -833,7 +837,11 @@ def print_event(cpu, data, size):
             if comp and comp != "/":
                 parts.append(comp)
         parts.reverse()
-        full_path = "/" + "/".join(parts)
+        dentry_path = "/" + "/".join(parts)
+        if mount_point and mount_point != "/":
+            full_path = mount_point + dentry_path
+        else:
+            full_path = dentry_path
     elif not dir_mode:
         full_path = abs_path
 

--- a/tools/filewatch_example.txt
+++ b/tools/filewatch_example.txt
@@ -1,0 +1,282 @@
+Demonstrations of filewatch, the Linux eBPF/bcc version.
+
+
+filewatch traces VFS access to a single file or an entire directory tree
+and dumps the full process ancestry for every event.  It is useful for
+answering "who or what just touched this file?" -- a common question
+when debugging configuration drift, unexpected writes, or short-lived
+temporary files.
+
+It works on any filesystem (ext4, btrfs, ZFS, VxFS, XFS, tmpfs, NFS)
+because it hooks the VFS layer, not individual filesystem drivers.
+
+
+Watching a single file for writes (the default):
+
+# ./filewatch /etc/fstab
+filewatch - VFS file access tracer
+  file  : /etc/fstab
+  inode : 131073
+  dev   : major=8, minor=1 (kernel_dev=8388609)
+  mode  : writes
+Hit Ctrl-C to end.
+
+Loading probes...
+Attached probes: vfs_write, vfs_writev
+
+========================================================================
+WRITE  10:23:45  file=fstab  bytes=42  user=root
+       path: /etc/fstab
+Process tree (caller first):
+
+>>> [51234] bash
+    cmdline: bash -c echo '# test' >> /etc/fstab
+    exe:     /usr/bin/bash
+    cwd:     /root
+      [51200] sshd
+      cmdline: sshd: root@pts/0
+      exe:     /usr/libexec/openssh/sshd-session
+        [4562] sshd
+        cmdline: sshd: /usr/sbin/sshd -D [listener] 0 of 10-100 startups
+        exe:     /usr/sbin/sshd
+          [1] systemd
+          cmdline: /usr/lib/systemd/systemd --switched-root --system
+          exe:     /usr/lib/systemd/systemd  (init)
+
+The process tree shows the full ancestry from the process that performed
+the write (bash -c) all the way up to systemd.  The caller's command line
+is captured inside the BPF probe, so even short-lived processes that exit
+immediately after the I/O are recorded.
+
+
+Watching a directory tree for reads and writes:
+
+# ./filewatch -rw /etc/
+filewatch - VFS file access tracer
+  dir   : /etc  (recursive)
+  inode : 2
+  dev   : major=8, minor=1 (kernel_dev=8388609)
+  mode  : reads + writes
+  depth : up to 24 levels
+Hit Ctrl-C to end.
+
+Loading probes...
+Attached probes: vfs_read, vfs_readv, vfs_write, vfs_writev
+
+========================================================================
+READ   10:25:12  file=resolv.conf  bytes=4096  user=root
+       path: /etc/resolv.conf
+Process tree (caller first):
+
+>>> [2847] NetworkManager
+    cmdline: /usr/sbin/NetworkManager --no-daemon
+    exe:     /usr/sbin/NetworkManager
+      [1] systemd  (init)
+
+In directory mode, files at any depth under the watched directory are
+caught.  The matching is done in-kernel by walking the dentry parent
+chain, so there is no userspace filtering overhead.
+
+
+Tracing metadata changes (touch, chmod, chown):
+
+# ./filewatch -m /etc/passwd
+filewatch - VFS file access tracer
+  file  : /etc/passwd
+  inode : 131088
+  dev   : major=8, minor=1 (kernel_dev=8388609)
+  mode  : metadata
+Hit Ctrl-C to end.
+
+Loading probes...
+Attached probes: notify_change
+
+========================================================================
+META   10:30:01  file=passwd  attrs=MTIME|MTIME_SET  user=root
+       path: /etc/passwd
+Process tree (caller first):
+
+>>> [62001] touch
+      [61900] bash
+      cmdline: -bash
+      exe:     /usr/bin/bash
+        [1] systemd  (init)
+
+The attrs field decodes the iattr flags to show exactly what metadata
+was changed.  Common values: MODE (chmod), UID (chown), GID (chgrp),
+SIZE (truncate), MTIME|MTIME_SET (touch).
+
+
+Tracing file creation and deletion in a directory:
+
+# ./filewatch -cu /tmp/
+filewatch - VFS file access tracer
+  dir   : /tmp  (recursive)
+  inode : 1
+  dev   : major=0, minor=38 (kernel_dev=38)
+  mode  : create + unlink
+  depth : up to 24 levels
+Hit Ctrl-C to end.
+
+Loading probes...
+Attached probes: security_inode_create, security_inode_mkdir,
+  security_inode_unlink, security_inode_rmdir
+
+========================================================================
+CREATE 10:35:10  file=myfile.txt  user=alice
+       path: /tmp/myfile.txt
+Process tree (caller first):
+
+>>> [71234] touch
+      [71200] bash
+      cmdline: -bash
+      exe:     /usr/bin/bash
+        [1] systemd  (init)
+
+========================================================================
+UNLINK 10:35:15  file=myfile.txt  user=alice
+       path: /tmp/myfile.txt
+Process tree (caller first):
+
+>>> [71240] rm
+      [71200] bash
+      cmdline: -bash
+      exe:     /usr/bin/bash
+        [1] systemd  (init)
+
+Both file and directory creation/deletion are traced.  The CREATE
+operation hooks security_inode_create (files) and security_inode_mkdir
+(directories).  The UNLINK operation hooks security_inode_unlink (files)
+and security_inode_rmdir (directories).
+
+
+Watching for a non-existent file to be created:
+
+# ./filewatch -a /tmp/config_not_yet_created.yml
+filewatch - VFS file access tracer
+  dir   : /tmp  (recursive)
+  inode : 1
+  dev   : major=0, minor=38 (kernel_dev=38)
+  mode  : reads + writes + metadata + create + unlink
+  depth : up to 24 levels
+  filter: config_not_yet_created.yml (waiting for creation)
+Hit Ctrl-C to end.
+
+Loading probes...
+Attached probes: vfs_read, vfs_readv, vfs_write, vfs_writev,
+  notify_change, security_inode_create, security_inode_mkdir,
+  security_inode_unlink, security_inode_rmdir
+
+When the target path does not exist, filewatch automatically watches
+the parent directory and filters for the expected filename.  Events
+for other files in the directory are silently ignored.  The tool stays
+resident through create/delete cycles, acting as a sentry on that name.
+
+
+Single file unlink causes clean exit:
+
+# ./filewatch -a /etc/hosts
+[...]
+========================================================================
+UNLINK 10:40:00  file=hosts  user=root
+       path: /etc/hosts
+Process tree (caller first):
+
+>>> [81234] rm
+      [81200] bash
+      cmdline: -bash
+      exe:     /usr/bin/bash
+        [1] systemd  (init)
+
+  *** target was unlinked -- exiting ***
+
+When watching a single file (not a directory), filewatch exits cleanly
+after the file is unlinked.  The UNLINK event is printed with the full
+process tree before exiting.
+
+
+Including kernel stack traces:
+
+# ./filewatch -wk /etc/fstab
+
+Adding -k captures the kernel stack at the point of the VFS call.  This
+is useful for understanding the kernel code path that led to the access,
+for example distinguishing a direct write from a writeback or a page
+fault.
+
+========================================================================
+WRITE  10:45:00  file=fstab  bytes=42  user=root
+       path: /etc/fstab
+Process tree (caller first):
+
+>>> [91234] bash
+    [...]
+
+    Kernel stack:
+      vfs_write
+      ksys_write
+      do_syscall_64
+      entry_SYSCALL_64_after_hwframe
+
+
+Debouncing high-frequency events:
+
+# ./filewatch -w /var/log/messages -d 1.0
+
+The -d flag suppresses repeated events from the same PID and operation
+type within the specified window.  This is useful for log files or
+databases where a single process may write hundreds of times per second.
+With -d 1.0, you see at most one WRITE event per second per PID.
+
+
+Using -a (all) to trace everything:
+
+# ./filewatch -a /etc/
+
+This enables all five modes at once: reads, writes, metadata changes,
+file creation, and file deletion.  On a quiet directory this gives a
+complete picture of all access.  On a busy directory, combine with -d
+to keep the output manageable.
+
+
+USAGE message:
+
+# ./filewatch -h
+usage: filewatch [-h] [-r] [-w] [-m] [-c] [-u] [-a] [-d SEC] [-k]
+                 [--ebpf] path
+
+Watch a file or directory tree for VFS access and dump the full process
+ancestry with command lines.  Works on any filesystem (ext4, btrfs,
+ZFS, VxFS, XFS, NFS, ...).
+
+positional arguments:
+  path                  file or directory to watch (directories are
+                        recursive)
+
+options:
+  -h, --help            show this help message and exit
+  -r, --reads           trace reads (vfs_read / vfs_readv)
+  -w, --writes          trace writes (vfs_write / vfs_writev)
+  -m, --meta            trace metadata changes: touch, chmod, chown,
+                        truncate
+  -c, --create          trace file/directory creation (directory mode
+                        only)
+  -u, --unlink          trace file/directory deletion (unlink/rmdir)
+  -a, --all             trace everything: reads + writes + metadata +
+                        create + unlink
+  -d SEC, --debounce SEC
+                        minimum seconds between reports for same PID+op
+                        (default: 0 = every event)
+  -k, --kstack          capture and display kernel stack traces
+
+examples:
+    ./filewatch /etc/fstab            # watch one file (writes)
+    ./filewatch /etc/                 # watch entire /etc/ tree
+    ./filewatch -rw /etc/             # reads + writes, tree
+    ./filewatch -r  /etc/shadow       # reads only, one file
+    ./filewatch -m  /etc/passwd       # metadata (touch/chmod/...)
+    ./filewatch -c  /tmp/             # creation only (dir mode)
+    ./filewatch -u  /etc/hosts        # unlink only
+    ./filewatch -a  /etc/             # all: r+w+m+create+unlink
+    ./filewatch -w  /path -d 1.0      # writes, debounce 1s
+    ./filewatch -rwk /etc/hosts       # include kernel stacks


### PR DESCRIPTION
## Description

This PR aims to propose a new script : tools/filewatch

## Why this approach

I wrote the filewatch tool (with the help of Cursor AI to do the heavy lifting) to observe files on production systems.
Sometimes, mysterious files pop up in directories, and it's difficult to trace their origin. Sometimes, short-lived files are created and immediately deleted in some shared directories (think /tmp, etc.), making it difficult to attribute ownership.

I am aware that the auditd filesystem, ftrace and bcc's opensnoop / fileslower tools exist but I wanted something to walk back the process to identify rogue processes/tools and that could be used by sysadmins without having to create a custom ad'hoc, script.

The most compelling examples are real-world "mystery solved" scenarios that sysadmins face daily. Here are three that I'd pick for the PR:

1. "Who keeps modifying my config?" -- the classic sysadmin headache:

```
# ./filewatch /etc/resolv.conf
========================================================================
WRITE  03:15:01  file=resolv.conf  bytes=89  user=root
       path: /etc/resolv.conf
Process tree (caller first):
>>> [8842] NetworkManager
    cmdline: /usr/sbin/NetworkManager --no-daemon
    exe:     /usr/sbin/NetworkManager
      [1] systemd  (init)
```
This immediately answers "why does my resolv.conf keep reverting?" -- a question that with auditd would require setting up rules, parsing audit.log, and correlating ausearch output.

2. Catching an automation tool mid-flight -- the ancestry is the value:

```
# ./filewatch -w /etc/hosts
========================================================================
WRITE  14:22:33  file=hosts  bytes=156  user=root
       path: /etc/hosts
Process tree (caller first):
>>> [51234] sed
    cmdline: sed -i s/oldhost/newhost/g /etc/hosts
    exe:     /usr/bin/sed
      [51230] bash
      cmdline: /bin/bash /tmp/ansible_xyz/command.sh
      exe:     /usr/bin/bash
        [51200] python3
        cmdline: /usr/bin/python3 /usr/bin/ansible-playbook site.yml
        exe:     /usr/bin/python3
          [4562] sshd
          cmdline: sshd: deploy@pts/2
          exe:     /usr/libexec/openssh/sshd-session
            [1] systemd  (init)
```
This shows the full chain: sed was called by a bash wrapper, spawned by Ansible, running over SSH as user deploy. No other tool gives you this in a single command.

3. Catching short-lived processes -- the in-kernel cmdline capture:

```
# ./filewatch -cu /tmp/
========================================================================
CREATE 09:01:00  file=tmpXk9f3a  user=www-data
       path: /tmp/tmpXk9f3a
Process tree (caller first):
>>> [9921] php-fpm
    cmdline: php-fpm: pool www
    exe:     /usr/sbin/php-fpm
      [1203] php-fpm
      cmdline: php-fpm: master process (/etc/php-fpm.conf)
        [1] systemd  (init)
========================================================================
UNLINK 09:01:00  file=tmpXk9f3a  user=www-data
       path: /tmp/tmpXk9f3a
Process tree (caller first):
>>> [9921] php-fpm
    [...]
```
This catches temp file churn that would be invisible to lsof (file comes and goes in under a second) and that inotifywait would report without any process information.

And another one (who changed the sudoers global config without using sudo as his/her user?):
```
========================================================================
READ   09:43:38  file=sudoers  bytes=4096  user=root
       path: /etc/sudoers
Process tree (caller first):

>>> [307916] visudo
    exe:     /usr/sbin/visudo
    cwd:     /root
      [303669] bash
      cmdline: -bash
      exe:     /usr/bin/bash
        [303668] sudo
        cmdline: sudo -i
        exe:     /usr/bin/sudo
          [303492] sudo
          cmdline: sudo -i
          exe:     /usr/bin/sudo
            [302656] bash
            cmdline: -/bin/bash
            exe:     /usr/bin/bash
              [148341] screen
              cmdline: SCREEN -dRRR
              exe:     /usr/bin/screen
                [148321] screen
                cmdline: screen -dRRR
                exe:     /usr/bin/screen
                  [139545] bash
                  cmdline: -bash
                  exe:     /usr/bin/bash
                    [139417] sshd-session
                    cmdline: sshd-session: raistlin@pts/12
                    exe:     /usr/libexec/openssh/sshd-session
                      [135473] sshd-session
                      cmdline: sshd-session: raistlin [priv]  
                      exe:     /usr/libexec/openssh/sshd-session
                        [4514] sshd
                        cmdline: sshd: /usr/sbin/sshd -D -f /etc/ssh/sshd_config -oPidFile=/var/run/sshd.pid [listener] 0 of 10-100 startups
                        exe:     /usr/sbin/sshd
                          [1] systemd
                          cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 31
                          exe:     /usr/lib/systemd/systemd  (init)

```

Happy to make changes and open to suggestions. 

---

## Checklist

- [x] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [x] Commit body explains **why** this change is needed

**For new tools only**
- [x] Explains why this tool is needed and what existing tools cannot cover this use case
- [x] Includes at least one real production use case
- [x] Man page (`man/man8/`) with an OVERHEAD section
- [x] Example output file (`*_example.txt`)
- [x] README.md entry added
- [x] Smoke test added to `tests/python/test_tools_smoke.py`

---

