### PR TITLE
libbpf-tools/memleak: fix child process not exiting on execl failure

### DIFF
--- a/libbpf-tools/memleak.c
+++ b/libbpf-tools/memleak.c
@@ -728,11 +728,9 @@ pid_t fork_sync_exec(const char *command, int fd)
 
 		printf("received go event. executing child command\n");
 
-		const int err = execl(command, command, NULL);
-		if (err) {
-			perror("failed to execute child command");
-			return -1;
-		}
+		execl(command, command, NULL);
+		perror("failed to execute child command");
+		exit(EXIT_FAILURE);
 
 		break;
 	}


### PR DESCRIPTION
In fork_sync_exec(), when execl() fails, the child process returned -1 back to main() instead of terminating. This caused the child to continue executing the rest of main() alongside the parent, leading to two processes competing for the same BPF resources.

Replace the erroneous return with exit(EXIT_FAILURE) so the child terminates immediately on execl failure.

## Description

<!-- What does this PR do? Which problem does it solve? -->

## Why this approach

<!-- Explain why you chose this approach over alternatives. -->

---

## Checklist

- [ ] Commit prefix matches changed area (e.g., `tools/toolname:`, `libbpf-tools/toolname:`, `src/cc:`, `docs:`, `build:`, `tests/python:`)
- [ ] Commit body explains **why** this change is needed

**For new tools only**
- [ ] Explains why this tool is needed and what existing tools cannot cover this use case
- [ ] Includes at least one real production use case
- [ ] Man page (`man/man8/`) with an OVERHEAD section
- [ ] Example output file (`*_example.txt`)
- [ ] README.md entry added
- [ ] Smoke test added to `tests/python/test_tools_smoke.py`

---

> **About AI Code Review:** This project uses GitHub Copilot to assist with code review.
> If a Copilot review is added, treat its feedback as you would any reviewer comment — you can
> agree, disagree (with explanation), or ask questions. The maintainer makes all final decisions.
