### PR TITLE
libbpf-tools: Fix 64-bit format portability

### DIFF
--- a/libbpf-tools/bashreadline.c
+++ b/libbpf-tools/bashreadline.c
@@ -83,7 +83,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_size)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 static char *find_readline_function_name(const char *bash_path)

--- a/libbpf-tools/bindsnoop.c
+++ b/libbpf-tools/bindsnoop.c
@@ -174,7 +174,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/biosnoop.c
+++ b/libbpf-tools/biosnoop.c
@@ -214,7 +214,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 static void blk_account_io_set_attach_target(struct biosnoop_bpf *obj)

--- a/libbpf-tools/cachestat.c
+++ b/libbpf-tools/cachestat.c
@@ -7,6 +7,7 @@
 //                             use fentry/kprobe
 // 15-Feb-2023   Rong Tao      Add tracepoint writeback_dirty_{page,folio}
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -112,8 +113,8 @@ static int get_meminfo(__u64 *buffers, __u64 *cached)
 		   "MemTotal: %*u kB\n"
 		   "MemFree: %*u kB\n"
 		   "MemAvailable: %*u kB\n"
-		   "Buffers: %llu kB\n"
-		   "Cached: %llu kB\n",
+		   "Buffers: %" SCNu64 " kB\n"
+		   "Cached: %" SCNu64 " kB\n",
 		   buffers, cached) != 2) {
 		fclose(f);
 		return -1;

--- a/libbpf-tools/capable.c
+++ b/libbpf-tools/capable.c
@@ -296,7 +296,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/drsnoop.c
+++ b/libbpf-tools/drsnoop.c
@@ -139,7 +139,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/execsnoop.c
+++ b/libbpf-tools/execsnoop.c
@@ -258,7 +258,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	fprintf(stderr, "Lost %llu events on CPU #%d!\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/exitsnoop.c
+++ b/libbpf-tools/exitsnoop.c
@@ -159,7 +159,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/filelife.c
+++ b/libbpf-tools/filelife.c
@@ -117,7 +117,7 @@ int handle_event(void *ctx, void *data, size_t data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/fsslower.c
+++ b/libbpf-tools/fsslower.c
@@ -12,6 +12,7 @@
  * 27-Oct-2023  Pcheng Cui   Add support for F2FS.
  */
 #include <argp.h>
+#include <inttypes.h>
 #include <libgen.h>
 #include <signal.h>
 #include <stdio.h>
@@ -346,7 +347,7 @@ static void print_headers()
 	}
 
 	if (min_lat_ms)
-		printf("Tracing %s operations slower than %llu ms", fs, min_lat_ms);
+		printf("Tracing %s operations slower than %" PRIu64 " ms", fs, min_lat_ms);
 	else
 		printf("Tracing %s operations", fs);
 
@@ -372,12 +373,12 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	memcpy(&e, data, sizeof(e));
 
 	if (csv) {
-		printf("%lld,%s,%d,%c,", e.end_ns, e.task, e.pid, file_op[e.op]);
+		printf("%" PRIu64 ",%s,%d,%c,", e.end_ns, e.task, e.pid, file_op[e.op]);
 		if (e.size == LLONG_MAX)
 			printf("LL_MAX,");
 		else
 			printf("%zd,", e.size);
-		printf("%lld,%lld,%s\n", e.offset, e.delta_us, e.file);
+		printf("%" PRId64 ",%" PRIu64 ",%s\n", e.offset, e.delta_us, e.file);
 		return;
 	}
 
@@ -388,12 +389,12 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 		printf("%-7s ", "LL_MAX");
 	else
 		printf("%-7zd ", e.size);
-	printf("%-8lld %7.2f %s\n", e.offset / 1024, (double)e.delta_us / 1000, e.file);
+	printf("%-8" PRId64 " %7.2f %s\n", e.offset / 1024, (double)e.delta_us / 1000, e.file);
 }
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/futexctn.c
+++ b/libbpf-tools/futexctn.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <time.h>
 #include <bpf/libbpf.h>
 #include <sys/resource.h>
@@ -287,8 +288,9 @@ static int print_map(struct futexctn_bpf *obj)
 		}
 		printf("\n\n");
 		printf(
-		    "%s[%u] lock 0x%llx contended %llu times, %llu avg %s "
-		    "[max: %llu %s, min %llu %s]\n",
+		    "%s[%u] lock 0x%" PRIx64 " contended %" PRIu64
+		    " times, %" PRIu64 " avg %s [max: %" PRIu64
+		    " %s, min %" PRIu64 " %s]\n",
 		    hist.comm, (__u32)next_key.pid_tgid, next_key.uaddr,
 		    hist.contended, hist.total_elapsed / hist.contended, units,
 		    hist.max, units, hist.min, units);

--- a/libbpf-tools/gethostlatency.c
+++ b/libbpf-tools/gethostlatency.c
@@ -115,7 +115,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 static int get_libc_path(char *path)

--- a/libbpf-tools/klockstat.c
+++ b/libbpf-tools/klockstat.c
@@ -15,6 +15,7 @@
 #endif
 #include <argp.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -593,7 +594,7 @@ static void print_acq_stat(struct ksyms *ksyms, struct stack_stat *ss,
 		printf("%37s\n", symname(ksyms, ss->bt[i], buf, sizeof(buf)));
 	}
 	if (nr_stack_entries > 1 && !env.per_thread)
-		printf("                              Max PID %llu, COMM %s, Lock %s (0x%llx)%s\n",
+		printf("                              Max PID %" PRIu64 ", COMM %s, Lock %s (0x%" PRIx64 ")%s\n",
 		       ss->ls.acq_max_id >> 32,
 		       ss->ls.acq_max_comm,
 		       get_lock_name(ksyms, ss->ls.acq_max_lock_ptr),
@@ -648,7 +649,7 @@ static void print_hld_stat(struct ksyms *ksyms, struct stack_stat *ss,
 		printf("%37s\n", symname(ksyms, ss->bt[i], buf, sizeof(buf)));
 	}
 	if (nr_stack_entries > 1 && !env.per_thread)
-		printf("                              Max PID %llu, COMM %s, Lock %s (0x%llx)%s\n",
+		printf("                              Max PID %" PRIu64 ", COMM %s, Lock %s (0x%" PRIx64 ")%s\n",
 		       ss->ls.hld_max_id >> 32,
 		       ss->ls.hld_max_comm,
 		       get_lock_name(ksyms, ss->ls.hld_max_lock_ptr),

--- a/libbpf-tools/ksnoop.c
+++ b/libbpf-tools/ksnoop.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -485,7 +486,7 @@ static int get_func_ip_mod(struct func *func)
 				goto out;
 			}
 		}
-		p_debug("%s =  <ip %llx, mod %s>", func->name, func->ip,
+		p_debug("%s =  <ip %" PRIx64 ", mod %s>", func->name, func->ip,
 			strlen(func->mod) > 0 ? func->mod : "vmlinux");
 		break;
 	}
@@ -705,7 +706,7 @@ static void trace_handler(void *ctx, int cpu, void *data, __u32 size)
 			size, sizeof(trace) - MAX_TRACE_BUF);
 		return;
 	}
-	printf("%16lld %4d %8u %s(\n", trace->time, trace->cpu, trace->pid,
+	printf("%16" PRIu64 " %4d %8u %s(\n", trace->time, trace->cpu, trace->pid,
 	       trace->func.name);
 
 	for (i = 0, shown = 0; i < trace->nr_traces; i++) {
@@ -735,7 +736,7 @@ static void trace_handler(void *ctx, int cpu, void *data, __u32 size)
 			printf(",\n");
 		printf("%34s %s = ", "", val->name);
 		if (val->flags & KSNOOP_F_PTR)
-			printf("*(0x%llx)", data->raw_value);
+			printf("*(0x%" PRIx64 ")", data->raw_value);
 		printf("\n");
 
 		if (data->err_type_id != 0) {
@@ -769,7 +770,7 @@ static void trace_handler(void *ctx, int cpu, void *data, __u32 size)
 
 static void lost_handler(void *ctx, int cpu, __u64 cnt)
 {
-	p_err("\t/* lost %llu events */", cnt);
+	p_err("\t/* lost %" PRIu64 " events */", cnt);
 }
 
 static void sig_int(int signo)

--- a/libbpf-tools/llcstat.c
+++ b/libbpf-tools/llcstat.c
@@ -5,6 +5,7 @@
 // 29-Sep-2020   Wenbo Zhang   Created this.
 // 20-Jun-2022   YeZhengMao    Added tid info.
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -165,7 +166,7 @@ static void print_map(struct bpf_map *map)
 		lookup_key = next_key;
 	}
 	total_hit = total_ref > total_miss ? total_ref - total_miss : 0;
-	printf("Total References: %llu Total Misses: %llu Hit Rate: %.2f%%\n",
+	printf("Total References: %" PRIu64 " Total Misses: %" PRIu64 " Hit Rate: %.2f%%\n",
 		total_ref, total_miss, total_ref > 0 ?
 		total_hit * 1.0 / total_ref * 100 : 0);
 

--- a/libbpf-tools/mdflush.c
+++ b/libbpf-tools/mdflush.c
@@ -80,7 +80,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/mountsnoop.c
+++ b/libbpf-tools/mountsnoop.c
@@ -15,6 +15,7 @@
 #include <argp.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <string.h>
 #include <time.h>
@@ -404,7 +405,7 @@ static int handle_event(void *ctx, void *data, size_t len)
 	printf("%sCOMM:   %s\n", indent, e->comm);
 	printf("%sOP:     %s\n", indent, op_name[e->op]);
 	printf("%sRET:    %s\n", indent, strerrno(e->ret));
-	printf("%sLAT:    %lldus\n", indent, e->delta / 1000);
+	printf("%sLAT:    %" PRIu64 "us\n", indent, e->delta / 1000);
 	printf("%sMNT_NS: %u\n", indent, e->mnt_ns);
 	switch (e->op) {
 	case MOUNT:
@@ -450,7 +451,7 @@ static int handle_event(void *ctx, void *data, size_t len)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/offcputime.c
+++ b/libbpf-tools/offcputime.c
@@ -6,6 +6,7 @@
 #include <argp.h>
 #include <signal.h>
 #include <stdio.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
@@ -283,7 +284,7 @@ print_ustack:
 
 skip_ustack:
 		printf("    %-16s %s (%d)\n", "-", val.comm, next_key.pid);
-		printf("        %lld\n\n", val.delta);
+		printf("        %" PRIu64 "\n\n", val.delta);
 	}
 
 cleanup:

--- a/libbpf-tools/oomkill.c
+++ b/libbpf-tools/oomkill.c
@@ -7,6 +7,7 @@
 // 17-Oct-2022   Krisztian Fekete Edited this.
 #include <argp.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -67,10 +68,10 @@ static int handle_event(void *ctx, void *data, size_t len)
 	str_timestamp("%H:%M:%S", ts, sizeof(ts));
 
 	if (str_loadavg(loadavg, sizeof(loadavg)) > 0)
-		printf("%s Triggered by PID %d (\"%s\"), OOM kill of PID %d (\"%s\"), %lld pages, loadavg: %s",
+		printf("%s Triggered by PID %d (\"%s\"), OOM kill of PID %d (\"%s\"), %" PRIu64 " pages, loadavg: %s",
 			ts, e->fpid, e->fcomm, e->tpid, e->tcomm, e->pages, loadavg);
 	else
-		printf("%s Triggered by PID %d (\"%s\"), OOM kill of PID %d (\"%s\"), %lld pages\n",
+		printf("%s Triggered by PID %d (\"%s\"), OOM kill of PID %d (\"%s\"), %" PRIu64 " pages\n",
 			ts, e->fpid, e->fcomm, e->tpid, e->tcomm, e->pages);
 
 	return 0;
@@ -78,7 +79,7 @@ static int handle_event(void *ctx, void *data, size_t len)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	printf("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	printf("Lost %llu events on CPU #%d!\n", (unsigned long long)lost_cnt, cpu);
 }
 
 static void sig_int(int signo)

--- a/libbpf-tools/opensnoop.c
+++ b/libbpf-tools/opensnoop.c
@@ -296,7 +296,7 @@ int handle_event(void *ctx, void *data, size_t data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	fprintf(stderr, "Lost %llu events on CPU #%d!\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/profile.c
+++ b/libbpf-tools/profile.c
@@ -448,13 +448,13 @@ static int print_count(struct key_t *event, __u64 count, int stack_map, bool fol
 		ret = print_kern_stacktrace(event, stack_map, ip, fmt, false);
 		print_user_stacktrace(event, stack_map, ip, fmt, ret && env.delimiter);
 		printf("    %-16s %s (%d)\n", "-", event->name, event->pid);
-		printf("        %lld\n\n", count);
+		printf("        %" PRIu64 "\n\n", count);
 	} else {
 		/* folded stack output */
 		printf("%s", event->name);
 		ret = print_user_stacktrace(event, stack_map, ip, fmt, false);
 		print_kern_stacktrace(event, stack_map, ip, fmt, ret && env.delimiter);
-		printf(" %lld\n", count);
+		printf(" %" PRIu64 "\n", count);
 	}
 
 	free(ip);

--- a/libbpf-tools/runqslower.c
+++ b/libbpf-tools/runqslower.c
@@ -4,6 +4,7 @@
 // Based on runqslower(8) from BCC by Ivan Babrou.
 // 11-Feb-2020   Andrii Nakryiko   Created this.
 #include <argp.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -148,7 +149,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	printf("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	printf("Lost %llu events on CPU #%d!\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)
@@ -205,7 +206,7 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	printf("Tracing run queue latency higher than %llu us\n", env.min_us);
+	printf("Tracing run queue latency higher than %" PRIu64 " us\n", env.min_us);
 	if (env.previous)
 		printf("%-8s %-16s %-6s %14s %-16s %-6s\n", "TIME", "COMM", "TID", "LAT(us)", "PREV COMM", "PREV TID");
 	else

--- a/libbpf-tools/sigsnoop.c
+++ b/libbpf-tools/sigsnoop.c
@@ -229,7 +229,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/softirqslower.c
+++ b/libbpf-tools/softirqslower.c
@@ -6,6 +6,7 @@
 // 27-May-2026   Ported to libbpf.
 #include <argp.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -94,8 +95,8 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		}
 		nr_cpus = libbpf_num_possible_cpus();
 		if (nr_cpus > 0 && val >= nr_cpus) {
-			fprintf(stderr, "cpu %lld out of range, system has %d CPUs (0-%d)\n",
-				val, nr_cpus, nr_cpus - 1);
+			fprintf(stderr, "cpu %d out of range, system has %d CPUs (0-%d)\n",
+				(int)val, nr_cpus, nr_cpus - 1);
 			argp_usage(state);
 		}
 		env.targ_cpu = (int)val;
@@ -159,7 +160,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	printf("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	printf("Lost %llu events on CPU #%d!\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)
@@ -214,7 +215,7 @@ int main(int argc, char **argv)
 		goto cleanup;
 	}
 
-	printf("Tracing softirq latency higher than %llu us... "
+	printf("Tracing softirq latency higher than %" PRIu64 " us... "
 			"Hit Ctrl-C to end.\n", env.min_us);
 	printf("%-8s %-20s %-8s %-14s %-6s %-16s\n",
 			"TIME", "STAGE", "SOFTIRQ", "LAT(us)", "CPU", "COMM");

--- a/libbpf-tools/solisten.c
+++ b/libbpf-tools/solisten.c
@@ -125,7 +125,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/statsnoop.c
+++ b/libbpf-tools/statsnoop.c
@@ -183,7 +183,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/syncsnoop.c
+++ b/libbpf-tools/syncsnoop.c
@@ -77,7 +77,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	printf("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	printf("Lost %llu events on CPU #%d!\n", (unsigned long long)lost_cnt, cpu);
 }
 
 static void sig_int(int signo)

--- a/libbpf-tools/tcpconnect.c
+++ b/libbpf-tools/tcpconnect.c
@@ -357,7 +357,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	warn("Lost %llu events on CPU #%d!\n", (unsigned long long)lost_cnt, cpu);
 }
 
 static void print_events(int perf_map_fd)

--- a/libbpf-tools/tcpconnlat.c
+++ b/libbpf-tools/tcpconnlat.c
@@ -151,7 +151,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/tcplife.c
+++ b/libbpf-tools/tcplife.c
@@ -141,7 +141,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/tcppktlat.c
+++ b/libbpf-tools/tcppktlat.c
@@ -168,7 +168,7 @@ static int handle_event(void *ctx, void *data, size_t data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	fprintf(stderr, "lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	fprintf(stderr, "lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/tcprtt.c
+++ b/libbpf-tools/tcprtt.c
@@ -6,6 +6,7 @@
 #define _DEFAULT_SOURCE
 #include <arpa/inet.h>
 #include <argp.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <signal.h>
 #include <unistd.h>
@@ -220,7 +221,7 @@ static int print_map(struct bpf_map *map)
 		}
 
 		if (env.extended)
-			printf("[AVG %llu]", hist.latency / hist.cnt);
+			printf("[AVG %" PRIu64 "]", hist.latency / hist.cnt);
 		printf("\n");
 		print_log2_hist(hist.slots, MAX_SLOTS, units);
 		lookup_key = &next_key;

--- a/libbpf-tools/tcpstates.c
+++ b/libbpf-tools/tcpstates.c
@@ -185,7 +185,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+	warn("lost %llu events on CPU #%d\n", (unsigned long long)lost_cnt, cpu);
 }
 
 int main(int argc, char **argv)

--- a/libbpf-tools/tcpsynbl.c
+++ b/libbpf-tools/tcpsynbl.c
@@ -4,6 +4,7 @@
 // Based on tcpsynbl(8) from BCC by Brendan Gregg.
 // 19-Dec-2021   Yaqi Chen   Created this.
 #include <argp.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <signal.h>
 #include <unistd.h>
@@ -151,7 +152,7 @@ static int print_log2_hists(int fd)
 			fprintf(stderr, "failed to lookup hist: %d\n", err);
 			return -1;
 		}
-		printf("backlog_max = %lld\n", next_key);
+		printf("backlog_max = %" PRIu64 "\n", next_key);
 		print_log2_hist(hist.slots, MAX_SLOTS, "backlog");
 		lookup_key = next_key;
 	}

--- a/libbpf-tools/tcptracer.c
+++ b/libbpf-tools/tcptracer.c
@@ -226,7 +226,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
 {
-	warn("Lost %llu events on CPU #%d!\n", lost_cnt, cpu);
+	warn("Lost %llu events on CPU #%d!\n", (unsigned long long)lost_cnt, cpu);
 }
 
 static void print_events(int perf_map_fd)

--- a/libbpf-tools/wakeuptime.c
+++ b/libbpf-tools/wakeuptime.c
@@ -6,6 +6,7 @@
 #include <argp.h>
 #include <signal.h>
 #include <stdio.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -194,7 +195,7 @@ static void print_map(struct ksyms *ksyms, struct wakeuptime_bpf *obj)
 		printf("	%16s %s\n","waker:", next_key.waker);
 		/*to convert val in microseconds*/
 		val /= 1000;
-		printf("	%lld\n", val);
+		printf("	%" PRIu64 "\n", val);
 	}
 
 	free(ip);


### PR DESCRIPTION
## Description

Use the portable integer format macros from <inttypes.h> for 64-bit values in libbpf-tools, and explicitly cast lost-event counters passed to variadic logging functions. This avoids assuming that Linux __u64 is always unsigned long long, which breaks builds on ppc64le where it is unsigned long.

The change covers the libbpf-tools format sites that would otherwise trigger -Werror=format, including the failure reported in #5330.

## Testing

- git diff --check
- make -C libbpf-tools -j2 (cannot complete on macOS because the environment lacks Linux headers such as asm/unistd.h and byteswap.h)

Fixes #5330